### PR TITLE
Bump Postgres scanner

### DIFF
--- a/.github/config/extensions/postgres_scanner.cmake
+++ b/.github/config/extensions/postgres_scanner.cmake
@@ -4,7 +4,7 @@ if (NOT MINGW AND NOT ${WASM_ENABLED})
     duckdb_extension_load(postgres_scanner
             DONT_LINK
             GIT_URL https://github.com/duckdb/duckdb-postgres
-            GIT_TAG c91ea5779322c97dfff1940f67b3a4d5b6a1e07e
+            GIT_TAG fffcb358dace990e62de5a1d74f7f0f25fadc642
             SUBMODULES database-connector
             )
  endif()

--- a/src/include/duckdb/main/extension_entries.hpp
+++ b/src/include/duckdb/main/extension_entries.hpp
@@ -1349,6 +1349,8 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"pg_experimental_filter_pushdown", "postgres_scanner"},
     {"pg_idle_in_transaction_timeout_millis", "postgres_scanner"},
     {"pg_null_byte_replacement", "postgres_scanner"},
+    {"pg_numeric_as_varchar", "postgres_scanner"},
+    {"pg_numeric_nan_as_null", "postgres_scanner"},
     {"pg_oauth_token", "postgres_scanner"},
     {"pg_order_pushdown", "postgres_scanner"},
     {"pg_pages_per_task", "postgres_scanner"},


### PR DESCRIPTION
This PR updates the Postgres extension to bring in the duckdb/duckdb-postgres#565 change to unblock the DuckLake PR duckdb/ducklake#1430.