### PR TITLE
Properly sort missing‑parameter error message by parameter index

### DIFF
--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -146,6 +146,7 @@ public:
 	                                     const identifier_map_t<PAYLOAD> &values, ClientContext *context = nullptr) {
 		// Missing values
 		identifier_set_t missing_set;
+		map<idx_t, Identifier> missing_idx_values;
 		for (auto &pair : parameters) {
 			auto &name = pair.first;
 			if (!values.count(name)) {
@@ -154,12 +155,16 @@ public:
 				    ClientConfig::GetConfig(*context).GetUserVariable(name, variable_value)) {
 					continue;
 				}
-				missing_set.insert(name);
+				if (!missing_set.count(name)) {
+					missing_set.insert(name);
+					missing_idx_values.try_emplace(pair.second, name);
+				}
 			}
 		}
+
 		vector<Identifier> missing_values;
-		for (auto &val : missing_set) {
-			missing_values.push_back(val);
+		for (auto &pair : missing_idx_values) {
+			missing_values.push_back(pair.second);
 		}
 		return StringUtil::Format("Values were not provided for the following parameters: %s",
 		                          StringUtil::Join(missing_values, ", "));

--- a/test/sql/prepared/prepared_named_param.test
+++ b/test/sql/prepared/prepared_named_param.test
@@ -31,3 +31,24 @@ statement error
 execute q01(a, 2, 0)
 ----
 Invalid Input Error: Only scalar parameters, named parameters or NULL supported for EXECUTE
+
+statement error
+CREATE TABLE t_miss_parameters_order_01 (n INTEGER NULL, i INTEGER NULL, b BIGINT NULL, d DECIMAL(10, 2) NULL, v VARCHAR NULL);
+prepare insert_t_miss_parameters_order_01 as INSERT INTO t_miss_parameters_order_01 VALUES ($aa, $bb, $cc, $dd, $ee);
+execute insert_t_miss_parameters_order_01(aa:=null, bb:=203);
+----
+Values were not provided for the following parameters: cc, dd, ee
+
+statement error
+CREATE TABLE t_miss_parameters_order_02 (n INTEGER NULL, i INTEGER NULL, b BIGINT NULL, d DECIMAL(10, 2) NULL, v VARCHAR NULL);
+prepare insert_t_miss_parameters_order_02 as INSERT INTO t_miss_parameters_order_02  VALUES ($ee, $dd, $cc, $bb, $aa);
+execute insert_t_miss_parameters_order_02(aa:=null, bb:=203);
+----
+Values were not provided for the following parameters: ee, dd, cc
+
+statement error
+CREATE TABLE t_miss_parameters_order_03 (n INTEGER NULL, i INTEGER NULL, b BIGINT NULL, d DECIMAL(10, 2) NULL, v VARCHAR NULL);
+prepare insert_t_miss_parameters_order_03 as INSERT INTO t_miss_parameters_order_03  VALUES ($aa, $aa, $bb, $cc, $bb);
+execute insert_t_miss_parameters_order_03(aa:=null, cc:=203);
+----
+Values were not provided for the following parameters: bb


### PR DESCRIPTION
Use std::map to preserve and sort missing parameters by their original index, ensuring error messages list parameters in the position‑based order rather than unordered‑set iteration order. Also avoid duplicate entries for the same named parameter in error output.

Add sqllogictest cases for ordered missing‑parameter error output.

Partially fix #25299