### PR TITLE
Add C API v2 headers to static/shared tarballs

### DIFF
--- a/.github/workflows/Android.yml
+++ b/.github/workflows/Android.yml
@@ -93,7 +93,12 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
-        zip -j libduckdb-android_${{matrix.arch}}.zip build/release/src/libduckdb*.* src/include/duckdb.h src/include/duckdb_extension.h
+        zip -j libduckdb-android_${{matrix.arch}}.zip \
+          build/release/src/libduckdb*.* \
+          src/include/duckdb.h \
+          src/include/duckdb_v2.h \
+          src/include/duckdb_extension.h \
+          src/include/duckdb_extension_v2.h
         ./scripts/upload-assets-to-staging.sh github_release libduckdb-android_${{matrix.arch}}.zip
 
     - uses: actions/upload-artifact@v7

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -576,12 +576,21 @@ jobs:
       run: |
         assets=()
         if [[ "${{ matrix.config.publish_source }}" == "true" ]]; then
-          zip -j libduckdb-src.zip src/include/duckdb.h src/include/duckdb_extension.h
+          zip -j libduckdb-src.zip \
+            src/include/duckdb.h \
+            src/include/duckdb_v2.h \
+            src/include/duckdb_extension.h \
+            src/include/duckdb_extension_v2.h
           assets+=(libduckdb-src.zip)
         fi
         if [[ "${{ matrix.config.publish_static }}" == "true" ]]; then
           make gather-libs
-          zip -r -j static-libs-${{ matrix.config.artifact_suffix }}.zip src/include/duckdb.h build/release/libs/
+          zip -r -j static-libs-${{ matrix.config.artifact_suffix }}.zip \
+            src/include/duckdb.h \
+            src/include/duckdb_v2.h \
+            src/include/duckdb_extension.h \
+            src/include/duckdb_extension_v2.h \
+            build/release/libs/
           assets+=(static-libs-${{ matrix.config.artifact_suffix }}.zip)
         fi
         if [[ "${{ matrix.config.is_canonical_build }}" == "true" ]]; then

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -164,8 +164,18 @@ jobs:
           make cli-release-artifact ARTIFACT_SUFFIX=osx-arm64 CLI_BINARY=build/release_arm64/duckdb
           make cli-release-artifact ARTIFACT_SUFFIX=osx-amd64 CLI_BINARY=build/release_amd64/duckdb
           make shared-libs-release-artifact ARTIFACT_SUFFIX=osx-universal SHARED_LIBRARIES="build/release/src/libduckdb*.dylib"
-          zip -r -j static-libs-osx-arm64.zip src/include/duckdb.h build/release_arm64/libs/
-          zip -r -j static-libs-osx-amd64.zip src/include/duckdb.h build/release_amd64/libs/
+          zip -r -j static-libs-osx-arm64.zip \
+            src/include/duckdb.h \
+            src/include/duckdb_v2.h \
+            src/include/duckdb_extension.h \
+            src/include/duckdb_extension_v2.h \
+            build/release_arm64/libs/
+          zip -r -j static-libs-osx-amd64.zip \
+            src/include/duckdb.h \
+            src/include/duckdb_v2.h \
+            src/include/duckdb_extension.h \
+            src/include/duckdb_extension_v2.h \
+            build/release_amd64/libs/
 
           ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-osx-universal.tar.gz duckdb-cli-osx-arm64.tar.gz duckdb-cli-osx-amd64.tar.gz duckdb-shared-libs-osx-universal.tar.gz static-libs-osx-arm64.zip static-libs-osx-amd64.zip
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -364,7 +364,12 @@ jobs:
          run: |
            tmp_zip_dir="$(mktemp -d)"
            archive_path="$(pwd)/static-libs-windows-mingw.zip"
-           cp src/include/duckdb.h "${tmp_zip_dir}/"
+           cp \
+             src/include/duckdb.h \
+             src/include/duckdb_v2.h \
+             src/include/duckdb_extension.h \
+             src/include/duckdb_extension_v2.h \
+             "${tmp_zip_dir}/"
            find build/release/libs -type f -exec cp {} "${tmp_zip_dir}/" \;
            (cd "${tmp_zip_dir}" && "/c/Program Files/7-Zip/7z.exe" a -tzip "${archive_path}" ./*)
            rm -rf "${tmp_zip_dir}"

--- a/scripts/ci/test_package_release_artifact.py
+++ b/scripts/ci/test_package_release_artifact.py
@@ -60,7 +60,14 @@ class PackageReleaseArtifactTest(unittest.TestCase):
                 members = {member.name: member for member in archive.getmembers()}
                 self.assertEqual(
                     set(members),
-                    {"libduckdb.so", "libduckdb.so.1", "duckdb.h", "duckdb_extension.h"},
+                    {
+                        "libduckdb.so",
+                        "libduckdb.so.1",
+                        "duckdb.h",
+                        "duckdb_v2.h",
+                        "duckdb_extension.h",
+                        "duckdb_extension_v2.h",
+                    },
                 )
                 self.assertTrue(members["libduckdb.so"].issym())
                 self.assertEqual(members["libduckdb.so"].linkname, "libduckdb.so.1")

--- a/scripts/package_release_artifact.sh
+++ b/scripts/package_release_artifact.sh
@@ -83,7 +83,9 @@ else
 	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 	repository_root="$(cd "$script_dir/.." && pwd)"
 	stage_file "$repository_root/src/include/duckdb.h"
+	stage_file "$repository_root/src/include/duckdb_v2.h"
 	stage_file "$repository_root/src/include/duckdb_extension.h"
+	stage_file "$repository_root/src/include/duckdb_extension_v2.h"
 fi
 
 tar -C "$staging_dir" -czf "$temporary_archive" "${members[@]}"


### PR DESCRIPTION
Add `src/include/{duckdb.h,duckdb_v2.h,duckdb_extension.h,duckdb_extension_v2.h}` to static/shared tarballs.