### PR TITLE
planner: merge transaction-local statistics into table->GetStatistics

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -30,6 +30,7 @@
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
@@ -246,7 +247,23 @@ const ColumnList &DuckTableEntry::GetColumns() const {
 }
 
 unique_ptr<BaseStatistics> DuckTableEntry::GetStatistics(ClientContext &context, const StorageIndex &column_id) {
-	return storage->GetStatistics(context, column_id);
+	// Get the committed statistics
+	auto stats = storage->GetStatistics(context, column_id);
+	if (!stats) {
+		return nullptr;
+	}
+	// Merge the transaction-local statistics in so the result describes the transaction-visible data.
+	auto &local_storage = LocalStorage::Get(context, ParentCatalog());
+	auto local_table_storage = local_storage.GetStorage(*storage);
+	if (!local_table_storage) {
+		return stats;
+	}
+	auto local_stats = local_table_storage->GetCollection().CopyStats(column_id);
+	if (!local_stats) {
+		return stats;
+	}
+	stats->Merge(*local_stats);
+	return stats;
 }
 
 unique_ptr<BaseStatistics> DuckTableEntry::GetStatistics(ClientContext &context, column_t column_id) {
@@ -259,7 +276,7 @@ unique_ptr<BaseStatistics> DuckTableEntry::GetStatistics(ClientContext &context,
 		return nullptr;
 	}
 	auto storage_index = GetStorageIndex(ColumnIndex(column_id));
-	return storage->GetStatistics(context, storage_index);
+	return GetStatistics(context, storage_index);
 }
 
 unique_ptr<BlockingSample> DuckTableEntry::GetSample() {

--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -878,18 +878,12 @@ unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &context,
 
 static unique_ptr<BaseStatistics> TableScanStatistics(ClientContext &context, TableFunctionGetStatisticsInput &input) {
 	auto &column_id = input.column_index;
-	auto &bind_data = input.bind_data->Cast<TableScanBindData>();
-	auto &duck_table = bind_data.table.Cast<DuckTableEntry>();
-	auto &local_storage = LocalStorage::Get(context, duck_table.catalog);
-
-	// Don't emit statistics for tables with outstanding transaction-local data.
-	if (local_storage.Find(duck_table.GetStorage())) {
-		return nullptr;
-	}
-
 	if (column_id.IsRowIdColumn() || column_id.IsRowNumberColumn()) {
 		return nullptr;
 	}
+
+	auto &bind_data = input.bind_data->Cast<TableScanBindData>();
+	auto &duck_table = bind_data.table.Cast<DuckTableEntry>();
 	auto &column = duck_table.GetColumn(LogicalIndex(column_id.GetPrimaryIndex()));
 	if (column.Generated()) {
 		return nullptr;

--- a/test/sql/join/mark/test_null_safe_semi_uncommitted_stats.test
+++ b/test/sql/join/mark/test_null_safe_semi_uncommitted_stats.test
@@ -1,0 +1,178 @@
+# name: test/sql/join/mark/test_null_safe_semi_uncommitted_stats.test
+# description: Issue #25266 - IS NOT DISTINCT FROM semi-join must not be degraded to '=' while the transaction holds uncommitted appends
+# group: [mark]
+
+# only the physical plan is asserted below
+statement ok
+SET explain_output='physical_only';
+
+statement ok
+CREATE TABLE a(x INTEGER);
+
+statement ok
+INSERT INTO a VALUES (1), (NULL);
+
+# b.y currently has no NULLs: its committed statistics claim NOT NULL
+statement ok
+CREATE TABLE b(y INTEGER);
+
+statement ok
+INSERT INTO b VALUES (1);
+
+statement ok
+BEGIN;
+
+# same transaction, earlier statement: b becomes {1, NULL}, but the statistics snapshot
+# taken now does not see this row
+statement ok
+INSERT INTO b VALUES (NULL);
+
+# a.x = NULL should match b.y = NULL under IS NOT DISTINCT FROM, so both rows of a pass
+query I
+SELECT count(*) FROM a WHERE EXISTS (SELECT 1 FROM b WHERE a.x IS NOT DISTINCT FROM b.y);
+----
+2
+
+# ... and the plan must keep the null-safe comparison rather than rewriting it to '='
+query II
+EXPLAIN SELECT count(*) FROM a WHERE EXISTS (SELECT 1 FROM b WHERE a.x IS NOT DISTINCT FROM b.y);
+----
+physical_plan	<REGEX>:.*Join Type: SEMI.*IS NOT DISTINCT FROM.*
+
+statement ok
+COMMIT;
+
+# the same query is correct after the append is committed (statistics are up to date)
+query I
+SELECT count(*) FROM a WHERE EXISTS (SELECT 1 FROM b WHERE a.x IS NOT DISTINCT FROM b.y);
+----
+2
+
+# empty committed table + uncommitted NULL-only append: the committed statistics hold no
+# rows, so 'no NULLs' there is a default, not an observation - the NOT-NULL proof rests
+# entirely on the merged transaction-local statistics in this case
+statement ok
+CREATE TABLE c(k INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO c VALUES (NULL);
+
+# a.x = NULL must still match the uncommitted NULL
+query I
+SELECT count(*) FROM a WHERE EXISTS (SELECT 1 FROM c WHERE a.x IS NOT DISTINCT FROM c.k);
+----
+1
+
+query II
+EXPLAIN SELECT count(*) FROM a WHERE EXISTS (SELECT 1 FROM c WHERE a.x IS NOT DISTINCT FROM c.k);
+----
+physical_plan	<REGEX>:.*Join Type: SEMI.*IS NOT DISTINCT FROM.*
+
+statement ok
+ROLLBACK;
+
+# empty committed table + uncommitted non-NULL append: the proof is kept, so the
+# null-safe condition is rewritten to '=' while the transaction is still open
+statement ok
+CREATE TABLE n(k INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO n VALUES (5);
+
+query II
+EXPLAIN SELECT count(*) FROM n n1 WHERE EXISTS (SELECT 1 FROM n n2 WHERE n1.k IS NOT DISTINCT FROM n2.k);
+----
+physical_plan	<REGEX>:.*Join Type: SEMI.*Conditions: k = k.*
+
+statement ok
+ROLLBACK;
+
+# uncommitted append updated to NULL: the update statistics must invalidate the NOT-NULL proof
+statement ok
+CREATE TABLE u(x INTEGER);
+
+statement ok
+INSERT INTO u VALUES (1), (NULL);
+
+statement ok
+CREATE TABLE v(y INTEGER);
+
+statement ok
+INSERT INTO v VALUES (1);
+
+statement ok
+BEGIN;
+
+# append a non-NULL row, then update it to NULL in the same transaction
+statement ok
+INSERT INTO v VALUES (2);
+
+statement ok
+UPDATE v SET y = NULL WHERE y = 2;
+
+query I
+SELECT count(*) FROM u WHERE EXISTS (SELECT 1 FROM v WHERE u.x IS NOT DISTINCT FROM v.y);
+----
+2
+
+query II
+EXPLAIN SELECT count(*) FROM u WHERE EXISTS (SELECT 1 FROM v WHERE u.x IS NOT DISTINCT FROM v.y);
+----
+physical_plan	<REGEX>:.*Join Type: SEMI.*IS NOT DISTINCT FROM.*
+
+statement ok
+ROLLBACK;
+
+# uncommitted append without NULLs: the merged statistics still prove NOT NULL, so the
+# null-safe condition is rewritten to '=' while the transaction is still open
+statement ok
+CREATE TABLE w(z INTEGER);
+
+statement ok
+INSERT INTO w VALUES (1);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO w VALUES (2), (3);
+
+query II
+EXPLAIN SELECT count(*) FROM w w1 WHERE EXISTS (SELECT 1 FROM w w2 WHERE w1.z IS NOT DISTINCT FROM w2.z);
+----
+physical_plan	<REGEX>:.*Join Type: SEMI.*Conditions: z = z.*
+
+statement ok
+ROLLBACK;
+
+# uncommitted appends that are large enough to engage the optimistic writer (parallel
+# insert): the transaction-local rows must still be covered by the merged statistics
+statement ok
+PRAGMA threads=8;
+
+statement ok
+CREATE TABLE p(k INTEGER);
+
+statement ok
+INSERT INTO p VALUES (1);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO p SELECT CASE WHEN i % 2 = 0 THEN NULL ELSE i END FROM range(300000) t(i);
+
+# the 150000 uncommitted NULLs must match the NULL probe row
+query I
+SELECT count(*) FROM a WHERE EXISTS (SELECT 1 FROM p WHERE a.x IS NOT DISTINCT FROM p.k);
+----
+2
+
+statement ok
+ROLLBACK;


### PR DESCRIPTION
Fixes #25266

Found this when investigating the improvement of pr #24706. `NotNullExpressionAnalyzer` proves a column non-NULL from `table->GetStatistics()`, which only covers committed row groups. Rows appended by an earlier statement of the same transaction live in LocalStorage: they are visible to scans but invisible to the statistics. `SimplifyNullSafeSemiJoinConditions` then rewrites an `IS NOT DISTINCT FROM` semi-join condition to a regular `=`, dropping the NULL==NULL match and losing the probe rows.

This PR fixes `DuckTableEntry::GetStatistics`. When the transaction holds appends for the scanned table, the transaction-local column statistics are merged into the committed statistics, so the returned statistics describe the transaction-visible data. An uncommitted NULL invalidates a NOT-NULL proof, while an uncommitted append without NULLs preserves it.

Updates and deletes of committed rows do not need special handling: their write paths update the affected column statistics, and deleting rows can only make the statistics conservatively report NULLs that are no longer present.

The same blind spot affected `ConstantOrNullSimplification` and the `Deliminator`, which share the analyzer, and is closed here as well.