### PR TITLE
Fix Top-N window elimination binding regressions

### DIFF
--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -1032,8 +1032,9 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 			// However, we allow replacing references to join columns as they are equal to the other side by condition.
 			column_binding_map_t<ColumnBinding> replaceable_bindings;
 			for (auto &condition : join.conditions) {
+				// A condition that is not a left/right comparison has no bindings to replace
 				if (!condition.IsComparison()) {
-					return false;
+					continue;
 				}
 				if (condition.GetComparisonType() != ExpressionType::COMPARE_EQUAL) {
 					return false;

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -258,6 +258,22 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	// We have made sure that this is an operator sequence of filter -> N optional projections -> window
 	auto &filter = op->Cast<LogicalFilter>();
 	reference<LogicalOperator> child = *filter.children[0];
+	while (child.get().type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		child = *child.get().children[0];
+	}
+	D_ASSERT(child.get().type == LogicalOperatorType::LOGICAL_WINDOW);
+	auto &window = child.get().Cast<LogicalWindow>();
+
+	// Optimize window children and propagate any changed bindings through the owning plan
+	ColumnBindingReplacer child_replacer;
+	window.children[0] = OptimizeInternal(std::move(window.children[0]), child_replacer);
+	if (!child_replacer.replacement_bindings.empty()) {
+		child_replacer.VisitOperator(*op);
+		replacer.replacement_bindings.insert(replacer.replacement_bindings.end(),
+		                                     child_replacer.replacement_bindings.begin(),
+		                                     child_replacer.replacement_bindings.end());
+	}
+	child = *filter.children[0];
 
 	// Get bindings and types from filter to use in top-most operator later
 	const auto topmost_bindings = filter.GetColumnBindings();
@@ -268,7 +284,6 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 	}
 
 	D_ASSERT(child.get().type == LogicalOperatorType::LOGICAL_WINDOW);
-	auto &window = child.get().Cast<LogicalWindow>();
 	const TableIndex window_idx = window.window_index;
 
 	// Map the input column offsets of the group columns to the output offset if there are projections on the group
@@ -286,9 +301,6 @@ unique_ptr<LogicalOperator> TopNWindowElimination::OptimizeInternal(unique_ptr<L
 		}
 	}
 	const bool used_late_materialization = late_mat_lhs != nullptr;
-
-	// Optimize window children
-	window.children[0] = Optimize(std::move(window.children[0]));
 
 	op = CreateAggregateOperator(window, std::move(aggregate_payload), params);
 	op = TryCreateUnnestOperator(std::move(op), params);
