### PR TITLE
Decouple string scan states

### DIFF
--- a/src/include/duckdb/storage/compression/dictionary/decompression.hpp
+++ b/src/include/duckdb/storage/compression/dictionary/decompression.hpp
@@ -7,13 +7,12 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Scan
 //===--------------------------------------------------------------------===//
-// FIXME: why is this StringScanState when we also define: `BufferHandle handle` ???
-struct CompressedStringScanState : public StringScanState {
+struct CompressedStringScanState : public SegmentScanState {
 public:
 	explicit CompressedStringScanState(BufferHandle &&handle_p)
-	    : StringScanState(), owned_handle(std::move(handle_p)), handle(owned_handle) {
+	    : owned_handle(std::move(handle_p)), handle(owned_handle) {
 	}
-	explicit CompressedStringScanState(BufferHandle &handle_p) : StringScanState(), owned_handle(), handle(handle_p) {
+	explicit CompressedStringScanState(BufferHandle &handle_p) : owned_handle(), handle(handle_p) {
 	}
 
 public:

--- a/src/include/duckdb/storage/string_uncompressed.hpp
+++ b/src/include/duckdb/storage/string_uncompressed.hpp
@@ -229,14 +229,16 @@ public:
 	static void WriteString(ColumnSegment &segment, string_t string, block_id_t &result_block, int32_t &result_offset);
 	static void WriteStringMemory(ColumnSegment &segment, string_t string, block_id_t &result_block,
 	                              int32_t &result_offset);
-	static string_t ReadOverflowString(ColumnSegment &segment, Vector &result, block_id_t block, int32_t offset);
+	static string_t ReadOverflowString(const QueryContext &context, ColumnSegment &segment, Vector &result,
+	                                   block_id_t block, int32_t offset);
 	static string_t ReadString(data_ptr_t target, int32_t offset, uint32_t string_length);
 	static string_t ReadStringWithLength(data_ptr_t target, int32_t offset);
 	static void WriteStringMarker(data_ptr_t target, block_id_t block_id, int32_t offset);
 	static void ReadStringMarker(data_ptr_t target, block_id_t &block_id, int32_t &offset);
 
-	inline static string_t FetchStringFromDict(ColumnSegment &segment, uint32_t dict_end_offset, Vector &result,
-	                                           data_ptr_t base_ptr, int32_t dict_offset, uint32_t string_length) {
+	inline static string_t FetchStringFromDict(const QueryContext &context, ColumnSegment &segment,
+	                                           uint32_t dict_end_offset, Vector &result, data_ptr_t base_ptr,
+	                                           int32_t dict_offset, uint32_t string_length) {
 		D_ASSERT(dict_offset <= NumericCast<int32_t>(segment.GetBlockSize()));
 		if (DUCKDB_LIKELY(dict_offset >= 0)) {
 			// regular string - fetch from dictionary
@@ -260,7 +262,7 @@ public:
 			int32_t offset;
 			ReadStringMarker(base_ptr + dict_end_offset - AbsValue<int32_t>(dict_offset), block_id, offset);
 
-			return ReadOverflowString(segment, result, block_id, offset);
+			return ReadOverflowString(context, segment, result, block_id, offset);
 		}
 	}
 

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -679,7 +679,7 @@ void FSSTStorage::StringScanPartial(ColumnSegment &segment, ColumnScanState &sta
 		for (idx_t i = 0; i < scan_count; i++) {
 			uint32_t string_length = bitunpack_buffer[i + offsets.scan_offset];
 			result_data[i] = UncompressedStringStorage::FetchStringFromDict(
-			    segment, dict.end, result, baseptr,
+			    state.context, segment, dict.end, result, baseptr,
 			    UnsafeNumericCast<int32_t>(delta_decode_buffer[i + offsets.unused_delta_decoded_values]),
 			    string_length);
 		}
@@ -767,7 +767,7 @@ void FSSTStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state
 	uint32_t string_length = bitunpack_buffer[offsets.scan_offset];
 
 	string_t compressed_string = UncompressedStringStorage::FetchStringFromDict(
-	    segment, dict.end, result, base_ptr,
+	    state.context, segment, dict.end, result, base_ptr,
 	    UnsafeNumericCast<int32_t>(delta_decode_buffer[offsets.unused_delta_decoded_values]), string_length);
 
 	auto &str_allocator = StringVector::GetStringAllocator(result);

--- a/src/storage/compression/fsst.cpp
+++ b/src/storage/compression/fsst.cpp
@@ -505,7 +505,7 @@ void FSSTStorage::FinalizeCompress(CompressionState &state_p) {
 //===--------------------------------------------------------------------===//
 // Scan
 //===--------------------------------------------------------------------===//
-struct FSSTScanState : public StringScanState {
+struct FSSTScanState : public SegmentScanState {
 	explicit FSSTScanState(const idx_t string_block_limit) {
 		ResetStoredDelta();
 		decompress_buffer.resize(string_block_limit + 1);
@@ -513,6 +513,7 @@ struct FSSTScanState : public StringScanState {
 
 	buffer_ptr<void> duckdb_fsst_decoder;
 	void *duckdb_fsst_decoder_ptr = nullptr;
+	BufferHandle handle;
 
 	vector<unsigned char> decompress_buffer;
 	bitpacking_width_t current_width;

--- a/src/storage/compression/string_uncompressed.cpp
+++ b/src/storage/compression/string_uncompressed.cpp
@@ -82,7 +82,7 @@ unique_ptr<SegmentScanState> UncompressedStringStorage::StringInitScan(const Que
                                                                        ColumnSegment &segment) {
 	auto result = make_uniq<StringScanState>();
 	auto &buffer_manager = BufferManager::GetBufferManager(segment.GetDatabase());
-	result->handle = buffer_manager.Pin(segment.GetBlockHandle());
+	result->handle = buffer_manager.Pin(context, segment.GetBlockHandle());
 	return std::move(result);
 }
 
@@ -107,7 +107,7 @@ void UncompressedStringStorage::StringScanPartial(ColumnSegment &segment, Column
 		auto current_offset = base_data[start + i];
 		auto string_length = UnsafeNumericCast<uint32_t>(std::abs(current_offset) - std::abs(previous_offset));
 		result_data[result_offset + i] =
-		    FetchStringFromDict(segment, dict_end, result, baseptr, current_offset, string_length);
+		    FetchStringFromDict(state.context, segment, dict_end, result, baseptr, current_offset, string_length);
 		previous_offset = base_data[start + i];
 	}
 }
@@ -136,7 +136,8 @@ void UncompressedStringStorage::Select(ColumnSegment &segment, ColumnScanState &
 		auto current_offset = base_data[index];
 		auto prev_offset = index > 0 ? base_data[index - 1] : 0;
 		auto string_length = UnsafeNumericCast<uint32_t>(std::abs(current_offset) - std::abs(prev_offset));
-		result_data[i] = FetchStringFromDict(segment, dict_end, result, baseptr, current_offset, string_length);
+		result_data[i] =
+		    FetchStringFromDict(state.context, segment, dict_end, result, baseptr, current_offset, string_length);
 	}
 }
 
@@ -150,7 +151,7 @@ BufferHandle &ColumnFetchState::GetOrInsertHandle(ColumnSegment &segment) {
 	if (entry == handles.end()) {
 		// not pinned yet: pin it
 		auto &buffer_manager = BufferManager::GetBufferManager(segment.GetDatabase());
-		auto handle = buffer_manager.Pin(segment.GetBlockHandle());
+		auto handle = buffer_manager.Pin(context, segment.GetBlockHandle());
 		auto pinned_entry = handles.insert(make_pair(primary_id, std::move(handle)));
 		return pinned_entry.first->second;
 	} else {
@@ -178,7 +179,8 @@ void UncompressedStringStorage::StringFetchRow(ColumnSegment &segment, ColumnFet
 	} else {
 		string_length = NumericCast<uint32_t>(std::abs(dict_offset) - std::abs(base_data[row_id - 1]));
 	}
-	result_data[result_idx] = FetchStringFromDict(segment, dict_end, result, baseptr, dict_offset, string_length);
+	result_data[result_idx] =
+	    FetchStringFromDict(state.context, segment, dict_end, result, baseptr, dict_offset, string_length);
 }
 
 //===--------------------------------------------------------------------===//
@@ -367,8 +369,8 @@ void UncompressedStringStorage::WriteStringMemory(ColumnSegment &segment, string
 	state.head->offset += total_length;
 }
 
-string_t UncompressedStringStorage::ReadOverflowString(ColumnSegment &segment, Vector &result, block_id_t block,
-                                                       int32_t offset) {
+string_t UncompressedStringStorage::ReadOverflowString(const QueryContext &context, ColumnSegment &segment,
+                                                       Vector &result, block_id_t block, int32_t offset) {
 	auto &buffer_manager = segment.GetBlockHandle()->GetMemory().GetBufferManager();
 	auto &state = segment.GetSegmentState()->Cast<UncompressedStringSegmentState>();
 
@@ -379,7 +381,7 @@ string_t UncompressedStringStorage::ReadOverflowString(ColumnSegment &segment, V
 		// read the overflow string from disk
 		// pin the initial handle and read the length
 		auto block_handle = state.GetHandle(segment.GetBlockHandle()->GetBlockManager(), block);
-		auto handle = buffer_manager.Pin(block_handle);
+		auto handle = buffer_manager.Pin(context, block_handle);
 
 		// read header
 		uint32_t length = Load<uint32_t>(handle.GetDataMutable() + offset);
@@ -412,7 +414,7 @@ string_t UncompressedStringStorage::ReadOverflowString(ColumnSegment &segment, V
 				// read the next block
 				block_id_t next_block = Load<block_id_t>(handle.GetDataMutable() + offset);
 				block_handle = state.GetHandle(segment.GetBlockHandle()->GetBlockManager(), next_block);
-				handle = buffer_manager.Pin(block_handle);
+				handle = buffer_manager.Pin(context, block_handle);
 				offset = 0;
 			}
 		}
@@ -429,7 +431,7 @@ string_t UncompressedStringStorage::ReadOverflowString(ColumnSegment &segment, V
 	// read the overflow string from memory
 	// first pin the handle, if it is not pinned yet
 	auto string_block = state.FindOverflowBlock(block);
-	auto handle = buffer_manager.Pin(string_block.get().block);
+	auto handle = buffer_manager.Pin(context, string_block.get().block);
 	auto final_buffer = handle.GetDataMutable();
 	StringVector::AddHandle(result, std::move(handle));
 	return ReadStringWithLength(final_buffer, offset);


### PR DESCRIPTION
Small PR that separates the scan states used by uncompressed strings, FSST and dictionary compression. Doing this now makes moving the individual algorithms over to the `CompressionSegmentReader` touch fewer files. It also ensures query context is used when pinning uncompressed string read buffers.

## Changes
- Make the FSST scan state own its buffer handle instead of inheriting it from `StringScanState`.
- Remove the dictionary scan state's redundant `StringScanState` base.
- Use the supplied query context when pinning uncompressed string scan, fetch and overflow blocks.
- Pass the query context through the dictionary entry helper shared with FSST so overflow block pins use it.