### PR TITLE
Report missing prepared statement parameters in declaration order (#25299)

### DIFF
--- a/src/include/duckdb/main/prepared_statement.hpp
+++ b/src/include/duckdb/main/prepared_statement.hpp
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/identifier.hpp"
+#include "duckdb/common/pair.hpp"
 #include "duckdb/common/winapi.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
 #include "duckdb/main/pending_query_result.hpp"
@@ -145,21 +147,24 @@ public:
 	static string MissingValuesException(const identifier_map_t<idx_t> &parameters,
 	                                     const identifier_map_t<PAYLOAD> &values, ClientContext *context = nullptr) {
 		// Missing values
-		identifier_set_t missing_set;
-		for (auto &pair : parameters) {
-			auto &name = pair.first;
+		vector<pair<idx_t, Identifier>> missing;
+		for (auto &param_pair : parameters) {
+			auto &name = param_pair.first;
 			if (!values.count(name)) {
 				Value variable_value;
 				if (context && AllowsUserVariableFallback(name) &&
 				    ClientConfig::GetConfig(*context).GetUserVariable(name, variable_value)) {
 					continue;
 				}
-				missing_set.insert(name);
+				missing.emplace_back(param_pair.second, name);
 			}
 		}
+		// Report missing parameters in the order they were declared, not hash-map iteration order.
+		std::sort(missing.begin(), missing.end(),
+		          [](const pair<idx_t, Identifier> &a, const pair<idx_t, Identifier> &b) { return a.first < b.first; });
 		vector<Identifier> missing_values;
-		for (auto &val : missing_set) {
-			missing_values.push_back(val);
+		for (auto &val : missing) {
+			missing_values.push_back(val.second);
 		}
 		return StringUtil::Format("Values were not provided for the following parameters: %s",
 		                          StringUtil::Join(missing_values, ", "));

--- a/test/sql/prepared/prepared_named_param.test
+++ b/test/sql/prepared/prepared_named_param.test
@@ -31,3 +31,12 @@ statement error
 execute q01(a, 2, 0)
 ----
 Invalid Input Error: Only scalar parameters, named parameters or NULL supported for EXECUTE
+
+# missing named parameters must be reported in declaration order, not hash order
+statement ok
+prepare q03 as select $aa, $bb, $cc, $dd, $ee;
+
+statement error
+execute q03(aa := 1, bb := 2);
+----
+Invalid Input Error: Values were not provided for the following parameters: cc, dd, ee


### PR DESCRIPTION
## Summary
- `PreparedStatement::MissingValuesException()` collected the names of missing prepared-statement parameters into an `identifier_set_t` (an `unordered_set`), so the order reported in the error message depended on hash-bucket layout rather than the order the parameters were declared in the statement.
- The parser already assigns each named parameter an incrementing index as it's parsed (`PEGTransformer::SetParam`), stored as the `idx_t` value in the `named_param_map`. That index was available but unused for ordering.
- Fixed by collecting `(index, name)` pairs while scanning for missing parameters and sorting by index before formatting the message, so the reported order now matches declaration order deterministically.

Fixes #25299