### PR TITLE
Backport (#24855) Arena allocate per-group buffers in bit/mode aggregates

### DIFF
--- a/extension/core_functions/aggregate/distributive/bitagg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitagg.cpp
@@ -134,24 +134,41 @@ struct BitXorOperation : public BitwiseOperation {
 };
 
 struct BitStringBitwiseOperation : public BitwiseOperation {
-	template <class STATE>
-	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
-		if (state.is_set && !state.value.IsInlined()) {
-			delete[] state.value.GetData();
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE &state, const INPUT_TYPE &input, AggregateUnaryInput &unary_input) {
+		if (!state.is_set) {
+			OP::template Assign<INPUT_TYPE>(state, input, unary_input.input);
+			state.is_set = true;
+		} else {
+			OP::template Execute<INPUT_TYPE>(state, input);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &aggr_input_data) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target.is_set) {
+			// target is NULL, use source value directly.
+			OP::template Assign<typename STATE::TYPE>(target, source.value, aggr_input_data);
+			target.is_set = true;
+		} else {
+			OP::template Execute<typename STATE::TYPE>(target, source.value);
 		}
 	}
 
 	template <class INPUT_TYPE, class STATE>
-	static void Assign(STATE &state, INPUT_TYPE input) {
+	static void Assign(STATE &state, INPUT_TYPE input, AggregateInputData &aggr_input_data) {
 		D_ASSERT(state.is_set == false);
 		if (input.IsInlined()) {
 			state.value = input;
 		} else { // non-inlined string, need to allocate space for it
 			auto len = input.GetSize();
-			auto ptr = new char[len];
+			auto ptr = aggr_input_data.allocator.Allocate(len);
 			memcpy(ptr, input.GetData(), len);
-
-			state.value = string_t(ptr, UnsafeNumericCast<uint32_t>(len));
+			state.value = string_t(char_ptr_cast(ptr), UnsafeNumericCast<uint32_t>(len));
 		}
 	}
 
@@ -203,7 +220,7 @@ AggregateFunctionSet BitAndFun::GetFunctions() {
 	}
 
 	bit_and.AddFunction(
-	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringAndOperation>(
+	    AggregateFunction::UnaryAggregate<BitState<string_t>, string_t, string_t, BitStringAndOperation>(
 	        LogicalType::BIT, LogicalType::BIT));
 	return bit_and;
 }
@@ -213,9 +230,8 @@ AggregateFunctionSet BitOrFun::GetFunctions() {
 	for (auto &type : LogicalType::Integral()) {
 		bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
 	}
-	bit_or.AddFunction(
-	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringOrOperation>(
-	        LogicalType::BIT, LogicalType::BIT));
+	bit_or.AddFunction(AggregateFunction::UnaryAggregate<BitState<string_t>, string_t, string_t, BitStringOrOperation>(
+	    LogicalType::BIT, LogicalType::BIT));
 	return bit_or;
 }
 
@@ -225,7 +241,7 @@ AggregateFunctionSet BitXorFun::GetFunctions() {
 		bit_xor.AddFunction(GetBitfieldUnaryAggregate<BitXorOperation>(type));
 	}
 	bit_xor.AddFunction(
-	    AggregateFunction::UnaryAggregateDestructor<BitState<string_t>, string_t, string_t, BitStringXorOperation>(
+	    AggregateFunction::UnaryAggregate<BitState<string_t>, string_t, string_t, BitStringXorOperation>(
 	        LogicalType::BIT, LogicalType::BIT));
 	return bit_xor;
 }

--- a/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
+++ b/extension/core_functions/aggregate/distributive/bitstring_agg.cpp
@@ -95,8 +95,14 @@ struct BitStringAggOperation {
 				    NumericHelper::ToString(state.min), NumericHelper::ToString(state.max));
 			}
 			idx_t len = Bit::ComputeBitstringLen(bit_range);
-			auto target = len > string_t::INLINE_LENGTH ? string_t(new char[len], UnsafeNumericCast<uint32_t>(len))
-			                                            : string_t(UnsafeNumericCast<uint32_t>(len));
+
+			string_t target;
+			if (len <= string_t::INLINE_LENGTH) {
+				target = string_t(UnsafeNumericCast<uint32_t>(len));
+			} else {
+				target = string_t(char_ptr_cast(unary_input.input.allocator.Allocate(len)),
+				                  UnsafeNumericCast<uint32_t>(len));
+			}
 			Bit::SetEmptyBitString(target, bit_range);
 
 			state.value = target;
@@ -139,12 +145,12 @@ struct BitStringAggOperation {
 	}
 
 	template <class STATE, class OP>
-	static void Combine(const STATE &source, STATE &target, AggregateInputData &) {
+	static void Combine(const STATE &source, STATE &target, AggregateInputData &unary_input) {
 		if (!source.is_set) {
 			return;
 		}
 		if (!target.is_set) {
-			Assign(target, source.value);
+			Assign(target, source.value, unary_input);
 			target.is_set = true;
 			target.min = source.min;
 			target.max = source.max;
@@ -154,15 +160,15 @@ struct BitStringAggOperation {
 	}
 
 	template <class INPUT_TYPE, class STATE>
-	static void Assign(STATE &state, INPUT_TYPE input) {
+	static void Assign(STATE &state, INPUT_TYPE input, AggregateInputData &unary_input) {
 		D_ASSERT(state.is_set == false);
 		if (input.IsInlined()) {
 			state.value = input;
 		} else { // non-inlined string, need to allocate space for it
 			auto len = input.GetSize();
-			auto ptr = new char[len];
+			auto ptr = unary_input.allocator.Allocate(len);
 			memcpy(ptr, input.GetData(), len);
-			state.value = string_t(ptr, UnsafeNumericCast<uint32_t>(len));
+			state.value = string_t(char_ptr_cast(ptr), UnsafeNumericCast<uint32_t>(len));
 		}
 	}
 
@@ -172,13 +178,6 @@ struct BitStringAggOperation {
 			finalize_data.ReturnNull();
 		} else {
 			target = StringVector::AddStringOrBlob(finalize_data.result, state.value);
-		}
-	}
-
-	template <class STATE>
-	static void Destroy(STATE &state, AggregateInputData &aggr_input_data) {
-		if (state.is_set && !state.value.IsInlined()) {
-			delete[] state.value.GetData();
 		}
 	}
 
@@ -260,9 +259,8 @@ unique_ptr<FunctionData> BindBitstringAgg(ClientContext &context, AggregateFunct
 
 template <class TYPE>
 void BindBitString(AggregateFunctionSet &bitstring_agg, const LogicalTypeId &type) {
-	auto function =
-	    AggregateFunction::UnaryAggregateDestructor<BitAggState<TYPE>, TYPE, string_t, BitStringAggOperation>(
-	        type, LogicalType::BIT);
+	auto function = AggregateFunction::UnaryAggregate<BitAggState<TYPE>, TYPE, string_t, BitStringAggOperation>(
+	    type, LogicalType::BIT);
 	function.SetBindCallback(BindBitstringAgg); // create new a 'BitstringAggBindData'
 	function.SetSerializeCallback(BitstringAggBindData::Serialize);
 	function.SetDeserializeCallback(BitstringAggBindData::Deserialize);

--- a/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/extension/core_functions/aggregate/holistic/mode.cpp
@@ -39,10 +39,7 @@ struct ModeStandard {
 		return RESULT_TYPE(input);
 	}
 
-	static void Destroy(T *mode) {
-	}
-
-	static T *Update(T *mode, const T &key) {
+	static T *Update(T *mode, uint32_t &, const T &key, AggregateInputData &) {
 		if (!mode) {
 			mode = new T(key);
 		}
@@ -67,39 +64,33 @@ struct ModeString {
 		return StringVector::AddStringOrBlob(result, input);
 	}
 
-	static void Destroy(string_t *mode) {
-		if (mode && !mode->IsInlined()) {
-			delete[] mode->GetData();
-			mode->SetPointer(nullptr);
-		}
-	}
-
-	static string_t *Update(string_t *mode, const string_t &key) {
+	static string_t *Update(string_t *mode, uint32_t &alloc_size, const string_t &key,
+	                        AggregateInputData &aggr_input_data) {
 		if (key.IsInlined()) {
-			Destroy(mode);
 			if (!mode) {
 				mode = new string_t(nullptr, 0);
 			}
 			*mode = key;
+			alloc_size = 0;
 			return mode;
 		}
 
 		// non-inlined string, need to allocate space for it somehow
-		const auto len = key.GetSize();
+		const auto len = UnsafeNumericCast<uint32_t>(key.GetSize());
 		char *ptr;
-		if (!mode || mode->GetSize() < len) {
-			// we cannot fit this into the current slot - destroy it and re-allocate
-			Destroy(mode);
+		if (mode && alloc_size >= len) {
+			// this fits into the current arena allocation - reuse it
+			ptr = mode->GetDataWriteable();
+		} else {
+			// round up so repeatedly growing keys don't churn through a new arena allocation every time
+			alloc_size = UnsafeNumericCast<uint32_t>(NextPowerOfTwo(len));
+			ptr = char_ptr_cast(aggr_input_data.allocator.Allocate(alloc_size));
 			if (!mode) {
 				mode = new string_t(nullptr, 0);
 			}
-			ptr = new char[len];
-		} else {
-			// this fits into the current slot - take over the pointer
-			ptr = mode->GetDataWriteable();
 		}
 		memcpy(ptr, key.GetData(), len);
-		*mode = string_t(ptr, UnsafeNumericCast<uint32_t>(len));
+		*mode = string_t(ptr, len);
 		return mode;
 	}
 };
@@ -114,6 +105,7 @@ struct ModeState {
 	SubFrames prevs;
 	Counts *frequency_map = nullptr;
 	KEY_TYPE *mode = nullptr;
+	uint32_t mode_alloc_size = 0;
 	size_t nonzero = 0;
 	bool valid = false;
 	size_t count = 0;
@@ -133,10 +125,7 @@ struct ModeState {
 		if (frequency_map) {
 			delete frequency_map;
 		}
-		if (mode) {
-			TYPE_OP::Destroy(mode);
-			delete mode;
-		}
+		delete mode;
 		if (scan) {
 			delete scan;
 		}
@@ -193,7 +182,7 @@ struct ModeState {
 		valid = false;
 	}
 
-	void ModeAdd(idx_t row) {
+	void ModeAdd(idx_t row, AggregateInputData &aggr_input_data) {
 		const auto &key = GetCell(row);
 		auto &attr = (*frequency_map)[key];
 		auto new_count = (attr.count += 1);
@@ -206,7 +195,7 @@ struct ModeState {
 		if (new_count > count) {
 			valid = true;
 			count = new_count;
-			Update(key);
+			Update(key, aggr_input_data);
 		}
 	}
 
@@ -222,8 +211,8 @@ struct ModeState {
 		}
 	}
 
-	void Update(const KEY_TYPE &key) {
-		mode = TYPE_OP::Update(mode, key);
+	void Update(const KEY_TYPE &key, AggregateInputData &aggr_input_data) {
+		mode = TYPE_OP::Update(mode, mode_alloc_size, key, aggr_input_data);
 	}
 
 	typename Counts::const_iterator Scan() const {
@@ -336,8 +325,10 @@ struct ModeFunction : TypedModeFunction<TYPE_OP> {
 	struct UpdateWindowState {
 		STATE &state;
 		ModeIncluded<STATE> &included;
+		AggregateInputData &aggr_input_data;
 
-		inline UpdateWindowState(STATE &state, ModeIncluded<STATE> &included) : state(state), included(included) {
+		inline UpdateWindowState(STATE &state, ModeIncluded<STATE> &included, AggregateInputData &aggr_input_data)
+		    : state(state), included(included), aggr_input_data(aggr_input_data) {
 		}
 
 		inline void Neither(idx_t begin, idx_t end) {
@@ -354,7 +345,7 @@ struct ModeFunction : TypedModeFunction<TYPE_OP> {
 		inline void Right(idx_t begin, idx_t end) {
 			for (; begin < end; ++begin) {
 				if (included(begin)) {
-					state.ModeAdd(begin);
+					state.ModeAdd(begin, aggr_input_data);
 				}
 			}
 		}
@@ -392,13 +383,13 @@ struct ModeFunction : TypedModeFunction<TYPE_OP> {
 			for (const auto &frame : frames) {
 				for (auto i = frame.start; i < frame.end; ++i) {
 					if (included(i)) {
-						state.ModeAdd(i);
+						state.ModeAdd(i, aggr_input_data);
 					}
 				}
 			}
 		} else {
 			using Updater = UpdateWindowState<STATE, INPUT_TYPE>;
-			Updater updater(state, included);
+			Updater updater(state, included, aggr_input_data);
 			AggregateExecutor::IntersectFrames(prevs, frames, updater);
 		}
 
@@ -406,7 +397,7 @@ struct ModeFunction : TypedModeFunction<TYPE_OP> {
 			// Rescan
 			auto highest_frequency = state.Scan();
 			if (highest_frequency != state.frequency_map->end()) {
-				state.Update(highest_frequency->first);
+				state.Update(highest_frequency->first, aggr_input_data);
 				state.count = highest_frequency->second.count;
 				state.valid = (state.count > 0);
 			}

--- a/test/sql/aggregate/aggregates/bitagg_memory_limit.test
+++ b/test/sql/aggregate/aggregates/bitagg_memory_limit.test
@@ -1,0 +1,27 @@
+# name: test/sql/aggregate/aggregates/bitagg_memory_limit.test
+# description: Test BIT_AND/BIT_OR/BIT_XOR memory limit enforcement over BIT columns
+# group: [aggregates]
+
+statement ok
+SET memory_limit='256MB';
+
+statement ok
+SET threads=4;
+
+# disable spilling so the memory limit assertion below is deterministic, not a race against the
+# radix hash table's spill-to-disk speed
+statement ok
+PRAGMA temp_directory=''
+
+statement ok
+PRAGMA max_temp_directory_size='0B'
+
+# each of the 1,000,000 groups needs ~763 bytes of state (6096-bit value), i.e. ~750MB total,
+# which must be tracked against the 256MB memory_limit rather than allocated as untracked raw heap
+statement error
+SELECT count(*) AS groups, max(length(a)) AS bits
+FROM (SELECT g, bit_and(v) AS a, bit_or(v) AS o, bit_xor(v) AS x
+      FROM (SELECT i::BIGINT AS g, repeat('1', 6096)::BIT AS v FROM range(1000000) t(i))
+      GROUP BY g);
+----
+Out of Memory Error

--- a/test/sql/aggregate/aggregates/bitstring_agg_memory_limit.test
+++ b/test/sql/aggregate/aggregates/bitstring_agg_memory_limit.test
@@ -1,0 +1,29 @@
+# name: test/sql/aggregate/aggregates/bitstring_agg_memory_limit.test
+# description: Test BITSTRING_AGG memory limit enforcement
+# group: [aggregates]
+
+statement ok
+SET memory_limit='256MB';
+
+statement ok
+SET threads=4;
+
+# disable spilling so the memory limit assertion below is deterministic, not a race against the
+# radix hash table's spill-to-disk speed
+statement ok
+PRAGMA temp_directory=''
+
+statement ok
+PRAGMA max_temp_directory_size='0B'
+
+statement ok
+CREATE TABLE src AS
+SELECT (i // 2)::BIGINT AS g, ((i * 7) % 96)::INTEGER AS v
+FROM range(2000000) t(i);
+
+# Correctly throw an error instead of OOM when the memory limit is exceeded
+statement error
+SELECT count(*) AS groups, max(length(bm)) AS bits
+FROM (SELECT g, bitstring_agg(v, 0, 6096) AS bm FROM src GROUP BY g);
+----
+Out of Memory Error

--- a/test/sql/window/test_mode_window_varlen.test
+++ b/test/sql/window/test_mode_window_varlen.test
@@ -1,0 +1,42 @@
+# name: test/sql/window/test_mode_window_varlen.test
+# description: Test MODE window function with non-inlined VARCHAR keys of varying length (grow/shrink of the arena-backed "current mode" buffer)
+# group: [window]
+
+statement ok
+CREATE TABLE modes_str AS
+SELECT i AS r,
+  CASE
+    WHEN i < 3 THEN repeat('x', 50)
+    WHEN i < 6 THEN repeat('y', 5)
+    WHEN i < 9 THEN repeat('z', 100)
+    ELSE repeat('y', 5)
+  END AS v
+FROM range(12) t(i);
+
+# the winning mode shrinks (x50 -> y5), then grows past its original capacity (y5 -> z100), then shrinks
+# again (z100 -> y5); each transition must correctly resize/preserve the arena-backed buffer
+query III
+SELECT r, substr(m, 1, 1) AS ch, length(m) AS len
+FROM (SELECT r, mode(v) OVER (ORDER BY r ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS m FROM modes_str)
+ORDER BY r;
+----
+0	x	50
+1	x	50
+2	x	50
+3	x	50
+4	y	5
+5	y	5
+6	y	5
+7	z	100
+8	z	100
+9	z	100
+10	y	5
+11	y	5
+
+# every value must be byte-for-byte one of the three known constants, not a truncated/corrupted mix
+query I
+SELECT count(*) FROM (
+    SELECT mode(v) OVER (ORDER BY r ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS m FROM modes_str
+) WHERE m NOT IN (repeat('x', 50), repeat('y', 5), repeat('z', 100));
+----
+0


### PR DESCRIPTION
A backport of (#24855) for 1.5, removed changes related to 2.0 when directly cherry-picked.

Changes made
- Change from UnaryAggregateDestructor -> UnaryAggregate was required.

Feel free to close if there is no wish to backport this to 1.5