### PR TITLE
[async results] Add drain mode param to interpreted_benchmark's resultmode

### DIFF
--- a/benchmark/group_descriptions.list
+++ b/benchmark/group_descriptions.list
@@ -30,6 +30,10 @@ The join micro benchmark set contains benchmarks that look at the speed of vario
 [Order]
 The order micro benchmark set contains benchmarks that look at the speed of sorting data using the ORDER BY clause.
 
+[result_collection]
+[Result Collection]
+The result collection benchmarks measure how query results are delivered to a client: streaming results drained fully or materialized.
+
 [tpch]
 [TPC-H]
 The TPC-H benchmark is an industry standard benchmark geared towards measuring the performance of OLAP systems. It consists of 22 different queries that test different optimizations in the system.

--- a/benchmark/include/interpreted_benchmark.hpp
+++ b/benchmark/include/interpreted_benchmark.hpp
@@ -118,6 +118,8 @@ private:
 	bool in_memory = true;
 	string storage_version;
 	QueryResultType result_type = QueryResultType::MATERIALIZED_RESULT;
+	//! Discard fetched chunks instead of materializing them into the benchmark result
+	bool discard_stream_result = false;
 	idx_t arrow_batch_size = STANDARD_VECTOR_SIZE;
 	bool require_reinit = false;
 };

--- a/benchmark/interpreted_benchmark.cpp
+++ b/benchmark/interpreted_benchmark.cpp
@@ -242,10 +242,15 @@ void InterpretedBenchmark::ProcessFile(const string &path) {
 				ThrowResultModeError(reader);
 			}
 			if (splits[1] == "streaming") {
-				if (splits.size() != 2) {
+				if (splits.size() > 3) {
 					throw std::runtime_error(
-					    reader.FormatException("resultmode 'streaming' does not accept a parameter"));
+					    reader.FormatException("resultmode 'streaming' accepts one optional drain mode"));
 				}
+				if (splits.size() == 3 && splits[2] != "drop" && splits[2] != "materialize") {
+					throw std::runtime_error(
+					    reader.FormatException("resultmode 'streaming' drain mode must be 'materialize' or 'drop'"));
+				}
+				discard_stream_result = splits.size() == 3 && splits[2] == "drop";
 				result_type = QueryResultType::STREAM_RESULT;
 			} else if (splits[1] == "arrow") {
 				arrow_batch_size = STANDARD_VECTOR_SIZE;
@@ -496,6 +501,10 @@ void InterpretedBenchmark::LoadBenchmark() {
 		throw InvalidInputException("Invalid benchmark file: no \"run\" query specified");
 	}
 	run_query = queries["run"];
+	if (discard_stream_result && !result_queries.empty()) {
+		throw InvalidInputException(
+		    "Invalid benchmark file: resultmode 'streaming drop' discards the result and cannot verify it");
+	}
 	is_loaded = true;
 }
 
@@ -690,7 +699,19 @@ void InterpretedBenchmark::Run(BenchmarkState *state_p) {
 	}
 	if (temp_result->GetResultType() == QueryResultType::STREAM_RESULT) {
 		auto &stream_query = temp_result->Cast<StreamQueryResult>();
-		state.result = stream_query.Materialize();
+		if (discard_stream_result) {
+			// Fetching from a result that already carries an error throws instead of returning nullptr
+			while (!stream_query.HasError()) {
+				auto chunk = stream_query.Fetch();
+				if (!chunk || chunk->size() == 0) {
+					break;
+				}
+			}
+			state.result =
+			    stream_query.HasError() ? make_uniq<MaterializedQueryResult>(stream_query.GetErrorObject()) : nullptr;
+		} else {
+			state.result = stream_query.Materialize();
+		}
 	} else if (temp_result->GetResultType() == QueryResultType::ARROW_RESULT) {
 		/* no-op, this is only used to test the overhead of the result collector */
 		state.result = nullptr;

--- a/benchmark/micro/result_collection/stream_drop.benchmark
+++ b/benchmark/micro/result_collection/stream_drop.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/micro/result_collection/stream_drop.benchmark
+# description: Streaming result: blocking Fetch drives execution, chunks dropped
+# group: [result_collection]
+
+name stream_drop
+group micro
+subgroup result_collection
+
+resultmode streaming drop
+
+cache stream_drain_data.duckdb
+
+init
+set streaming_buffer_size='1000000b';
+
+load
+create table tbl as select 'this is a reasonably long string ' || i as a from range(25000000) t(i);
+
+run
+select * from tbl;

--- a/benchmark/micro/result_collection/stream_materialize.benchmark
+++ b/benchmark/micro/result_collection/stream_materialize.benchmark
@@ -1,0 +1,20 @@
+# name: benchmark/micro/result_collection/stream_materialize.benchmark
+# description: Streaming result: blocking drain materializes every chunk
+# group: [result_collection]
+
+name stream_materialize
+group micro
+subgroup result_collection
+
+resultmode streaming materialize
+
+cache stream_drain_data.duckdb
+
+init
+set streaming_buffer_size='1000000b';
+
+load
+create table tbl as select 'this is a reasonably long string ' || i as a from range(25000000) t(i);
+
+run
+select * from tbl;


### PR DESCRIPTION
Stack:
- [ ] This PR
- [ ] Enable the two new regression tests
- [ ] Buffer redesign
- [ ] API work: merge pending, streaming and materialized results into a single `QueryResult` type that supports non-blocking `Poll()` and `TryFetch()`, setting a notifier callback, and a blocking `Fetch()` that participates in / drives execution. I think we should keep shims for the old result types while the CLI and Sqlogic runner still depends on them.
- [ ] Deprecate the "custom collector" idea with an output format API that uses a format agnostic (but managed) buffer underneath. Move the Arrow collector to this API as the first consumer.

This adds a drain mode (either `drop` or `materialize`) to the interpreted benchmark runner, and two benchmarks that are just selects on a large dataset. They're not added to micro.csv yet, because I think that'll crash the Regression job since the baseline runner won't support three params yet. I'll add them in a follow up to this.

This is in preparation for the async result mode.