### PR TITLE
Check key uniqueness on topk import

### DIFF
--- a/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -528,7 +528,11 @@ void ApproxTopKImportState(AggregateImportInputData &input) {
 			const auto &str_val = value_strings[sel_idx];
 			ApproxTopKString topk_string(str_val, Hash(str_val));
 			InternalApproxTopKState::CopyValue(val, topk_string, allocator);
-			target.lookup_map.insert(make_pair(val.str_val, reference<ApproxTopKValue>(val)));
+			const bool inserted =
+			    target.lookup_map.insert(make_pair(val.str_val, reference<ApproxTopKValue>(val))).second;
+			if (!inserted) {
+				throw InvalidInputException("Invalid approx_top_k state - the state values must be unique");
+			}
 			val.count = count_data[idx];
 		}
 		for (idx_t filter_idx = 0; filter_idx < filter_entries[i].length; filter_idx++) {

--- a/test/sql/aggregate/aggregate_state_export/approx_top_k_export_state.test
+++ b/test/sql/aggregate/aggregate_state_export/approx_top_k_export_state.test
@@ -107,3 +107,16 @@ statement error
 SELECT finalize(combine(approx_top_k(x, 2) EXPORT_STATE, (SELECT approx_top_k(y, 3) EXPORT_STATE FROM (VALUES ('a')) s(y)))) FROM (VALUES ('a')) t(x);
 ----
 <REGEX>:.*cannot combine approx_top_K with different k values.*
+
+# importing a state with duplicate values is an error
+statement error
+SELECT finalize(to_aggregate_state({
+	'k': 2::UBIGINT,
+	'values': [
+		{'value': 'a'::VARCHAR, 'count': 5::UBIGINT},
+		{'value': 'a'::VARCHAR, 'count': 3::UBIGINT}
+	]::STRUCT("value" VARCHAR, "count" UBIGINT)[],
+	'filter': list_transform(range(64), lambda x: 0::UBIGINT)
+}, 'approx_top_k', ['VARCHAR', 'BIGINT']));
+----
+<REGEX>:Invalid Input Error: Invalid approx_top_k state.*


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/24444

No performance hurt, simply check the return value for map insertion.