### PR TITLE
[async results] Enable stream drain benchmarks

### DIFF
--- a/.github/regression/micro.csv
+++ b/.github/regression/micro.csv
@@ -37,3 +37,5 @@ benchmark/micro/optimizer/topn_window_elimination.benchmark
 benchmark/micro/optimizer/count_not_null_column_prune.benchmark
 benchmark/micro/aggregate/group_two_string_dictionaries.benchmark
 benchmark/micro/functions/nested_macros.benchmark
+benchmark/micro/result_collection/stream_drop.benchmark
+benchmark/micro/result_collection/stream_materialize.benchmark


### PR DESCRIPTION
Stack:
- [x] #25287 Adds a drain mode to the benchmark runner to distinguish between materializing and dropping chunks, and two regression tests
- [ ] This PR
- [ ] Buffer redesign
- [ ] API work: merge pending, streaming and materialized results into a single `QueryResult` type that supports non-blocking `Poll()` and `TryFetch()`, setting a notifier callback, and a blocking `Fetch()` that participates in / drives execution. I think we should keep shims for the old result types while the CLI and Sqlogic runner still depends on them.
- [ ] Deprecate the "custom collector" idea with an output format API that uses a format agnostic (but managed) buffer underneath. Move the Arrow collector to this API as the first consumer.

This enables the two new regression benchmarks in #25287.

This is in preparation for the async result mode.