### PR TITLE
Rename new division setting to `error_on_division_by_zero`

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -716,6 +716,16 @@
         "custom_implementation": true
     },
     {
+        "name": "error_on_division_by_zero",
+        "description": "Throw an error instead of returning NULL when dividing by zero.",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "true",
+        "on_callbacks": [
+            "set"
+        ]
+    },
+    {
         "name": "errors_as_json",
         "description": "Output error messages as structured JSON instead of as a raw string",
         "type": "BOOLEAN",
@@ -1096,16 +1106,6 @@
         "type": "UBIGINT",
         "default_scope": "local",
         "default_value": "5"
-    },
-    {
-        "name": "null_on_division_by_zero",
-        "description": "Return NULL instead of throwing an error when dividing by zero.",
-        "type": "BOOLEAN",
-        "default_scope": "local",
-        "default_value": "false",
-        "on_callbacks": [
-            "set"
-        ]
     },
     {
         "name": "old_implicit_casting",

--- a/src/function/scalar/operator/arithmetic.cpp
+++ b/src/function/scalar/operator/arithmetic.cpp
@@ -1143,7 +1143,7 @@ namespace {
 
 [[noreturn]] void ThrowDivisionByZero(const Expression &expr) {
 	throw InvalidInputException("Division by zero in expression %s. Use TRY(...) to return NULL for this expression, "
-	                            "or SET null_on_division_by_zero=true to return NULL for all divisions by zero.",
+	                            "or SET error_on_division_by_zero=false to return NULL for all divisions by zero.",
 	                            expr.ToString());
 }
 
@@ -1263,7 +1263,7 @@ template <class OP>
 unique_ptr<FunctionData> BindDivisionByZero(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
-	auto null_on_zero = Settings::Get<NullOnDivisionByZeroSetting>(context);
+	auto null_on_zero = !Settings::Get<ErrorOnDivisionByZeroSetting>(context);
 	bound_function.SetFunctionCallback(
 	    GetBinaryFunctionZeroCheck<OP>(bound_function.GetReturnType().InternalType(), null_on_zero));
 	return nullptr;
@@ -1272,7 +1272,7 @@ unique_ptr<FunctionData> BindDivisionByZero(BindScalarFunctionInput &input) {
 unique_ptr<FunctionData> BindIntervalDivide(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &bound_function = input.GetBoundFunction();
-	if (Settings::Get<NullOnDivisionByZeroSetting>(context)) {
+	if (!Settings::Get<ErrorOnDivisionByZeroSetting>(context)) {
 		bound_function.SetFunctionCallback(BinaryScalarFunctionZeroCheck<interval_t, double, interval_t, DivideOperator,
 		                                                                 BinaryZeroCheckWrapper<true>>);
 	} else {
@@ -1290,7 +1290,7 @@ unique_ptr<FunctionData> BindBinaryFloatingPoint(BindScalarFunctionInput &input)
 	if (Settings::Get<IeeeFloatingPointOpsSetting>(context)) {
 		bound_function.SetFunctionCallback(GetScalarBinaryFunction<OP>(bound_function.GetReturnType().InternalType()));
 	} else {
-		auto null_on_zero = Settings::Get<NullOnDivisionByZeroSetting>(context);
+		auto null_on_zero = !Settings::Get<ErrorOnDivisionByZeroSetting>(context);
 		bound_function.SetFunctionCallback(
 		    GetBinaryFunctionZeroCheck<OP>(bound_function.GetReturnType().InternalType(), null_on_zero));
 	}
@@ -1334,7 +1334,7 @@ struct DividePropagateStatistics {
 };
 
 // When propagation fails the divisor range may contain zero, and division by zero either raises or (with
-// null_on_division_by_zero) produces NULLs that the inputs do not have: return no statistics instead of the
+// error_on_division_by_zero=false) produces NULLs that the inputs do not have: return no statistics instead of the
 // validity-only statistics that PropagateNumericStats falls back to.
 unique_ptr<BaseStatistics> PropagateIntegerDivideStats(ClientContext &context, FunctionStatisticsInput &input) {
 	auto stats = PropagateNumericStats<TryDivideOperator, DividePropagateStatistics, DivideOperator>(context, input);
@@ -1391,7 +1391,7 @@ static unique_ptr<FunctionData> BindDecimalModulo(BindScalarFunctionInput &input
 		bound_function.SetReturnType(LogicalType::DOUBLE);
 	}
 	auto &result_type = bound_function.GetReturnType();
-	auto null_on_zero = Settings::Get<NullOnDivisionByZeroSetting>(input.GetClientContext());
+	auto null_on_zero = !Settings::Get<ErrorOnDivisionByZeroSetting>(input.GetClientContext());
 	bound_function.SetFunctionCallback(GetBinaryFunctionZeroCheck<OP>(result_type.InternalType(), null_on_zero));
 	return std::move(bind_data);
 }

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -1093,6 +1093,17 @@ struct EnabledLogTypes {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct ErrorOnDivisionByZeroSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "error_on_division_by_zero";
+	static constexpr const char *Description = "Throw an error instead of returning NULL when dividing by zero.";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "true";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+	static void OnSet(SettingCallbackInfo &info, Value &input);
+};
+
 struct ErrorsAsJSONSetting {
 	using RETURN_TYPE = bool;
 	static constexpr const char *Name = "errors_as_json";
@@ -1600,17 +1611,6 @@ struct NestedLoopJoinThresholdSetting {
 	static constexpr const char *DefaultValue = "5";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-};
-
-struct NullOnDivisionByZeroSetting {
-	using RETURN_TYPE = bool;
-	static constexpr const char *Name = "null_on_division_by_zero";
-	static constexpr const char *Description = "Return NULL instead of throwing an error when dividing by zero.";
-	static constexpr const char *InputType = "BOOLEAN";
-	static constexpr const char *DefaultValue = "false";
-	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
-	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
-	static void OnSet(SettingCallbackInfo &info, Value &input);
 };
 
 struct OldImplicitCastingSetting {

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -155,6 +155,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_LOCAL(EnableProgressBarPrintSetting),
     DUCKDB_SETTING(EnableViewDependenciesSetting),
     DUCKDB_GLOBAL(EnabledLogTypes),
+    DUCKDB_SETTING_CALLBACK(ErrorOnDivisionByZeroSetting),
     DUCKDB_SETTING(ErrorsAsJSONSetting),
     DUCKDB_SETTING_CALLBACK(ExperimentalMetadataReuseSetting),
     DUCKDB_SETTING_CALLBACK(ExplainOutputSetting),
@@ -201,7 +202,6 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(MaxVacuumTasksSetting),
     DUCKDB_SETTING(MergeJoinThresholdSetting),
     DUCKDB_SETTING(NestedLoopJoinThresholdSetting),
-    DUCKDB_SETTING_CALLBACK(NullOnDivisionByZeroSetting),
     DUCKDB_SETTING(OldImplicitCastingSetting),
     DUCKDB_LOCAL(OperatorMemoryLimitSetting),
     DUCKDB_SETTING(OrderByNonIntegerLiteralSetting),
@@ -250,7 +250,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 130),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 131),
                                                      DUCKDB_SETTING_ALIAS("null_order", 60),
                                                      DUCKDB_SETTING_ALIAS("profile_output", 153),
                                                      DUCKDB_SETTING_ALIAS("user", 173),

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1789,6 +1789,10 @@ void EnableObjectCacheSetting::OnSet(SettingCallbackInfo &info, Value &) {
 	WarnDeprecatedSetting(info, EnableObjectCacheSetting::Name);
 }
 
+void ErrorOnDivisionByZeroSetting::OnSet(SettingCallbackInfo &info, Value &) {
+	WarnDeprecatedSetting(info, ErrorOnDivisionByZeroSetting::Name);
+}
+
 void ExperimentalMetadataReuseSetting::OnSet(SettingCallbackInfo &info, Value &) {
 	WarnDeprecatedSetting(info, ExperimentalMetadataReuseSetting::Name);
 }
@@ -1803,10 +1807,6 @@ void LegacyDisableNullTypeSetting::OnSet(SettingCallbackInfo &info, Value &) {
 
 void LegacyMetricsFormatSetting::OnSet(SettingCallbackInfo &info, Value &) {
 	WarnDeprecatedSetting(info, LegacyMetricsFormatSetting::Name);
-}
-
-void NullOnDivisionByZeroSetting::OnSet(SettingCallbackInfo &info, Value &) {
-	WarnDeprecatedSetting(info, NullOnDivisionByZeroSetting::Name);
 }
 
 void RegexMatchOperatorSemanticsSetting::OnSet(SettingCallbackInfo &info, Value &input) {

--- a/src/optimizer/rule/arithmetic_simplification.cpp
+++ b/src/optimizer/rule/arithmetic_simplification.cpp
@@ -62,7 +62,7 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 			if (constant.GetValue() == 1) {
 				// divide by 1, replace with non-constant child
 				return std::move(root.GetChildrenMutable()[1 - constant_child]);
-			} else if (constant.GetValue() == 0 && Settings::Get<NullOnDivisionByZeroSetting>(rewriter.context)) {
+			} else if (constant.GetValue() == 0 && !Settings::Get<ErrorOnDivisionByZeroSetting>(rewriter.context)) {
 				// divide by 0, replace with NULL
 				return make_uniq<BoundConstantExpression>(Value(root.GetReturnType()));
 			}

--- a/test/api/test_reset.cpp
+++ b/test/api/test_reset.cpp
@@ -125,7 +125,7 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"enable_progress_bar_print", {false}},
 	    {"scalar_subquery_error_on_multiple_rows", {false}},
 	    {"ieee_floating_point_ops", {false}},
-	    {"null_on_division_by_zero", {true}},
+	    {"error_on_division_by_zero", {false}},
 	    {"progress_bar_time", {0}},
 	    {"regex_match_operator_semantics", {"full"}},
 	    {"temp_directory", {"tmp"}},

--- a/test/issues/rigger/complex_division.test
+++ b/test/issues/rigger/complex_division.test
@@ -6,7 +6,7 @@ statement ok
 SET ieee_floating_point_ops=false;
 
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 statement ok
 BEGIN TRANSACTION;

--- a/test/issues/rigger/division_by_zero_null.test
+++ b/test/issues/rigger/division_by_zero_null.test
@@ -6,7 +6,7 @@ statement ok
 SET ieee_floating_point_ops=false;
 
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 statement ok
 BEGIN TRANSACTION;

--- a/test/optimizer/arithmetic_simplification.test
+++ b/test/optimizer/arithmetic_simplification.test
@@ -43,9 +43,9 @@ SELECT X//0 FROM (VALUES (1)) t(X)
 ----
 <REGEX>:.*Division by zero.*
 
-# with null_on_division_by_zero, division by zero results in a NULL
+# with error_on_division_by_zero disabled, division by zero results in a NULL
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 query I nosort xnull
 EXPLAIN SELECT NULL::INTEGER FROM test

--- a/test/sql/function/numeric/test_fdiv_fmod.test
+++ b/test/sql/function/numeric/test_fdiv_fmod.test
@@ -48,9 +48,9 @@ SELECT fdiv(42, 0)
 ----
 <REGEX>:.*Division by zero.*
 
-# unless null_on_division_by_zero is set
+# unless error_on_division_by_zero is disabled
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 # fmod by 0 results in NULL: should be NaN (if supported)
 query I
@@ -83,7 +83,7 @@ SELECT fdiv(0, 0)
 NULL
 
 statement ok
-SET null_on_division_by_zero=false;
+SET error_on_division_by_zero=true;
 
 query R
 SELECT fmod(12.3456789, 5)

--- a/test/sql/function/numeric/test_mod.test
+++ b/test/sql/function/numeric/test_mod.test
@@ -19,9 +19,9 @@ select mod(42, 0)
 ----
 <REGEX>:.*Division by zero.*
 
-# unless null_on_division_by_zero is set
+# unless error_on_division_by_zero is disabled
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 query I
 select mod(42, 0)
@@ -29,7 +29,7 @@ select mod(42, 0)
 NULL
 
 statement ok
-SET null_on_division_by_zero=false;
+SET error_on_division_by_zero=true;
 
 query R
 select mod(a, 2) from modme

--- a/test/sql/function/operator/test_division_by_zero.test
+++ b/test/sql/function/operator/test_division_by_zero.test
@@ -136,9 +136,9 @@ SELECT INTERVAL '1 day' / 2
 ----
 12:00:00
 
-# null_on_division_by_zero restores the old behavior of returning NULL
+# disabling error_on_division_by_zero restores the old behavior of returning NULL
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 foreach type TINYINT SMALLINT INTEGER BIGINT HUGEINT UTINYINT USMALLINT UINTEGER UBIGINT UHUGEINT DECIMAL(4,1) DECIMAL(9,2) DECIMAL(18,3) DECIMAL(38,4)
 
@@ -194,7 +194,7 @@ NULL
 endloop
 
 statement ok
-SET null_on_division_by_zero=false;
+SET error_on_division_by_zero=true;
 
 statement error
 SELECT 7 // 0

--- a/test/sql/optimizer/divide_zonemap_pruning.test
+++ b/test/sql/optimizer/divide_zonemap_pruning.test
@@ -92,9 +92,9 @@ SELECT count(*) FROM divide_pruning WHERE i // 0 = 5;
 ----
 <REGEX>:.*Division by zero.*
 
-# With null_on_division_by_zero the middle row group is scanned and yields NULLs.
+# Without error_on_division_by_zero the middle row group is scanned and yields NULLs.
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 query II
 EXPLAIN ANALYZE SELECT count(*) FROM divide_pruning WHERE 6144 // (i - 3000) = 123456;
@@ -113,7 +113,7 @@ SELECT count(*) FROM divide_pruning WHERE i // 0 = 5;
 0
 
 statement ok
-SET null_on_division_by_zero=false;
+SET error_on_division_by_zero=true;
 
 # The first row group contains the minimum integer: statistics derivation must
 # not evaluate INT32_MIN // -1, and pruning must not swallow the overflow error

--- a/test/sql/optimizer/expression/test_nop_arithmetic.test
+++ b/test/sql/optimizer/expression/test_nop_arithmetic.test
@@ -84,9 +84,9 @@ SELECT a // 0 FROM test
 <REGEX>:.*Division by zero.*
 
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
-# a / 0 => NULL with null_on_division_by_zero
+# a / 0 => NULL without error_on_division_by_zero
 query I
 SELECT a // 0 FROM test
 ----
@@ -94,7 +94,7 @@ NULL
 NULL
 
 statement ok
-SET null_on_division_by_zero=false;
+SET error_on_division_by_zero=true;
 
 # 0 / a => 0
 query I
@@ -136,7 +136,7 @@ SELECT 0 / rowid FROM test
 <REGEX>:.*Division by zero.*
 
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 query I
 SELECT 0 / rowid FROM test

--- a/test/sql/settings/deprecated_settings.test
+++ b/test/sql/settings/deprecated_settings.test
@@ -25,9 +25,9 @@ SET legacy_metrics_format=true;
 The 'legacy_metrics_format' setting is deprecated and will be removed in a future release.
 
 statement error
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 ----
-The 'null_on_division_by_zero' setting is deprecated and will be removed in a future release.
+The 'error_on_division_by_zero' setting is deprecated and will be removed in a future release.
 
 statement error
 SET experimental_metadata_reuse=false;

--- a/test/sql/types/float/ieee_floating_points.test
+++ b/test/sql/types/float/ieee_floating_points.test
@@ -44,9 +44,9 @@ SELECT val, val % 0::{type} FROM tbl
 ----
 <REGEX>:.*Division by zero.*
 
-# unless null_on_division_by_zero is set
+# unless error_on_division_by_zero is disabled
 statement ok
-SET null_on_division_by_zero = true;
+SET error_on_division_by_zero = false;
 
 # division by zero
 query II
@@ -69,7 +69,7 @@ nan	NULL
 inf	NULL
 
 statement ok
-SET null_on_division_by_zero = false;
+SET error_on_division_by_zero = true;
 
 # math domain cases still error when IEEE behavior is disabled
 statement ok

--- a/test/sql/types/interval/test_interval.test
+++ b/test/sql/types/interval/test_interval.test
@@ -238,7 +238,7 @@ SELECT INTERVAL '1 year 2 days 2 seconds' / 0;
 <REGEX>:.*Division by zero.*
 
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 query T
 SELECT INTERVAL '1 year 2 days 2 seconds' / 0;
@@ -246,7 +246,7 @@ SELECT INTERVAL '1 year 2 days 2 seconds' / 0;
 NULL
 
 statement ok
-SET null_on_division_by_zero=false;
+SET error_on_division_by_zero=true;
 
 # invalid intervals
 # empty interval

--- a/test/sql/types/null/test_null.test
+++ b/test/sql/types/null/test_null.test
@@ -41,7 +41,7 @@ SELECT 4 / 0
 <REGEX>:.*Division by zero.*
 
 statement ok
-SET null_on_division_by_zero=true;
+SET error_on_division_by_zero=false;
 
 # division by zero
 query I


### PR DESCRIPTION
The current name for `null_on_division_by_zero` is a bit confusing because division by zero can result in `nan` (and not `NULL`) for doubles. This PR flips the setting and calls it `error_on_division_by_zero` (default to true) instead of `null_on_division_by_zero` (default to false). 