### PR TITLE
Fix parallel CSV reader duplicate rows with \r\r\n line endings

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1454,6 +1454,7 @@ void StringValueScanner::ProcessOverBufferValue() {
 				iterator.pos.buffer_pos++;
 			}
 		} else {
+			idx_t pre_carry_pos = iterator.pos.buffer_pos;
 			while (iterator.pos.buffer_pos < cur_buffer_handle->actual_size &&
 			       (buffer_handle_ptr[iterator.pos.buffer_pos] == '\n' ||
 			        buffer_handle_ptr[iterator.pos.buffer_pos] == '\r')) {
@@ -1481,6 +1482,18 @@ void StringValueScanner::ProcessOverBufferValue() {
 				}
 				state_machine->Transition(states, buffer_handle_ptr[iterator.pos.buffer_pos]);
 				iterator.pos.buffer_pos++;
+			}
+			// If we consumed newline characters but didn't add a row, and the previous
+			// buffer's scanner already fully counted the row (last_position overshoots the
+			// buffer), return early to avoid double-counting the next row. This handles
+			// \\r\\r\\n line endings where the first \\r triggered AddRow in the previous
+			// buffer and the remaining \\r\\n is here. We check that the first consumed
+			// character is \\r (not \\n) to avoid false-positives for \\r\\n line endings
+			// where \\r was at the end of the previous buffer and \\n is here.
+			if (over_buffer_string.empty() && iterator.pos.buffer_pos > pre_carry_pos &&
+			    result.last_position.buffer_pos > previous_buffer_handle->actual_size &&
+			    buffer_handle_ptr[pre_carry_pos] == '\r') {
+				return;
 			}
 		}
 	}

--- a/test/sql/copy/csv/parallel/test_rrrn_parallel.test
+++ b/test/sql/copy/csv/parallel/test_rrrn_parallel.test
@@ -1,0 +1,81 @@
+# name: test/sql/copy/csv/parallel/test_rrrn_parallel.test
+# description: Test parallel CSV reader handles \r\r\n line endings without duplicate rows (issue #25164)
+# group: [parallel]
+
+require notwindows
+
+# Generate a CSV file with \r\r\n line endings whose layout forces a buffer
+# boundary to split a row terminator between the two \r characters:
+#   - header line: 23 'p' chars + "\r\r\n" terminator  -> 26 bytes
+#   - 60 data rows of fixed width 25 bytes ("NN,x<19 x's>\r\r\n", NN zero-padded)
+#     -> rows occupy bytes [26, 1526)
+# Row i's terminator starts at 26 + 25*i + 22, so its first \r is the last byte
+# of the 1024-byte buffer for row 39 (offset 1023). The buffer boundary at
+# offset 1024 therefore splits row 39's "\r\r\n" as "\r" | "\r\n".
+# Without the fix the parallel reader then falls through and double-counts
+# row 40 (61 rows total, id=40 seen twice); with the fix both parallel and
+# sequential reads return exactly 60 rows.
+
+statement ok
+COPY (
+    SELECT (repeat('p', 23) || chr(13) || chr(13) || chr(10) ||
+        string_agg(lpad(CAST(t.id AS VARCHAR), 2, '0') || ',' ||
+                   repeat('x', 19) || chr(13) || chr(13) || chr(10), '')
+    )::BLOB
+    FROM generate_series(0, 59) t(id)
+) TO '{TEST_DIR}/rrrn_test.csv' (FORMAT BLOB);
+
+# Force parallelism
+statement ok
+PRAGMA verify_parallelism
+
+# Parallel row count must match sequential: the straddling terminator must not
+# produce a duplicate row 40
+query II
+SELECT
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_test.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'BIGINT','val':'VARCHAR'},
+        strict_mode=false, ignore_errors=true,
+        buffer_size=1024, parallel=true)) AS parallel_count,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_test.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'BIGINT','val':'VARCHAR'},
+        strict_mode=false, ignore_errors=true,
+        buffer_size=1024, parallel=false)) AS sequential_count
+----
+60	60
+
+# The row before the boundary (39) and the row after it (40) must each appear
+# exactly once in parallel mode
+query II
+SELECT
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_test.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'BIGINT','val':'VARCHAR'},
+        strict_mode=false, ignore_errors=true,
+        buffer_size=1024, parallel=true)
+     WHERE id = 40) AS id40_count,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_test.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'BIGINT','val':'VARCHAR'},
+        strict_mode=false, ignore_errors=true,
+        buffer_size=1024, parallel=true)
+     WHERE id = 39) AS id39_count
+----
+1	1
+
+# No duplicate rows exist in parallel mode
+query I
+SELECT COUNT(*) FROM (
+    SELECT id, COUNT(*) AS cnt
+    FROM read_csv('{TEST_DIR}/rrrn_test.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'BIGINT','val':'VARCHAR'},
+        strict_mode=false, ignore_errors=true,
+        buffer_size=1024, parallel=true)
+    GROUP BY id
+    HAVING cnt > 1
+)
+----
+0


### PR DESCRIPTION
Fixes #25164. Port of #25232 to main.

Problem: When a CSV file uses \r\r\n line endings and is read in parallel mode, a buffer boundary can fall between the two \r characters of a row terminator. The previous buffer's scanner counts the row via AddRow(), and ProcessOverBufferValue() then consumes the remaining \r\n from the new buffer but falls through to the "second buffer" loop — so the next row is counted by both the current scanner and the next scanner, producing duplicate rows.

Fix: In ProcessOverBufferValue(), return early after the CARRY_ON newline-consuming while loop when no cross-buffer value exists (over_buffer_string is empty), newline characters were consumed, the previous buffer's scanner already fully counted the row (last_position > actual_size), and the first consumed character is \r.

Testing: Regression test test/sql/copy/csv/parallel/test_rrrn_parallel.test generates the CSV on the fly with fixed-width rows that place a terminator's first \r on the last byte of a 1024-byte buffer, forcing the \r | \r\n split. Verified on a relassert build against main: the test fails without the fix (parallel returns 61 rows, id 40 duplicated) and passes with it (60/60, matching sequential). Full parallel CSV suite passes (13 test cases, 13015 assertions).