### PR TITLE
Prevent duplicate streaming window final output

### DIFF
--- a/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -449,7 +449,7 @@ OperatorFinalizeResultType PhysicalStreamingWindow::FinalExecute(ExecutionContex
 	auto &gstate = gstate_p.Cast<StreamingWindowGlobalState>();
 	auto &state = gstate.local_state->Cast<StreamingWindowState>();
 
-	if (state.initialized && state.lead_count) {
+	if (state.initialized && state.lead_count && !state.flushed_delayed) {
 		auto &delayed = state.delayed;
 		//	There are no more input rows
 		auto &input = state.shifted;
@@ -462,6 +462,7 @@ OperatorFinalizeResultType PhysicalStreamingWindow::FinalExecute(ExecutionContex
 			return OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 		}
 		ExecuteDelayed(context, delayed, input, output, gstate_p);
+		state.flushed_delayed = true;
 	}
 
 	return OperatorFinalizeResultType::FINISHED;

--- a/test/sql/window/test_streaming_lead_lag.test
+++ b/test/sql/window/test_streaming_lead_lag.test
@@ -158,6 +158,17 @@ FROM range(10) tbl(i);
 8	9
 9	50
 
+# Test final output with a resuming downstream operator
+query II
+SELECT count(*), sum(x)
+FROM (
+	SELECT unnest(range(200000)) AS u, x
+	FROM (SELECT lead(i, 1, 7) OVER () AS x FROM range(1) t(i))
+	LIMIT 200001
+)
+----
+200000	1400000
+
 # Test sparse leads
 query TT
 EXPLAIN


### PR DESCRIPTION
Fixes #25306.

  ## Description

  A streaming window can emit its final delayed chunk more than once when a downstream operator returns `HAVE_MORE_OUTPUT` and pipeline execution resumes.

  `PhysicalStreamingWindow::FinalExecute` previously returned the delayed output without recording that the final chunk had already been flushed. A subsequent call could therefore emit the same rows again.

  This change reuses the existing `flushed_delayed` state to:

  - skip delayed output that has already been flushed;
  - mark the final delayed chunk as flushed after it is emitted.

  This keeps the change local to the streaming window operator and follows the existing finalization pattern where operators clear or advance their cached-output state after returning it.

  A regression test covers a streaming `LEAD` followed by `UNNEST` and `LIMIT`. The query previously returned 200,001 rows instead of 200,000.

  ## Tests

  - `GEN=ninja make reldebug`
  - `build/reldebug/test/unittest test/sql/window/test_streaming_lead_lag.test`
  - `build/reldebug/test/unittest 'test/sql/window/*'`
  - `build/reldebug/test/unittest 'Test TryFlushCachingOperators interrupted ExecutePushInternal'`
  - `build/reldebug/test/unittest 'Caching TableInOutFunction'`
  - `make format-fix`