### PR TITLE
Fix OOB vector access in map() PIVOT constant folding (#25276, #25278)

### DIFF
--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -319,6 +319,9 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 			value = Value::LIST(child_type, values);
 			return true;
 		} else if (function.FunctionName() == "map") {
+			if (function.GetArguments().size() != 2) {
+				return false;
+			}
 			Value keys;
 			if (!ConstructConstantFromExpression(function.GetArguments()[0].GetExpression(), keys)) {
 				return false;

--- a/test/sql/pivot/pivot_map_no_args.test
+++ b/test/sql/pivot/pivot_map_no_args.test
@@ -1,0 +1,26 @@
+# name: test/sql/pivot/pivot_map_no_args.test
+# description: Test PIVOT IN-list with a map() call whose argument count is not 2 (issue #25276)
+# group: [pivot]
+
+statement ok
+CREATE TABLE t(col VARCHAR);
+
+query I
+SELECT * FROM t PIVOT (count(*) FOR col IN (CAST(map() AS VARCHAR)));
+----
+0
+
+statement error
+SELECT * FROM t PIVOT (count(*) FOR col IN (CAST(map(['a']) AS VARCHAR)));
+----
+No function matches the given name and argument types 'map(VARCHAR[])'
+
+statement error
+SELECT * FROM t PIVOT (count(*) FOR col IN (CAST(map(['a'],[1],[2]) AS VARCHAR)));
+----
+No function matches the given name and argument types 'map(VARCHAR[], INTEGER[], INTEGER[])'
+
+query I
+SELECT CAST(map() AS VARCHAR);
+----
+{}


### PR DESCRIPTION
## Summary
- `PEGTransformerFactory::ConstructConstantFromExpression()` unconditionally accessed `function.GetArguments()[0]` and `[1]` in the `map` branch, without checking that at least two arguments exist.
- A PIVOT IN-list containing `CAST(map() AS VARCHAR)` recurses into this branch for the zero-argument `map()` call, triggering an out-of-bounds `std::vector` access and an INTERNAL Error abort.
- Added a check that `map()` has exactly 2 arguments before indexing into them; otherwise the function now returns `false`, which the caller already handles by falling back to normal (non-constant-folded) expression binding — so an invalid `map()` call now produces a normal binder error instead of crashing.

Fixes #25276
Fixes #25278 