### PR TITLE
Avoid deduplicating UNION twice

### DIFF
--- a/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/src/planner/binder/query_node/bind_setop_node.cpp
@@ -291,7 +291,10 @@ BoundStatement Binder::BindNode(SetOperationNode &statement) {
 
 	if (!statement.setop_all) {
 		statement.modifiers.insert(statement.modifiers.begin(), make_uniq<DistinctModifier>());
-		statement.setop_all = false; // Already handled
+		if (statement.setop_type == SetOperationType::UNION ||
+		    statement.setop_type == SetOperationType::UNION_BY_NAME) {
+			result.setop_all = true;
+		}
 	}
 
 	SelectBindState bind_state;

--- a/test/sql/setops/union_single_dedup.test
+++ b/test/sql/setops/union_single_dedup.test
@@ -1,0 +1,59 @@
+# name: test/sql/setops/union_single_dedup.test
+# description: A plain UNION must de-duplicate once, not once in the set operation and again in a DISTINCT modifier
+# group: [setops]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TABLE t1 AS SELECT range AS i FROM range(10);
+
+statement ok
+CREATE TABLE t2 AS SELECT range AS i FROM range(5, 15);
+
+query I
+SELECT count(*) FROM (SELECT i FROM t1 UNION SELECT i FROM t2);
+----
+15
+
+query I
+SELECT count(*) FROM (SELECT i FROM t1 UNION BY NAME SELECT i FROM t2);
+----
+15
+
+# collation-aware de-duplication (#17251) must be kept
+statement ok
+CREATE TABLE c1(col1 VARCHAR COLLATE NOCASE);
+
+statement ok
+CREATE TABLE c2(col1 VARCHAR COLLATE NOCASE);
+
+statement ok
+INSERT INTO c1 VALUES ('a');
+
+statement ok
+INSERT INTO c2 VALUES ('A');
+
+query I
+SELECT count(*) FROM (SELECT * FROM c1 UNION SELECT * FROM c2);
+----
+1
+
+statement ok
+PRAGMA explain_output='physical_only';
+
+# exactly one de-duplication operator for a plain UNION
+query II
+EXPLAIN SELECT i FROM t1 UNION SELECT i FROM t2;
+----
+physical_plan	<REGEX>:.*HASH_GROUP_BY.*
+
+query II
+EXPLAIN SELECT i FROM t1 UNION SELECT i FROM t2;
+----
+physical_plan	<!REGEX>:.*HASH_GROUP_BY.*HASH_GROUP_BY.*
+
+query II
+EXPLAIN SELECT i FROM t1 UNION BY NAME SELECT i FROM t2;
+----
+physical_plan	<!REGEX>:.*HASH_GROUP_BY.*HASH_GROUP_BY.*


### PR DESCRIPTION
We noticed a regression in 1.5 (introduced by #17267) where a UNION is deduplicating the data twice.

In particular #17267 was putting a collation-aware DISTINCT modifier on top of every non-ALL set operation but left the operation itself with set semantics, so the physical planner still appended its own HASH_GROUP_BY.