### PR TITLE
Fixes to allow compiling with LLVM 23 cxx library

### DIFF
--- a/src/include/duckdb/common/enums/date_part_specifier.hpp
+++ b/src/include/duckdb/common/enums/date_part_specifier.hpp
@@ -10,6 +10,11 @@
 
 #include "duckdb/common/constants.hpp"
 
+// <langinfo.h>, pulled in by libc++ locale support, defines ERA as a macro
+#ifdef ERA
+#undef ERA
+#endif
+
 namespace duckdb {
 
 enum class DatePartSpecifier : uint8_t {

--- a/src/include/duckdb/common/exception.hpp
+++ b/src/include/duckdb/common/exception.hpp
@@ -15,6 +15,7 @@
 
 #include <vector>
 #include <stdexcept>
+#include <exception>
 
 namespace duckdb {
 enum class PhysicalType : uint8_t;

--- a/src/include/duckdb/common/serializer/async_file_writer.hpp
+++ b/src/include/duckdb/common/serializer/async_file_writer.hpp
@@ -14,6 +14,8 @@
 #include "duckdb/common/serializer/write_stream.hpp"
 #include "duckdb/common/query_context.hpp"
 
+#include <exception>
+
 namespace duckdb {
 
 class ClientContext;


### PR DESCRIPTION
This is basically future proofing against newer libcxx implementation