### PR TITLE
Save cache for workflow_dispatch events

### DIFF
--- a/.github/actions/ccache-action/action.yml
+++ b/.github/actions/ccache-action/action.yml
@@ -8,7 +8,7 @@ inputs:
   save:
     description: 'Whether to save cache after the job'
     required: false
-    default: ${{ github.repository != 'duckdb/duckdb' || contains('["main", "v1.5-variegata"]', github.ref_name) || github.event_name == 'merge_group' }}
+    default: ${{ github.repository != 'duckdb/duckdb' || github.event_name == 'workflow_dispatch' }}
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/_manual_extension_deploy.yml
+++ b/.github/workflows/_manual_extension_deploy.yml
@@ -38,7 +38,6 @@ on:
         default: ""
 
 env:
-  BRANCHES_TO_BE_CACHED: ${{ github.repository == 'duckdb/duckdb' && '["refs/heads/main", "refs/heads/v1.4-andium", "refs/heads/v1.5-variegata"]' || ''}}
   DUCKDB_VERSION: ${{ inputs.duckdb_version }}
   DUCKDB_COMMIT: ${{ inputs.duckdb_commit }}
 
@@ -72,18 +71,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 
-  vars:
-    runs-on: ubuntu-24.04
-    outputs:
-      BRANCHES_TO_BE_CACHED: ${{ env.BRANCHES_TO_BE_CACHED }}
-    steps:
-      - run: echo "Exposing env vars"
-
   build:
     name: Build Extension
-    needs:
-      - load-extension-configs
-      - vars
+    needs: load-extension-configs
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       override_repository: duckdb/extension-template
@@ -101,7 +91,7 @@ jobs:
       use_merged_vcpkg_manifest: '1'
       duckdb_tag: ${{ inputs.duckdb_version }}
       skip_tests: ${{ inputs.skip_tests && true || false }}
-      save_cache: ${{ needs.vars.outputs.BRANCHES_TO_BE_CACHED == '' || contains(needs.vars.outputs.BRANCHES_TO_BE_CACHED, github.ref) }}
+      save_cache: true
       extensions_test_selection: 'complete'
       extra_extension_config: ${{ needs.load-extension-configs.outputs.extension_config }}
 

--- a/scripts/ci/job_stages.py
+++ b/scripts/ci/job_stages.py
@@ -96,12 +96,7 @@ class JobSelectionInput:
 
 
 def should_save_cache(selection_input: JobSelectionInput) -> bool:
-    return (
-        selection_input.repository != "duckdb/duckdb"
-        or selection_input.ref_name == "main"
-        or selection_input.ref_name == "v1.5-variegata"
-        or selection_input.event_name == "merge_group"
-    )
+    return selection_input.repository != "duckdb/duckdb" or selection_input.event_name == "workflow_dispatch"
 
 
 def enabled_jobs(selection_input: JobSelectionInput) -> list[str]:

--- a/scripts/ci/test_job_stages.py
+++ b/scripts/ci/test_job_stages.py
@@ -133,14 +133,14 @@ class JobStagesTest(unittest.TestCase):
         required_jobs = {"linux-relassert", "linux-release", "linux-release-tests", "tidy-check"}
         self.assertTrue(required_jobs.issubset(set(selection.enabled_jobs)))
         self.assertNotIn("osx", selection.enabled_jobs)
-        self.assertTrue(selection.save_cache)
+        self.assertFalse(selection.save_cache)
 
     @unittest.skipIf(os.getenv("OVERRIDE_JOBS") is not None, SKIP_IF_OVERRIDE)
     def test_main_includes_main_only_jobs(self):
         selection = self._compute_job_selection("push", "main", "duckdb/duckdb", changed_keys={"osx"})
         self.assertIn("codecov", selection.enabled_jobs)
         self.assertEqual(selection.enabled_jobs.count("osx"), 1)
-        self.assertTrue(selection.save_cache)
+        self.assertFalse(selection.save_cache)
 
     @unittest.skipIf(os.getenv("OVERRIDE_JOBS") is not None, SKIP_IF_OVERRIDE)
     def test_workflow_dispatch_adds_release_jobs(self):
@@ -174,7 +174,7 @@ class JobStagesTest(unittest.TestCase):
                 ],
                 ["amd64 optimized", "arm64 optimized"],
             )
-            self.assertEqual(workflow_dispatch_selection.save_cache, push_selection.save_cache)
+            self.assertTrue(workflow_dispatch_selection.save_cache)
 
     def test_regular_branch_excludes_main_only_jobs(self):
         selection = self._compute_job_selection("pull_request", "feature/my-branch", "duckdb/duckdb")
@@ -282,7 +282,7 @@ class JobStagesTest(unittest.TestCase):
             with open(output_path, "r", encoding="utf-8") as f:
                 out = f.read()
             self.assertIn("enabled_jobs=", out)
-            self.assertIn("save_cache=true", out)
+            self.assertIn("save_cache=false", out)
             payload = out.splitlines()[0].split("=", 1)[1]
             selected_jobs = json.loads(payload)
             required_jobs = {"linux-relassert", "linux-release", "linux-release-tests", "tidy-check"}


### PR DESCRIPTION
The nightly and lunch CI runs use `workflow_dispatch`. If used, save the cache.

This removes the need for detecting if the current branch is a (new) release branches or main.

I disabled saving the cache for merge queue branches, because github's cache [isolation](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache) prevents using those saved cache files in other (merge queue) CI runs.