@@ -1020,9 +1032,8 @@ bool TopNWindowElimination::CanUseLateMaterialization(const LogicalWindow &windo
 			// However, we allow replacing references to join columns as they are equal to the other side by condition.
 			column_binding_map_t<ColumnBinding> replaceable_bindings;
 			for (auto &condition : join.conditions) {
-				// A condition that is not a left/right comparison has no bindings to replace
 				if (!condition.IsComparison()) {
-					continue;
+					return false;
 				}
 				if (condition.GetComparisonType() != ExpressionType::COMPARE_EQUAL) {
 					return false;
@@ -1171,9 +1182,11 @@ TopNWindowElimination::TryPrepareLateMaterialization(const LogicalWindow &window
 	}
 	auto rhs_rowid_idxs =
 	    LateMaterializationHelper::GetOrInsertRowIds(rhs_get, rhs_rowid_column_idxs, rhs_rowid_columns);
-
-	// Add rowid column to the operators on the right-hand side
-	TableIndex last_table_idx = rhs_get.table_index;
+	vector<ColumnBinding> rhs_rowid_bindings;
+	rhs_rowid_bindings.reserve(rhs_rowid_idxs.size());
+	for (const auto rowid_idx : rhs_rowid_idxs) {
+		rhs_rowid_bindings.emplace_back(rhs_get.table_index, rowid_idx);
+	}
 
 	// Add rowid projections to the query tree on the right-hand side
 	for (auto stack_it = std::next(stack.rbegin()); stack_it != stack.rend(); ++stack_it) {
@@ -1183,29 +1196,24 @@ TopNWindowElimination::TryPrepareLateMaterialization(const LogicalWindow &window
 		case LogicalOperatorType::LOGICAL_PROJECTION: {
 			for (idx_t i = 0; i < rhs_rowid_columns.size(); i++) {
 				auto &rowid_column = rhs_rowid_columns[i];
-				op.expressions.push_back(make_uniq<BoundColumnRefExpression>(
-				    rowid_column.name, rowid_column.type, ColumnBinding {last_table_idx, rhs_rowid_idxs[i]}));
-				rhs_rowid_idxs[i] = ProjectionIndex(op.expressions.size() - 1);
+				op.expressions.push_back(
+				    make_uniq<BoundColumnRefExpression>(rowid_column.name, rowid_column.type, rhs_rowid_bindings[i]));
+				rhs_rowid_bindings[i] = {op.GetTableIndex()[0], ProjectionIndex(op.expressions.size() - 1)};
 			}
-			last_table_idx = op.GetTableIndex()[0];
 			break;
 		}
 		case LogicalOperatorType::LOGICAL_FILTER: {
 			if (op.HasProjectionMap()) {
 				auto &filter = op.Cast<LogicalFilter>();
-				for (const auto rowid_idx : rhs_rowid_idxs) {
-					//	The rowid_idx is the index into the rhs_get.column_ids,
-					//	not the index of the rhs_get schema.
-					auto schema_idx = rowid_idx;
-					if (last_table_idx == rhs_get.table_index && !rhs_get.projection_ids.empty()) {
-						for (schema_idx = ProjectionIndex(0); schema_idx < rhs_get.projection_ids.size();
-						     ++schema_idx) {
-							if (rhs_get.projection_ids[schema_idx] == rowid_idx) {
-								break;
-							}
-						}
+				const auto child_bindings = op.children[0]->GetColumnBindings();
+				for (const auto &rowid_binding : rhs_rowid_bindings) {
+					auto entry = std::find(child_bindings.begin(), child_bindings.end(), rowid_binding);
+					D_ASSERT(entry != child_bindings.end());
+					const ProjectionIndex projection_idx(entry - child_bindings.begin());
+					if (std::find(filter.projection_map.begin(), filter.projection_map.end(), projection_idx) ==
+					    filter.projection_map.end()) {
+						filter.projection_map.push_back(projection_idx);
 					}
-					filter.projection_map.push_back(schema_idx);
 				}
 			}
 			break;
@@ -1219,8 +1227,15 @@ TopNWindowElimination::TryPrepareLateMaterialization(const LogicalWindow &window
 				                                                                       : join.right_projection_map;
 				// An empty map already projects every column, including the newly added row ID.
 				if (!projection_map.empty()) {
-					for (const auto rowid_idx : rhs_rowid_idxs) {
-						projection_map.push_back(rowid_idx);
+					const auto child_bindings = op_child.GetColumnBindings();
+					for (const auto &rowid_binding : rhs_rowid_bindings) {
+						auto entry = std::find(child_bindings.begin(), child_bindings.end(), rowid_binding);
+						D_ASSERT(entry != child_bindings.end());
+						const ProjectionIndex projection_idx(entry - child_bindings.begin());
+						if (std::find(projection_map.begin(), projection_map.end(), projection_idx) ==
+						    projection_map.end()) {
+							projection_map.push_back(projection_idx);
+						}
 					}
 				}
 			}
@@ -1235,7 +1250,7 @@ TopNWindowElimination::TryPrepareLateMaterialization(const LogicalWindow &window
 	args.clear();
 	for (idx_t i = 0; i < rhs_rowid_columns.size(); i++) {
 		args.push_back(make_uniq<BoundColumnRefExpression>(rhs_rowid_columns[i].name, rhs_rowid_columns[i].type,
-		                                                   ColumnBinding {last_table_idx, rhs_rowid_idxs[i]}));
+		                                                   rhs_rowid_bindings[i]));
 	}
 
 	return lhs;

--- a/test/issues/general/test_24710.test
+++ b/test/issues/general/test_24710.test
@@ -1,0 +1,28 @@
+# name: test/issues/general/test_24710.test
+# description: Issue 24710 - propagate bindings through nested Top-N window rewrites
+# group: [general]
+
+statement ok
+CREATE TABLE t2__base (c_pk BIGINT NOT NULL, c_int BIGINT)
+
+statement ok
+INSERT INTO t2__base VALUES (1, 5), (2, -7), (3, 0)
+
+statement ok
+CREATE TABLE t2_keyed AS
+SELECT c_pk, c_int, ROW_NUMBER() OVER (ORDER BY c_pk) AS eq_key_1
+FROM t2__base
+
+statement ok
+CREATE VIEW t2 AS
+SELECT c_pk, c_int
+FROM t2_keyed
+QUALIFY ROW_NUMBER() OVER (PARTITION BY eq_key_1 ORDER BY eq_key_1) = 1
+
+query II
+SELECT *
+FROM t2
+WHERE c_int::BOOLEAN
+QUALIFY ROW_NUMBER() OVER (ORDER BY c_pk) <= 1
+----
+1	5

--- a/test/issues/general/test_24711.test
+++ b/test/issues/general/test_24711.test
@@ -1,0 +1,57 @@
+# name: test/issues/general/test_24711.test
+# description: Issue 24711 - preserve join projections during Top-N window late materialization
+# group: [general]
+
+statement ok
+CREATE TABLE t__base (c_pk INTEGER NOT NULL, c_int INTEGER, c_dbl DOUBLE, c_txt VARCHAR)
+
+statement ok
+INSERT INTO t__base VALUES (1, NULL, NULL, NULL), (2, 1, 0.0, NULL), (3, 2, 1.5, 'a')
+
+statement ok
+CREATE TABLE t_uid AS
+SELECT c_pk, c_int, c_dbl, c_txt, ROW_NUMBER() OVER (ORDER BY c_pk) AS eq_uid_1
+FROM t__base
+
+statement ok
+CREATE TABLE t_flag AS SELECT eq_uid_1, 1 AS eq_flag_1 FROM t_uid
+
+statement ok
+CREATE VIEW issue_24711 AS
+SELECT l.c_pk, l.c_int, l.c_dbl, l.c_txt
+FROM t_uid l
+INNER JOIN t_flag r ON l.eq_uid_1 = r.eq_uid_1
+WHERE r.eq_flag_1 = 1
+
+query RI
+SELECT c_dbl, c_int
+FROM issue_24711
+WHERE c_txt IS NULL
+QUALIFY ROW_NUMBER() OVER (ORDER BY c_pk) <= 10
+ORDER BY c_pk
+----
+NULL	NULL
+0.0	1
+
+# Arbitrary join conditions cannot establish equivalence for late materialization.
+statement ok
+CREATE TABLE issue_24711_join (id INTEGER, v INTEGER, ts INTEGER, tag VARCHAR)
+
+statement ok
+INSERT INTO issue_24711_join VALUES (1, 100, 1, 'a'), (1, 200, 2, 'a')
+
+query TII
+WITH cur AS (
+	SELECT id, v
+	FROM issue_24711_join
+	QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY ts DESC) = 1
+),
+prev AS (
+	SELECT t.tag, t.v, ROW_NUMBER() OVER (PARTITION BY t.id ORDER BY t.ts DESC) AS rn
+	FROM issue_24711_join t
+	JOIN cur ON cur.id = t.id
+	WHERE abs(t.v - cur.v) >= 1
+)
+SELECT * FROM prev WHERE rn = 1
+----
+a	100	1


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb/issues/24710
fixes https://github.com/duckdb/duckdb/issues/24711

This PR fixes a column binding issue that would appear with multiple amenable window functions. This fixed by rewriting the functions from query tree bottom to top instead of the other way around.

The second part fixes incorrect rowid propagation during late materialization. We now reject late materialization for sub-plans with non-comparison join conditions and use actual `ColumnBinding`s to resolve the column position in each operator.