### PR TITLE
Fix Substring Clamping Issue

### DIFF
--- a/src/function/scalar/string/substring.cpp
+++ b/src/function/scalar/string/substring.cpp
@@ -52,16 +52,16 @@ static string_t SubstringSlice(Vector &result, const char *input_data, int64_t o
 }
 
 // compute start and end characters from the given input size and offset/length
-static bool SubstringStartEnd(int64_t input_size, int64_t offset, int64_t length, int64_t &start, int64_t &end) {
+static bool SubstringStartEnd(int64_t offset, int64_t length, int64_t &start, int64_t &end) {
 	if (length == 0) {
 		return false;
 	}
 	if (offset > 0) {
 		// positive offset: scan from start
-		start = MinValue<int64_t>(input_size, offset - 1);
+		start = offset - 1;
 	} else if (offset < 0) {
 		// negative offset: scan from end (i.e. start = end + offset)
-		start = MaxValue<int64_t>(input_size + offset, 0);
+		start = offset;
 	} else {
 		// offset = 0: special case, we start 1 character BEHIND the first character
 		start = 0;
@@ -72,17 +72,28 @@ static bool SubstringStartEnd(int64_t input_size, int64_t offset, int64_t length
 	}
 	if (length > 0) {
 		// positive length: go forward (i.e. end = start + offset)
-		end = MinValue<int64_t>(input_size, start + length);
+		end = start + length;
 	} else {
 		// negative length: go backwards (i.e. end = start, start = start + length)
 		end = start;
-		start = MaxValue<int64_t>(0, start + length);
+		start += length;
 	}
-	if (start == end) {
+	return true;
+}
+
+static bool SubstringASCIIBounds(int64_t input_size, int64_t offset, int64_t length, int64_t &start, int64_t &end) {
+	if (!SubstringStartEnd(offset, length, start, end)) {
 		return false;
 	}
-	D_ASSERT(start < end);
-	return true;
+	// Clamp start and end to string bounds
+	auto cast_input_size = UnsafeNumericCast<int64_t>(input_size);
+	if (offset < 0) {
+		start += cast_input_size;
+		end += cast_input_size;
+	}
+	start = MaxValue<int64_t>(0, MinValue<int64_t>(cast_input_size, start));
+	end = MaxValue<int64_t>(0, MinValue<int64_t>(cast_input_size, end));
+	return start < end;
 }
 
 string_t SubstringASCII(Vector &result, string_t input, int64_t offset, int64_t length) {
@@ -92,7 +103,7 @@ string_t SubstringASCII(Vector &result, string_t input, int64_t offset, int64_t 
 	AssertInSupportedRange(input_size, offset, length);
 
 	int64_t start, end;
-	if (!SubstringStartEnd(UnsafeNumericCast<int64_t>(input_size), offset, length, start, end)) {
+	if (!SubstringASCIIBounds(UnsafeNumericCast<int64_t>(input_size), offset, length, start, end)) {
 		return SubstringEmptyString(result);
 	}
 	return SubstringSlice(result, input_data, start, UnsafeNumericCast<int64_t>(end - start));
@@ -110,24 +121,18 @@ string_t SubstringUnicode(Vector &result, string_t input, int64_t offset, int64_
 	// first figure out which direction we need to scan
 	idx_t start_pos;
 	idx_t end_pos;
+	// negative offset: scan backwards
+	int64_t start, end;
+	if (!SubstringStartEnd(offset, length, start, end)) {
+		return SubstringEmptyString(result);
+	}
 	if (offset < 0) {
 		start_pos = 0;
 		end_pos = DConstants::INVALID_INDEX;
 
-		// negative offset: scan backwards
-		int64_t start, end;
-
 		// we express start and end as unicode codepoints from the back
-		offset--;
-		if (length < 0) {
-			// negative length
-			start = -offset - length;
-			end = -offset;
-		} else {
-			// positive length
-			start = -offset;
-			end = -offset - length;
-		}
+		start = -start + 1;
+		end = -end + 1;
 		if (end <= 0) {
 			end_pos = input_size;
 		}
@@ -157,20 +162,8 @@ string_t SubstringUnicode(Vector &result, string_t input, int64_t offset, int64_
 		start_pos = DConstants::INVALID_INDEX;
 		end_pos = input_size;
 
-		// positive offset: scan forwards
-		int64_t start, end;
-
 		// we express start and end as unicode codepoints from the front
-		offset--;
-		if (length < 0) {
-			// negative length
-			start = MaxValue<int64_t>(0, offset + length);
-			end = offset;
-		} else {
-			// positive length
-			start = MaxValue<int64_t>(0, offset);
-			end = offset + length;
-		}
+		start = MaxValue<int64_t>(0, start);
 
 		int64_t current_character = 0;
 		for (idx_t i = 0; i < input_size; i++) {
@@ -203,7 +196,7 @@ string_t SubstringGrapheme(Vector &result, string_t input, int64_t offset, int64
 	// we don't know yet if the substring is ascii, but we assume it is (for now)
 	// first get the start and end as if this was an ascii string
 	int64_t start, end;
-	if (!SubstringStartEnd(UnsafeNumericCast<int64_t>(input_size), offset, length, start, end)) {
+	if (!SubstringASCIIBounds(UnsafeNumericCast<int64_t>(input_size), offset, length, start, end)) {
 		return SubstringEmptyString(result);
 	}
 
@@ -230,7 +223,7 @@ string_t SubstringGrapheme(Vector &result, string_t input, int64_t offset, int64
 		// we first need to count the number of characters in the string
 		idx_t num_characters = Utf8Proc::GraphemeCount(input_data, input_size);
 		// now call substring start and end again, but with the number of unicode characters this time
-		SubstringStartEnd(UnsafeNumericCast<int64_t>(num_characters), offset, length, start, end);
+		SubstringASCIIBounds(UnsafeNumericCast<int64_t>(num_characters), offset, length, start, end);
 	}
 
 	// now scan the graphemes of the string to find the positions of the start and end characters

--- a/test/sql/function/string/test_substring.test
+++ b/test/sql/function/string/test_substring.test
@@ -297,6 +297,30 @@ SELECT {FUN}(s, 0, -4294967297) FROM strings
 ----
 Out of Range Error: Substring length outside of supported range (< -4294967296)
 
+# very large negative offset with a small positive length: the requested window is
+# entirely before the start of the string, so the result should be empty
+query T
+SELECT {FUN}(s, -12345678, 12) FROM strings
+----
+(empty)
+(empty)
+(empty)
+NULL
+
+query T
+SELECT {FUN}(s, -2147483648, 2) FROM strings
+----
+(empty)
+(empty)
+(empty)
+NULL
+
+# same as above, but with a string literal instead of a column reference
+query I
+SELECT {FUN}('abc', -12345678, 12)
+----
+(empty)
+
 endloop
 
 # SUBSTRING with FROM only (no FOR)

--- a/test/sql/function/string/test_substring_utf8.test
+++ b/test/sql/function/string/test_substring_utf8.test
@@ -57,4 +57,16 @@ SELECT {FUN}(s, 5) FROM strings
 ----
 three₡four🦆end
 
+# very large negative offset with a small positive length: the requested window is
+# entirely before the start of the string, so the result should be empty
+query T
+SELECT {FUN}(s, -12345678, 12) FROM strings
+----
+(empty)
+
+query T
+SELECT {FUN}(s, -2147483648, 2) FROM strings
+----
+(empty)
+
 endloop


### PR DESCRIPTION
This PR fixes a bug where the ASCII path and the unicode path computed the negative-offset window differently. The ASCII path incorrectly clamped the offset to the string bounds before applying the length, losing track of how far out of range the window was. This PR fixes that and makes both paths share the same computation.
          
Fixes: https://github.com/duckdb/duckdb/issues/24766