### PR TITLE
Harden temp file reads

### DIFF
--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -541,18 +541,35 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	handle->Read(context, &block_header_size, sizeof(idx_t), sizeof(idx_t));
 
 	idx_t offset = sizeof(idx_t) * 2;
+	if (EncryptTemporaryFiles()) {
+		offset += DEFAULT_ENCRYPTED_BUFFER_HEADER_SIZE;
+	}
+
+	// block_size and block_header_size are read off disk: validate them against the physical file before
+	// using them to size an allocation or to offset into the buffer. WriteTemporaryBuffer lays out the file
+	// as [size][header_size][optional nonce/tag][payload], where the payload is GetAllocSize(header + size).
+	auto file_size = handle->GetFileSize();
+	if (block_header_size > file_size || block_size > file_size) {
+		throw IOException(
+		    "Corrupt temporary file \"%s\": block header size (%llu) or block size (%llu) exceeds file size %llu", path,
+		    block_header_size, block_size, file_size);
+	}
+	if (offset + GetAllocSize(block_header_size + block_size) != file_size) {
+		throw IOException("Corrupt temporary file \"%s\": header describes %llu bytes but file is %llu", path,
+		                  offset + GetAllocSize(block_header_size + block_size), file_size);
+	}
 
 	// Allocate a buffer of the file's size and read the data into that buffer.
 	auto buffer = ConstructManagedBuffer(block_size, block_header_size, std::move(reusable_buffer));
 
 	if (EncryptTemporaryFiles()) {
-		// encrypted
+		// encrypted: the nonce/tag sit between the two size words and the payload (which starts at offset)
 		//! Read nonce and tag from file.
 		uint8_t encryption_metadata[DEFAULT_ENCRYPTED_BUFFER_HEADER_SIZE];
-		handle->Read(context, encryption_metadata, DEFAULT_ENCRYPTED_BUFFER_HEADER_SIZE, offset);
+		handle->Read(context, encryption_metadata, DEFAULT_ENCRYPTED_BUFFER_HEADER_SIZE, sizeof(idx_t) * 2);
 
 		//! Read and decrypt the buffer.
-		buffer->Read(context, *handle, offset + DEFAULT_ENCRYPTED_BUFFER_HEADER_SIZE);
+		buffer->Read(context, *handle, offset);
 		EncryptionEngine::DecryptTemporaryBuffer(GetDatabase(), buffer->InternalBuffer(), buffer->AllocSize(),
 		                                         encryption_metadata);
 	} else {

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/storage/temporary_file_manager.hpp"
 
+#include "duckdb/common/exception.hpp"
+
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/storage/buffer/temporary_file_information.hpp"
@@ -253,15 +255,24 @@ unique_ptr<FileBuffer> TemporaryFileHandle::ReadTemporaryBuffer(QueryContext con
 		return buffer;
 	}
 
-	// Decompress into buffer
+	// Decompress into buffer.
+	// The leading length word and the compressed payload both come off disk, so validate them before
+	// handing them to zstd: an oversized length would make ZSTD_decompress read past compressed_buffer.
 	const auto compressed_size = Load<idx_t>(compressed_buffer.get());
-	D_ASSERT(!duckdb_zstd::ZSTD_isError(compressed_size));
+	if (compressed_size > compressed_buffer.GetSize() - sizeof(idx_t)) {
+		throw IOException("Corrupt temporary file: compressed block claims %llu bytes but only %llu are available",
+		                  compressed_size, compressed_buffer.GetSize() - sizeof(idx_t));
+	}
 	const auto decompressed_size = duckdb_zstd::ZSTD_decompress(
 	    buffer->InternalBuffer(), buffer->AllocSize(), compressed_buffer.get() + sizeof(idx_t), compressed_size);
-	(void)decompressed_size;
-	D_ASSERT(!duckdb_zstd::ZSTD_isError(decompressed_size));
-
-	D_ASSERT(decompressed_size == buffer->AllocSize());
+	if (duckdb_zstd::ZSTD_isError(decompressed_size)) {
+		throw IOException("Corrupt temporary file: failed to decompress block (%s)",
+		                  duckdb_zstd::ZSTD_getErrorName(decompressed_size));
+	}
+	if (decompressed_size != buffer->AllocSize()) {
+		throw IOException("Corrupt temporary file: decompressed block is %llu bytes but expected %llu",
+		                  decompressed_size, buffer->AllocSize());
+	}
 	return buffer;
 }
 


### PR DESCRIPTION
Improve some reads from corrupted compressed `.tmp` or `.block` files, where in release we wouldn't perform any checks. Those checks are basically integer comparisons, and better be sure not be dealing with clearly invalid data.