### PR TITLE
Add ProcessUtil: OS dependent informations about process id & co

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library_unity(
   hive_partitioning.cpp
   json_document.cpp
   pipe_file_system.cpp
+  process_util.cpp
   local_file_system.cpp
   memory_mapped_file.cpp
   error_data.cpp

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/memory_mapped_file.hpp"
+#include "duckdb/common/process_util.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/windows.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
@@ -14,6 +15,7 @@
 #include "duckdb/logging/log_manager.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 
+#include <climits>
 #include <cstdint>
 #include <cstdio>
 #include <sys/stat.h>
@@ -41,26 +43,14 @@ extern "C" WINBASEAPI BOOL QueryFullProcessImageNameW(HANDLE, DWORD, LPWSTR, PDW
 #undef FILE_CREATE // woo mingw
 #endif
 
-// includes for giving a better error message on lock conflicts
-#if defined(__linux__) || defined(__APPLE__)
-#include <pwd.h>
-#endif
-
 #if defined(__linux__)
 // See https://man7.org/linux/man-pages/man2/fallocate.2.html
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE /* See feature_test_macros(7) */
 #endif
 #include <fcntl.h>
-#include <libgen.h>
-// See e.g.:
-// https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
-#elif defined(__APPLE__)
-#include <TargetConditionals.h>
-#if not(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
-#include <libproc.h>
-#endif
 #elif defined(_WIN32)
+// for giving a better error message on lock conflicts
 #include <restartmanager.h>
 #endif
 
@@ -279,93 +269,6 @@ static FileMetadata StatsInternal(int fd, const string &path) {
 	return StatsFromStruct(s);
 }
 
-#if __APPLE__ && !TARGET_OS_IPHONE
-
-static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
-	if (pid == getpid()) {
-		return "Lock is already held in current process, likely another DuckDB instance";
-	}
-
-	string process_name, process_owner;
-	// macOS >= 10.7 has PROC_PIDT_SHORTBSDINFO
-#ifdef PROC_PIDT_SHORTBSDINFO
-	// try to find out more about the process holding the lock
-	struct proc_bsdshortinfo proc;
-	if (proc_pidinfo(pid, PROC_PIDT_SHORTBSDINFO, 0, &proc, PROC_PIDT_SHORTBSDINFO_SIZE) ==
-	    PROC_PIDT_SHORTBSDINFO_SIZE) {
-		process_name = proc.pbsi_comm; // only a short version however, let's take it in case proc_pidpath() below fails
-		// try to get actual name of conflicting process owner
-		auto pw = getpwuid(proc.pbsi_uid);
-		if (pw) {
-			process_owner = pw->pw_name;
-		}
-	}
-#else
-	return string();
-#endif
-	// try to get a better process name (full path)
-	char full_exec_path[PROC_PIDPATHINFO_MAXSIZE];
-	if (proc_pidpath(pid, full_exec_path, PROC_PIDPATHINFO_MAXSIZE) > 0) {
-		// somehow could not get the path, lets use some sensible fallback
-		process_name = full_exec_path;
-	}
-	return StringUtil::Format("Conflicting lock is held in %s%s",
-	                          !process_name.empty() ? StringUtil::Format("%s (PID %d)", process_name, pid)
-	                                                : StringUtil::Format("PID %d", pid),
-	                          !process_owner.empty() ? StringUtil::Format(" by user %s", process_owner) : "");
-}
-
-#elif __linux__
-
-static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
-	if (pid == getpid()) {
-		return "Lock is already held in current process, likely another DuckDB instance";
-	}
-	string process_name, process_owner;
-
-	try {
-		auto cmdline_file = fs.OpenFile(StringUtil::Format("/proc/%d/cmdline", pid), FileFlags::FILE_FLAGS_READ);
-		auto cmdline = cmdline_file->ReadLine(QueryContext());
-		process_name = basename(const_cast<char *>(cmdline.c_str())); // NOLINT: old C API does not take const
-	} catch (std::exception &) {
-		// ignore
-	}
-
-	// we would like to provide a full path to the executable if possible but we might not have rights
-	{
-		char exe_target[PATH_MAX];
-		memset(exe_target, '\0', PATH_MAX);
-		auto proc_exe_link = StringUtil::Format("/proc/%d/exe", pid);
-		auto readlink_n = readlink(proc_exe_link.c_str(), exe_target, PATH_MAX);
-		if (readlink_n > 0) {
-			process_name = exe_target;
-		}
-	}
-
-	// try to find out who created that process
-	try {
-		auto loginuid_file = fs.OpenFile(StringUtil::Format("/proc/%d/loginuid", pid), FileFlags::FILE_FLAGS_READ);
-		auto uid = std::stoi(loginuid_file->ReadLine(QueryContext()));
-		auto pw = getpwuid(uid);
-		if (pw) {
-			process_owner = pw->pw_name;
-		}
-	} catch (std::exception &) {
-		// ignore
-	}
-
-	return StringUtil::Format("Conflicting lock is held in %s%s",
-	                          !process_name.empty() ? StringUtil::Format("%s (PID %d)", process_name, pid)
-	                                                : StringUtil::Format("PID %d", pid),
-	                          !process_owner.empty() ? StringUtil::Format(" by user %s", process_owner) : "");
-}
-
-#else
-static string AdditionalProcessInfo(FileSystem &fs, pid_t pid) {
-	return "";
-}
-#endif
-
 // Apply a fcntl advisory lock per flags.Lock(); throws (and closes fd) on failure. Shared
 // by OpenFile and MemoryMapFile.
 static void TryAcquireFileLock(FileSystem &fs, int fd, const string &path, FileOpenFlags flags) {
@@ -405,8 +308,13 @@ static void TryAcquireFileLock(FileSystem &fs, int fd, const string &path, FileO
 		rc = fcntl(fd, F_GETLK, &fl);
 		if (rc == -1) {
 			extended_error = strerror(errno);
+		} else if (fl.l_pid == ProcessUtil::CurrentProcessId()) {
+			extended_error = "Lock is already held in current process, likely another DuckDB instance";
 		} else {
-			extended_error = AdditionalProcessInfo(fs, fl.l_pid);
+			auto process = ProcessUtil::GetProcessDescription(fs, fl.l_pid);
+			if (!process.empty()) {
+				extended_error = "Conflicting lock is held in " + process;
+			}
 		}
 		if (flags.Lock() == FileLockType::WRITE_LOCK) {
 			// could we get a read lock?

--- a/src/common/process_util.cpp
+++ b/src/common/process_util.cpp
@@ -1,0 +1,170 @@
+#include "duckdb/common/process_util.hpp"
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/query_context.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/windows.hpp"
+
+#ifdef _WIN32
+#include "duckdb/common/windows_util.hpp"
+#ifdef __MINGW32__
+// need to manually define this for mingw
+extern "C" WINBASEAPI BOOL QueryFullProcessImageNameW(HANDLE, DWORD, LPWSTR, PDWORD);
+#endif
+#else
+#include <cerrno>
+#include <csignal>
+#include <unistd.h>
+#endif
+
+// includes for describing the process holding a lock
+#if defined(__linux__) || defined(__APPLE__)
+#include <pwd.h>
+#endif
+
+#if defined(__linux__)
+#include <climits>
+#include <cstring>
+#include <libgen.h>
+#elif defined(__APPLE__)
+// See e.g.:
+// https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
+#include <TargetConditionals.h>
+#if not(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
+#include <libproc.h>
+#endif
+#endif
+
+namespace duckdb {
+
+int64_t ProcessUtil::CurrentProcessId() {
+#ifdef _WIN32
+	return static_cast<int64_t>(GetCurrentProcessId());
+#else
+	return static_cast<int64_t>(getpid());
+#endif
+}
+
+bool ProcessUtil::ProcessIsRunning(int64_t pid) {
+	if (pid <= 0) {
+		// not a process id anybody handed out: kill(0) would signal our own process group
+		return true;
+	}
+#ifdef _WIN32
+	auto process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(pid));
+	if (!process) {
+		return GetLastError() != ERROR_INVALID_PARAMETER;
+	}
+	DWORD exit_code = 0;
+	auto running = GetExitCodeProcess(process, &exit_code) && exit_code == STILL_ACTIVE;
+	CloseHandle(process);
+	return running;
+#else
+	// EPERM means it exists and belongs to somebody else
+	return kill(static_cast<pid_t>(pid), 0) == 0 || errno == EPERM;
+#endif
+}
+
+namespace {
+
+string FormatProcessDescription(const string &process_name, const string &process_owner, int64_t pid) {
+	return StringUtil::Format("%s%s",
+	                          !process_name.empty() ? StringUtil::Format("%s (PID %d)", process_name, pid)
+	                                                : StringUtil::Format("PID %d", pid),
+	                          !process_owner.empty() ? StringUtil::Format(" by user %s", process_owner) : "");
+}
+
+} // namespace
+
+#if defined(__APPLE__) && !TARGET_OS_IPHONE
+
+string ProcessUtil::GetProcessDescription(FileSystem &fs, int64_t pid) {
+	string process_name, process_owner;
+	// macOS >= 10.7 has PROC_PIDT_SHORTBSDINFO
+#ifdef PROC_PIDT_SHORTBSDINFO
+	struct proc_bsdshortinfo proc;
+	if (proc_pidinfo(static_cast<pid_t>(pid), PROC_PIDT_SHORTBSDINFO, 0, &proc, PROC_PIDT_SHORTBSDINFO_SIZE) ==
+	    PROC_PIDT_SHORTBSDINFO_SIZE) {
+		process_name = proc.pbsi_comm; // only a short version however, let's take it in case proc_pidpath() below fails
+		auto pw = getpwuid(proc.pbsi_uid);
+		if (pw) {
+			process_owner = pw->pw_name;
+		}
+	}
+#else
+	return string();
+#endif
+	// try to get a better process name (full path)
+	char full_exec_path[PROC_PIDPATHINFO_MAXSIZE];
+	if (proc_pidpath(static_cast<pid_t>(pid), full_exec_path, PROC_PIDPATHINFO_MAXSIZE) > 0) {
+		process_name = full_exec_path;
+	}
+	return FormatProcessDescription(process_name, process_owner, pid);
+}
+
+#elif defined(__linux__)
+
+string ProcessUtil::GetProcessDescription(FileSystem &fs, int64_t pid) {
+	string process_name, process_owner;
+
+	try {
+		auto cmdline_file = fs.OpenFile(StringUtil::Format("/proc/%d/cmdline", pid), FileFlags::FILE_FLAGS_READ);
+		auto cmdline = cmdline_file->ReadLine(QueryContext());
+		process_name = basename(const_cast<char *>(cmdline.c_str())); // NOLINT: old C API does not take const
+	} catch (std::exception &) {
+		// ignore
+	}
+
+	// we would like to provide a full path to the executable if possible but we might not have rights
+	{
+		char exe_target[PATH_MAX];
+		memset(exe_target, '\0', PATH_MAX);
+		auto proc_exe_link = StringUtil::Format("/proc/%d/exe", pid);
+		auto readlink_n = readlink(proc_exe_link.c_str(), exe_target, PATH_MAX);
+		if (readlink_n > 0) {
+			process_name = exe_target;
+		}
+	}
+
+	// try to find out who created that process
+	try {
+		auto loginuid_file = fs.OpenFile(StringUtil::Format("/proc/%d/loginuid", pid), FileFlags::FILE_FLAGS_READ);
+		auto uid = std::stoi(loginuid_file->ReadLine(QueryContext()));
+		auto pw = getpwuid(uid);
+		if (pw) {
+			process_owner = pw->pw_name;
+		}
+	} catch (std::exception &) {
+		// ignore
+	}
+
+	return FormatProcessDescription(process_name, process_owner, pid);
+}
+
+#elif defined(_WIN32)
+
+string ProcessUtil::GetProcessDescription(FileSystem &fs, int64_t pid) {
+	auto process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(pid));
+	if (!process) {
+		return string();
+	}
+	string process_name;
+	WCHAR full_path[MAX_PATH];
+	DWORD full_path_size = MAX_PATH;
+	if (QueryFullProcessImageNameW(process, 0, full_path, &full_path_size) && full_path_size <= MAX_PATH) {
+		process_name = WindowsUtil::UnicodeToUTF8(full_path);
+	}
+	CloseHandle(process);
+	// the owner would need the process token, which we do not ask for
+	return FormatProcessDescription(process_name, string(), pid);
+}
+
+#else
+
+string ProcessUtil::GetProcessDescription(FileSystem &fs, int64_t pid) {
+	return string();
+}
+
+#endif
+
+} // namespace duckdb

--- a/src/include/duckdb/common/process_util.hpp
+++ b/src/include/duckdb/common/process_util.hpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/process_util.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+class FileSystem;
+
+//! What the operating system can tell us about processes: who we are, who is still alive, and
+//! who to name in an error message.
+struct ProcessUtil {
+	//! The id of the process this code is running in
+	DUCKDB_API static int64_t CurrentProcessId();
+	//! Whether a process with this id exists. Answers true whenever it cannot tell, so a process
+	//! we may not inspect is never taken for a dead one.
+	DUCKDB_API static bool ProcessIsRunning(int64_t pid);
+	//! Best-effort description of a process - its name, and its owner where we can get it - for
+	//! error messages. Empty when the platform cannot say.
+	DUCKDB_API static string GetProcessDescription(FileSystem &fs, int64_t pid);
+};
+
+} // namespace duckdb

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(cpp)
 
 set(TEST_API_OBJECTS
     test_api.cpp
+    test_process_util.cpp
     test_bind_statement.cpp
     test_scalar_function_decimal_return.cpp
     test_aggregate_state_bind_data.cpp

--- a/test/api/test_process_util.cpp
+++ b/test/api/test_process_util.cpp
@@ -1,0 +1,27 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/process_util.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("Test ProcessUtil", "[api]") {
+	SECTION("the process running this test is running") {
+		auto pid = ProcessUtil::CurrentProcessId();
+		REQUIRE(pid > 0);
+		REQUIRE(ProcessUtil::ProcessIsRunning(pid));
+	}
+
+	SECTION("an id that cannot belong to a process is reported as running") {
+		// callers reap what they can prove is gone, so anything unanswerable has to count as live
+		REQUIRE(ProcessUtil::ProcessIsRunning(0));
+		REQUIRE(ProcessUtil::ProcessIsRunning(-1));
+	}
+
+	SECTION("describing a process never throws") {
+		// best effort: platforms that cannot say return an empty string rather than failing
+		LocalFileSystem fs;
+		REQUIRE_NOTHROW(ProcessUtil::GetProcessDescription(fs, ProcessUtil::CurrentProcessId()));
+		REQUIRE_NOTHROW(ProcessUtil::GetProcessDescription(fs, 0));
+	}
+}


### PR DESCRIPTION
Three questions about processes have no home in `common/`: who we are, whether a given process is still alive, and how to name one in an error message. The third is answered today by three static AdditionalProcessInfo copies in local_file_system.cpp; the first two are about to be answered a fourth time, in temporary_file_manager.cpp, which needs to tell whether the instance that left a temporary file behind is still running.

Collect them as ProcessUtil, with one #if per platform in the .cpp:
```
CurrentProcessId()                  getpid / GetCurrentProcessId
ProcessIsRunning(pid)               kill(pid, 0) / OpenProcess + GetExitCodeProcess
GetProcessDescription(fs, pid)      proc_pidinfo / /proc / QueryFullProcessImageNameW
```

This restructures and move code around, addressing comment at https://github.com/duckdb/duckdb/pull/24811#discussion_r3820088191