### PR TITLE
C-API-V2: Part 3

### DIFF
--- a/api_spec/v2/arrow/arrow.yaml
+++ b/api_spec/v2/arrow/arrow.yaml
@@ -5,60 +5,78 @@ module: arrow
 #
 # The three standard Arrow structs -- ArrowSchema, ArrowArray and ArrowArrayStream -- are
 # emitted into the generated header under the same ARROW_C_DATA_INTERFACE /
-# ARROW_C_STREAM_INTERFACE guards that pyarrow, nanoarrow and arrow use, so the definitions
+# ARROW_C_STREAM_INTERFACE guards the Arrow specification prescribes, so the definitions
 # coexist with a consumer's own Arrow headers (first definition wins; the layouts are
-# byte-identical by spec). They keep their upstream names and are deliberately NOT wrapped in
-# opaque duckdb_v2_arrow_* handles, because the ownership contract is caller-allocates /
-# library-fills: a binding author must be able to declare an ArrowSchema on the stack with only
-# this header in hand.
+# byte-identical by spec). They keep their upstream names and are not wrapped in opaque
+# duckdb_v2_arrow_* handles: the ownership contract is caller-allocates / library-fills, so a
+# binding must be able to declare an ArrowSchema on the stack with only this header in hand.
 #
-# Ownership follows the Arrow C Data Interface, not this API's usual handle rules, and is
-# restated per function. Exporting fills a caller-allocated struct and sets its `release`, which
-# the caller then calls. Importing transfers the source array's data into the produced data
-# chunk and nulls the source's `release`, so the caller must not release it afterwards.
+# Two handles cover the two directions:
 #
-# The converters take a `context` because they are meant to run inside a callback -- a scalar
-# function, a table function, a cast -- that already holds one with an active transaction.
-# Building an Arrow schema is not a pure function of the logical types: extension
-# populate-schema callbacks and ENUM dictionaries read the catalog. Code outside a callback
-# reaches Arrow through `result_to_arrow_stream`, which supplies the context itself.
+#   arrow_importer   created from an ArrowSchema, converts ArrowArrays into data chunks
+#   arrow_exporter   created from DuckDB column types, converts data chunks into ArrowArrays
 #
-# Schema and array conversion are separate on the import side on purpose. An ArrowSchema is
-# resolved once into an `arrow_converter`, and each array is then converted through that
-# plan, so a table function binds the schema in its bind callback and pays nothing per chunk.
+# Both work the same way: append one input, take outputs until none is left, repeat. The
+# `batch_size` given at creation caps the rows per output. A long input is split across several
+# outputs. Rows left over that do not fill a batch are held back and joined with the next input,
+# so an output may span two inputs. The converter cannot tell when the input ends, so the append
+# call takes a `flush` flag that releases the held rows as a final short output.
+# `[[result_to_arrow_stream]]` owns its source and needs no flush. A `batch_size` of 0 means no
+# maximum: each input becomes one output and nothing is held back.
 #
-# Deliberately out of scope, left to language bindings or to later work:
-#   - Registering an Arrow stream as a SQL table. A binding keeps its own name-to-stream
-#     registry and exposes it through an ordinary table function or a replacement scan; that
-#     composes from the general function API and needs nothing Arrow-specific beyond these
-#     converters.
-#   - Arrow IPC, the serialized wire format. A different transport from the C Data Interface,
-#     provided by the arrow extension as SQL functions reached through the normal query path.
-#   - A parallel, buffered Arrow collector. `result_to_arrow_stream` converts single-threaded
-#     as the consumer pulls; a pipelined collector has to be installed before execution starts,
-#     so it needs a query entry point that does not exist yet.
-#   - Database-level registration of custom Arrow type extensions, mapping to the engine's
-#     ArrowTypeExtension. It builds on this converter surface rather than changing it.
+# Resolving the type mapping happens once, at creation, so a table function can create a
+# converter at bind time and pay nothing per batch. Creation reads the catalog for extension
+# types and ENUM dictionaries, so it needs a context with an active transaction; a callback
+# context has one.
+#
+# An exporter also captures the session's Arrow settings at creation, so the schema it reports
+# and the arrays it produces always agree, even if a setting changes afterwards.
+#
+# Ownership differs between the directions because the mechanics do. Importing is zero-copy: the
+# chunks point into the Arrow buffers, so something has to keep those buffers alive. Exporting
+# copies into freshly allocated Arrow buffers, so nothing needs to be retained. Both appends take
+# a `consume` flag; each documents what it means there.
+#
+# Out of scope, left to language bindings or to later work:
+#   - Registering an Arrow stream as a SQL table. A binding can keep its own name-to-stream
+#     registry and expose it through a table function or a replacement scan, built from the
+#     general function API and these converters.
+#   - Arrow IPC, the serialized wire format. Provided by the arrow extension as SQL functions.
+#   - A parallel, buffered Arrow collector. `[[result_to_arrow_stream]]` converts on the
+#     consumer's thread as it pulls. A pipelined collector has to be installed before execution
+#     starts, which needs a query entry point that does not exist yet.
+#   - Database-level registration of custom Arrow type extensions (the engine's
+#     ArrowTypeExtension).
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Handles
 #-----------------------------------------------------------------------------------------------------------------------
 handles:
-  arrow_converter:
+  arrow_importer:
     description: |
-      An owned, resolved interpretation of an ArrowSchema: the DuckDB logical type of every column plus the per-column
-      Arrow type information needed to import an array. Built once from an ArrowSchema with
-      `[[arrow_converter_create]]` and reused across many arrays by `[[arrow_converter_array_to_chunk]]`, so a table
-      function can resolve the schema at bind time and pay nothing per chunk. Read the resolved names and types back
-      with `[[arrow_converter_get_schema]]`, and destroy with `[[arrow_converter_destroy]]`.
-    cleanup_with: arrow_converter_destroy
+      Converts Arrow arrays into DuckDB data chunks, against one resolved ArrowSchema. Create it with
+      `[[arrow_importer_create]]`, which resolves every column's DuckDB type once, so the same importer serves any
+      number of arrays of that shape. `[[arrow_importer_get_schema]]` reports the resolved DuckDB schema.
+      `[[arrow_importer_append]]` takes an array, `[[arrow_importer_next_chunk]]` produces chunks from it, and
+      `[[arrow_importer_destroy]]` frees the importer.
+
+      The importer borrows the context it was created with and must not outlive it. One array is in flight at a
+      time, and an importer must not be used from two threads at once.
+  arrow_exporter:
+    description: |
+      Converts DuckDB data chunks into Arrow arrays, for one fixed list of columns. Create it with
+      `[[arrow_exporter_create]]`, which captures the session's Arrow settings and resolves the extension types once.
+      `[[arrow_exporter_get_schema]]` reports the Arrow schema. `[[arrow_exporter_append]]` takes a chunk,
+      `[[arrow_exporter_next_array]]` produces arrays from it, and `[[arrow_exporter_destroy]]` frees the exporter.
+
+      An exporter must not be used from two threads at once.
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Functions
 #-----------------------------------------------------------------------------------------------------------------------
 functions:
   #---------------------------------------------------------------------------------------------------------------------
-  # Exporting to Arrow
+  # Streaming a result
   #---------------------------------------------------------------------------------------------------------------------
   result_to_arrow_stream:
     lifecycle:
@@ -66,26 +84,25 @@ functions:
     description: |
       Exports a result as a lazy ArrowArrayStream. Consuming.
 
-      Takes the result by transfer, setting the slot to NULL, and fills the caller-allocated `out_stream`. The stream
-      owns the result from then on: releasing it does not drain anything, but it does close the query and free the
-      connection's live-result slot exactly as `[[result_destroy]]` would, so the connection can run its next query.
-      Release it by calling `out_stream->release(out_stream)`.
+      Takes ownership of the result, sets the slot to NULL, and fills the caller-allocated `out_stream`. The stream
+      owns the result from then on. Releasing the stream, with `out_stream->release(out_stream)`, does not drain the
+      result, but closes the query and frees the connection's live-result slot as `[[result_destroy]]` would, so the
+      connection can run its next query.
 
-      The stream is lazy. Its `get_next` drives the result, stepping past waiting states internally until a batch is
-      ready, and coalesces DuckDB chunks into one Arrow array of up to `batch_size` rows. Its `get_schema` returns the
-      Arrow schema and never touches the catalog, because both the schema and the extension type map are built and
-      cached while this call still holds the query's transaction. That caching is a correctness requirement rather
-      than an optimization: building the schema can run extension populate-schema callbacks and read ENUM
-      dictionaries, neither of which is available once the transaction is gone.
+      The stream's `get_next` drives the result, waiting internally until a batch is ready, and gathers DuckDB chunks
+      into one Arrow array of up to `batch_size` rows. The Arrow schema and the extension type map are built and
+      cached here, while the query's transaction is still active, because building them can run extension
+      populate-schema callbacks and read ENUM dictionaries. `get_schema` returns a copy of the cached schema and never
+      touches the catalog.
 
-      Passing a result that has already yielded some chunks is allowed and produces a stream over what remains.
+      A result that has already yielded some chunks is allowed and produces a stream over the remaining rows.
 
-      A statement that expanded into a group whose row-producing fragment has not started yet is stepped far enough
-      here for its schema to be cached, which can block briefly; no rows are lost, since none can be produced before
-      that fragment is prepared. For an ordinary statement nothing executes here.
+      If the statement expanded into a group whose row-producing fragment has not started yet, this call steps the
+      result far enough to cache the schema, which may block briefly. No rows are lost, since none are produced
+      before that fragment is prepared. For an ordinary statement nothing executes here.
 
       The result is consumed on every path that reaches the engine, including failures. Only a null-argument
-      rejection leaves it intact, and `out_stream` is untouched unless the call succeeds.
+      rejection leaves it intact. `out_stream` is untouched unless the call succeeds.
     role: method
     belongs_to: result
     parameters:
@@ -97,8 +114,7 @@ functions:
       batch_size:
         type: idx
         description: |
-          Target rows per Arrow array. Pass 0 for the default of 131072, which is 64 vectors in a default build and
-          matches pyarrow's dataset scanner.
+          Maximum rows per Arrow array. Pass 0 for the default of 131072, which is 64 vectors in a default build.
       out_stream:
         type: ArrowArrayStream
         indirection: 1
@@ -110,23 +126,209 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  logical_types_to_arrow_schema:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Importing: Arrow arrays -> data chunks
+  #---------------------------------------------------------------------------------------------------------------------
+  arrow_importer_create:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Converts a list of column types and names into an Arrow schema.
+      Resolves an Arrow schema into a reusable importer.
 
-      Fills the caller-allocated `out_schema` using the Arrow options carried by `context`. The caller owns the
-      result and releases it with `out_schema->release(out_schema)`.
+      Works out every column's DuckDB logical type and the Arrow type information the conversion needs, once, so any
+      number of arrays of that shape can be imported without re-reading the schema. `schema` is read, not consumed:
+      the caller keeps ownership and still releases it.
 
-      `types` and `names` are parallel arrays of `count` entries, and may be NULL only when `count` is 0. Building
-      the schema can read the catalog -- extension populate-schema callbacks, ENUM dictionaries -- so `context` must
-      have an active transaction, which a callback context does.
-    role: method
+      `batch_size` caps the rows per produced chunk. A long array is split across several chunks. Rows left over that
+      do not fill a batch are held back and joined with the next array, unless the append asked to flush. Pass 0 for
+      no maximum: each array becomes one chunk, however long it is.
+
+      Resolving reads the catalog for extension types, so `context` must have an active transaction. The importer
+      keeps using that context for every conversion and must not outlive it. Within one connection the context is
+      the same throughout, so an importer created in a bind callback is usable from the matching exec callback.
+      `*out_importer` is set to NULL on failure.
+    role: constructor
+    belongs_to: arrow_importer
     parameters:
       context:
         type: context
-        description: The context whose Arrow options and transaction drive the conversion.
+        description: The context used to resolve the Arrow types, extension types included.
+      schema:
+        type: ArrowSchema
+        indirection: 1
+        description: The schema to resolve. Read, not consumed; the caller keeps ownership.
+      batch_size:
+        type: idx
+        description: Maximum rows per produced chunk, or 0 for no maximum.
+      out_importer:
+        type: arrow_importer
+        indirection: 1
+        kind: OUT
+        description: On success, receives the new importer. Owned by the caller; destroy via `[[arrow_importer_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  arrow_importer_get_schema:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the resolved DuckDB schema.
+
+      Writes an owned schema handle with the DuckDB name and logical type of every column the importer resolved.
+      This is how a caller learns the DuckDB shape of an ArrowSchema, to declare a table function's result columns
+      for instance, without reimplementing the mapping from Arrow format strings to logical types.
+
+      The fields were resolved at creation, so this reads no catalog and needs no transaction. `*out_schema` is set
+      to NULL on failure.
+    role: getter
+    belongs_to: arrow_importer
+    parameters:
+      importer:
+        type: arrow_importer
+        description: The importer to read.
+      out_schema:
+        type: schema
+        indirection: 1
+        kind: OUT
+        description: On success, receives an owned schema. Destroy via `[[schema_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  arrow_importer_append:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Gives the importer one array to convert.
+
+      Take the chunks with `[[arrow_importer_next_chunk]]` until that returns NULL. Appending while the previous array
+      still has rows left is rejected with `ERROR_INPUT_INVALID`. An array whose shape does not match the resolved
+      schema -- a different child count, a child whose length differs from the array's, a null or already-released
+      child -- is rejected the same way, before anything is read.
+
+      `flush` marks the end of the input: rows that do not fill a batch then come out as a final short chunk instead
+      of being held back for the next array. Pass NULL for `array` with `flush` set to release the held rows without
+      supplying more input.
+
+      `consume` decides what happens to the caller's array.
+
+      When true, the importer takes over the array and sets its `release` to NULL; the caller must not release it
+      afterwards. The produced chunks reference the Arrow buffers directly, without copying, and keep them alive, so
+      the chunks stay valid after the importer is destroyed. Prefer this path.
+
+      When false, the caller keeps the array and must keep it valid until the drain finishes. The produced chunks are
+      copies, so they do not depend on the array, at the cost of one copy per chunk.
+
+      Either way, a chunk that joins rows held back from the previous array is a copy, since it cannot reference two
+      arrays.
+
+      Only the default, dictionary-encoded and run-end-encoded Arrow layouts are supported. Any other layout reports
+      `ERROR_QUERY_NOT_IMPLEMENTED` when the column is converted.
+    role: method
+    belongs_to: arrow_importer
+    parameters:
+      importer:
+        type: arrow_importer
+        description: The importer to feed.
+      array:
+        type: ArrowArray
+        indirection: 1
+        description: The array to convert. Its `release` is set to NULL when `consume` is true.
+      consume:
+        type: bool
+        description: |
+          True to hand the array over for a zero-copy import; false to keep it, in which case every produced chunk is
+          a copy.
+      flush:
+        type: bool
+        description: |
+          True to mark the end of the input, releasing held rows as a final short chunk. Pass NULL for `array` with
+          this set to flush without supplying more input.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  arrow_importer_next_chunk:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Produces the next chunk of the appended array, or NULL once the array is drained.
+
+      Call it in a loop until `*out_chunk` is NULL. An importer with no array appended also returns NULL. Each chunk
+      holds at most the importer's `batch_size` rows, or the whole array when that is 0. A chunk may start with rows
+      held back from the previous array, and rows that do not fill a batch are held back in turn unless the append
+      asked to flush. So NULL means the array has been read, not that all of its rows have come out.
+
+      The conversion runs under the context the importer was created with, which must still be alive. `*out_chunk`
+      is set to NULL on failure.
+    role: method
+    belongs_to: arrow_importer
+    parameters:
+      importer:
+        type: arrow_importer
+        description: The importer to drain.
+      out_chunk:
+        type: data_chunk
+        indirection: 1
+        kind: OUT
+        description: On success, receives the next chunk, or NULL once the array is drained. Destroy via `[[data_chunk_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  arrow_importer_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Destroys an importer.
+
+      Null-safe: passing NULL, or a slot already set to NULL, is a no-op. Chunks already produced stay valid,
+      including the zero-copy ones, which keep the Arrow buffers alive themselves. An array appended with `consume`
+      true and not fully drained is released here. Rows held back for a next array are dropped. On success the slot
+      is set to NULL.
+    role: destructor
+    belongs_to: arrow_importer
+    parameters:
+      importer:
+        type: arrow_importer
+        indirection: 1
+        description: The importer to destroy.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Exporting: data chunks -> Arrow arrays
+  #---------------------------------------------------------------------------------------------------------------------
+  arrow_exporter_create:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Creates an exporter for one fixed list of columns.
+
+      Resolves the extension types and captures the session's Arrow settings, so every array this exporter produces
+      matches the schema `[[arrow_exporter_get_schema]]` reports, even if a setting changes afterwards.
+
+      `batch_size` caps the rows per produced array. A long chunk is split across several arrays. Rows left over that
+      do not fill a batch are held back and joined with the next chunk, unless the append asked to flush. Pass 0 for
+      no maximum: each chunk becomes one array, however long it is.
+
+      `types` and `names` are parallel arrays of `count` entries, borrowed and copied; they may be NULL only when
+      `count` is 0. Resolving reads the catalog, so `context` must have an active transaction. `*out_exporter` is
+      set to NULL on failure.
+    role: constructor
+    belongs_to: arrow_exporter
+    parameters:
+      context:
+        type: context
+        description: The context whose Arrow settings are captured and whose transaction resolves the types.
       types:
         type: logical_type
         indirection: 1
@@ -140,6 +342,35 @@ functions:
       count:
         type: idx
         description: The number of columns, being the length of both `types` and `names`.
+      batch_size:
+        type: idx
+        description: Maximum rows per produced array, or 0 for no maximum.
+      out_exporter:
+        type: arrow_exporter
+        indirection: 1
+        kind: OUT
+        description: On success, receives the new exporter. Owned by the caller; destroy via `[[arrow_exporter_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  arrow_exporter_get_schema:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the Arrow schema of the arrays this exporter produces.
+
+      Fills the caller-allocated `out_schema`. The caller owns the result and releases it with
+      `out_schema->release(out_schema)`. Callable at any point, and always returns the same schema, since it is built
+      from the settings captured at creation.
+    role: getter
+    belongs_to: arrow_exporter
+    parameters:
+      exporter:
+        type: arrow_exporter
+        description: The exporter to read.
       out_schema:
         type: ArrowSchema
         indirection: 1
@@ -151,163 +382,96 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  data_chunk_to_arrow_array:
+  arrow_exporter_append:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Converts a data chunk into an Arrow array.
+      Gives the exporter one chunk to convert.
 
-      Fills the caller-allocated `out_array`, using the Arrow options and extension type casts resolved from
-      `context`. The caller owns the result and releases it with `out_array->release(out_array)`. The chunk is
-      borrowed, not consumed, and stays valid afterwards.
+      The chunk is converted in full before this returns. The conversion copies into freshly allocated Arrow buffers,
+      so nothing of the caller's is retained. Every array completed by this chunk becomes available from
+      `[[arrow_exporter_next_array]]`; rows that do not complete a batch are held back and finished by the next
+      chunk. Completed arrays queue up, so appending again before they are taken is allowed.
 
-      The Arrow schema for the array comes from `[[logical_types_to_arrow_schema]]`, given the chunk's column types;
-      this call produces data only.
+      `flush` marks the end of the input: the held rows are then finished as a final short array. Pass NULL for
+      `chunk` with `flush` set to release the held rows without supplying more input.
+
+      The chunk's types must match the ones the exporter was created with, or the call is rejected with
+      `ERROR_INPUT_INVALID` before anything is read.
+
+      `consume` decides only what happens to the caller's handle, since the data is copied either way. When true the
+      chunk is destroyed and the slot set to NULL, saving a `[[data_chunk_destroy]]` for a chunk the caller owns.
+      When false the chunk is left untouched, which is what a chunk borrowed from a callback needs, such as the output
+      chunk of a table function's exec callback, which the caller does not own and must not destroy.
     role: method
-    belongs_to: data_chunk
+    belongs_to: arrow_exporter
     parameters:
-      context:
-        type: context
-        description: The context whose Arrow options and transaction drive the conversion.
+      exporter:
+        type: arrow_exporter
+        description: The exporter to feed.
       chunk:
         type: data_chunk
-        description: The chunk to convert. Borrowed; not consumed.
+        indirection: 1
+        description: The chunk to convert. Destroyed and set to NULL only when `consume` is true.
+      consume:
+        type: bool
+        description: True to hand the chunk over, destroying it; false to leave the caller's handle untouched.
+      flush:
+        type: bool
+        description: |
+          True to mark the end of the input, releasing the held rows as a final short array. Pass NULL for `chunk`
+          with this set to flush without supplying more input.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  arrow_exporter_next_array:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Takes the next completed array, or reports that none is ready.
+
+      Call it in a loop after every `[[arrow_exporter_append]]` until `out_array->release` is NULL, which is how the
+      Arrow C Data Interface signals "no array" and what a stream's `get_next` does at end of input. Rows held back
+      towards an unfinished batch are not an array yet; they come out after a further append or a flush.
+
+      Each array is owned by the caller and released with `out_array->release(out_array)`, independently of the
+      exporter and of every other array.
+    role: method
+    belongs_to: arrow_exporter
+    parameters:
+      exporter:
+        type: arrow_exporter
+        description: The exporter to drain.
       out_array:
         type: ArrowArray
         indirection: 1
         kind: OUT
-        description: Caller-allocated array the library fills. Release it with `out_array->release(out_array)`.
+        description: |
+          Caller-allocated array the library fills. Left released -- `release` NULL -- when none is ready. Release a
+          filled one with `out_array->release(out_array)`.
       err:
         type: error_info
         indirection: 1
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  #---------------------------------------------------------------------------------------------------------------------
-  # Importing from Arrow
-  #---------------------------------------------------------------------------------------------------------------------
-  arrow_converter_create:
+  arrow_exporter_destroy:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Resolves an Arrow schema into a reusable converter.
+      Destroys an exporter.
 
-      Interprets `schema` against `context`, working out each column's DuckDB logical type and the Arrow type
-      information an import needs, and returns a converter that `[[arrow_converter_array_to_chunk]]` reuses across every
-      array of that shape. `schema` is read, not consumed: the caller keeps ownership and still releases it.
-
-      Resolving reads the catalog for extension types, so `context` must have an active transaction. The converter itself
-      captures no context: build it under a bind-time context and use it at execution time under another.
-
-      `*out_converter` is set to NULL on failure.
-    role: constructor
-    belongs_to: arrow_converter
-    parameters:
-      context:
-        type: context
-        description: The context used to resolve the Arrow types, extension types included.
-      schema:
-        type: ArrowSchema
-        indirection: 1
-        description: The schema to resolve. Read, not consumed; the caller keeps ownership.
-      out_converter:
-        type: arrow_converter
-        indirection: 1
-        kind: OUT
-        description: On success, receives the new converter. Owned by the caller; destroy via `[[arrow_converter_destroy]]`.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  arrow_converter_array_to_chunk:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: |
-      Converts an Arrow array into a data chunk, interpreting it through a converter. Consuming.
-
-      The chunk adopts the array's buffers zero-copy and `array->release` is set to NULL, so the caller must not
-      release `array` afterwards; destroying the chunk releases the Arrow data. Ownership transfers even on the
-      failure paths that have already taken it, so a caller must never release an array it has passed here.
-
-      The chunk is sized to the array's length, which may exceed the engine's vector size: that is the size of a
-      chunk flowing through a pipeline, not a cap on a chunk that stands alone.
-
-      An array whose shape disagrees with the converter -- a different child count, a child length that does not match the
-      array's, a null or already-released child -- is rejected with `ERROR_INPUT_INVALID` rather than read. Only the
-      default, dictionary-encoded and run-end-encoded layouts are supported; any other reports
-      `ERROR_QUERY_NOT_IMPLEMENTED`. `*out_chunk` is set to NULL on failure.
-    role: method
-    belongs_to: arrow_converter
-    parameters:
-      context:
-        type: context
-        description: The context used during the conversion.
-      array:
-        type: ArrowArray
-        indirection: 1
-        description: The array to convert. Its data is adopted by the chunk and its `release` is set to NULL.
-      converter:
-        type: arrow_converter
-        description: The converter describing the array, from `[[arrow_converter_create]]`.
-      out_chunk:
-        type: data_chunk
-        indirection: 1
-        kind: OUT
-        description: On success, receives the new chunk. Owned by the caller; destroy via `[[data_chunk_destroy]]`.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  arrow_converter_get_schema:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: |
-      Returns the converter's resolved columns as a schema.
-
-      Writes an owned schema handle carrying the DuckDB name and logical type of every column the converter resolved.
-      This is how a caller learns the DuckDB shape of an arbitrary ArrowSchema, to declare a table function's result
-      columns for instance: mapping Arrow format strings onto logical types is engine knowledge, not something a
-      binding should reimplement.
-
-      The fields are copied from what was resolved at creation, so this reads no catalog and needs no transaction.
-      `*out_schema` is set to NULL on failure.
-    role: getter
-    belongs_to: arrow_converter
-    parameters:
-      converter:
-        type: arrow_converter
-        description: The converter to read.
-      out_schema:
-        type: schema
-        indirection: 1
-        kind: OUT
-        description: On success, receives an owned schema. Destroy via `[[schema_destroy]]`.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  #---------------------------------------------------------------------------------------------------------------------
-  # Destructor
-  #---------------------------------------------------------------------------------------------------------------------
-  arrow_converter_destroy:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: |
-      Destroys an Arrow converter.
-
-      Null-safe: passing NULL, or a slot already set to NULL, is a no-op. Chunks already produced through it are independent of the converter
-      and stay valid. On success the slot is set to NULL.
+      Null-safe: passing NULL, or a slot already set to NULL, is a no-op. Arrays already taken stay valid. Arrays
+      still queued inside are released here, and rows held back towards an unfinished batch are dropped. On success
+      the slot is set to NULL.
     role: destructor
-    belongs_to: arrow_converter
+    belongs_to: arrow_exporter
     parameters:
-      converter:
-        type: arrow_converter
+      exporter:
+        type: arrow_exporter
         indirection: 1
-        description: The converter to destroy.
+        description: The exporter to destroy.
     return_type: ERROR

--- a/api_spec/v2/arrow/arrow.yaml
+++ b/api_spec/v2/arrow/arrow.yaml
@@ -1,0 +1,313 @@
+module: arrow
+#
+# Arrow C Data Interface interop: convert between DuckDB and Arrow in both directions, and
+# export a streaming result as an ArrowArrayStream.
+#
+# The three standard Arrow structs -- ArrowSchema, ArrowArray and ArrowArrayStream -- are
+# emitted into the generated header under the same ARROW_C_DATA_INTERFACE /
+# ARROW_C_STREAM_INTERFACE guards that pyarrow, nanoarrow and arrow use, so the definitions
+# coexist with a consumer's own Arrow headers (first definition wins; the layouts are
+# byte-identical by spec). They keep their upstream names and are deliberately NOT wrapped in
+# opaque duckdb_v2_arrow_* handles, because the ownership contract is caller-allocates /
+# library-fills: a binding author must be able to declare an ArrowSchema on the stack with only
+# this header in hand.
+#
+# Ownership follows the Arrow C Data Interface, not this API's usual handle rules, and is
+# restated per function. Exporting fills a caller-allocated struct and sets its `release`, which
+# the caller then calls. Importing transfers the source array's data into the produced data
+# chunk and nulls the source's `release`, so the caller must not release it afterwards.
+#
+# The converters take a `context` because they are meant to run inside a callback -- a scalar
+# function, a table function, a cast -- that already holds one with an active transaction.
+# Building an Arrow schema is not a pure function of the logical types: extension
+# populate-schema callbacks and ENUM dictionaries read the catalog. Code outside a callback
+# reaches Arrow through `result_to_arrow_stream`, which supplies the context itself.
+#
+# Schema and array conversion are separate on the import side on purpose. An ArrowSchema is
+# resolved once into an `arrow_converter`, and each array is then converted through that
+# plan, so a table function binds the schema in its bind callback and pays nothing per chunk.
+#
+# Deliberately out of scope, left to language bindings or to later work:
+#   - Registering an Arrow stream as a SQL table. A binding keeps its own name-to-stream
+#     registry and exposes it through an ordinary table function or a replacement scan; that
+#     composes from the general function API and needs nothing Arrow-specific beyond these
+#     converters.
+#   - Arrow IPC, the serialized wire format. A different transport from the C Data Interface,
+#     provided by the arrow extension as SQL functions reached through the normal query path.
+#   - A parallel, buffered Arrow collector. `result_to_arrow_stream` converts single-threaded
+#     as the consumer pulls; a pipelined collector has to be installed before execution starts,
+#     so it needs a query entry point that does not exist yet.
+#   - Database-level registration of custom Arrow type extensions, mapping to the engine's
+#     ArrowTypeExtension. It builds on this converter surface rather than changing it.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  arrow_converter:
+    description: |
+      An owned, resolved interpretation of an ArrowSchema: the DuckDB logical type of every column plus the per-column
+      Arrow type information needed to import an array. Built once from an ArrowSchema with
+      `[[arrow_converter_create]]` and reused across many arrays by `[[arrow_converter_array_to_chunk]]`, so a table
+      function can resolve the schema at bind time and pay nothing per chunk. Read the resolved names and types back
+      with `[[arrow_converter_get_schema]]`, and destroy with `[[arrow_converter_destroy]]`.
+    cleanup_with: arrow_converter_destroy
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Exporting to Arrow
+  #---------------------------------------------------------------------------------------------------------------------
+  result_to_arrow_stream:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Exports a result as a lazy ArrowArrayStream. Consuming.
+
+      Takes the result by transfer, setting the slot to NULL, and fills the caller-allocated `out_stream`. The stream
+      owns the result from then on: releasing it does not drain anything, but it does close the query and free the
+      connection's live-result slot exactly as `[[result_destroy]]` would, so the connection can run its next query.
+      Release it by calling `out_stream->release(out_stream)`.
+
+      The stream is lazy. Its `get_next` drives the result, stepping past waiting states internally until a batch is
+      ready, and coalesces DuckDB chunks into one Arrow array of up to `batch_size` rows. Its `get_schema` returns the
+      Arrow schema and never touches the catalog, because both the schema and the extension type map are built and
+      cached while this call still holds the query's transaction. That caching is a correctness requirement rather
+      than an optimization: building the schema can run extension populate-schema callbacks and read ENUM
+      dictionaries, neither of which is available once the transaction is gone.
+
+      Passing a result that has already yielded some chunks is allowed and produces a stream over what remains.
+
+      A statement that expanded into a group whose row-producing fragment has not started yet is stepped far enough
+      here for its schema to be cached, which can block briefly; no rows are lost, since none can be produced before
+      that fragment is prepared. For an ordinary statement nothing executes here.
+
+      The result is consumed on every path that reaches the engine, including failures. Only a null-argument
+      rejection leaves it intact, and `out_stream` is untouched unless the call succeeds.
+    role: method
+    belongs_to: result
+    parameters:
+      result:
+        type: result
+        indirection: 1
+        kind: IN_TRANSFER
+        description: The result to export. Consumed and set to NULL, except when the call rejects a null argument.
+      batch_size:
+        type: idx
+        description: |
+          Target rows per Arrow array. Pass 0 for the default of 131072, which is 64 vectors in a default build and
+          matches pyarrow's dataset scanner.
+      out_stream:
+        type: ArrowArrayStream
+        indirection: 1
+        kind: OUT
+        description: Caller-allocated stream the library fills. Release it with `out_stream->release(out_stream)`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  logical_types_to_arrow_schema:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Converts a list of column types and names into an Arrow schema.
+
+      Fills the caller-allocated `out_schema` using the Arrow options carried by `context`. The caller owns the
+      result and releases it with `out_schema->release(out_schema)`.
+
+      `types` and `names` are parallel arrays of `count` entries, and may be NULL only when `count` is 0. Building
+      the schema can read the catalog -- extension populate-schema callbacks, ENUM dictionaries -- so `context` must
+      have an active transaction, which a callback context does.
+    role: method
+    parameters:
+      context:
+        type: context
+        description: The context whose Arrow options and transaction drive the conversion.
+      types:
+        type: logical_type
+        indirection: 1
+        const: true
+        description: An array of `count` column types. May be NULL only when `count` is 0.
+      names:
+        type: str
+        indirection: 1
+        const: true
+        description: An array of `count` column names, parallel to `types`. May be NULL only when `count` is 0.
+      count:
+        type: idx
+        description: The number of columns, being the length of both `types` and `names`.
+      out_schema:
+        type: ArrowSchema
+        indirection: 1
+        kind: OUT
+        description: Caller-allocated schema the library fills. Release it with `out_schema->release(out_schema)`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  data_chunk_to_arrow_array:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Converts a data chunk into an Arrow array.
+
+      Fills the caller-allocated `out_array`, using the Arrow options and extension type casts resolved from
+      `context`. The caller owns the result and releases it with `out_array->release(out_array)`. The chunk is
+      borrowed, not consumed, and stays valid afterwards.
+
+      The Arrow schema for the array comes from `[[logical_types_to_arrow_schema]]`, given the chunk's column types;
+      this call produces data only.
+    role: method
+    belongs_to: data_chunk
+    parameters:
+      context:
+        type: context
+        description: The context whose Arrow options and transaction drive the conversion.
+      chunk:
+        type: data_chunk
+        description: The chunk to convert. Borrowed; not consumed.
+      out_array:
+        type: ArrowArray
+        indirection: 1
+        kind: OUT
+        description: Caller-allocated array the library fills. Release it with `out_array->release(out_array)`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Importing from Arrow
+  #---------------------------------------------------------------------------------------------------------------------
+  arrow_converter_create:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Resolves an Arrow schema into a reusable converter.
+
+      Interprets `schema` against `context`, working out each column's DuckDB logical type and the Arrow type
+      information an import needs, and returns a converter that `[[arrow_converter_array_to_chunk]]` reuses across every
+      array of that shape. `schema` is read, not consumed: the caller keeps ownership and still releases it.
+
+      Resolving reads the catalog for extension types, so `context` must have an active transaction. The converter itself
+      captures no context: build it under a bind-time context and use it at execution time under another.
+
+      `*out_converter` is set to NULL on failure.
+    role: constructor
+    belongs_to: arrow_converter
+    parameters:
+      context:
+        type: context
+        description: The context used to resolve the Arrow types, extension types included.
+      schema:
+        type: ArrowSchema
+        indirection: 1
+        description: The schema to resolve. Read, not consumed; the caller keeps ownership.
+      out_converter:
+        type: arrow_converter
+        indirection: 1
+        kind: OUT
+        description: On success, receives the new converter. Owned by the caller; destroy via `[[arrow_converter_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  arrow_converter_array_to_chunk:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Converts an Arrow array into a data chunk, interpreting it through a converter. Consuming.
+
+      The chunk adopts the array's buffers zero-copy and `array->release` is set to NULL, so the caller must not
+      release `array` afterwards; destroying the chunk releases the Arrow data. Ownership transfers even on the
+      failure paths that have already taken it, so a caller must never release an array it has passed here.
+
+      The chunk is sized to the array's length, which may exceed the engine's vector size: that is the size of a
+      chunk flowing through a pipeline, not a cap on a chunk that stands alone.
+
+      An array whose shape disagrees with the converter -- a different child count, a child length that does not match the
+      array's, a null or already-released child -- is rejected with `ERROR_INPUT_INVALID` rather than read. Only the
+      default, dictionary-encoded and run-end-encoded layouts are supported; any other reports
+      `ERROR_QUERY_NOT_IMPLEMENTED`. `*out_chunk` is set to NULL on failure.
+    role: method
+    belongs_to: arrow_converter
+    parameters:
+      context:
+        type: context
+        description: The context used during the conversion.
+      array:
+        type: ArrowArray
+        indirection: 1
+        description: The array to convert. Its data is adopted by the chunk and its `release` is set to NULL.
+      converter:
+        type: arrow_converter
+        description: The converter describing the array, from `[[arrow_converter_create]]`.
+      out_chunk:
+        type: data_chunk
+        indirection: 1
+        kind: OUT
+        description: On success, receives the new chunk. Owned by the caller; destroy via `[[data_chunk_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  arrow_converter_get_schema:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the converter's resolved columns as a schema.
+
+      Writes an owned schema handle carrying the DuckDB name and logical type of every column the converter resolved.
+      This is how a caller learns the DuckDB shape of an arbitrary ArrowSchema, to declare a table function's result
+      columns for instance: mapping Arrow format strings onto logical types is engine knowledge, not something a
+      binding should reimplement.
+
+      The fields are copied from what was resolved at creation, so this reads no catalog and needs no transaction.
+      `*out_schema` is set to NULL on failure.
+    role: getter
+    belongs_to: arrow_converter
+    parameters:
+      converter:
+        type: arrow_converter
+        description: The converter to read.
+      out_schema:
+        type: schema
+        indirection: 1
+        kind: OUT
+        description: On success, receives an owned schema. Destroy via `[[schema_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destructor
+  #---------------------------------------------------------------------------------------------------------------------
+  arrow_converter_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Destroys an Arrow converter.
+
+      Null-safe: passing NULL, or a slot already set to NULL, is a no-op. Chunks already produced through it are independent of the converter
+      and stay valid. On success the slot is set to NULL.
+    role: destructor
+    belongs_to: arrow_converter
+    parameters:
+      converter:
+        type: arrow_converter
+        indirection: 1
+        description: The converter to destroy.
+    return_type: ERROR

--- a/api_spec/v2/catalog/catalog.yaml
+++ b/api_spec/v2/catalog/catalog.yaml
@@ -1,0 +1,303 @@
+module: catalog
+#
+# Resolve-and-read catalog primitives: look one named object up and read the
+# facts of its resolution. Enumeration (listing tables, schemas, columns)
+# stays in SQL, where the system table functions already provide it.
+
+# // TODO: Maybe we should just remove this API, you can get this information from the system tables instead.
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  table_description:
+    description: |
+      An owned snapshot of one base table taken at creation: where the name resolved, the table's columns, and
+      per-column catalog facts. Later DDL does not update it. Create with `[[connection_describe_table]]`, read the
+      resolved location via `[[table_description_get_qname]]`, and the columns via
+      `[[table_description_get_column_count]]` and `[[table_description_get_column]]`. Destroy via
+      `[[table_description_destroy]]`.
+  column_description:
+    description: |
+      An owned snapshot of one column of a described table: its name, type, and catalog facts. Obtain with
+      `[[table_description_get_column]]`, read with `[[column_description_get_name]]`,
+      `[[column_description_get_type]]`, `[[column_description_has_default]]` and
+      `[[column_description_has_generated]]`, and destroy with `[[column_description_destroy]]`.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Constructors
+  #---------------------------------------------------------------------------------------------------------------------
+  connection_describe_table:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Resolves a table name and snapshots its description.
+
+      Resolves name in the connection's catalogs and returns an owned description of the table it names. name may be
+      partial: an unqualified or schema-qualified name resolves through the connection's search path, exactly as the
+      same name resolves in SQL. A two-part name tries the first part as a schema and as an attached database, as SQL
+      does, and is rejected when both readings exist. A name that resolves to nothing is rejected with the engine's
+      missing-table error; a name that resolves to a view is rejected with the engine's not-a-table error, since a
+      description snapshots a base table.
+    role: constructor
+    belongs_to: table_description
+    parameters:
+      conn:
+        type: connection
+        description: The connection whose catalogs and search path resolve the name.
+      name:
+        type: qname
+        description: The possibly partial table name to resolve. Borrowed for the call only.
+      desc:
+        type: table_description
+        indirection: 1
+        kind: OUT
+        description: On success, receives the owned description. Destroy via `[[table_description_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Table Description
+  #---------------------------------------------------------------------------------------------------------------------
+  table_description_get_qname:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the resolved qualified name of the described table.
+
+      Returns an owned copy of the fully resolved name: the catalog, schema, and table the lookup landed on, with the
+      casing the table was created with, never an echo of the requested name. Rendering it produces SQL that pins the
+      described table regardless of search path.
+    role: getter
+    belongs_to: table_description
+    parameters:
+      desc:
+        type: table_description
+        description: The description.
+      name:
+        type: qname
+        indirection: 1
+        kind: OUT
+        description: Receives the owned resolved name. Destroy via `[[qname_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_description_is_readonly:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns whether the described table's catalog is read-only.
+
+      True when the catalog the name resolved into was attached read-only, in which case no write to the table can
+      succeed. False does not by itself prove a write will succeed; it clears the catalog-level check only.
+    role: getter
+    belongs_to: table_description
+    parameters:
+      desc:
+        type: table_description
+        description: The description.
+      readonly:
+        type: bool
+        indirection: 1
+        kind: OUT
+        description: Receives whether the catalog is read-only.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_description_get_column_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of columns of the described table.
+
+      Counts every column in declared order, generated columns included. Valid indices for
+      `[[table_description_get_column]]` are [0, count).
+    role: getter
+    belongs_to: table_description
+    parameters:
+      desc:
+        type: table_description
+        description: The description.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the column count.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_description_get_column:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns an owned description of the column at index.
+
+      Columns are numbered in declared order, generated columns included. An out-of-range index is rejected with
+      `ERROR_INPUT_OUT_OF_RANGE`.
+    role: getter
+    belongs_to: table_description
+    parameters:
+      desc:
+        type: table_description
+        description: The description.
+      index:
+        type: idx
+        description: Zero-based column index.
+      column:
+        type: column_description
+        indirection: 1
+        kind: OUT
+        description: Receives the owned column description. Destroy via `[[column_description_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_description_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Destroys the table description, releasing its resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+      double-destruction. Column descriptions obtained from it are independent and stay valid.
+    role: destructor
+    belongs_to: table_description
+    parameters:
+      desc:
+        type: table_description
+        description: The description to destroy.
+        indirection: 1
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Column Description
+  #---------------------------------------------------------------------------------------------------------------------
+  column_description_get_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Borrows the name of the column.
+
+      The name carries the casing the column was declared with.
+    role: getter
+    belongs_to: column_description
+    parameters:
+      column:
+        type: column_description
+        description: The column description.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the column name. Valid until the column description is destroyed.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  column_description_get_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Borrows the type of the column.
+    role: getter
+    belongs_to: column_description
+    parameters:
+      column:
+        type: column_description
+        description: The column description.
+      type:
+        type: logical_type
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives the borrowed column type. Valid until the column description is destroyed; do not destroy it.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  column_description_has_default:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns whether the column has a default value.
+
+      True when the column declares a default expression; the engine evaluates it for rows that omit the column.
+      Generated columns report false.
+    role: getter
+    belongs_to: column_description
+    parameters:
+      column:
+        type: column_description
+        description: The column description.
+      has_default:
+        type: bool
+        indirection: 1
+        kind: OUT
+        description: Receives whether the column has a default value.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  column_description_has_generated:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns whether the column is generated.
+
+      True when the column is a generated column, computed by the engine from a generation expression and not
+      writable.
+    role: getter
+    belongs_to: column_description
+    parameters:
+      column:
+        type: column_description
+        description: The column description.
+      has_generated:
+        type: bool
+        indirection: 1
+        kind: OUT
+        description: Receives whether the column is generated.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  column_description_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Destroys the column description, releasing its resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+      double-destruction. Any name or type borrowed from it becomes dangling.
+    role: destructor
+    belongs_to: column_description
+    parameters:
+      column:
+        type: column_description
+        description: The column description to destroy.
+        indirection: 1
+    return_type: ERROR

--- a/api_spec/v2/data_chunk/column_data_collection.yaml
+++ b/api_spec/v2/data_chunk/column_data_collection.yaml
@@ -98,15 +98,38 @@ functions:
       Drops all buffered rows, keeping the column types.
 
       Drops all buffered rows and releases their memory. The column types are
-      unchanged and the collection is immediately appendable again. Outstanding
-      append and scan states are invalidated; create new ones. Must not be
-      called while a live result executes over the collection, because that
-      result's scan borrows the collection's buffers.
+      unchanged and the collection is immediately appendable again. Existing
+      append and scan states are invalidated. Use
+      `[[column_data_collection_clear]]` instead to keep the memory for the
+      next appends.
     belongs_to: column_data_collection
     parameters:
       collection:
         type: column_data_collection
         description: The collection to reset.
+      err:
+        type: error_info
+        indirection: 1
+        kind: OUT
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+    return_type: ERROR
+
+  column_data_collection_clear:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Drops all buffered rows, keeping the column types and the memory.
+
+      Like `[[column_data_collection_reset]]`, but the buffers are retained
+      rather than released, so the next appends write into memory that is
+      already allocated. Use this when the collection is refilled repeatedly.
+      The column types are unchanged and the collection is immediately
+      appendable again. Existing append and scan states are invalidated.
+    belongs_to: column_data_collection
+    parameters:
+      collection:
+        type: column_data_collection
+        description: The collection to clear.
       err:
         type: error_info
         indirection: 1

--- a/api_spec/v2/expression/expression.yaml
+++ b/api_spec/v2/expression/expression.yaml
@@ -1,0 +1,335 @@
+module: expression
+#
+# Read-only inspection of bound expressions: the expression trees the engine builds once a query has been bound,
+# with every column and function resolved. The engine hands them to callbacks that may want to look inside a
+# predicate, e.g. a table function offered a filter to push down (see `[[table_function_set_filter_pushdown_callback]]`).
+#
+# A bound expression is a tree. Every node has a type (`[[expression_get_type]]`), a return type
+# (`[[expression_get_return_type]]`) and zero or more children (`[[expression_get_child]]`); a few node types carry
+# one extra piece of information reachable through a type-specific accessor: the value of a constant, the column a
+# column reference points at, the name of a function or the mode of a cast.
+#
+# The surface deliberately covers only the node types a filter predicate can be made of. A node of any other type
+# reports `EXPRESSION_TYPE_INVALID`: its children can still be walked, but nothing else about it is exposed, and a
+# callback that meets one should leave the predicate to the engine.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Enums
+#-----------------------------------------------------------------------------------------------------------------------
+enums:
+  EXPRESSION_TYPE:
+    description: |
+      The type of a bound expression node. The values mirror the engine's own expression types, restricted to the
+      node types a filter predicate can contain; every other node type is reported as `EXPRESSION_TYPE_INVALID`.
+
+      Comparisons, `BETWEEN` and casts are regular scalar function calls once bound: they have the function's
+      children and name, and only their type tells them apart from any other function. A `CAST` therefore has one
+      child, the value being cast, and its target type is the node's return type.
+    values:
+      EXPRESSION_TYPE_INVALID:
+        value: 0
+        description: A node type this API does not model. Its children can still be walked.
+      EXPRESSION_TYPE_OPERATOR_CAST:
+        value: 12
+        description: A cast. One child; the target type is the node's return type and `[[expression_cast_get_mode]]` tells a `TRY_CAST` apart.
+      EXPRESSION_TYPE_OPERATOR_NOT:
+        value: 13
+        description: Logical `NOT`. One child.
+      EXPRESSION_TYPE_OPERATOR_IS_NULL:
+        value: 14
+        description: '`IS NULL`. One child.'
+      EXPRESSION_TYPE_OPERATOR_IS_NOT_NULL:
+        value: 15
+        description: '`IS NOT NULL`. One child.'
+      EXPRESSION_TYPE_COMPARE_EQUAL:
+        value: 25
+        description: '`=`. Two children.'
+      EXPRESSION_TYPE_COMPARE_NOTEQUAL:
+        value: 26
+        description: '`<>`. Two children.'
+      EXPRESSION_TYPE_COMPARE_LESSTHAN:
+        value: 27
+        description: '`<`. Two children.'
+      EXPRESSION_TYPE_COMPARE_GREATERTHAN:
+        value: 28
+        description: '`>`. Two children.'
+      EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO:
+        value: 29
+        description: '`<=`. Two children.'
+      EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO:
+        value: 30
+        description: '`>=`. Two children.'
+      EXPRESSION_TYPE_COMPARE_IN:
+        value: 35
+        description: '`IN`. The first child is the value tested, the remaining children are the candidates.'
+      EXPRESSION_TYPE_COMPARE_NOT_IN:
+        value: 36
+        description: '`NOT IN`. The first child is the value tested, the remaining children are the candidates.'
+      EXPRESSION_TYPE_COMPARE_DISTINCT_FROM:
+        value: 37
+        description: '`IS DISTINCT FROM`. Two children.'
+      EXPRESSION_TYPE_COMPARE_BETWEEN:
+        value: 38
+        description: '`BETWEEN`. Three children: the value tested, the lower bound and the upper bound.'
+      EXPRESSION_TYPE_COMPARE_NOT_DISTINCT_FROM:
+        value: 40
+        description: '`IS NOT DISTINCT FROM`. Two children.'
+      EXPRESSION_TYPE_CONJUNCTION_AND:
+        value: 50
+        description: Logical `AND`. Two or more children.
+      EXPRESSION_TYPE_CONJUNCTION_OR:
+        value: 51
+        description: Logical `OR`. Two or more children.
+      EXPRESSION_TYPE_VALUE_CONSTANT:
+        value: 75
+        description: A constant. No children; read it with `[[expression_constant_get_value]]`.
+      EXPRESSION_TYPE_VALUE_PARAMETER:
+        value: 76
+        description: A prepared statement parameter whose value is not known yet. No children.
+      EXPRESSION_TYPE_BOUND_FUNCTION:
+        value: 141
+        description: A call to a scalar function other than the ones listed above. The children are its arguments; read the name with `[[expression_function_get_name]]`.
+      EXPRESSION_TYPE_CASE_EXPR:
+        value: 150
+        description: A `CASE` expression. The children are each `WHEN` condition followed by its `THEN` result, then the `ELSE` result.
+      EXPRESSION_TYPE_OPERATOR_COALESCE:
+        value: 152
+        description: '`COALESCE`. One or more children.'
+      EXPRESSION_TYPE_BOUND_COLUMN_REF:
+        value: 228
+        description: A reference to a column. No children; read it with `[[expression_column_ref_get_index]]`.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  expression:
+    description: |
+      A borrowed opaque handle to a node of a bound expression tree. Read-only and owned by the engine: valid only
+      for the duration of the callback that handed it out, and never destroyed by the caller. Child nodes borrowed
+      via `[[expression_get_child]]` share their parent's lifetime.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Every Node
+  #---------------------------------------------------------------------------------------------------------------------
+  expression_get_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the type of an expression node.
+
+      The type decides which of the type-specific accessors apply, and what the node's children mean; see
+      `EXPRESSION_TYPE`. A node of a type this API does not model reports `EXPRESSION_TYPE_INVALID`.
+    parameters:
+      expression:
+        type: expression
+        description: The expression node.
+      type:
+        type: EXPRESSION_TYPE
+        indirection: 1
+        kind: OUT
+        description: Receives the node type.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  expression_get_return_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the logical type the expression node evaluates to.
+
+      For a cast this is the target type. The returned type is owned by the caller and must be destroyed via
+      `[[logical_type_destroy]]`.
+    parameters:
+      expression:
+        type: expression
+        description: The expression node.
+      type:
+        type: logical_type
+        indirection: 1
+        kind: OUT
+        description: Receives the owned logical type.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  expression_get_child_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of child nodes of an expression node.
+
+      Works for every node type, including `EXPRESSION_TYPE_INVALID`. Constants, parameters and column references
+      have no children.
+    parameters:
+      expression:
+        type: expression
+        description: The expression node.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of children.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  expression_get_child:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves a child node of an expression node by index.
+
+      Fails if the index is out of bounds. Children are ordered as the node type describes (see
+      `EXPRESSION_TYPE`). The child is borrowed and shares the lifetime of its parent.
+    parameters:
+      expression:
+        type: expression
+        description: The expression node.
+      index:
+        type: idx
+        description: The index of the child to retrieve.
+      child:
+        type: expression
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives the borrowed child node.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Type-Specific Accessors
+  #---------------------------------------------------------------------------------------------------------------------
+  expression_constant_get_value:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the value of a constant node.
+
+      Fails if the node is not of type `EXPRESSION_TYPE_VALUE_CONSTANT`. The returned value is owned by the caller
+      and must be destroyed via `[[value_destroy]]`.
+    parameters:
+      expression:
+        type: expression
+        description: The constant node.
+      value:
+        type: value
+        indirection: 1
+        kind: OUT
+        description: Receives the owned constant value.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  expression_column_ref_get_index:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the column a column reference node points at.
+
+      Fails if the node is not of type `EXPRESSION_TYPE_BOUND_COLUMN_REF`. The index counts the columns of the
+      operator the predicate is evaluated against, which is not necessarily the full set of columns that operator
+      can produce: a callback resolves it through whatever handed it the expression, e.g.
+      `[[table_function_filter_pushdown_get_column_index]]` for a filter offered to a table function.
+    parameters:
+      expression:
+        type: expression
+        description: The column reference node.
+      index:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the column index.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  expression_function_get_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the name of the scalar function a function node calls.
+
+      Applies to `EXPRESSION_TYPE_BOUND_FUNCTION` and to the node types that are function calls underneath: the
+      comparisons, `EXPRESSION_TYPE_COMPARE_BETWEEN` and `EXPRESSION_TYPE_OPERATOR_CAST`. Fails for any other node
+      type. For a comparison the name is its operator, e.g. `<`; for `BETWEEN` and casts it is an internal name, so
+      dispatch on the type rather than the name for those. The name is borrowed and shares the lifetime of the node.
+    parameters:
+      expression:
+        type: expression
+        description: The function node.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the function name.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  expression_function_get_qname:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the qualified name of the scalar function a function node calls.
+
+      Applies to the same node types as `[[expression_function_get_name]]`, and fails for any other. The name is
+      qualified with the catalog and schema the function was resolved in, where known. The returned name is owned
+      by the caller and must be destroyed via `[[qname_destroy]]`.
+    parameters:
+      expression:
+        type: expression
+        description: The function node.
+      name:
+        type: qname
+        indirection: 1
+        kind: OUT
+        description: Receives the owned qualified name.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  expression_cast_get_mode:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns whether a cast node is a regular `CAST` or a `TRY_CAST`.
+
+      Fails if the node is not of type `EXPRESSION_TYPE_OPERATOR_CAST`. A `TRY_CAST` yields NULL for a value it
+      cannot convert where a regular `CAST` would fail the query.
+    parameters:
+      expression:
+        type: expression
+        description: The cast node.
+      mode:
+        type: CAST_MODE
+        indirection: 1
+        kind: OUT
+        description: Receives the cast mode.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR

--- a/api_spec/v2/filesystem/file_system.yaml
+++ b/api_spec/v2/filesystem/file_system.yaml
@@ -1,0 +1,513 @@
+module: file system
+#
+# Access to the file system DuckDB itself reads and writes through, so an
+# extension or embedder opens files the same way the engine does -- honouring
+# whatever is configured, including virtual and remote file systems registered
+# by other extensions.
+#
+# A file system is borrowed from a context or a connection and lives as long as
+# that does. Files opened through it are owned by the caller.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Enums
+#-----------------------------------------------------------------------------------------------------------------------
+enums:
+  FILE_FLAG:
+    description: |
+      How `[[file_system_open]]` opens a file. These are not a bitmask -- apply
+      them one at a time with `[[file_open_options_set_flag]]`, calling it once
+      per behaviour you want, e.g. `FILE_FLAG_WRITE` then `FILE_FLAG_CREATE` to
+      write to a file and create it when it does not exist.
+    values:
+      FILE_FLAG_INVALID:
+        value: 0
+        description: Not a flag. The zero value, so that an uninitialized variable does not name a behaviour; applying it is an error.
+      FILE_FLAG_READ:
+        value: 1
+        description: Open the file with "read" capabilities.
+      FILE_FLAG_WRITE:
+        value: 2
+        description: Open the file with "write" capabilities.
+      FILE_FLAG_CREATE:
+        value: 3
+        description: Create the file if it does not exist, and open it as it is if it does.
+      FILE_FLAG_CREATE_NEW:
+        value: 4
+        description: Create the file if it does not exist, and truncate it to empty if it does. To fail instead of truncating, combine `FILE_FLAG_CREATE` with `FILE_FLAG_EXCLUSIVE_CREATE`.
+      FILE_FLAG_APPEND:
+        value: 5
+        description: Open the file in "append" mode.
+      FILE_FLAG_EXCLUSIVE_CREATE:
+        value: 6
+        description: Fail if the file already exists. A modifier on `FILE_FLAG_CREATE`, and meaningless without it.
+      FILE_FLAG_PARALLEL_ACCESS:
+        value: 7
+        description: |
+          The file will be read and written at explicit offsets from several threads at once. Pass it whenever
+          `[[file_read_at]]` or `[[file_write_at]]` are used concurrently -- a file system that would otherwise
+          assume sequential access, by caching, buffering, or keeping a single cursor, needs to know not to.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  file_system:
+    description: |
+      A borrowed opaque handle to a file system. Obtained from
+      `[[file_system_get_from_context]]` or `[[file_system_get_from_connection]]`, and used to open files with
+      `[[file_system_open]]`. Borrowed: the handle belongs to the context or connection it came from, is valid only
+      for as long as that is, and must not be destroyed.
+
+  file_open_options:
+    description: |
+      An owned opaque handle to the options a file is opened with. Created with `[[file_open_options_create]]`,
+      configured with `[[file_open_options_set_flag]]` and `[[file_open_options_set_value]]`, passed to
+      `[[file_system_open]]`, and destroyed with `[[file_open_options_destroy]]`. One options object can open any number
+      of files, and destroying it does not affect files already opened with it.
+
+  file:
+    description: |
+      An owned opaque handle to an open file, produced by `[[file_system_open]]` and destroyed with
+      `[[file_destroy]]`. Read, write, seek and sync through the `file_*` functions. Only usable while the file
+      system it was opened through is still valid.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # File System
+  #---------------------------------------------------------------------------------------------------------------------
+  file_system_get_from_context:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Borrows the file system of a context.
+
+      Use this from inside a callback, where a context is in hand. The returned handle is borrowed: it is valid only
+      for as long as the context is, and must not be destroyed.
+    parameters:
+      context:
+        type: context
+        description: The context to take the file system from.
+      file_system:
+        type: file_system
+        indirection: 1
+        kind: OUT
+        description: Receives the borrowed file system.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_system_get_from_connection:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Borrows the file system of a connection.
+
+      The connection form of `[[file_system_get_from_context]]`, for callers outside a callback. The returned handle
+      is borrowed: it is valid only for as long as the connection is, and must not be destroyed.
+    parameters:
+      connection:
+        type: connection
+        description: The connection to take the file system from.
+      file_system:
+        type: file_system
+        indirection: 1
+        kind: OUT
+        description: Receives the borrowed file system.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_open_options_create:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a set of open options for a file system.
+
+      The options start out empty: give them flags with `[[file_open_options_set_flag]]`, which is required, and
+      optionally attach values with `[[file_open_options_set_value]]`. They are then passed to `[[file_system_open]]`,
+      and can be reused for as many opens as you like. The caller owns the returned handle and must destroy it with
+      `[[file_open_options_destroy]]`.
+
+      The options belong to the file system they were created from, since which values mean anything depends on
+      which file system ends up handling the path.
+    parameters:
+      file_system:
+        type: file_system
+        description: The file system the options are for.
+      options:
+        type: file_open_options
+        indirection: 1
+        kind: OUT
+        description: On success, receives the new options. Owned by the caller; destroy via `[[file_open_options_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_open_options_set_flag:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Applies one flag to the options.
+
+      Additive: call it once per behaviour you want, and applying the same flag twice is harmless. At least one
+      flag must be applied before the options can open anything, since the flags are what say whether the file is
+      being read or written. There is no way to take a flag back -- build a fresh set of options instead.
+
+      `FILE_FLAG_INVALID` names no behaviour and is rejected, as is any value that is not a `[[FILE_FLAG]]`.
+    parameters:
+      options:
+        type: file_open_options
+        description: The options to apply the flag to.
+      flag:
+        type: FILE_FLAG
+        description: The flag to apply.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_open_options_set_value:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Attaches a named value to the options.
+
+      These are hints for whichever file system ends up handling the path, and what they mean is that file system's
+      business: a value it does not recognise is ignored rather than rejected, and the same name can mean different
+      things to different file systems. They are the same values a file system reports when listing files, so a
+      known file size or modification time learned from a listing can be handed straight back to avoid re-reading
+      it.
+
+      The name and the value are borrowed and copied, so the caller may destroy the value immediately after.
+      Setting the same name again replaces the previous value. Names are case-sensitive.
+    parameters:
+      options:
+        type: file_open_options
+        description: The options to set the value on.
+      name:
+        type: str
+        description: The name of the value. Borrowed and copied.
+      value:
+        type: value
+        description: The value. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_open_options_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Destroys the options, releasing their resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+      double-destruction. Files already opened with these options are unaffected.
+    parameters:
+      options:
+        type: file_open_options
+        description: The options to destroy.
+        indirection: 1
+    return_type: ERROR
+
+  file_system_open:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Opens a file.
+
+      Opens the file at the given path through the file system, which routes it the way the engine would -- a path
+      handled by a registered virtual or remote file system goes there rather than to local disk. The returned
+      handle is owned by the caller and must be destroyed with `[[file_destroy]]`.
+
+      The options carry the flags and any file-system-specific values; see `[[file_open_options_create]]`. Opening
+      without having set flags fails, since the flags are what say whether the file is being read or written.
+
+      Failure to open -- a missing file without `FILE_FLAG_CREATE`, insufficient permissions, an existing file
+      under `FILE_FLAG_EXCLUSIVE_CREATE` -- is reported as an error.
+
+      Flag combinations that contradict each other, such as naming neither read nor write or combining
+      `FILE_FLAG_CREATE` with `FILE_FLAG_CREATE_NEW`, are a programming error rather than a supported input. An
+      assertion build catches them; elsewhere the behaviour is whatever the underlying file system does with them.
+    parameters:
+      file_system:
+        type: file_system
+        description: The file system to open the file through.
+      file_path:
+        type: str
+        description: The path of the file to open. Borrowed for the call only.
+      options:
+        type: file_open_options
+        description: How to open the file. Borrowed for the call only, and reusable across opens.
+      file:
+        type: file
+        indirection: 1
+        kind: OUT
+        description: On success, receives the open file. Owned by the caller; destroy via `[[file_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # File
+  #---------------------------------------------------------------------------------------------------------------------
+  file_read:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Reads from the file into a caller-supplied buffer.
+
+      Reads up to `buffer_size` bytes from the file's current position, advancing it by however many were read.
+      Fewer bytes than asked for is normal at the end of the file, and zero means there is nothing left; neither is
+      an error. The file must have been opened with `FILE_FLAG_READ`.
+
+      Use `[[file_read_at]]` to read at an explicit offset instead, which leaves the position alone and so can run
+      on several threads at once.
+    parameters:
+      file:
+        type: file
+        description: The file to read from.
+      buffer:
+        type: void
+        indirection: 1
+        description: A caller-owned buffer of at least `buffer_size` bytes, receiving what was read.
+      buffer_size:
+        type: idx
+        description: The maximum number of bytes to read.
+      bytes_read:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives how many bytes were actually read, which may be fewer than `buffer_size` at the end of the file.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_write:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Writes a caller-supplied buffer to the file.
+
+      Writes up to `buffer_size` bytes at the file's current position, advancing it by however many were written.
+      The file must have been opened with `FILE_FLAG_WRITE` or `FILE_FLAG_APPEND`. Writes may be buffered; use
+      `[[file_sync]]` to force them out.
+
+      Use `[[file_write_at]]` to write at an explicit offset instead, which leaves the position alone and so can run
+      on several threads at once.
+    parameters:
+      file:
+        type: file
+        description: The file to write to.
+      buffer:
+        type: void
+        const: true
+        indirection: 1
+        description: A caller-owned buffer of at least `buffer_size` bytes, holding what to write.
+      buffer_size:
+        type: idx
+        description: The number of bytes to write.
+      bytes_written:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives how many bytes were actually written.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_read_at:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Reads from a fixed offset, without moving the file's position.
+
+      Reads exactly `buffer_size` bytes starting at `location`. Unlike `[[file_read]]`, a short read is an error
+      rather than a result: reaching the end of the file before `buffer_size` bytes fails, so there is no count to
+      report back. The file's read/write position is untouched, which is what makes this safe to call from several
+      threads at once -- provided the file was opened with `FILE_FLAG_PARALLEL_ACCESS`.
+
+      The file must have been opened with `FILE_FLAG_READ`.
+    parameters:
+      file:
+        type: file
+        description: The file to read from.
+      buffer:
+        type: void
+        indirection: 1
+        description: A caller-owned buffer of at least `buffer_size` bytes, receiving what was read.
+      buffer_size:
+        type: idx
+        description: The number of bytes to read. All of them are read, or the call fails.
+      location:
+        type: idx
+        description: The absolute byte offset to read from, measured from the start of the file.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_write_at:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Writes at a fixed offset, without moving the file's position.
+
+      Writes exactly `buffer_size` bytes starting at `location`, extending the file when the offset is past its end.
+      Unlike `[[file_write]]` there is no count to report back: all of the bytes are written, or the call fails. The
+      file's read/write position is untouched, which is what makes this safe to call from several threads at once --
+      provided the file was opened with `FILE_FLAG_PARALLEL_ACCESS`, and that the threads write disjoint ranges.
+
+      The file must have been opened with `FILE_FLAG_WRITE`. Writes may be buffered; use `[[file_sync]]` to force
+      them out.
+    parameters:
+      file:
+        type: file
+        description: The file to write to.
+      buffer:
+        type: void
+        const: true
+        indirection: 1
+        description: A caller-owned buffer of at least `buffer_size` bytes, holding what to write.
+      buffer_size:
+        type: idx
+        description: The number of bytes to write. All of them are written, or the call fails.
+      location:
+        type: idx
+        description: The absolute byte offset to write at, measured from the start of the file.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_tell:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: Returns the file's current read/write position, as a byte offset from the start of the file.
+    parameters:
+      file:
+        type: file
+        description: The file to query.
+      position:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the current position, as a byte offset from the start of the file.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_size:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: Returns the total size of the file in bytes.
+    parameters:
+      file:
+        type: file
+        description: The file to query.
+      size:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the total size of the file in bytes.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_seek:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Moves the file's read/write position.
+
+      Sets the position to an absolute byte offset from the start of the file; subsequent reads and writes start
+      there. Seeking past the end is allowed, and reading from there yields nothing.
+    parameters:
+      file:
+        type: file
+        description: The file to seek within.
+      position:
+        type: idx
+        description: The absolute byte offset to seek to, measured from the start of the file.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_sync:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Flushes buffered writes to persistent storage.
+
+      Forces anything still buffered out to storage, which is what makes writes durable across a crash or a
+      process exit. Closing or destroying the handle flushes as well.
+    parameters:
+      file:
+        type: file
+        description: The file to synchronize.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  file_close:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Closes the file without destroying the handle.
+
+      Releases the operating-system resources behind the file, such as its descriptor. The handle itself stays
+      valid and must still be destroyed with `[[file_destroy]]`, but it can no longer read, write or seek.
+    parameters:
+      file:
+        type: file
+        description: The file to close.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destroy
+  #---------------------------------------------------------------------------------------------------------------------
+  file_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Destroys the file, closing it if it is still open.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+      double-destruction.
+    parameters:
+      file:
+        type: file
+        description: The file to destroy.
+        indirection: 1
+    return_type: ERROR

--- a/api_spec/v2/function/cast.yaml
+++ b/api_spec/v2/function/cast.yaml
@@ -1,0 +1,399 @@
+module: cast
+#
+# Cast functions convert values of one logical type into another. A cast is
+# registered for a (source type, target type) pair rather than by name, and is
+# reached from SQL through CAST / TRY_CAST -- and, when it declares an implicit
+# cast cost, through the binder resolving argument types on its own.
+#
+# The single exec callback is handed an input vector, an output vector and a
+# row count, and converts a whole batch at a time. Whether a per-row conversion
+# failure aborts the query or turns into a NULL is decided by the cast mode,
+# which the callback reads with `[[cast_function_exec_get_mode]]`.
+#
+# Casts are typically registered alongside a custom type: see
+# `[[custom_type_register]]` for how a name is bound to a base type.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Enums
+#-----------------------------------------------------------------------------------------------------------------------
+enums:
+  CAST_MODE:
+    description: |
+      The mode a cast is being executed in. A normal cast must either succeed
+      for every row or report an error, which aborts the query. A "try" cast
+      (SQL TRY_CAST, and implicit casts the engine probes speculatively)
+      tolerates per-row failures: the callback writes NULL for the rows it
+      could not convert instead of aborting. Read with
+      `[[cast_function_exec_get_mode]]`.
+    values:
+      CAST_MODE_NORMAL:
+        value: 0
+        description: A regular cast. A conversion failure reported through the error slot aborts the query.
+      CAST_MODE_TRY:
+        value: 1
+        description: A "try" cast. Conversion failures should be written as NULLs into the output vector; an error reported through the slot is swallowed and the affected rows are left NULL.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  cast_function:
+    description: |
+      An owned opaque handle to a cast function being built. Created with `[[cast_function_create_with_connection]]`
+      or `[[cast_function_create_with_extension]]`, configured with the setter functions (e.g.
+      `[[cast_function_set_source_type]]`, `[[cast_function_set_exec_callback]]`, etc.), made available with
+      `[[cast_function_register]]`, and destroyed with `[[cast_function_destroy]]`.
+
+  cast_function_exec_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a cast function during the execution "exec" phase.
+      The "exec" callback receives this handle and can use it to access the input vector, the output vector to
+      write into, the number of rows to convert, and the mode the cast is running in.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Callbacks
+#-----------------------------------------------------------------------------------------------------------------------
+callbacks:
+  cast_function_exec_callback:
+    parameters:
+      info:
+        type: cast_function_exec_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Constructors
+  #---------------------------------------------------------------------------------------------------------------------
+  cast_function_create_with_connection:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a new cast function that will be registered on the connection's database.
+
+      The function starts out empty: configure it with the setter functions (e.g.
+      `[[cast_function_set_source_type]]`, `[[cast_function_set_exec_callback]]`, etc.), then make it available
+      with `[[cast_function_register]]`. The caller owns the returned handle and must destroy it with
+      `[[cast_function_destroy]]`, also after registration.
+    parameters:
+      connection:
+        type: connection
+        description: The connection to create the function in.
+      function:
+        type: cast_function
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created cast function. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_create_with_extension:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a new cast function that will be registered on the loading extension's database.
+
+      Use this from an extension load callback, where an extension handle is available. The function starts out
+      empty: configure it with the setter functions (e.g. `[[cast_function_set_source_type]]`,
+      `[[cast_function_set_exec_callback]]`, etc.), then make it available with `[[cast_function_register]]`.
+      The caller owns the returned handle and must destroy it with `[[cast_function_destroy]]`, also after
+      registration.
+    parameters:
+      extension:
+        type: extension
+        description: The extension to create the function in.
+      function:
+        type: cast_function
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created cast function. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Properties
+  #---------------------------------------------------------------------------------------------------------------------
+  cast_function_set_source_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets the type the cast converts from.
+
+      The type is borrowed and copied. Calling this again replaces the previous source type. A source type must
+      be set before registration, and it must be a fully defined concrete type.
+    parameters:
+      function:
+        type: cast_function
+        description: The function to set the source type of.
+      source_type:
+        type: logical_type
+        description: The type to cast from. Borrowed for the call only.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_set_target_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets the type the cast converts to.
+
+      The type is borrowed and copied. Calling this again replaces the previous target type. A target type must
+      be set before registration, and it must be a fully defined concrete type.
+    parameters:
+      function:
+        type: cast_function
+        description: The function to set the target type of.
+      target_type:
+        type: logical_type
+        description: The type to cast to. Borrowed for the call only.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_set_implicit_cast_cost:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets what it costs to apply this cast implicitly.
+
+      The binder uses the cost to choose between candidate implicit casts: a lower non-negative cost makes the
+      cast more likely to be picked, a higher one less likely. Built-in widening casts sit in the [0, 20] range,
+      so a cost above 100 effectively puts this cast last. A negative cost -- the default -- means the cast is
+      never applied implicitly and is reached only through an explicit CAST or TRY_CAST.
+    parameters:
+      function:
+        type: cast_function
+        description: The function to set the implicit cast cost of.
+      cost:
+        type: i64
+        description: The cost. Negative disables implicit casting.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_set_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets arbitrary user data on the cast function.
+
+      Associates an opaque pointer with the function, retrievable from the exec callback via
+      `[[cast_function_exec_get_user_data]]`. The opaque handle bundles the pointer with an optional destructor,
+      invoked when the data is no longer needed. The data is read-only during execution: the same pointer is
+      shared by every thread running the cast.
+    parameters:
+      function:
+        type: cast_function
+        description: The function to set the user data of.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the user data pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_set_exec_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets the exec callback of the cast function.
+
+      The exec callback implements the conversion: it is invoked during query execution with a batch of input
+      values and must fill the output vector. An exec callback must be set before registration.
+    parameters:
+      function:
+        type: cast_function
+        description: The function to set the exec callback of.
+      callback:
+        type: cast_function_exec_callback
+        description: The exec callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Exec Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  cast_function_exec_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: Retrieves the user data set via `[[cast_function_set_user_data]]`.
+    parameters:
+      info:
+        type: cast_function_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_exec_get_row_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Returns how many rows this execution must convert.
+
+      The number of rows held by the input vector, and the number of entries the callback must write to the
+      output vector. Note that this may be less than a full vector: a constant input is converted as a single
+      row and the result is expanded by the engine.
+    parameters:
+      info:
+        type: cast_function_exec_info
+        description: The exec info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of rows.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_exec_get_input:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Retrieves the input vector holding the values to convert.
+
+      The vector holds the source type's values for the current batch; use `[[cast_function_exec_get_row_count]]`
+      for the number of rows. Borrowed; valid only for the duration of the callback.
+    parameters:
+      info:
+        type: cast_function_exec_info
+        description: The exec info handle.
+      vector:
+        type: vector
+        indirection: 1
+        kind: OUT
+        description: Receives the borrowed input vector.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_exec_get_output:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Retrieves the output vector the exec callback must write into.
+
+      The callback must write one entry per input row; use `[[cast_function_exec_get_row_count]]` for the number
+      of rows. Borrowed; valid only for the duration of the callback.
+    parameters:
+      info:
+        type: cast_function_exec_info
+        description: The exec info handle.
+      vector:
+        type: vector
+        indirection: 1
+        kind: OUT
+        description: Receives the borrowed output vector to write into.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  cast_function_exec_get_mode:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Returns the mode the cast is being executed in.
+
+      In `CAST_MODE_TRY` a conversion failure should be written as a NULL into the output vector rather than
+      reported through the error slot, since the engine discards the error and keeps whatever the callback left
+      in the output.
+    parameters:
+      info:
+        type: cast_function_exec_info
+        description: The exec info handle.
+      mode:
+        type: CAST_MODE
+        indirection: 1
+        kind: OUT
+        description: Receives the cast mode.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Register
+  #---------------------------------------------------------------------------------------------------------------------
+  cast_function_register:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Registers the cast function, making it available to CAST and TRY_CAST.
+
+      The function is registered on the target given at creation: the connection's database or the loading
+      extension. Registration requires a source type, a target type and an exec callback; both types must be
+      fully defined concrete types. Registering a cast for a pair that already has one replaces it. The caller
+      still owns the handle after registration and must destroy it with `[[cast_function_destroy]]`, which does
+      not affect the registered function.
+    parameters:
+      function:
+        type: cast_function
+        description: The function to register.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destroy
+  #---------------------------------------------------------------------------------------------------------------------
+  cast_function_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Destroys the cast function, releasing its resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to
+      prevent double-destruction. Destroying the handle after registration does not affect the registered
+      function.
+    parameters:
+      function:
+        type: cast_function
+        description: The function to destroy.
+        indirection: 1
+    return_type: ERROR

--- a/api_spec/v2/function/copy.yaml
+++ b/api_spec/v2/function/copy.yaml
@@ -5,52 +5,88 @@ module: copy
 handles:
   copy_function:
     description: |
-      An owned opaque handle to a custom copy function being built. Created with
-      `[[copy_function_create_with_connection]]` or `[[copy_function_create_with_extension]]`, configured with the
-      setter functions (e.g. `[[copy_function_set_name]]`, `[[copy_function_set_batch_callback]]`, etc.), made
+      An owned opaque handle to a custom copy function being built: an output format for `COPY ... TO`, an input
+      format for `COPY ... FROM`, or both. Created with `[[copy_function_create_with_connection]]` or
+      `[[copy_function_create_with_extension]]`, configured with the setter functions (e.g.
+      `[[copy_function_set_name]]`, `[[copy_to_set_batch_callback]]`, `[[copy_from_set_exec_callback]]`, etc.), made
       available with `[[copy_function_register]]`, and destroyed with `[[copy_function_destroy]]`.
 
-  copy_function_bind_info:
+  copy_to_bind_info:
     description: |
-      A borrowed opaque handle to the arguments supplied to a copy function during the query preparation "bind"
-      phase. The "bind" callback receives this handle and can use it to e.g. inspect the names and types of the
-      columns being copied and initialize some constant state.
+      A borrowed opaque handle to the arguments supplied to a copy function during the query preparation "bind" phase
+      of a `COPY ... TO` statement. The "bind" callback receives this handle and can use it to e.g. inspect the names
+      and types of the columns being written, read the statement's options and initialize some constant state.
 
-  copy_function_init_info:
+  copy_to_batch_size_info:
     description: |
-      A borrowed opaque handle to the arguments supplied to a copy function during the per-file "init" phase. The
-      "init" callback receives this handle and can use it to e.g. read the path of the file being written and set
-      up the state shared by every batch written to that file.
+      A borrowed opaque handle to the arguments supplied to a copy function during the "batch size" phase of a
+      `COPY ... TO` statement. The "batch size" callback receives this handle and must use it to report how many rows
+      a batch should carry.
 
-  copy_function_batch_info:
+  copy_to_init_info:
     description: |
-      A borrowed opaque handle to the arguments supplied to a copy function during the "batch" phase. The "batch"
-      callback receives this handle and can use it to take ownership of the rows of the batch and to set the
-      prepared form of the batch handed to the "flush" callback.
+      A borrowed opaque handle to the arguments supplied to a copy function during the per-file "init" phase of a
+      `COPY ... TO` statement. The "init" callback receives this handle and can use it to e.g. read the path of the
+      file being written and set up the state shared by every batch written to that file.
 
-  copy_function_flush_info:
+  copy_to_batch_info:
     description: |
-      A borrowed opaque handle to the arguments supplied to a copy function during the "flush" phase. The "flush"
-      callback receives this handle and can use it to access the prepared batch and write it to the output.
+      A borrowed opaque handle to the arguments supplied to a copy function during the "batch" phase of a
+      `COPY ... TO` statement. The "batch" callback receives this handle and can use it to take ownership of the rows
+      of the batch and to set the prepared form of the batch handed to the "flush" callback.
 
-  copy_function_batch_size_info:
+  copy_to_flush_info:
     description: |
-      A borrowed opaque handle to the arguments supplied to a copy function during the "batch size" phase. The
-      "batch size" callback receives this handle and must use it to report how many rows a batch should carry.
+      A borrowed opaque handle to the arguments supplied to a copy function during the "flush" phase of a
+      `COPY ... TO` statement. The "flush" callback receives this handle and can use it to access the prepared batch
+      and write it to the output.
 
-  copy_function_finalize_info:
+  copy_to_finalize_info:
     description: |
-      A borrowed opaque handle to the arguments supplied to a copy function during the per-file "finalize" phase.
-      The "finalize" callback receives this handle and can use it to e.g. close the file after every batch has been
-      flushed to it.
+      A borrowed opaque handle to the arguments supplied to a copy function during the per-file "finalize" phase of a
+      `COPY ... TO` statement. The "finalize" callback receives this handle and can use it to e.g. close the file
+      after every batch has been flushed to it.
+
+  copy_from_bind_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the query preparation "bind" phase
+      of a `COPY ... FROM` statement. The "bind" callback receives this handle and can use it to e.g. read the path of
+      the file to read, inspect the names and types of the columns the target table expects, read the statement's
+      options, hint at the number of rows the read will produce and initialize some constant state.
+
+  copy_from_init_global_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the global state initialization
+      "init global" phase of a `COPY ... FROM` statement. The "init global" callback receives this handle and can use
+      it to e.g. set up the state shared by every thread reading the file, and to declare how many threads may read
+      it.
+
+  copy_from_init_local_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the local state initialization
+      "init local" phase of a `COPY ... FROM` statement. The "init local" callback receives this handle and can use it
+      to e.g. set up worker-local state, typically by claiming work from the shared global state.
+
+  copy_from_exec_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the execution "exec" phase of a
+      `COPY ... FROM` statement. The "exec" callback receives this handle and can use it to e.g. access the global and
+      local state and write the next batch of rows to the output chunk.
+
+  copy_from_progress_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the "progress" phase of a
+      `COPY ... FROM` statement. The "progress" callback receives this handle and can use it to report how far the read
+      has advanced.
+
 #-----------------------------------------------------------------------------------------------------------------------
 # Callbacks
 #-----------------------------------------------------------------------------------------------------------------------
 callbacks:
-  copy_function_bind_callback:
+  copy_to_bind_callback:
     parameters:
       info:
-        type: copy_function_bind_info
+        type: copy_to_bind_info
         description: Borrowed opaque handle providing access to the information available to the callback.
       context:
         type: context
@@ -61,10 +97,10 @@ callbacks:
         description: Borrowed error info handle to use to report errors that occur during the callback.
     return_type: void
 
-  copy_function_init_callback:
+  copy_to_batch_size_callback:
     parameters:
       info:
-        type: copy_function_init_info
+        type: copy_to_batch_size_info
         description: Borrowed opaque handle providing access to the information available to the callback.
       context:
         type: context
@@ -75,10 +111,10 @@ callbacks:
         description: Borrowed error info handle to use to report errors that occur during the callback.
     return_type: void
 
-  copy_function_batch_callback:
+  copy_to_init_callback:
     parameters:
       info:
-        type: copy_function_batch_info
+        type: copy_to_init_info
         description: Borrowed opaque handle providing access to the information available to the callback.
       context:
         type: context
@@ -89,10 +125,10 @@ callbacks:
         description: Borrowed error info handle to use to report errors that occur during the callback.
     return_type: void
 
-  copy_function_flush_callback:
+  copy_to_batch_callback:
     parameters:
       info:
-        type: copy_function_flush_info
+        type: copy_to_batch_info
         description: Borrowed opaque handle providing access to the information available to the callback.
       context:
         type: context
@@ -103,10 +139,10 @@ callbacks:
         description: Borrowed error info handle to use to report errors that occur during the callback.
     return_type: void
 
-  copy_function_batch_size_callback:
+  copy_to_flush_callback:
     parameters:
       info:
-        type: copy_function_batch_size_info
+        type: copy_to_flush_info
         description: Borrowed opaque handle providing access to the information available to the callback.
       context:
         type: context
@@ -117,10 +153,10 @@ callbacks:
         description: Borrowed error info handle to use to report errors that occur during the callback.
     return_type: void
 
-  copy_function_finalize_callback:
+  copy_to_finalize_callback:
     parameters:
       info:
-        type: copy_function_finalize_info
+        type: copy_to_finalize_info
         description: Borrowed opaque handle providing access to the information available to the callback.
       context:
         type: context
@@ -130,6 +166,77 @@ callbacks:
         indirection: 1
         description: Borrowed error info handle to use to report errors that occur during the callback.
     return_type: void
+
+  copy_from_bind_callback:
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_from_init_global_callback:
+    parameters:
+      info:
+        type: copy_from_init_global_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_from_init_local_callback:
+    parameters:
+      info:
+        type: copy_from_init_local_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_from_exec_callback:
+    parameters:
+      info:
+        type: copy_from_exec_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_from_progress_callback:
+    parameters:
+      info:
+        type: copy_from_progress_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
 #-----------------------------------------------------------------------------------------------------------------------
 # Functions
 #-----------------------------------------------------------------------------------------------------------------------
@@ -143,10 +250,11 @@ functions:
     description: |
       Creates a new copy function that will be registered on the connection's database.
 
-      A copy function implements an output format for `COPY ... TO`: once registered, SQL reaches it with
-      `COPY ... TO 'path' (FORMAT name)`. The function starts out empty: configure it with the setter functions
-      (e.g. `[[copy_function_set_name]]`, `[[copy_function_set_batch_callback]]`, etc.), then make it available
-      with `[[copy_function_register]]`. The caller owns the returned handle and must destroy it with
+      A copy function implements a file format for `COPY`: once registered, SQL reaches it with
+      `COPY ... TO 'path' (FORMAT name)` and `COPY table FROM 'path' (FORMAT name)`. The function starts out
+      empty: configure it with the setter functions (e.g. `[[copy_function_set_name]]`, the `copy_to_set_*` callbacks
+      for writing, the `copy_from_set_*` callbacks for reading, or both), then make it available with
+      `[[copy_function_register]]`. The caller owns the returned handle and must destroy it with
       `[[copy_function_destroy]]`, also after registration.
     parameters:
       connection:
@@ -169,11 +277,12 @@ functions:
     description: |
       Creates a new copy function that will be registered on the loading extension's database.
 
-      Use this from an extension load callback, where an extension handle is available. The function starts out
-      empty: configure it with the setter functions (e.g. `[[copy_function_set_name]]`,
-      `[[copy_function_set_batch_callback]]`, etc.), then make it available with `[[copy_function_register]]`.
-      The caller owns the returned handle and must destroy it with `[[copy_function_destroy]]`, also after
-      registration.
+      A copy function implements a file format for `COPY`: once registered, SQL reaches it with
+      `COPY ... TO 'path' (FORMAT name)` and `COPY table FROM 'path' (FORMAT name)`. Use this from an extension load callback, where an extension handle is available. The function starts out
+      empty: configure it with the setter functions (e.g. `[[copy_function_set_name]]`, the `copy_to_set_*` callbacks
+      for writing, the `copy_from_set_*` callbacks for reading, or both), then make it available with
+      `[[copy_function_register]]`. The caller owns the returned handle and must destroy it with
+      `[[copy_function_destroy]]`, also after registration.
     parameters:
       extension:
         type: extension
@@ -198,8 +307,9 @@ functions:
     description: |
       Sets the name of the copy function.
 
-      The name is the format SQL selects the function with: `COPY ... TO 'path' (FORMAT name)`. It is borrowed and
-      copied. Calling this again replaces the previous name. A name must be set before registration.
+      The name is the format SQL selects the function with: `COPY ... TO 'path' (FORMAT name)` or
+      `COPY table FROM 'path' (FORMAT name)`. It is borrowed and copied. Calling this again replaces the previous
+      name. A name must be set before registration.
     parameters:
       function:
         type: copy_function
@@ -220,9 +330,9 @@ functions:
     description: |
       Sets arbitrary user data on the copy function.
 
-      Associates an opaque pointer with the function, retrievable from each callback via its user data accessor
-      (e.g. `[[copy_function_bind_get_user_data]]`, `[[copy_function_batch_get_user_data]]`, etc.). The opaque
-      handle bundles the pointer with an optional destructor, invoked when the data is no longer needed.
+      Associates an opaque pointer with the function, retrievable from each callback of either side via its user data
+      accessor (e.g. `[[copy_to_bind_get_user_data]]`, `[[copy_from_exec_get_user_data]]`, etc.). The opaque handle
+      bundles the pointer with an optional destructor, invoked when the data is no longer needed.
     parameters:
       function:
         type: copy_function
@@ -237,137 +347,140 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_set_batch_size_callback:
+  #---------------------------------------------------------------------------------------------------------------------
+  # COPY TO Callbacks
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_to_set_bind_callback:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Sets the optional batch size callback of the copy function.
+      Sets the optional bind callback of the `COPY ... TO` side.
+
+      The bind callback is invoked during query planning for each `COPY ... TO` statement that uses the function. It
+      can inspect the names and types of the columns being written, read the statement's options and set "bind data"
+      that is shared with the other `COPY ... TO` callbacks.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the callback of.
+      callback:
+        type: copy_to_bind_callback
+        description: The callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_to_set_batch_size_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional batch size callback of the `COPY ... TO` side.
 
       The batch size callback is invoked during query planning, after the bind callback, for each `COPY ... TO`
       statement that does not set `BATCH_SIZE` itself. It must report how many rows a batch should carry via
-      `[[copy_function_batch_size_set_target]]`; the engine then cuts the rows being copied into batches of that
-      size and hands each to the batch callback. Without a batch size from either the statement or the callback, a
-      batch is cut for every chunk of rows sunk, i.e. a vector at a time. A batch may still be smaller than the
-      reported size (the last one of a file, or when `BATCH_SIZE_BYTES` cuts it first).
+      `[[copy_to_batch_size_set_target]]`; the engine then cuts the rows being written into batches of that size and
+      hands each to the batch callback. Without a batch size from either the statement or the callback, a batch is
+      cut for every chunk of rows sunk, i.e. a vector at a time. A batch may still be smaller than the reported size
+      (the last one of a file, or when `BATCH_SIZE_BYTES` cuts it first).
     parameters:
       function:
         type: copy_function
-        description: The function to set the batch size callback of.
+        description: The function to set the callback of.
       callback:
-        type: copy_function_batch_size_callback
-        description: The batch size callback to set.
+        type: copy_to_batch_size_callback
+        description: The callback to set.
       err:
         type: error_info
         indirection: 1
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_set_bind_callback:
+  copy_to_set_init_callback:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Sets the optional bind callback of the copy function.
+      Sets the optional init callback of the `COPY ... TO` side.
 
-      The bind callback is invoked during query planning for each `COPY ... TO` statement that uses the function.
-      It can inspect the names and types of the columns being copied and set "bind data" that is shared with the
-      other callbacks.
+      The init callback is invoked once per output file, before any batch destined for that file is prepared. It can
+      read the path of the file via `[[copy_to_init_get_file_path]]` and set "init data" that is shared with the
+      batch, flush and finalize callbacks of that file. A statement may write several files, e.g. when its output is
+      partitioned; each gets its own init data.
     parameters:
       function:
         type: copy_function
-        description: The function to set the bind callback of.
+        description: The function to set the callback of.
       callback:
-        type: copy_function_bind_callback
-        description: The bind callback to set.
+        type: copy_to_init_callback
+        description: The callback to set.
       err:
         type: error_info
         indirection: 1
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_set_init_callback:
+  copy_to_set_batch_callback:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Sets the optional init callback of the copy function.
+      Sets the batch callback of the `COPY ... TO` side.
 
-      The init callback is invoked once per output file, before any batch destined for that file is prepared. It
-      can read the path of the file via `[[copy_function_init_get_file_path]]`, which is only available here, and
-      set "init data" that is shared with the batch, flush and finalize callbacks of that file. A statement may
-      write several files, e.g. when its output is partitioned; each gets its own init data.
+      The batch callback is invoked during query execution with a batch of the rows being written, taken via
+      `[[copy_to_batch_take_input]]`. It prepares the batch for writing, e.g. by encoding it into the output format,
+      and sets "batch data" via `[[copy_to_batch_set_batch_data]]` that is handed to the flush callback. Batches may
+      be prepared by several threads at once, so the callback must synchronize its own access to the init data. A
+      batch callback must be set for the `COPY ... TO` side to be registered.
     parameters:
       function:
         type: copy_function
-        description: The function to set the init callback of.
+        description: The function to set the callback of.
       callback:
-        type: copy_function_init_callback
-        description: The init callback to set.
+        type: copy_to_batch_callback
+        description: The callback to set.
       err:
         type: error_info
         indirection: 1
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_set_batch_callback:
+  copy_to_set_flush_callback:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Sets the batch callback of the copy function.
-
-      The batch callback is invoked during query execution with a batch of the rows being copied, taken via
-      `[[copy_function_batch_take_input]]`. It prepares the batch for writing, e.g. by encoding it into the output
-      format, and sets "batch data" via `[[copy_function_batch_set_batch_data]]` that is handed to the flush
-      callback. Batches may be prepared by several threads at once, so the callback must synchronize its own
-      access to the init data. A batch callback must be set before registration.
-    parameters:
-      function:
-        type: copy_function
-        description: The function to set the batch callback of.
-      callback:
-        type: copy_function_batch_callback
-        description: The batch callback to set.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  copy_function_set_flush_callback:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: |
-      Sets the flush callback of the copy function.
+      Sets the flush callback of the `COPY ... TO` side.
 
       The flush callback is invoked once per prepared batch to write its batch data, available via
-      `[[copy_function_flush_get_batch_data]]`, to the output. Flushes of the same file never run concurrently.
-      A flush callback must be set before registration.
+      `[[copy_to_flush_get_batch_data]]`, to the output. Flushes of the same file never run concurrently. A flush
+      callback must be set for the `COPY ... TO` side to be registered.
     parameters:
       function:
         type: copy_function
-        description: The function to set the flush callback of.
+        description: The function to set the callback of.
       callback:
-        type: copy_function_flush_callback
-        description: The flush callback to set.
+        type: copy_to_flush_callback
+        description: The callback to set.
       err:
         type: error_info
         indirection: 1
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_set_finalize_callback:
+  copy_to_set_finalize_callback:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Sets the optional finalize callback of the copy function.
+      Sets the optional finalize callback of the `COPY ... TO` side.
 
       The finalize callback is invoked once per output file after the last batch destined for that file has been
       flushed. It can e.g. write a footer and close the file.
     parameters:
       function:
         type: copy_function
-        description: The function to set the finalize callback of.
+        description: The function to set the callback of.
       callback:
-        type: copy_function_finalize_callback
-        description: The finalize callback to set.
+        type: copy_to_finalize_callback
+        description: The callback to set.
       err:
         type: error_info
         indirection: 1
@@ -375,15 +488,15 @@ functions:
     return_type: ERROR
 
   #---------------------------------------------------------------------------------------------------------------------
-  # Bind Callback Functions
+  # COPY TO Bind Callback Functions
   #---------------------------------------------------------------------------------------------------------------------
-  copy_function_bind_get_user_data:
+  copy_to_bind_get_user_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
     parameters:
       info:
-        type: copy_function_bind_info
+        type: copy_to_bind_info
         description: The bind info handle.
       data:
         type: void
@@ -396,18 +509,19 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_bind_set_bind_data:
+  copy_to_bind_set_bind_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
       Sets the function's "bind data" from the bind callback.
 
-      The bind data is stored with the bound statement and retrievable from the other callbacks. The opaque handle
-      bundles the pointer with an optional destructor, invoked when the bind data is no longer needed, and an
-      optional equality callback used when comparing two bound statements; without one, pointer equality is used.
+      The bind data is stored with the bound statement and retrievable from the other callbacks of the same side.
+      The opaque handle bundles the pointer with an optional destructor, invoked when the bind data is no longer
+      needed, and an optional equality callback used when comparing two bound statements; without one, pointer
+      equality is used.
     parameters:
       info:
-        type: copy_function_bind_info
+        type: copy_to_bind_info
         description: The bind info handle.
       data:
         type: opaque
@@ -419,17 +533,40 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_bind_get_column_count:
+  copy_to_bind_get_file_path:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Returns the number of columns being copied.
+      Retrieves the path the `COPY ... TO` statement writes to, as written in the statement.
 
-      This is the number of columns of the rows every batch carries. Valid indices for
-      `[[copy_function_bind_get_column_type]]` and `[[copy_function_bind_get_column_name]]` are [0, count).
+      This is the target before the engine's own rewrites: the path of each file actually being written, e.g. a
+      temporary name or a per-partition path, is only known to the init callback via `[[copy_to_init_get_file_path]]`.
+      The path is borrowed and valid only for the duration of the callback.
     parameters:
       info:
-        type: copy_function_bind_info
+        type: copy_to_bind_info
+        description: The bind info handle.
+      path:
+        type: str
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the file path. Valid only for the duration of the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_to_bind_get_column_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of columns being written, i.e. the columns of the rows every batch carries.
+
+      Valid indices for `[[copy_to_bind_get_column_type]]` and `[[copy_to_bind_get_column_name]]` are [0, count).
+    parameters:
+      info:
+        type: copy_to_bind_info
         description: The bind info handle.
       count:
         type: idx
@@ -442,7 +579,7 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_bind_get_column_type:
+  copy_to_bind_get_column_type:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
@@ -452,7 +589,7 @@ functions:
       `[[logical_type_destroy]]`.
     parameters:
       info:
-        type: copy_function_bind_info
+        type: copy_to_bind_info
         description: The bind info handle.
       index:
         type: idx
@@ -468,7 +605,7 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_bind_get_column_name:
+  copy_to_bind_get_column_name:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
@@ -477,7 +614,7 @@ functions:
       Fails if the index is out of bounds. The name is borrowed and valid only for the duration of the callback.
     parameters:
       info:
-        type: copy_function_bind_info
+        type: copy_to_bind_info
         description: The bind info handle.
       index:
         type: idx
@@ -493,16 +630,94 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
+  copy_to_bind_get_option_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of options the `COPY` statement passed to the function.
+
+      The engine's own options (e.g. `USE_TMP_FILE` or `BATCH_SIZE`) are handled before the function sees the
+      statement and are not included. Valid indices for `[[copy_to_bind_get_option_name]]` and `[[copy_to_bind_get_option_value]]` are
+      [0, count). The options are ordered by name.
+    parameters:
+      info:
+        type: copy_to_bind_info
+        description: The bind info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of options.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_to_bind_get_option_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the name of the option at the given index.
+
+      Option names are SQL identifiers, matched case-insensitively. Fails if the index is out of bounds. The name is
+      borrowed and valid only for the duration of the callback.
+    parameters:
+      info:
+        type: copy_to_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the option to get the name of.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the option name. Valid only for the duration of the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_to_bind_get_option_value:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the value of the option at the given index.
+
+      An option written with a single value (e.g. `DELIM ','`) yields that value. An option written as a bare name
+      (e.g. `HEADER`) yields the BOOLEAN `true`. An option written with a parenthesized list (e.g. `KEYS (a, b)`)
+      yields a tuple: an unnamed STRUCT with one field per element, in order. Fails if the index is out of bounds.
+      The returned value is owned by the caller and must be destroyed via `[[value_destroy]]`.
+    parameters:
+      info:
+        type: copy_to_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the option.
+      value:
+        type: value
+        indirection: 1
+        kind: OUT
+        description: Receives the option's value. Owned by the caller; destroy via `[[value_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
   #---------------------------------------------------------------------------------------------------------------------
-  # Batch Size Callback Functions
+  # COPY TO Batch Size Callback Functions
   #---------------------------------------------------------------------------------------------------------------------
-  copy_function_batch_size_get_user_data:
+  copy_to_batch_size_get_user_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
     parameters:
       info:
-        type: copy_function_batch_size_info
+        type: copy_to_batch_size_info
         description: The batch size info handle.
       data:
         type: void
@@ -515,13 +730,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_batch_size_get_bind_data:
+  copy_to_batch_size_get_bind_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: Retrieves the bind data set by the function's bind callback.
+    description: Retrieves the bind data set by the function's `COPY ... TO` bind callback.
     parameters:
       info:
-        type: copy_function_batch_size_info
+        type: copy_to_batch_size_info
         description: The batch size info handle.
       data:
         type: void
@@ -534,7 +749,7 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_batch_size_set_target:
+  copy_to_batch_size_set_target:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
@@ -542,7 +757,7 @@ functions:
       callback must set this to a value greater than 0; the statement fails otherwise.
     parameters:
       info:
-        type: copy_function_batch_size_info
+        type: copy_to_batch_size_info
         description: The batch size info handle.
       rows:
         type: idx
@@ -554,15 +769,15 @@ functions:
     return_type: ERROR
 
   #---------------------------------------------------------------------------------------------------------------------
-  # Init Callback Functions
+  # COPY TO Init Callback Functions
   #---------------------------------------------------------------------------------------------------------------------
-  copy_function_init_get_user_data:
+  copy_to_init_get_user_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
     parameters:
       info:
-        type: copy_function_init_info
+        type: copy_to_init_info
         description: The init info handle.
       data:
         type: void
@@ -575,13 +790,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_init_get_bind_data:
+  copy_to_init_get_bind_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: Retrieves the bind data set by the function's bind callback.
+    description: Retrieves the bind data set by the function's `COPY ... TO` bind callback.
     parameters:
       info:
-        type: copy_function_init_info
+        type: copy_to_init_info
         description: The init info handle.
       data:
         type: void
@@ -594,18 +809,18 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_init_get_file_path:
+  copy_to_init_get_file_path:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
       Retrieves the path of the file the init callback is preparing.
 
-      This is the path the batches of this file are to be written to, after the engine has applied its own
-      rewrites (e.g. a temporary name while the file is being written, or a per-partition path). The path is
-      borrowed and valid only for the duration of the callback.
+      This is the path the batches of this file are to be written to, after the engine has applied its own rewrites
+      (e.g. a temporary name while the file is being written, or a per-partition path). The path is borrowed and
+      valid only for the duration of the callback.
     parameters:
       info:
-        type: copy_function_init_info
+        type: copy_to_init_info
         description: The init info handle.
       path:
         type: str
@@ -618,7 +833,7 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_init_set_init_data:
+  copy_to_init_set_init_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
@@ -630,7 +845,7 @@ functions:
       optional destructor, invoked when the file is done with the data.
     parameters:
       info:
-        type: copy_function_init_info
+        type: copy_to_init_info
         description: The init info handle.
       data:
         type: opaque
@@ -643,15 +858,15 @@ functions:
     return_type: ERROR
 
   #---------------------------------------------------------------------------------------------------------------------
-  # Batch Callback Functions
+  # COPY TO Batch Callback Functions
   #---------------------------------------------------------------------------------------------------------------------
-  copy_function_batch_get_user_data:
+  copy_to_batch_get_user_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
     parameters:
       info:
-        type: copy_function_batch_info
+        type: copy_to_batch_info
         description: The batch info handle.
       data:
         type: void
@@ -664,13 +879,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_batch_get_bind_data:
+  copy_to_batch_get_bind_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: Retrieves the bind data set by the function's bind callback.
+    description: Retrieves the bind data set by the function's `COPY ... TO` bind callback.
     parameters:
       info:
-        type: copy_function_batch_info
+        type: copy_to_batch_info
         description: The batch info handle.
       data:
         type: void
@@ -683,13 +898,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_batch_get_init_data:
+  copy_to_batch_get_init_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: Retrieves the init data set by the function's init callback for the file this batch belongs to.
+    description: Retrieves the init data set by the function's `COPY ... TO` init callback for the file this batch belongs to.
     parameters:
       info:
-        type: copy_function_batch_info
+        type: copy_to_batch_info
         description: The batch info handle.
       data:
         type: void
@@ -702,20 +917,20 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_batch_take_input:
+  copy_to_batch_take_input:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
       Takes ownership of the rows of the batch to prepare.
 
-      The collection holds one column per column reported by `[[copy_function_bind_get_column_count]]`, in the
-      same order, and can be scanned with `[[column_data_collection_scan]]`. The batch can only be taken once:
-      a second call fails. Once taken, the caller owns the collection and must destroy it via
-      `[[column_data_collection_destroy]]`, e.g. by keeping it as the batch data with that destructor. A batch
-      that is never taken is destroyed when the callback returns.
+      The collection holds one column per column reported by `[[copy_to_bind_get_column_count]]`, in the same order,
+      and can be scanned with `[[column_data_collection_scan]]`. The batch can only be taken once: a second call
+      fails. Once taken, the caller owns the collection and must destroy it via `[[column_data_collection_destroy]]`,
+      e.g. by keeping it as the batch data with that destructor. A batch that is never taken is destroyed when the
+      callback returns.
     parameters:
       info:
-        type: copy_function_batch_info
+        type: copy_to_batch_info
         description: The batch info handle.
       collection:
         type: column_data_collection
@@ -728,18 +943,18 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_batch_set_batch_data:
+  copy_to_batch_set_batch_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
       Sets the prepared "batch data" from the batch callback.
 
       The batch data is the prepared form of the batch and is handed to the flush callback via
-      `[[copy_function_flush_get_batch_data]]`. The opaque handle bundles the pointer with an optional destructor,
-      invoked once the batch has been flushed.
+      `[[copy_to_flush_get_batch_data]]`. The opaque handle bundles the pointer with an optional destructor, invoked
+      once the batch has been flushed.
     parameters:
       info:
-        type: copy_function_batch_info
+        type: copy_to_batch_info
         description: The batch info handle.
       data:
         type: opaque
@@ -752,15 +967,15 @@ functions:
     return_type: ERROR
 
   #---------------------------------------------------------------------------------------------------------------------
-  # Flush Callback Functions
+  # COPY TO Flush Callback Functions
   #---------------------------------------------------------------------------------------------------------------------
-  copy_function_flush_get_user_data:
+  copy_to_flush_get_user_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
     parameters:
       info:
-        type: copy_function_flush_info
+        type: copy_to_flush_info
         description: The flush info handle.
       data:
         type: void
@@ -773,13 +988,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_flush_get_bind_data:
+  copy_to_flush_get_bind_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: Retrieves the bind data set by the function's bind callback.
+    description: Retrieves the bind data set by the function's `COPY ... TO` bind callback.
     parameters:
       info:
-        type: copy_function_flush_info
+        type: copy_to_flush_info
         description: The flush info handle.
       data:
         type: void
@@ -792,13 +1007,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_flush_get_init_data:
+  copy_to_flush_get_init_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: Retrieves the init data set by the function's init callback for the file this batch belongs to.
+    description: Retrieves the init data set by the function's `COPY ... TO` init callback for the file this batch belongs to.
     parameters:
       info:
-        type: copy_function_flush_info
+        type: copy_to_flush_info
         description: The flush info handle.
       data:
         type: void
@@ -811,13 +1026,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_flush_get_batch_data:
+  copy_to_flush_get_batch_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: Retrieves the batch data set by the function's batch callback for the batch being flushed.
     parameters:
       info:
-        type: copy_function_flush_info
+        type: copy_to_flush_info
         description: The flush info handle.
       data:
         type: void
@@ -831,15 +1046,15 @@ functions:
     return_type: ERROR
 
   #---------------------------------------------------------------------------------------------------------------------
-  # Finalize Callback Functions
+  # COPY TO Finalize Callback Functions
   #---------------------------------------------------------------------------------------------------------------------
-  copy_function_finalize_get_user_data:
+  copy_to_finalize_get_user_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
     parameters:
       info:
-        type: copy_function_finalize_info
+        type: copy_to_finalize_info
         description: The finalize info handle.
       data:
         type: void
@@ -852,13 +1067,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_finalize_get_bind_data:
+  copy_to_finalize_get_bind_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: Retrieves the bind data set by the function's bind callback.
+    description: Retrieves the bind data set by the function's `COPY ... TO` bind callback.
     parameters:
       info:
-        type: copy_function_finalize_info
+        type: copy_to_finalize_info
         description: The finalize info handle.
       data:
         type: void
@@ -871,13 +1086,13 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  copy_function_finalize_get_init_data:
+  copy_to_finalize_get_init_data:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
-    description: Retrieves the init data set by the function's init callback for the file being finalized.
+    description: Retrieves the init data set by the function's `COPY ... TO` init callback for the file being finalized.
     parameters:
       info:
-        type: copy_function_finalize_info
+        type: copy_to_finalize_info
         description: The finalize info handle.
       data:
         type: void
@@ -891,18 +1106,744 @@ functions:
     return_type: ERROR
 
   #---------------------------------------------------------------------------------------------------------------------
+  # COPY FROM Callbacks
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_from_set_bind_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the bind callback of the `COPY ... FROM` side.
+
+      The bind callback is invoked during query planning for each `COPY ... FROM` statement that uses the function.
+      It can read the path of the file to read and the statement's options, inspect the names and types of the
+      columns the target table expects, hint at the number of rows the read will produce, and set "bind data" that is
+      shared with the other `COPY ... FROM` callbacks. The columns are fixed by the target table: the function must
+      produce them as they are. A bind callback must be set for the `COPY ... FROM` side to be registered.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the callback of.
+      callback:
+        type: copy_from_bind_callback
+        description: The callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_set_init_global_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional global init callback of the `COPY ... FROM` side.
+
+      The global init callback is invoked once per statement, at the start of execution. It can set "global state"
+      shared by every thread reading the file, and declare how many threads may read it in parallel via
+      `[[copy_from_init_global_set_max_threads]]`.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the callback of.
+      callback:
+        type: copy_from_init_global_callback
+        description: The callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_set_init_local_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional local init callback of the `COPY ... FROM` side.
+
+      The local init callback is invoked once per thread that will read the file. It can set worker-local "local
+      state", retrievable from the exec callback, typically derived from the shared global state.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the callback of.
+      callback:
+        type: copy_from_init_local_callback
+        description: The callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_set_exec_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the exec callback of the `COPY ... FROM` side.
+
+      The exec callback implements the read: it is invoked repeatedly during query execution and writes the next
+      batch of rows to the output chunk, until it produces an empty batch to signal the end of the read. An exec
+      callback must be set for the `COPY ... FROM` side to be registered.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the callback of.
+      callback:
+        type: copy_from_exec_callback
+        description: The callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_set_progress_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional progress callback of the `COPY ... FROM` side.
+
+      The progress callback is invoked on demand during execution to report how far the read has advanced, which the
+      engine surfaces as the query's progress. It is invoked concurrently with the exec callback, so it must read the
+      global state in a thread-safe way.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the callback of.
+      callback:
+        type: copy_from_progress_callback
+        description: The callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # COPY FROM Bind Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_from_bind_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_set_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the function's "bind data" from the bind callback.
+
+      The bind data is stored with the bound statement and retrievable from the other callbacks of the same side.
+      The opaque handle bundles the pointer with an optional destructor, invoked when the bind data is no longer
+      needed, and an optional equality callback used when comparing two bound statements; without one, pointer
+      equality is used.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the bind data pointer plus optional destructor and equality callbacks.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_get_file_path:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the path the `COPY ... FROM` statement reads from, as written in the statement.
+
+      The engine does not expand globs or check that the file exists; both are left to the function. The path is
+      borrowed and valid only for the duration of the callback.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      path:
+        type: str
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the file path. Valid only for the duration of the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_get_column_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of columns the target table expects, i.e. the columns every batch the exec callback
+      produces must carry, in this order.
+
+      Valid indices for `[[copy_from_bind_get_column_type]]` and `[[copy_from_bind_get_column_name]]` are [0, count).
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of columns.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_get_column_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the type of the column at the given index.
+
+      Fails if the index is out of bounds. The returned type is owned by the caller and must be destroyed via
+      `[[logical_type_destroy]]`.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the column to get the type of.
+      type:
+        type: logical_type
+        indirection: 1
+        kind: OUT
+        description: Receives the column type. Owned by the caller; destroy via `[[logical_type_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_get_column_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the name of the column at the given index.
+
+      Fails if the index is out of bounds. The name is borrowed and valid only for the duration of the callback.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the column to get the name of.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the column name. Valid only for the duration of the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_get_option_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of options the `COPY` statement passed to the function.
+
+      Every option other than `FORMAT` is included. Valid indices for `[[copy_from_bind_get_option_name]]` and `[[copy_from_bind_get_option_value]]` are
+      [0, count). The options are ordered by name.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of options.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_get_option_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the name of the option at the given index.
+
+      Option names are SQL identifiers, matched case-insensitively. Fails if the index is out of bounds. The name is
+      borrowed and valid only for the duration of the callback.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the option to get the name of.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the option name. Valid only for the duration of the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_get_option_value:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the value of the option at the given index.
+
+      An option written with a single value (e.g. `DELIM ','`) yields that value. An option written as a bare name
+      (e.g. `HEADER`) yields the BOOLEAN `true`. An option written with a parenthesized list (e.g. `KEYS (a, b)`)
+      yields a tuple: an unnamed STRUCT with one field per element, in order. Fails if the index is out of bounds.
+      The returned value is owned by the caller and must be destroyed via `[[value_destroy]]`.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the option.
+      value:
+        type: value
+        indirection: 1
+        kind: OUT
+        description: Receives the option's value. Owned by the caller; destroy via `[[value_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_bind_set_cardinality:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Reports the estimated number of rows the read will produce.
+
+      The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error.
+      Without it, the optimizer falls back on its own defaults.
+    parameters:
+      info:
+        type: copy_from_bind_info
+        description: The bind info handle.
+      cardinality:
+        type: idx
+        description: The estimated number of rows.
+      is_exact:
+        type: bool
+        description: Whether the estimate is exact, which also makes it an upper bound on the row count.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # COPY FROM Global Init Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_from_init_global_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_from_init_global_info
+        description: The global init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_init_global_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's `COPY ... FROM` bind callback.
+    parameters:
+      info:
+        type: copy_from_init_global_info
+        description: The global init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_init_global_set_global_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the function's "global state" from the global init callback.
+
+      The global state lives for the duration of the read and is retrievable from the local init, exec and progress
+      callbacks. Every thread reading the file shares it, so the function must synchronize its own access to it. The
+      opaque handle bundles the pointer with an optional destructor, invoked when the read is done with the state.
+    parameters:
+      info:
+        type: copy_from_init_global_info
+        description: The global init info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the global state pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_init_global_set_max_threads:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets how many threads may read the file in parallel.
+
+      Defaults to 1, a single-threaded read. The engine creates at most this many local states, and therefore runs at
+      most this many exec callbacks concurrently. It is an upper bound, not a request: the engine may use fewer
+      threads.
+    parameters:
+      info:
+        type: copy_from_init_global_info
+        description: The global init info handle.
+      max_threads:
+        type: idx
+        description: The maximum number of threads. Must be at least 1.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # COPY FROM Local Init Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_from_init_local_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_from_init_local_info
+        description: The local init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_init_local_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's `COPY ... FROM` bind callback.
+    parameters:
+      info:
+        type: copy_from_init_local_info
+        description: The local init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_init_local_get_global_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the global state set by the function's global init callback.
+
+      Shared with every other thread reading the file; access to it must be synchronized by the function.
+    parameters:
+      info:
+        type: copy_from_init_local_info
+        description: The local init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the global state pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_init_local_set_local_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the function's worker-local "local state" from the local init callback.
+
+      The local state is associated with the executing thread for the duration of the read and retrievable from the
+      exec callback via `[[copy_from_exec_get_local_state]]`. No other thread observes it, so it needs no
+      synchronization. The opaque handle bundles the pointer with an optional destructor, invoked when the local
+      state is no longer needed.
+    parameters:
+      info:
+        type: copy_from_init_local_info
+        description: The local init info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the local state pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # COPY FROM Exec Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_from_exec_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_from_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_exec_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's `COPY ... FROM` bind callback.
+    parameters:
+      info:
+        type: copy_from_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_exec_get_global_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the global state set by the function's global init callback.
+
+      Shared with every other thread reading the file; access to it must be synchronized by the function.
+    parameters:
+      info:
+        type: copy_from_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the global state pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_exec_get_local_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the worker-local local state set by the function's local init callback.
+    parameters:
+      info:
+        type: copy_from_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the local state pointer for the executing thread, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_exec_get_output_chunk:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the output chunk the exec callback must write the next batch of rows into.
+
+      The chunk holds one vector per column reported by `[[copy_from_bind_get_column_count]]`, in the same order;
+      reach them with `[[data_chunk_get_vector]]`. The chunk starts out empty on every invocation: write the rows,
+      then declare how many there are with `[[vector_set_size]]` on the first vector, which the engine takes as the
+      batch's row count and propagates to the other vectors. Producing an empty batch signals the end of the read,
+      after which the callback is not invoked again on that thread. Borrowed; valid only for the duration of the
+      callback.
+    parameters:
+      info:
+        type: copy_from_exec_info
+        description: The exec info handle.
+      chunk:
+        type: data_chunk
+        indirection: 1
+        kind: OUT
+        description: Receives the borrowed output chunk to write into.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # COPY FROM Progress Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_from_progress_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_from_progress_info
+        description: The progress info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_progress_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's `COPY ... FROM` bind callback.
+    parameters:
+      info:
+        type: copy_from_progress_info
+        description: The progress info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_progress_get_global_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the global state set by the function's global init callback.
+
+      The progress callback runs concurrently with the exec callbacks reading the file, so it must read the global
+      state in a thread-safe way.
+    parameters:
+      info:
+        type: copy_from_progress_info
+        description: The progress info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the global state pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_from_progress_set_progress:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Reports how far the read has advanced.
+
+      A fraction between 0.0 (nothing read yet) and 1.0 (done); values outside that range are clamped. A progress
+      callback that returns without calling this reports no progress.
+    parameters:
+      info:
+        type: copy_from_progress_info
+        description: The progress info handle.
+      progress:
+        type: f64
+        description: The fraction of the read that is complete, in [0.0, 1.0].
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
   # Register
   #---------------------------------------------------------------------------------------------------------------------
   copy_function_register:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-03" ]
     description: |
-      Registers the copy function, making it available as a `COPY ... TO` format.
+      Registers the copy function, making it available as a `COPY` format.
 
       The function is registered on the target given at creation: the connection's database or the loading
-      extension. Registration requires a name and the batch and flush callbacks. The caller still owns the handle
-      after registration and must destroy it with `[[copy_function_destroy]]`, which does not affect the registered
-      function.
+      extension. Registration requires a name and at least one configured side: a `COPY ... TO` side needs its batch
+      and flush callbacks, a `COPY ... FROM` side needs its bind and exec callbacks. A statement in a direction the
+      function does not implement fails with an error. The caller still owns the handle after registration and must
+      destroy it with `[[copy_function_destroy]]`, which does not affect the registered function.
     parameters:
       function:
         type: copy_function

--- a/api_spec/v2/function/copy.yaml
+++ b/api_spec/v2/function/copy.yaml
@@ -1,0 +1,933 @@
+module: copy
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  copy_function:
+    description: |
+      An owned opaque handle to a custom copy function being built. Created with
+      `[[copy_function_create_with_connection]]` or `[[copy_function_create_with_extension]]`, configured with the
+      setter functions (e.g. `[[copy_function_set_name]]`, `[[copy_function_set_batch_callback]]`, etc.), made
+      available with `[[copy_function_register]]`, and destroyed with `[[copy_function_destroy]]`.
+
+  copy_function_bind_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the query preparation "bind"
+      phase. The "bind" callback receives this handle and can use it to e.g. inspect the names and types of the
+      columns being copied and initialize some constant state.
+
+  copy_function_init_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the per-file "init" phase. The
+      "init" callback receives this handle and can use it to e.g. read the path of the file being written and set
+      up the state shared by every batch written to that file.
+
+  copy_function_batch_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the "batch" phase. The "batch"
+      callback receives this handle and can use it to take ownership of the rows of the batch and to set the
+      prepared form of the batch handed to the "flush" callback.
+
+  copy_function_flush_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the "flush" phase. The "flush"
+      callback receives this handle and can use it to access the prepared batch and write it to the output.
+
+  copy_function_batch_size_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the "batch size" phase. The
+      "batch size" callback receives this handle and must use it to report how many rows a batch should carry.
+
+  copy_function_finalize_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a copy function during the per-file "finalize" phase.
+      The "finalize" callback receives this handle and can use it to e.g. close the file after every batch has been
+      flushed to it.
+#-----------------------------------------------------------------------------------------------------------------------
+# Callbacks
+#-----------------------------------------------------------------------------------------------------------------------
+callbacks:
+  copy_function_bind_callback:
+    parameters:
+      info:
+        type: copy_function_bind_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_function_init_callback:
+    parameters:
+      info:
+        type: copy_function_init_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_function_batch_callback:
+    parameters:
+      info:
+        type: copy_function_batch_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_function_flush_callback:
+    parameters:
+      info:
+        type: copy_function_flush_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_function_batch_size_callback:
+    parameters:
+      info:
+        type: copy_function_batch_size_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  copy_function_finalize_callback:
+    parameters:
+      info:
+        type: copy_function_finalize_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Constructors
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_create_with_connection:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Creates a new copy function that will be registered on the connection's database.
+
+      A copy function implements an output format for `COPY ... TO`: once registered, SQL reaches it with
+      `COPY ... TO 'path' (FORMAT name)`. The function starts out empty: configure it with the setter functions
+      (e.g. `[[copy_function_set_name]]`, `[[copy_function_set_batch_callback]]`, etc.), then make it available
+      with `[[copy_function_register]]`. The caller owns the returned handle and must destroy it with
+      `[[copy_function_destroy]]`, also after registration.
+    parameters:
+      connection:
+        type: connection
+        description: The connection to create the function in.
+      function:
+        type: copy_function
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created copy function. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_create_with_extension:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Creates a new copy function that will be registered on the loading extension's database.
+
+      Use this from an extension load callback, where an extension handle is available. The function starts out
+      empty: configure it with the setter functions (e.g. `[[copy_function_set_name]]`,
+      `[[copy_function_set_batch_callback]]`, etc.), then make it available with `[[copy_function_register]]`.
+      The caller owns the returned handle and must destroy it with `[[copy_function_destroy]]`, also after
+      registration.
+    parameters:
+      extension:
+        type: extension
+        description: The extension to create the function in.
+      function:
+        type: copy_function
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created copy function. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Properties
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_set_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the name of the copy function.
+
+      The name is the format SQL selects the function with: `COPY ... TO 'path' (FORMAT name)`. It is borrowed and
+      copied. Calling this again replaces the previous name. A name must be set before registration.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the name of.
+      name:
+        type: str
+        indirection: 1
+        description: The name to set. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_set_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets arbitrary user data on the copy function.
+
+      Associates an opaque pointer with the function, retrievable from each callback via its user data accessor
+      (e.g. `[[copy_function_bind_get_user_data]]`, `[[copy_function_batch_get_user_data]]`, etc.). The opaque
+      handle bundles the pointer with an optional destructor, invoked when the data is no longer needed.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the user data of.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the user data pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_set_batch_size_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional batch size callback of the copy function.
+
+      The batch size callback is invoked during query planning, after the bind callback, for each `COPY ... TO`
+      statement that does not set `BATCH_SIZE` itself. It must report how many rows a batch should carry via
+      `[[copy_function_batch_size_set_target]]`; the engine then cuts the rows being copied into batches of that
+      size and hands each to the batch callback. Without a batch size from either the statement or the callback, a
+      batch is cut for every chunk of rows sunk, i.e. a vector at a time. A batch may still be smaller than the
+      reported size (the last one of a file, or when `BATCH_SIZE_BYTES` cuts it first).
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the batch size callback of.
+      callback:
+        type: copy_function_batch_size_callback
+        description: The batch size callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_set_bind_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional bind callback of the copy function.
+
+      The bind callback is invoked during query planning for each `COPY ... TO` statement that uses the function.
+      It can inspect the names and types of the columns being copied and set "bind data" that is shared with the
+      other callbacks.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the bind callback of.
+      callback:
+        type: copy_function_bind_callback
+        description: The bind callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_set_init_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional init callback of the copy function.
+
+      The init callback is invoked once per output file, before any batch destined for that file is prepared. It
+      can read the path of the file via `[[copy_function_init_get_file_path]]`, which is only available here, and
+      set "init data" that is shared with the batch, flush and finalize callbacks of that file. A statement may
+      write several files, e.g. when its output is partitioned; each gets its own init data.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the init callback of.
+      callback:
+        type: copy_function_init_callback
+        description: The init callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_set_batch_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the batch callback of the copy function.
+
+      The batch callback is invoked during query execution with a batch of the rows being copied, taken via
+      `[[copy_function_batch_take_input]]`. It prepares the batch for writing, e.g. by encoding it into the output
+      format, and sets "batch data" via `[[copy_function_batch_set_batch_data]]` that is handed to the flush
+      callback. Batches may be prepared by several threads at once, so the callback must synchronize its own
+      access to the init data. A batch callback must be set before registration.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the batch callback of.
+      callback:
+        type: copy_function_batch_callback
+        description: The batch callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_set_flush_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the flush callback of the copy function.
+
+      The flush callback is invoked once per prepared batch to write its batch data, available via
+      `[[copy_function_flush_get_batch_data]]`, to the output. Flushes of the same file never run concurrently.
+      A flush callback must be set before registration.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the flush callback of.
+      callback:
+        type: copy_function_flush_callback
+        description: The flush callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_set_finalize_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional finalize callback of the copy function.
+
+      The finalize callback is invoked once per output file after the last batch destined for that file has been
+      flushed. It can e.g. write a footer and close the file.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to set the finalize callback of.
+      callback:
+        type: copy_function_finalize_callback
+        description: The finalize callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Bind Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_bind_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_function_bind_info
+        description: The bind info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_bind_set_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the function's "bind data" from the bind callback.
+
+      The bind data is stored with the bound statement and retrievable from the other callbacks. The opaque handle
+      bundles the pointer with an optional destructor, invoked when the bind data is no longer needed, and an
+      optional equality callback used when comparing two bound statements; without one, pointer equality is used.
+    parameters:
+      info:
+        type: copy_function_bind_info
+        description: The bind info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the bind data pointer plus optional destructor and equality callbacks.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_bind_get_column_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of columns being copied.
+
+      This is the number of columns of the rows every batch carries. Valid indices for
+      `[[copy_function_bind_get_column_type]]` and `[[copy_function_bind_get_column_name]]` are [0, count).
+    parameters:
+      info:
+        type: copy_function_bind_info
+        description: The bind info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of columns.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_bind_get_column_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the type of the column at the given index.
+
+      Fails if the index is out of bounds. The returned type is owned by the caller and must be destroyed via
+      `[[logical_type_destroy]]`.
+    parameters:
+      info:
+        type: copy_function_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the column to get the type of.
+      type:
+        type: logical_type
+        indirection: 1
+        kind: OUT
+        description: Receives the column type. Owned by the caller; destroy via `[[logical_type_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_bind_get_column_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the name of the column at the given index.
+
+      Fails if the index is out of bounds. The name is borrowed and valid only for the duration of the callback.
+    parameters:
+      info:
+        type: copy_function_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the column to get the name of.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the column name. Valid only for the duration of the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Batch Size Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_batch_size_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_function_batch_size_info
+        description: The batch size info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_batch_size_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: copy_function_batch_size_info
+        description: The batch size info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_batch_size_set_target:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the number of rows a batch should carry, as the target the engine cuts batches at. The batch size
+      callback must set this to a value greater than 0; the statement fails otherwise.
+    parameters:
+      info:
+        type: copy_function_batch_size_info
+        description: The batch size info handle.
+      rows:
+        type: idx
+        description: The number of rows a batch should carry. Must be greater than 0.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Init Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_init_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_function_init_info
+        description: The init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_init_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: copy_function_init_info
+        description: The init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_init_get_file_path:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the path of the file the init callback is preparing.
+
+      This is the path the batches of this file are to be written to, after the engine has applied its own
+      rewrites (e.g. a temporary name while the file is being written, or a per-partition path). The path is
+      borrowed and valid only for the duration of the callback.
+    parameters:
+      info:
+        type: copy_function_init_info
+        description: The init info handle.
+      path:
+        type: str
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the file path. Valid only for the duration of the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_init_set_init_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the function's "init data" from the init callback.
+
+      The init data lives for the duration of the file being written and is retrievable from the batch, flush and
+      finalize callbacks of that file. Batches may be prepared by several threads at once, so the function must
+      synchronize its own access to it from the batch callback. The opaque handle bundles the pointer with an
+      optional destructor, invoked when the file is done with the data.
+    parameters:
+      info:
+        type: copy_function_init_info
+        description: The init info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the init data pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Batch Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_batch_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_function_batch_info
+        description: The batch info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_batch_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: copy_function_batch_info
+        description: The batch info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_batch_get_init_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the init data set by the function's init callback for the file this batch belongs to.
+    parameters:
+      info:
+        type: copy_function_batch_info
+        description: The batch info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the init data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_batch_take_input:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Takes ownership of the rows of the batch to prepare.
+
+      The collection holds one column per column reported by `[[copy_function_bind_get_column_count]]`, in the
+      same order, and can be scanned with `[[column_data_collection_scan]]`. The batch can only be taken once:
+      a second call fails. Once taken, the caller owns the collection and must destroy it via
+      `[[column_data_collection_destroy]]`, e.g. by keeping it as the batch data with that destructor. A batch
+      that is never taken is destroyed when the callback returns.
+    parameters:
+      info:
+        type: copy_function_batch_info
+        description: The batch info handle.
+      collection:
+        type: column_data_collection
+        indirection: 1
+        kind: OUT
+        description: Receives the collection holding the rows of the batch. Owned by the caller; destroy via `[[column_data_collection_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_batch_set_batch_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the prepared "batch data" from the batch callback.
+
+      The batch data is the prepared form of the batch and is handed to the flush callback via
+      `[[copy_function_flush_get_batch_data]]`. The opaque handle bundles the pointer with an optional destructor,
+      invoked once the batch has been flushed.
+    parameters:
+      info:
+        type: copy_function_batch_info
+        description: The batch info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the batch data pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Flush Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_flush_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_function_flush_info
+        description: The flush info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_flush_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: copy_function_flush_info
+        description: The flush info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_flush_get_init_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the init data set by the function's init callback for the file this batch belongs to.
+    parameters:
+      info:
+        type: copy_function_flush_info
+        description: The flush info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the init data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_flush_get_batch_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the batch data set by the function's batch callback for the batch being flushed.
+    parameters:
+      info:
+        type: copy_function_flush_info
+        description: The flush info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the batch data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Finalize Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_finalize_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the user data set via `[[copy_function_set_user_data]]`.
+    parameters:
+      info:
+        type: copy_function_finalize_info
+        description: The finalize info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_finalize_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: copy_function_finalize_info
+        description: The finalize info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  copy_function_finalize_get_init_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: Retrieves the init data set by the function's init callback for the file being finalized.
+    parameters:
+      info:
+        type: copy_function_finalize_info
+        description: The finalize info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the init data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Register
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_register:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Registers the copy function, making it available as a `COPY ... TO` format.
+
+      The function is registered on the target given at creation: the connection's database or the loading
+      extension. Registration requires a name and the batch and flush callbacks. The caller still owns the handle
+      after registration and must destroy it with `[[copy_function_destroy]]`, which does not affect the registered
+      function.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to register.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destroy
+  #---------------------------------------------------------------------------------------------------------------------
+  copy_function_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Destroys the copy function, releasing its resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to
+      prevent double-destruction. Destroying the handle after registration does not affect the registered
+      function.
+    parameters:
+      function:
+        type: copy_function
+        description: The function to destroy.
+        indirection: 1
+    return_type: ERROR

--- a/api_spec/v2/function/replacement_scan.yaml
+++ b/api_spec/v2/function/replacement_scan.yaml
@@ -35,7 +35,8 @@ handles:
     description: |
       A borrowed opaque handle to the arguments supplied to a replacement scan when the binder consults it. The
       callback receives this handle and can use it to inspect the unresolved name and to claim it by naming what to
-      read instead. Valid only for the duration of the callback, as are the name views obtained through it.
+      read instead. Valid only for the duration of the callback; the name it hands out is owned separately and
+      outlives it.
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Callbacks
@@ -149,7 +150,7 @@ functions:
       Sets the callback of the replacement scan.
 
       The callback is invoked during query planning for each table reference the catalog could not resolve. It can
-      inspect the unresolved name via `[[replacement_scan_get_table_name]]` and its qualifiers, and claim the
+      inspect the unresolved name via `[[replacement_scan_get_name]]`, and claim the
       reference via `[[replacement_scan_set_function_name]]`, `[[replacement_scan_set_collection]]` or
       `[[replacement_scan_set_subquery]]`; returning without claiming declines it. The context passed to the callback
       may be used to read settings, but not to run queries. A callback must be set before registration.
@@ -212,69 +213,25 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  replacement_scan_get_catalog_name:
+  replacement_scan_get_name:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-02" ]
     description: |
-      Retrieves the catalog name of the unresolved reference.
+      Retrieves the name the catalog could not resolve.
 
-      Returns the empty view `{NULL, 0}` when the reference carries no catalog qualifier. The name is borrowed and
-      valid only for the duration of the callback.
+      The name as written in the query, as a path: an unqualified reference has a single part, and a qualified one
+      carries its catalog and schema before it -- see `[[qname_get_part]]`. For a file-backed reference the single
+      part is the path with the quotes stripped. The returned name is owned by the caller and must be destroyed via
+      `[[qname_destroy]]`; being owned, it may outlive the callback.
     parameters:
       info:
         type: replacement_scan_info
         description: The info handle.
       name:
-        type: identifier
+        type: qname
         indirection: 1
-        kind: OUT_BORROW
-        description: Receives the borrowed catalog name, or the empty view when the reference carries no catalog qualifier.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  replacement_scan_get_schema_name:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-02" ]
-    description: |
-      Retrieves the schema name of the unresolved reference.
-
-      Returns the empty view `{NULL, 0}` when the reference carries no schema qualifier. The name is borrowed and
-      valid only for the duration of the callback.
-    parameters:
-      info:
-        type: replacement_scan_info
-        description: The info handle.
-      name:
-        type: identifier
-        indirection: 1
-        kind: OUT_BORROW
-        description: Receives the borrowed schema name, or the empty view when the reference carries no schema qualifier.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  replacement_scan_get_table_name:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-02" ]
-    description: |
-      Retrieves the table name of the unresolved reference.
-
-      This is the name as written in the query, which for a file-backed reference is the path with the quotes
-      stripped. Never the empty view. The name is borrowed and valid only for the duration of the callback.
-    parameters:
-      info:
-        type: replacement_scan_info
-        description: The info handle.
-      name:
-        type: identifier
-        indirection: 1
-        kind: OUT_BORROW
-        description: Receives the borrowed table name.
+        kind: OUT
+        description: Receives the unresolved name. Owned by the caller; destroy via `[[qname_destroy]]`.
       err:
         type: error_info
         indirection: 1
@@ -291,10 +248,10 @@ functions:
       Claims the reference by naming a table function to read instead.
 
       Arguments to the function are added with `[[replacement_scan_add_argument]]` and
-      `[[replacement_scan_add_named_argument]]`. The name is borrowed and copied. It is matched case-insensitively
-      and is never split on ".", so it always names an unqualified function; an empty name results in an error. The
-      name is not resolved here: an unknown function fails later, when the replacement is bound. Calling this again
-      replaces the previous name and keeps the arguments added so far.
+      `[[replacement_scan_add_named_argument]]`. The name is borrowed and copied, and its parts are matched
+      case-insensitively. A qualified name targets a function in a particular schema or catalog, exactly as writing
+      it out in SQL would. The name is not resolved here: an unknown function fails later, when the replacement is
+      bound. Calling this again replaces the previous name and keeps the arguments added so far.
 
       The three claim forms, `[[replacement_scan_set_function_name]]`, `[[replacement_scan_set_collection]]` and
       `[[replacement_scan_set_subquery]]`, are mutually exclusive: claiming the reference through a second, different
@@ -304,8 +261,8 @@ functions:
         type: replacement_scan_info
         description: The info handle.
       name:
-        type: identifier
-        description: The name of the table function to read instead. Borrowed and copied.
+        type: qname
+        description: The table function to read instead. Borrowed and copied.
       err:
         type: error_info
         indirection: 1

--- a/api_spec/v2/function/replacement_scan.yaml
+++ b/api_spec/v2/function/replacement_scan.yaml
@@ -324,8 +324,14 @@ functions:
 
       The collection is borrowed, not copied: the caller keeps ownership and must keep it alive, and must not clear,
       reset or destroy it, for as long as any result reading it is live, since the result scans its buffers directly.
-      A prepared statement holds on to the collection it was bound against, so destroy such statements before
-      releasing the collection.
+
+      A prepared statement extends that lifetime well beyond its own results. Preparing a statement over a claimed
+      name captures the borrow in the plan, and since a collection claim reads no database there is nothing to
+      invalidate that plan: `[[prepared_statement_reuses_plan]]` reports true, and every later execution reuses the
+      captured borrow without consulting the callback again. So dropping the name from whatever the callback resolves
+      against does not release the collection, and releasing it while such a statement is live leaves the next
+      execution reading freed memory. Destroy every prepared statement over a claimed name before clearing,
+      resetting or destroying the collection behind it.
 
       By default the collection's columns are named col1..colN. Pass `column_names` to name them instead. When
       supplied, `column_count` must equal the collection's column count and no name may be empty; pass NULL and 0

--- a/api_spec/v2/function/replacement_scan.yaml
+++ b/api_spec/v2/function/replacement_scan.yaml
@@ -1,0 +1,492 @@
+module: replacement scan
+#
+# A replacement scan is a callback the binder consults when a table name cannot
+# be resolved in the catalog; it is what makes `SELECT * FROM 'file.parquet'`
+# work. The callback inspects the unresolved (possibly qualified) name and
+# either claims it, by naming what to read instead, or declines it by claiming
+# nothing, which lets the next registered scan try. When no scan claims the
+# name, the usual "table does not exist" error is raised.
+#
+# A claim names one of three things: a table function and its arguments, a
+# `[[column_data_collection]]` the caller holds, or a SQL query.
+#
+# Scope follows the constructor. A scan created with
+# `[[replacement_scan_create_with_connection]]` is visible only to that
+# connection, is released when it closes, and is consulted before every
+# database-wide scan, including the built-in file scans. A scan created with
+# `[[replacement_scan_create_with_database]]` or
+# `[[replacement_scan_create_with_extension]]` is visible to every connection
+# to that database and lives until the database closes. A registered scan
+# cannot be unregistered.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  replacement_scan:
+    description: |
+      An owned opaque handle to a replacement scan being built. Created with
+      `[[replacement_scan_create_with_connection]]`, `[[replacement_scan_create_with_database]]` or
+      `[[replacement_scan_create_with_extension]]`, configured with `[[replacement_scan_set_callback]]` and
+      `[[replacement_scan_set_user_data]]`, made available with `[[replacement_scan_register]]`, and destroyed with
+      `[[replacement_scan_destroy]]`.
+
+  replacement_scan_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a replacement scan when the binder consults it. The
+      callback receives this handle and can use it to inspect the unresolved name and to claim it by naming what to
+      read instead. Valid only for the duration of the callback, as are the name views obtained through it.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Callbacks
+#-----------------------------------------------------------------------------------------------------------------------
+callbacks:
+  replacement_scan_callback:
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Constructors
+  #---------------------------------------------------------------------------------------------------------------------
+  replacement_scan_create_with_connection:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a new replacement scan that will be registered on the connection.
+
+      The scan is visible only to queries on this connection and is released when the connection closes. It is
+      consulted before every database-wide scan, so it can claim a name that a built-in scan would otherwise take.
+      The scan starts out empty: configure it with `[[replacement_scan_set_callback]]` and optionally
+      `[[replacement_scan_set_user_data]]`, then make it available with `[[replacement_scan_register]]`. The caller
+      owns the returned handle and must destroy it with `[[replacement_scan_destroy]]`, also after registration.
+    parameters:
+      connection:
+        type: connection
+        description: The connection to create the scan on.
+      scan:
+        type: replacement_scan
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created replacement scan. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_create_with_database:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a new replacement scan that will be registered on the database.
+
+      The scan is visible to every connection to the database and lives until the database closes. The scan starts
+      out empty: configure it with `[[replacement_scan_set_callback]]` and optionally
+      `[[replacement_scan_set_user_data]]`, then make it available with `[[replacement_scan_register]]`. The caller
+      owns the returned handle and must destroy it with `[[replacement_scan_destroy]]`, also after registration.
+    parameters:
+      database:
+        type: database
+        description: The database to create the scan on.
+      scan:
+        type: replacement_scan
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created replacement scan. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_create_with_extension:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a new replacement scan that will be registered on the loading extension's database.
+
+      Use this from an extension load callback, where an extension handle is available. The scan is visible to every
+      connection to that database and lives until the database closes. The scan starts out empty: configure it with
+      `[[replacement_scan_set_callback]]` and optionally `[[replacement_scan_set_user_data]]`, then make it available
+      with `[[replacement_scan_register]]`. The caller owns the returned handle and must destroy it with
+      `[[replacement_scan_destroy]]`, also after registration.
+    parameters:
+      extension:
+        type: extension
+        description: The extension to create the scan on.
+      scan:
+        type: replacement_scan
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created replacement scan. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Properties
+  #---------------------------------------------------------------------------------------------------------------------
+  replacement_scan_set_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets the callback of the replacement scan.
+
+      The callback is invoked during query planning for each table reference the catalog could not resolve. It can
+      inspect the unresolved name via `[[replacement_scan_get_table_name]]` and its qualifiers, and claim the
+      reference via `[[replacement_scan_set_function_name]]`, `[[replacement_scan_set_collection]]` or
+      `[[replacement_scan_set_subquery]]`; returning without claiming declines it. The context passed to the callback
+      may be used to read settings, but not to run queries. A callback must be set before registration.
+    parameters:
+      scan:
+        type: replacement_scan
+        description: The scan to set the callback of.
+      callback:
+        type: replacement_scan_callback
+        description: The callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_set_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets arbitrary user data on the replacement scan.
+
+      Associates an opaque pointer with the scan, retrievable from the callback via
+      `[[replacement_scan_get_user_data]]`. The opaque handle bundles the pointer with an optional destructor,
+      invoked when the data is no longer needed, at the latest when the scan's scope ends. The callback may be
+      invoked from several connections at once, so the data must be safe to read concurrently.
+    parameters:
+      scan:
+        type: replacement_scan
+        description: The scan to set the user data of.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the user data pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Callback Functions: Inspecting the Reference
+  #---------------------------------------------------------------------------------------------------------------------
+  replacement_scan_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: Retrieves the user data set via `[[replacement_scan_set_user_data]]`.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_get_catalog_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Retrieves the catalog name of the unresolved reference.
+
+      Returns the empty view `{NULL, 0}` when the reference carries no catalog qualifier. The name is borrowed and
+      valid only for the duration of the callback.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives the borrowed catalog name, or the empty view when the reference carries no catalog qualifier.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_get_schema_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Retrieves the schema name of the unresolved reference.
+
+      Returns the empty view `{NULL, 0}` when the reference carries no schema qualifier. The name is borrowed and
+      valid only for the duration of the callback.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives the borrowed schema name, or the empty view when the reference carries no schema qualifier.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_get_table_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Retrieves the table name of the unresolved reference.
+
+      This is the name as written in the query, which for a file-backed reference is the path with the quotes
+      stripped. Never the empty view. The name is borrowed and valid only for the duration of the callback.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      name:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives the borrowed table name.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Callback Functions: Claiming the Reference
+  #---------------------------------------------------------------------------------------------------------------------
+  replacement_scan_set_function_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Claims the reference by naming a table function to read instead.
+
+      Arguments to the function are added with `[[replacement_scan_add_argument]]` and
+      `[[replacement_scan_add_named_argument]]`. The name is borrowed and copied. It is matched case-insensitively
+      and is never split on ".", so it always names an unqualified function; an empty name results in an error. The
+      name is not resolved here: an unknown function fails later, when the replacement is bound. Calling this again
+      replaces the previous name and keeps the arguments added so far.
+
+      The three claim forms, `[[replacement_scan_set_function_name]]`, `[[replacement_scan_set_collection]]` and
+      `[[replacement_scan_set_subquery]]`, are mutually exclusive: claiming the reference through a second, different
+      form results in an error.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      name:
+        type: identifier
+        description: The name of the table function to read instead. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_add_argument:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Appends a positional argument to the claimed table function.
+
+      Positional arguments are passed in the order they are added, before any named ones. The value is borrowed and
+      copied, so the caller may destroy it after the call. Requires `[[replacement_scan_set_function_name]]` to have
+      been called first; otherwise the call results in an error.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      value:
+        type: value
+        description: The argument value. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_add_named_argument:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Appends a named argument to the claimed table function.
+
+      Equivalent to writing `name := value` at the call site. The name and the value are borrowed and copied, so the
+      caller may destroy the value after the call. Requires `[[replacement_scan_set_function_name]]` to have been
+      called first; otherwise the call results in an error.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      name:
+        type: identifier
+        description: The name of the parameter to bind the value to. Borrowed and copied.
+      value:
+        type: value
+        description: The argument value. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_set_collection:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Claims the reference by naming a column data collection to read instead.
+
+      The collection is borrowed, not copied: the caller keeps ownership and must keep it alive, and must not clear,
+      reset or destroy it, for as long as any result reading it is live, since the result scans its buffers directly.
+      A prepared statement holds on to the collection it was bound against, so destroy such statements before
+      releasing the collection.
+
+      By default the collection's columns are named col1..colN. Pass `column_names` to name them instead. When
+      supplied, `column_count` must equal the collection's column count and no name may be empty; pass NULL and 0
+      for the default names.
+
+      The three claim forms, `[[replacement_scan_set_function_name]]`, `[[replacement_scan_set_collection]]` and
+      `[[replacement_scan_set_subquery]]`, are mutually exclusive: claiming the reference through a second, different
+      form results in an error.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      collection:
+        type: column_data_collection
+        description: The collection to read instead. Borrowed; the caller keeps ownership and must keep it alive.
+      column_names:
+        type: identifier
+        indirection: 1
+        const: true
+        description: Optional. An array of `column_count` column names, in order. Pass NULL for the default names col1..colN.
+      column_count:
+        type: idx
+        description: The number of names in `column_names`. Must equal the collection's column count, or 0 for the default names.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_set_subquery:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Claims the reference by naming a query to read instead.
+
+      The text is parsed at the call and must contain exactly one SELECT statement: a syntax error, several
+      statements or a statement of another kind results in an error. The text is borrowed for the call only. Prefer
+      `[[replacement_scan_set_function_name]]` when a single table function call suffices, as it avoids the parse
+      and keeps the plan flatter.
+
+      The three claim forms, `[[replacement_scan_set_function_name]]`, `[[replacement_scan_set_collection]]` and
+      `[[replacement_scan_set_subquery]]`, are mutually exclusive: claiming the reference through a second, different
+      form results in an error.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      sql:
+        type: str
+        description: The SELECT statement to read instead. Borrowed for the call only.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  replacement_scan_set_alias:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets the alias the claimed replacement is bound under.
+
+      Optional, and independent of the claim form. An alias written in the query takes precedence over this one;
+      without either, the table name of the reference is used, which for a file-backed reference is the path. The
+      alias is borrowed and copied.
+    parameters:
+      info:
+        type: replacement_scan_info
+        description: The info handle.
+      alias:
+        type: identifier
+        description: The alias to bind the replacement under. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Register
+  #---------------------------------------------------------------------------------------------------------------------
+  replacement_scan_register:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Registers the replacement scan, making it consulted for names the catalog cannot resolve.
+
+      The scan is registered on the target given at creation: the connection, the database or the loading
+      extension's database. Registration requires a callback. Scans are consulted in registration order within their
+      scope, connection-scoped ones before database-wide ones, and the first to claim a name wins. A scan cannot be
+      registered twice, and a registered scan cannot be unregistered: it lives until its scope ends. Registering a
+      database-wide scan while queries are binding on other connections is not thread-safe; register from an
+      extension load callback or before issuing queries. The caller still owns the handle after registration and
+      must destroy it with `[[replacement_scan_destroy]]`, which does not affect the registered scan.
+    parameters:
+      scan:
+        type: replacement_scan
+        description: The scan to register.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destroy
+  #---------------------------------------------------------------------------------------------------------------------
+  replacement_scan_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Destroys the replacement scan, releasing its resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+      double-destruction. Destroying the handle after registration does not affect the registered scan.
+    parameters:
+      scan:
+        type: replacement_scan
+        description: The scan to destroy.
+        indirection: 1
+    return_type: ERROR

--- a/api_spec/v2/function/table.yaml
+++ b/api_spec/v2/function/table.yaml
@@ -41,6 +41,13 @@ handles:
       A borrowed opaque handle to the arguments supplied to a table function during the "progress" phase. The
       "progress" callback receives this handle and can use it to report how far the scan has advanced.
 
+
+  table_function_filter_pushdown_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a table function during the "filter pushdown" phase of
+      query optimization. The "filter pushdown" callback receives this handle and can use it to inspect the filter
+      predicates the query applies to the function's rows, and to accept the ones it will apply itself.
+
 #-----------------------------------------------------------------------------------------------------------------------
 # Callbacks
 #-----------------------------------------------------------------------------------------------------------------------
@@ -114,6 +121,21 @@ callbacks:
         indirection: 1
         description: Borrowed error info handle to use to report errors that occur during the callback.
     return_type: void
+
+  table_function_filter_pushdown_callback:
+    parameters:
+      info:
+        type: table_function_filter_pushdown_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
 #-----------------------------------------------------------------------------------------------------------------------
 # Functions
 #-----------------------------------------------------------------------------------------------------------------------
@@ -357,6 +379,58 @@ functions:
       callback:
         type: table_function_progress_callback
         description: The progress callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+
+  table_function_set_projection_pushdown:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets whether the table function supports projection pushdown. Defaults to false.
+
+      With projection pushdown, the engine asks the function for only the columns a query actually uses: the exec
+      callback's output chunk holds one vector per requested column rather than one per column declared in bind,
+      and the global init, local init and exec callbacks can look up which declared column each vector stands for
+      via e.g. `[[table_function_exec_get_column_index]]`. Without it the output chunk always holds every declared
+      column, and the engine drops the unused ones itself.
+    parameters:
+      function:
+        type: table_function
+        description: The function to configure.
+      enable:
+        type: bool
+        description: Whether the function supports projection pushdown.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_set_filter_pushdown_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Sets the optional filter pushdown callback of the table function.
+
+      The filter pushdown callback is invoked while the query is optimized, after the bind callback and before any
+      init callback, with the filter predicates the query applies to the function's rows. Each predicate is a
+      bound expression the callback can inspect with the `expression` functions; the callback accepts the
+      predicates it will apply itself via `[[table_function_filter_pushdown_accept]]`, typically after
+      recording what they select in the bind data. The engine then stops applying the accepted predicates and
+      keeps applying the rest above the scan, so accepting a predicate is a promise to filter the rows exactly as
+      it would have. The optimizer may invoke the callback more than once for the same query, each time with the
+      predicates not yet accepted; it is not invoked when there are none.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the filter pushdown callback of.
+      callback:
+        type: table_function_filter_pushdown_callback
+        description: The filter pushdown callback to set.
       err:
         type: error_info
         indirection: 1
@@ -625,6 +699,59 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
+
+  table_function_init_global_get_column_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of columns the scan produces.
+
+      With projection pushdown (see `[[table_function_set_projection_pushdown]]`) this is the number of columns the
+      query uses, which is the number of vectors in the exec callback's output chunk; without it, it is the number
+      of columns declared in bind. Valid indices for `[[table_function_init_global_get_column_index]]` are `0` up to
+      (but excluding) this count.
+    parameters:
+      info:
+        type: table_function_init_global_info
+        description: The global init info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of columns the scan produces.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_init_global_get_column_index:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns which declared column the scan's column at the given index stands for.
+
+      The result indexes the columns declared with `[[table_function_bind_add_result_column]]`, in declaration
+      order: the exec callback fills the output chunk's vector at `index` with that column's data. Without
+      projection pushdown the mapping is the identity. Fails if the index is out of bounds.
+    parameters:
+      info:
+        type: table_function_init_global_info
+        description: The global init info handle.
+      index:
+        type: idx
+        description: The index of the column in the scan's output.
+      column_index:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the index of the declared column.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
   #---------------------------------------------------------------------------------------------------------------------
   # Local Init Callback Functions
   #---------------------------------------------------------------------------------------------------------------------
@@ -706,6 +833,59 @@ functions:
         type: opaque
         indirection: 1
         description: Opaque handle bundling the local state pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+
+  table_function_init_local_get_column_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of columns the scan produces.
+
+      With projection pushdown (see `[[table_function_set_projection_pushdown]]`) this is the number of columns the
+      query uses, which is the number of vectors in the exec callback's output chunk; without it, it is the number
+      of columns declared in bind. Valid indices for `[[table_function_init_local_get_column_index]]` are `0` up to
+      (but excluding) this count.
+    parameters:
+      info:
+        type: table_function_init_local_info
+        description: The local init info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of columns the scan produces.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_init_local_get_column_index:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns which declared column the scan's column at the given index stands for.
+
+      The result indexes the columns declared with `[[table_function_bind_add_result_column]]`, in declaration
+      order: the exec callback fills the output chunk's vector at `index` with that column's data. Without
+      projection pushdown the mapping is the identity. Fails if the index is out of bounds.
+    parameters:
+      info:
+        type: table_function_init_local_info
+        description: The local init info handle.
+      index:
+        type: idx
+        description: The index of the column in the scan's output.
+      column_index:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the index of the declared column.
       err:
         type: error_info
         indirection: 1
@@ -821,6 +1001,59 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
+
+  table_function_exec_get_column_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of columns the scan produces.
+
+      With projection pushdown (see `[[table_function_set_projection_pushdown]]`) this is the number of columns the
+      query uses, which is the number of vectors in the exec callback's output chunk; without it, it is the number
+      of columns declared in bind. Valid indices for `[[table_function_exec_get_column_index]]` are `0` up to
+      (but excluding) this count.
+    parameters:
+      info:
+        type: table_function_exec_info
+        description: The exec info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of columns the scan produces.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_exec_get_column_index:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns which declared column the scan's column at the given index stands for.
+
+      The result indexes the columns declared with `[[table_function_bind_add_result_column]]`, in declaration
+      order: the exec callback fills the output chunk's vector at `index` with that column's data. Without
+      projection pushdown the mapping is the identity. Fails if the index is out of bounds.
+    parameters:
+      info:
+        type: table_function_exec_info
+        description: The exec info handle.
+      index:
+        type: idx
+        description: The index of the column in the scan's output.
+      column_index:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the index of the declared column.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
   #---------------------------------------------------------------------------------------------------------------------
   # Progress Callback Functions
   #---------------------------------------------------------------------------------------------------------------------
@@ -900,6 +1133,178 @@ functions:
       progress:
         type: f64
         description: The fraction of the scan that is complete, in [0.0, 1.0].
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Filter Pushdown Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_filter_pushdown_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the user data set via `[[table_function_set_user_data]]`, or null if none was set.
+    parameters:
+      info:
+        type: table_function_filter_pushdown_info
+        description: The filter pushdown info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_filter_pushdown_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the bind data set via `[[table_function_bind_set_bind_data]]`, or null if none was set.
+
+      This is the same object the init and exec callbacks later receive, so a predicate the callback accepts can be
+      recorded in it for the scan to apply.
+    parameters:
+      info:
+        type: table_function_filter_pushdown_info
+        description: The filter pushdown info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_filter_pushdown_get_filter_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of filter predicates offered to the function.
+
+      The predicates are combined with `AND`: every row the scan produces must satisfy all of them. Valid indices
+      for `[[table_function_filter_pushdown_get_filter]]` and `[[table_function_filter_pushdown_accept]]` are
+      `0` up to (but excluding) this count.
+    parameters:
+      info:
+        type: table_function_filter_pushdown_info
+        description: The filter pushdown info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of predicates.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_filter_pushdown_get_filter:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Retrieves the filter predicate at the given index.
+
+      Fails if the index is out of bounds. The predicate is a bound expression evaluating to `BOOLEAN`; inspect it
+      with `[[expression_get_type]]` and the other `expression` functions, and resolve the column references it
+      contains via `[[table_function_filter_pushdown_get_column_index]]`. Borrowed; valid only for the duration of
+      the callback.
+    parameters:
+      info:
+        type: table_function_filter_pushdown_info
+        description: The filter pushdown info handle.
+      index:
+        type: idx
+        description: The index of the predicate to retrieve.
+      filter:
+        type: expression
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives the borrowed predicate.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_filter_pushdown_accept:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Accepts the filter predicate at the given index: the function will apply it itself.
+
+      The engine stops applying an accepted predicate, so the scan must produce only rows that satisfy it, or the
+      query returns rows it should not. Predicates left unaccepted are applied by the engine as usual, so a callback
+      that recognizes nothing can simply return. Fails if the index is out of bounds.
+    parameters:
+      info:
+        type: table_function_filter_pushdown_info
+        description: The filter pushdown info handle.
+      index:
+        type: idx
+        description: The index of the predicate to accept.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_filter_pushdown_get_column_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Returns the number of columns the predicates can refer to.
+
+      A column reference inside a predicate (`[[expression_column_ref_get_index]]`) indexes the columns the query
+      reads from the function, not the columns declared in bind. Valid indices for
+      `[[table_function_filter_pushdown_get_column_index]]` are `0` up to (but excluding) this count.
+    parameters:
+      info:
+        type: table_function_filter_pushdown_info
+        description: The filter pushdown info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of referable columns.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_filter_pushdown_get_column_index:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Resolves a column reference found in a predicate to the declared column it refers to.
+
+      Takes the index a `EXPRESSION_TYPE_BOUND_COLUMN_REF` node reports and returns the index of the column among
+      the ones declared with `[[table_function_bind_add_result_column]]`, in declaration order. Fails if the index
+      is out of bounds.
+    parameters:
+      info:
+        type: table_function_filter_pushdown_info
+        description: The filter pushdown info handle.
+      index:
+        type: idx
+        description: The column index reported by a column reference node.
+      column_index:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the index of the declared column.
       err:
         type: error_info
         indirection: 1

--- a/api_spec/v2/function/table.yaml
+++ b/api_spec/v2/function/table.yaml
@@ -36,12 +36,6 @@ handles:
       The "exec" callback receives this handle and can use it to e.g. access the global and local state and write
       the next batch of rows to the output chunk.
 
-  table_function_cardinality_info:
-    description: |
-      A borrowed opaque handle to the arguments supplied to a table function during the "cardinality" estimation
-      phase. The "cardinality" callback receives this handle and can use it to report how many rows the scan is
-      expected to produce.
-
   table_function_progress_info:
     description: |
       A borrowed opaque handle to the arguments supplied to a table function during the "progress" phase. The
@@ -97,20 +91,6 @@ callbacks:
     parameters:
       info:
         type: table_function_exec_info
-        description: Borrowed opaque handle providing access to the information available to the callback.
-      context:
-        type: context
-        description: Borrowed handle to the context of the query currently executing the callback.
-      err:
-        type: error_info
-        indirection: 1
-        description: Borrowed error info handle to use to report errors that occur during the callback.
-    return_type: void
-
-  table_function_cardinality_callback:
-    parameters:
-      info:
-        type: table_function_cardinality_info
         description: Borrowed opaque handle providing access to the information available to the callback.
       context:
         type: context
@@ -361,30 +341,6 @@ functions:
         description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
     return_type: ERROR
 
-  table_function_set_cardinality_callback:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-01" ]
-    description: |
-      Sets the optional cardinality callback of the table function.
-
-      The cardinality callback is invoked during query optimization to estimate how many rows the scan will
-      produce, which the optimizer uses for cost-based decisions such as join ordering. It may be invoked more
-      than once per plan, so it should be cheap and free of side effects. Use
-      `[[table_function_bind_set_cardinality]]` instead when the row count is already known at bind time; the
-      callback takes precedence when both are provided.
-    parameters:
-      function:
-        type: table_function
-        description: The function to set the cardinality callback of.
-      callback:
-        type: table_function_cardinality_callback
-        description: The cardinality callback to set.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
   table_function_set_progress_callback:
     lifecycle:
       - [ "stable", "v2.0.0", "2026-09-01" ]
@@ -564,10 +520,8 @@ functions:
     description: |
       Sets the estimated number of rows the scan will produce.
 
-      A convenience for the common case where the row count is already known at bind time; use
-      `[[table_function_set_cardinality_callback]]` instead when the estimate depends on state only available
-      later. The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not
-      an error. When both are provided the callback takes precedence.
+      The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an
+      error. Without it, the optimizer falls back on its own defaults.
     parameters:
       info:
         type: table_function_bind_info
@@ -861,72 +815,6 @@ functions:
         indirection: 1
         kind: OUT
         description: Receives the borrowed output chunk to write into.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  #---------------------------------------------------------------------------------------------------------------------
-  # Cardinality Callback Functions
-  #---------------------------------------------------------------------------------------------------------------------
-  table_function_cardinality_get_user_data:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-01" ]
-    description: Retrieves the user data set via `[[table_function_set_user_data]]`.
-    parameters:
-      info:
-        type: table_function_cardinality_info
-        description: The cardinality info handle.
-      data:
-        type: void
-        indirection: 2
-        kind: OUT
-        description: Receives the user data pointer, or null if none was set.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  table_function_cardinality_get_bind_data:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-01" ]
-    description: Retrieves the bind data set by the function's bind callback.
-    parameters:
-      info:
-        type: table_function_cardinality_info
-        description: The cardinality info handle.
-      data:
-        type: void
-        indirection: 2
-        kind: OUT
-        description: Receives the bind data pointer, or null if none was set.
-      err:
-        type: error_info
-        indirection: 1
-        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
-    return_type: ERROR
-
-  table_function_cardinality_set_cardinality:
-    lifecycle:
-      - [ "stable", "v2.0.0", "2026-09-01" ]
-    description: |
-      Reports the estimated number of rows the scan will produce.
-
-      The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an
-      error. A cardinality callback that returns without calling this reports no estimate at all, leaving the
-      optimizer to fall back on its own defaults.
-    parameters:
-      info:
-        type: table_function_cardinality_info
-        description: The cardinality info handle.
-      cardinality:
-        type: idx
-        description: The estimated number of rows.
-      is_exact:
-        type: bool
-        description: Whether the estimate is exact, which also makes it an upper bound on the row count.
       err:
         type: error_info
         indirection: 1

--- a/api_spec/v2/function/table.yaml
+++ b/api_spec/v2/function/table.yaml
@@ -1,0 +1,1062 @@
+module: table
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  table_function:
+    description: |
+      An owned opaque handle to a custom table function being built. Created with
+      `[[table_function_create_with_connection]]` or `[[table_function_create_with_extension]]`, configured with the
+      setter functions (e.g. `[[table_function_set_name]]`, `[[table_function_set_exec_callback]]`, etc.) and the
+      signature obtained via `[[table_function_get_signature]]`, made available with `[[table_function_register]]`, and
+      destroyed with `[[table_function_destroy]]`.
+
+  table_function_bind_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a table function during the query preparation "bind"
+      phase. The "bind" callback receives this handle and must use it to declare the columns the function returns;
+      it can also inspect the arguments given to the function, initialize some constant state and hint at the
+      number of rows the scan will produce.
+
+  table_function_init_global_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a table function during the global state
+      initialization "init global" phase. The "init global" callback receives this handle and can use it to e.g.
+      set up the state shared by every thread scanning the function, and to declare how many threads may scan it.
+
+  table_function_init_local_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a table function during the local state
+      initialization "init local" phase. The "init local" callback receives this handle and can use it to e.g.
+      set up worker-local state, typically by claiming work from the shared global state.
+
+  table_function_exec_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a table function during the execution "exec" phase.
+      The "exec" callback receives this handle and can use it to e.g. access the global and local state and write
+      the next batch of rows to the output chunk.
+
+  table_function_cardinality_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a table function during the "cardinality" estimation
+      phase. The "cardinality" callback receives this handle and can use it to report how many rows the scan is
+      expected to produce.
+
+  table_function_progress_info:
+    description: |
+      A borrowed opaque handle to the arguments supplied to a table function during the "progress" phase. The
+      "progress" callback receives this handle and can use it to report how far the scan has advanced.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Callbacks
+#-----------------------------------------------------------------------------------------------------------------------
+callbacks:
+  table_function_bind_callback:
+    parameters:
+      info:
+        type: table_function_bind_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  table_function_init_global_callback:
+    parameters:
+      info:
+        type: table_function_init_global_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  table_function_init_local_callback:
+    parameters:
+      info:
+        type: table_function_init_local_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  table_function_exec_callback:
+    parameters:
+      info:
+        type: table_function_exec_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  table_function_cardinality_callback:
+    parameters:
+      info:
+        type: table_function_cardinality_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+
+  table_function_progress_callback:
+    parameters:
+      info:
+        type: table_function_progress_info
+        description: Borrowed opaque handle providing access to the information available to the callback.
+      context:
+        type: context
+        description: Borrowed handle to the context of the query currently executing the callback.
+      err:
+        type: error_info
+        indirection: 1
+        description: Borrowed error info handle to use to report errors that occur during the callback.
+    return_type: void
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Constructors
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_create_with_connection:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Creates a new table function that will be registered on the connection's database.
+
+      The function starts out empty: configure it with the setter functions (e.g. `[[table_function_set_name]]`,
+      `[[table_function_set_exec_callback]]`, etc.) and the signature obtained via
+      `[[table_function_get_signature]]`, then make it available with `[[table_function_register]]`.
+      The caller owns the returned handle and must destroy it with `[[table_function_destroy]]`, also after
+      registration.
+    parameters:
+      connection:
+        type: connection
+        description: The connection to create the function in.
+      function:
+        type: table_function
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created table function. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_create_with_extension:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Creates a new table function that will be registered on the loading extension's database.
+
+      Use this from an extension load callback, where an extension handle is available. The function starts out
+      empty: configure it with the setter functions (e.g. `[[table_function_set_name]]`,
+      `[[table_function_set_exec_callback]]`, etc.) and the signature obtained via
+      `[[table_function_get_signature]]`, then make it available with `[[table_function_register]]`.
+      The caller owns the returned handle and must destroy it with `[[table_function_destroy]]`, also after
+      registration.
+    parameters:
+      extension:
+        type: extension
+        description: The extension to create the function in.
+      function:
+        type: table_function
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created table function. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Properties
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_set_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the name of the table function.
+
+      The name is borrowed and copied. Calling this again replaces the previous name.
+      A name must be set before registration.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the name of.
+      name:
+        type: str
+        indirection: 1
+        description: The name to set. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_get_signature:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Returns the function's signature so it can be configured.
+
+      Add parameters with `[[function_signature_add_parameter]]` and set a variadic tail with
+      `[[function_signature_set_varargs]]`. The signature is modified in place. A table function maps the
+      signature onto the two ways SQL passes arguments to a table function: a parameter without a default value
+      becomes a required positional argument, a parameter with a default value becomes a named argument the
+      caller may omit. The variadic tail extends the positional arguments. A table function declares the columns
+      it returns from its bind callback instead of through a return type, so registration rejects a signature
+      whose return type was set with `[[function_signature_set_return_type]]`.
+    parameters:
+      function:
+        type: table_function
+        kind: IN
+        description: The function to get the signature of.
+      sig:
+        type: function_signature
+        indirection: 1
+        kind: OUT
+        description: The returned signature. Borrowed and valid for the lifetime of the function handle.
+      err:
+        type: error_info
+        indirection: 1
+        kind: OUT
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_set_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets arbitrary user data on the table function.
+
+      Associates an opaque pointer with the function, retrievable from the callbacks via
+      `[[table_function_bind_get_user_data]]`, `[[table_function_init_global_get_user_data]]`,
+      `[[table_function_exec_get_user_data]]` and their counterparts on the other phases. The opaque handle
+      bundles the pointer with an optional destructor, invoked when the data is no longer needed.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the user data of.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the user data pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_set_bind_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the bind callback of the table function.
+
+      The bind callback is invoked during query planning for each call site of the function. It must declare the
+      columns the function returns via `[[table_function_bind_add_result_column]]`. It can also inspect the
+      constant argument values and set "bind data" that is shared with all later callbacks. A bind callback must
+      be set before registration.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the bind callback of.
+      callback:
+        type: table_function_bind_callback
+        description: The bind callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_set_init_global_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the optional global init callback of the table function.
+
+      The global init callback is invoked once per scan, at the start of execution. It can set "global state"
+      shared by every thread scanning the function, and declare how many threads may scan it in parallel via
+      `[[table_function_init_global_set_max_threads]]`.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the global init callback of.
+      callback:
+        type: table_function_init_global_callback
+        description: The global init callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_set_init_local_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the optional local init callback of the table function.
+
+      The local init callback is invoked once per thread that will scan the function. It can set worker-local
+      "local state", retrievable from the exec callback, typically derived from the shared global state.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the local init callback of.
+      callback:
+        type: table_function_init_local_callback
+        description: The local init callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_set_exec_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the exec callback of the table function.
+
+      The exec callback implements the function's logic: it is invoked repeatedly during query execution and
+      writes the next batch of rows to the output chunk, until it produces an empty batch to signal the end of
+      the scan. An exec callback must be set before registration.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the exec callback of.
+      callback:
+        type: table_function_exec_callback
+        description: The exec callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_set_cardinality_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the optional cardinality callback of the table function.
+
+      The cardinality callback is invoked during query optimization to estimate how many rows the scan will
+      produce, which the optimizer uses for cost-based decisions such as join ordering. It may be invoked more
+      than once per plan, so it should be cheap and free of side effects. Use
+      `[[table_function_bind_set_cardinality]]` instead when the row count is already known at bind time; the
+      callback takes precedence when both are provided.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the cardinality callback of.
+      callback:
+        type: table_function_cardinality_callback
+        description: The cardinality callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_set_progress_callback:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the optional progress callback of the table function.
+
+      The progress callback is invoked on demand during execution to report how far the scan has advanced, which
+      the engine surfaces as the query's progress. It is invoked concurrently with the exec callback, so it must
+      read the global state in a thread-safe way.
+    parameters:
+      function:
+        type: table_function
+        description: The function to set the progress callback of.
+      callback:
+        type: table_function_progress_callback
+        description: The progress callback to set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Bind Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_bind_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the user data set via `[[table_function_set_user_data]]`.
+    parameters:
+      info:
+        type: table_function_bind_info
+        description: The bind info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_bind_set_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the function's "bind data" from the bind callback.
+
+      The bind data is stored with the bound call site and retrievable from every later callback. The opaque
+      handle bundles the pointer with an optional destructor, invoked when the bind data is no longer needed,
+      and an optional equality callback used when comparing two bound call sites; without one, pointer equality
+      is used.
+    parameters:
+      info:
+        type: table_function_bind_info
+        description: The bind info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the bind data pointer plus optional destructor and equality callbacks.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_bind_get_arg_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Returns the number of arguments of the call site being bound.
+
+      The arguments are presented in signature order: one for every parameter declared with
+      `[[function_signature_add_parameter]]`, followed by any variadic tail arguments. A parameter the call site
+      omitted is still present, carrying the default value declared for it, so the count only varies with the
+      length of the variadic tail. Valid indices for `[[table_function_bind_get_arg_type]]` and
+      `[[table_function_bind_get_arg_value]]` are [0, count).
+    parameters:
+      info:
+        type: table_function_bind_info
+        description: The bind info handle.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of arguments.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_bind_get_arg_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Retrieves the type of the argument at the given index.
+
+      Fails if the index is out of bounds. The returned type is owned by the caller and must be destroyed
+      via `[[logical_type_destroy]]`.
+    parameters:
+      info:
+        type: table_function_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the argument to get the type of.
+      type:
+        type: logical_type
+        indirection: 1
+        kind: OUT
+        description: Receives the argument type. Owned by the caller; destroy via `[[logical_type_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_bind_get_arg_value:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Retrieves the constant value of the argument at the given index.
+
+      The arguments of a table function are always constants, folded before the bind callback runs, so this
+      never fails for an index in bounds; it does fail when the index is out of bounds. The value may be NULL.
+      The returned value is owned by the caller and must be destroyed via `[[value_destroy]]`.
+    parameters:
+      info:
+        type: table_function_bind_info
+        description: The bind info handle.
+      index:
+        type: idx
+        description: The index of the argument to get the value of.
+      value:
+        type: value
+        indirection: 1
+        kind: OUT
+        description: Receives the constant value. Owned by the caller; destroy via `[[value_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_bind_add_result_column:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Declares one of the columns the function returns.
+
+      Call this once per column, in order: the columns declared here are the columns of the table the function
+      produces, and the vectors of the output chunk the exec callback fills follow the same order. At least one
+      column must be declared. The type must be a fully defined concrete type; ANY is rejected, as a result
+      column carries data. The name and type are borrowed and copied.
+    parameters:
+      info:
+        type: table_function_bind_info
+        description: The bind info handle.
+      name:
+        type: identifier
+        description: The name of the column. Borrowed and copied.
+      type:
+        type: logical_type
+        description: The type of the column. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_bind_set_cardinality:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the estimated number of rows the scan will produce.
+
+      A convenience for the common case where the row count is already known at bind time; use
+      `[[table_function_set_cardinality_callback]]` instead when the estimate depends on state only available
+      later. The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not
+      an error. When both are provided the callback takes precedence.
+    parameters:
+      info:
+        type: table_function_bind_info
+        description: The bind info handle.
+      cardinality:
+        type: idx
+        description: The estimated number of rows.
+      is_exact:
+        type: bool
+        description: Whether the estimate is exact, which also makes it an upper bound on the row count.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Global Init Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_init_global_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the user data set via `[[table_function_set_user_data]]`.
+    parameters:
+      info:
+        type: table_function_init_global_info
+        description: The global init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_init_global_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: table_function_init_global_info
+        description: The global init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_init_global_set_global_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the function's "global state" from the global init callback.
+
+      The global state lives for the duration of the scan and is retrievable from the local init, exec and
+      progress callbacks. Every thread scanning the function shares it, so the function must synchronize its own
+      access to it. The opaque handle bundles the pointer with an optional destructor, invoked when the scan is
+      done with the state.
+    parameters:
+      info:
+        type: table_function_init_global_info
+        description: The global init info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the global state pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_init_global_set_max_threads:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets how many threads may scan the function in parallel.
+
+      Defaults to 1, a single-threaded scan. The engine creates at most this many local states, and therefore
+      runs at most this many exec callbacks concurrently. It is an upper bound, not a request: the engine may
+      use fewer threads.
+    parameters:
+      info:
+        type: table_function_init_global_info
+        description: The global init info handle.
+      max_threads:
+        type: idx
+        description: The maximum number of threads. Must be at least 1.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Local Init Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_init_local_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the user data set via `[[table_function_set_user_data]]`.
+    parameters:
+      info:
+        type: table_function_init_local_info
+        description: The local init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_init_local_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: table_function_init_local_info
+        description: The local init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_init_local_get_global_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Retrieves the global state set by the function's global init callback.
+
+      Shared with every other thread scanning the function; access to it must be synchronized by the function.
+    parameters:
+      info:
+        type: table_function_init_local_info
+        description: The local init info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the global state pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_init_local_set_local_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Sets the function's worker-local "local state" from the local init callback.
+
+      The local state is associated with the executing thread for the duration of the scan and retrievable from
+      the exec callback via `[[table_function_exec_get_local_state]]`. No other thread observes it, so it needs
+      no synchronization. The opaque handle bundles the pointer with an optional destructor, invoked when the
+      local state is no longer needed.
+    parameters:
+      info:
+        type: table_function_init_local_info
+        description: The local init info handle.
+      data:
+        type: opaque
+        indirection: 1
+        description: Opaque handle bundling the local state pointer plus an optional destructor.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Exec Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_exec_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the user data set via `[[table_function_set_user_data]]`.
+    parameters:
+      info:
+        type: table_function_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_exec_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: table_function_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_exec_get_global_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Retrieves the global state set by the function's global init callback.
+
+      Shared with every other thread scanning the function; access to it must be synchronized by the function.
+    parameters:
+      info:
+        type: table_function_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the global state pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_exec_get_local_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the worker-local local state set by the function's local init callback.
+    parameters:
+      info:
+        type: table_function_exec_info
+        description: The exec info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the local state pointer for the executing thread, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_exec_get_output_chunk:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Retrieves the output chunk the exec callback must write the next batch of rows into.
+
+      The chunk holds one vector per column declared with `[[table_function_bind_add_result_column]]`, in the
+      same order; reach them with `[[data_chunk_get_vector]]`. The chunk starts out empty on every invocation:
+      write the rows, then declare how many there are with `[[vector_set_size]]` on the first vector, which the
+      engine takes as the batch's row count and propagates to the other vectors. Producing an empty batch signals
+      the end of the scan, after which the callback is not invoked again on that thread. Borrowed; valid only for
+      the duration of the callback.
+    parameters:
+      info:
+        type: table_function_exec_info
+        description: The exec info handle.
+      chunk:
+        type: data_chunk
+        indirection: 1
+        kind: OUT
+        description: Receives the borrowed output chunk to write into.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Cardinality Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_cardinality_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the user data set via `[[table_function_set_user_data]]`.
+    parameters:
+      info:
+        type: table_function_cardinality_info
+        description: The cardinality info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_cardinality_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: table_function_cardinality_info
+        description: The cardinality info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_cardinality_set_cardinality:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Reports the estimated number of rows the scan will produce.
+
+      The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an
+      error. A cardinality callback that returns without calling this reports no estimate at all, leaving the
+      optimizer to fall back on its own defaults.
+    parameters:
+      info:
+        type: table_function_cardinality_info
+        description: The cardinality info handle.
+      cardinality:
+        type: idx
+        description: The estimated number of rows.
+      is_exact:
+        type: bool
+        description: Whether the estimate is exact, which also makes it an upper bound on the row count.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Progress Callback Functions
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_progress_get_user_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the user data set via `[[table_function_set_user_data]]`.
+    parameters:
+      info:
+        type: table_function_progress_info
+        description: The progress info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the user data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_progress_get_bind_data:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: Retrieves the bind data set by the function's bind callback.
+    parameters:
+      info:
+        type: table_function_progress_info
+        description: The progress info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the bind data pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_progress_get_global_state:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Retrieves the global state set by the function's global init callback.
+
+      The progress callback runs concurrently with the exec callbacks scanning the function, so it must read the
+      global state in a thread-safe way.
+    parameters:
+      info:
+        type: table_function_progress_info
+        description: The progress info handle.
+      data:
+        type: void
+        indirection: 2
+        kind: OUT
+        description: Receives the global state pointer, or null if none was set.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  table_function_progress_set_progress:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Reports how far the scan has advanced.
+
+      A fraction between 0.0 (nothing scanned yet) and 1.0 (done); values outside that range are clamped. A
+      progress callback that returns without calling this reports no progress.
+    parameters:
+      info:
+        type: table_function_progress_info
+        description: The progress info handle.
+      progress:
+        type: f64
+        description: The fraction of the scan that is complete, in [0.0, 1.0].
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Register
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_register:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Registers the table function, making it available for use in SQL queries.
+
+      The function is registered on the target given at creation: the connection's database or the loading
+      extension. Registration requires a name, a bind callback and an exec callback, and rejects a signature
+      that declares a return type, since a table function declares the columns it returns from its bind
+      callback. The caller still owns the handle after registration and must destroy it with
+      `[[table_function_destroy]]`, which does not affect the registered function.
+    parameters:
+      function:
+        type: table_function
+        description: The function to register.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destroy
+  #---------------------------------------------------------------------------------------------------------------------
+  table_function_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-01" ]
+    description: |
+      Destroys the table function, releasing its resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to
+      prevent double-destruction. Destroying the handle after registration does not affect the registered
+      function.
+    parameters:
+      function:
+        type: table_function
+        description: The function to destroy.
+        indirection: 1
+    return_type: ERROR

--- a/api_spec/v2/identifier/identifier.yaml
+++ b/api_spec/v2/identifier/identifier.yaml
@@ -1,0 +1,50 @@
+module: identifier
+#
+# Operations on identifier-semantic names (the `identifier` alias declared in common). The engine matches identifiers
+# case-insensitively and quotes them into SQL only when required. Both are engine knowledge, so a name that will be
+# embedded in SQL text is rendered through this module rather than quoted by hand.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  identifier_render_quoted:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Renders a name as a SQL identifier, quoting and escaping only when required.
+
+      Produces the SQL text for the name: the name itself when it is already a legal bare identifier, or the name
+      double-quoted with interior double quotes doubled when it is a keyword or contains characters that require
+      quoting. This is the engine's own identifier rendering, so the result parses back to a name equal to the
+      input.
+
+      Writes into a caller-supplied buffer, so nothing is allocated on the caller's behalf and nothing has to be
+      freed. Pass out_text = NULL to size the buffer without rendering into it: out_length then receives the length,
+      and out_capacity is ignored. With out_text != NULL, out_capacity must be at least out_length + 1, or the call
+      returns ERROR_INPUT_OBJECT_SIZE with out_length set to the required length and out_text left untouched.
+
+      out_length never counts the terminator, but a successful write always appends one, so the buffer is usable as
+      a C string.
+    parameters:
+      name:
+        type: identifier
+        description: The name to render. Borrowed for the call only.
+      out_text:
+        type: char
+        indirection: 1
+        kind: OUT
+        description: Caller-owned buffer receiving the text plus a null terminator, or NULL to only report the required length in out_length.
+      out_capacity:
+        type: idx
+        description: Bytes available in out_text, terminator included. Ignored when out_text is NULL.
+      out_length:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the text length excluding the null terminator — written on success and on ERROR_INPUT_OBJECT_SIZE.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR

--- a/api_spec/v2/logical_type/custom_type.yaml
+++ b/api_spec/v2/logical_type/custom_type.yaml
@@ -1,0 +1,170 @@
+module: custom type
+#
+# Registration of user-defined types. A custom type is a name bound to a base
+# type: it borrows the base type's internal (physical) representation, so the
+# execution engine needs no special handling for it, while staying logically
+# distinct so it can carry its own cast functions.
+#
+# The handle follows the function families: create it against a connection or
+# a loading extension, configure it with the setters, make it available with
+# `[[custom_type_register]]`, and destroy it with `[[custom_type_destroy]]`.
+#
+# Values of a custom type are produced and consumed with the base type's
+# vector accessors. To hand a value back out under the custom type's name --
+# from a scalar function's bind callback, say -- alias the base type with
+# `[[context_create_type_with_alias]]`.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  custom_type:
+    description: |
+      An owned opaque handle to a custom type being built. Created with `[[custom_type_create_with_connection]]` or
+      `[[custom_type_create_with_extension]]`, configured with `[[custom_type_set_name]]` and
+      `[[custom_type_set_base_type]]`, made available with `[[custom_type_register]]`, and destroyed with
+      `[[custom_type_destroy]]`.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Constructors
+  #---------------------------------------------------------------------------------------------------------------------
+  custom_type_create_with_connection:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a new custom type that will be registered on the connection's database.
+
+      The type starts out empty: configure it with `[[custom_type_set_name]]` and `[[custom_type_set_base_type]]`,
+      then make it available with `[[custom_type_register]]`. The caller owns the returned handle and must destroy
+      it with `[[custom_type_destroy]]`, also after registration.
+    parameters:
+      connection:
+        type: connection
+        description: The connection to create the type in.
+      type:
+        type: custom_type
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created custom type. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  custom_type_create_with_extension:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a new custom type that will be registered on the loading extension's database.
+
+      Use this from an extension load callback, where an extension handle is available. The type starts out empty:
+      configure it with `[[custom_type_set_name]]` and `[[custom_type_set_base_type]]`, then make it available with
+      `[[custom_type_register]]`. The caller owns the returned handle and must destroy it with
+      `[[custom_type_destroy]]`, also after registration.
+    parameters:
+      extension:
+        type: extension
+        description: The extension to create the type in.
+      type:
+        type: custom_type
+        indirection: 1
+        kind: OUT
+        description: On success, receives the newly created custom type. Owned by the caller.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Properties
+  #---------------------------------------------------------------------------------------------------------------------
+  custom_type_set_name:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets the name of the custom type.
+
+      This is the name the type is referred to by in SQL, and the alias carried by every logical type instance of
+      it. The name is borrowed and copied. Calling this again replaces the previous name. A name must be set
+      before registration.
+    parameters:
+      type:
+        type: custom_type
+        description: The type to set the name of.
+      name:
+        type: identifier
+        description: The name to set. Borrowed and copied.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  custom_type_set_base_type:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Sets the base type of the custom type.
+
+      The custom type shares the base type's internal representation but is logically distinct, so it can carry
+      its own cast functions. The type is borrowed and copied. Calling this again replaces the previous base type.
+      A base type must be set before registration, and it must be a fully defined concrete type -- ANY is a
+      signature wildcard, not something a registered type can be built on.
+    parameters:
+      type:
+        type: custom_type
+        description: The type to set the base type of.
+      base_type:
+        type: logical_type
+        description: The logical type to base the custom type on. Borrowed for the call only.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Register
+  #---------------------------------------------------------------------------------------------------------------------
+  custom_type_register:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Registers the custom type, making it available for use in SQL queries.
+
+      The type is registered on the target given at creation: the connection's database or the loading extension.
+      Registration requires a name and a complete base type. The caller still owns the handle after registration
+      and must destroy it with `[[custom_type_destroy]]`, which does not affect the registered type.
+    parameters:
+      type:
+        type: custom_type
+        description: The type to register.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destroy
+  #---------------------------------------------------------------------------------------------------------------------
+  custom_type_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Destroys the custom type, releasing its resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+      double-destruction. Destroying the handle after registration does not affect the registered type.
+    parameters:
+      type:
+        type: custom_type
+        description: The type to destroy.
+        indirection: 1
+    return_type: ERROR

--- a/api_spec/v2/logical_type/logical_type.yaml
+++ b/api_spec/v2/logical_type/logical_type.yaml
@@ -212,11 +212,15 @@ functions:
     description: |
       Creates a logical type from a type name plus value parameters.
 
-      The generic constructor: resolves the name in the context's catalog —
-      search path first, then the system catalog — and binds it with the given
-      parameters, exactly as SQL binds a type expression. Built-in
-      parameterized kinds and registered extension types construct through this
-      same call.
+      The generic constructor: resolves the name in the context's catalog and
+      binds it with the given parameters, exactly as SQL binds a type
+      expression. Built-in parameterized kinds and registered extension types
+      construct through this same call.
+
+      An unqualified name is resolved along the search path first and then in
+      the system catalog, which is where the built-in kinds live. A qualified
+      name is resolved exactly as written, with no system-catalog fallback, so
+      it names the type in that catalog or schema or fails.
 
       Parameters are (name, value) pairs in two parallel arrays. param_names
       may be NULL to make every parameter positional, and a {NULL, 0} entry
@@ -248,8 +252,8 @@ functions:
         type: context
         description: The context supplying the catalog and active transaction.
       name:
-        type: identifier
-        description: View of the type name to resolve. Unqualified; case-insensitive.
+        type: qname
+        description: The type name to resolve. Parts are matched case-insensitively; qualify it to name a type in a particular catalog or schema.
       param_names:
         type: identifier
         indirection: 1
@@ -413,8 +417,8 @@ functions:
         type: connection
         description: The connection supplying the catalog and active transaction.
       name:
-        type: identifier
-        description: View of the type name to resolve. Unqualified; case-insensitive.
+        type: qname
+        description: The type name to resolve. Parts are matched case-insensitively; qualify it to name a type in a particular catalog or schema.
       param_names:
         type: identifier
         indirection: 1

--- a/api_spec/v2/prepared_statement/prepared_statement.yaml
+++ b/api_spec/v2/prepared_statement/prepared_statement.yaml
@@ -1,0 +1,214 @@
+module: prepared_statement
+#
+# The opt-in cached-execution path, a sibling to `statement_execute` rather than a
+# replacement for it. Both run a parsed statement and stream the same result handle
+# through the same state machine; they differ only in plan reuse. `statement_execute`
+# re-binds on every call, while a prepared statement may reuse the plan it built once.
+#
+# `prepared_statement_create` copies the statement's AST, binds and plans it once
+# (borrowing the statement, not consuming it), and returns a reusable handle.
+# `prepared_statement_execute` runs it with named or positional parameter values, as often
+# as the caller likes, and returns the same result handle `statement_execute` does.
+#
+# Reuse is reported, not assumed. Whether a prepared statement reuses its plan depends on
+# the statement: a plan is reused only when every parameter type was resolved at prepare
+# time and nothing in it must be re-bound each execution, which a table scan rules out.
+# When a plan is not reused, executing a prepared statement is no faster than
+# `statement_execute`, and `prepared_statement_reuses_plan` says so. `require_cacheable`
+# turns that into a prepare-time failure for a caller that only wants the handle if it is
+# the fast path.
+#
+# One live result per connection, as everywhere else in this API: both
+# `prepared_statement_create` and `prepared_statement_execute` refuse with
+# `ERROR_RESOURCE_IN_USE` while the connection has a live result. Open another connection
+# for concurrency; a prepared statement belongs to the connection it was prepared on.
+#
+# The handle is opaque and exposes no signature of its own: `statement_bind` already
+# returns both the output and parameter schemas for a statement, and
+# `result_get_schema` returns the output schema of a result. This module adds only
+# what neither can give -- `prepared_statement_reuses_plan`, a property of the built
+# plan rather than of the AST.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  prepared_statement:
+    description: |
+      An owned handle to a statement bound and planned once, executable repeatedly via
+      `[[prepared_statement_execute]]`. Construct with `[[prepared_statement_create]]` and destroy with
+      `[[prepared_statement_destroy]]`. It keeps its connection's session alive, so it stays usable across executions
+      and even after the connection is disconnected.
+    cleanup_with: prepared_statement_destroy
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Constructor
+  #---------------------------------------------------------------------------------------------------------------------
+  prepared_statement_create:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Prepares a parsed statement into a reusable handle. Non-consuming.
+
+      Copies the statement's AST, then binds and plans it once. Binder and catalog errors surface here, exactly as
+      they would from `[[statement_execute]]`. The statement is borrowed rather than consumed, since a copy is what
+      gets prepared, so it can be prepared again or executed directly; the caller destroys it with
+      `[[sql_statement_destroy]]`.
+
+      By default this succeeds for any preparable statement, whether or not its plan will be reused; ask
+      `[[prepared_statement_reuses_plan]]` which one you got. Setting `require_cacheable` instead fails with
+      `ERROR_INPUT_INVALID` when the plan would not be reused, so a caller who wants the handle only for the speedup
+      finds out here rather than after silently taking the slow path.
+
+      Refuses with `ERROR_RESOURCE_IN_USE` while the connection has a live result. Drain, destroy, or interrupt that
+      result first, or prepare on another connection. `*out_prepared` is set to NULL on failure.
+    role: constructor
+    belongs_to: prepared_statement
+    parameters:
+      conn:
+        type: connection
+        description: The connection supplying the catalog, transaction, and parser state. The prepared statement belongs to it.
+      statement:
+        type: sql_statement
+        description: The statement to prepare. Borrowed and copied, not consumed; destroy it with `[[sql_statement_destroy]]`.
+      require_cacheable:
+        type: bool
+        description: |
+          When true, fail with `ERROR_INPUT_INVALID` unless the prepared plan will be reused across executions, as
+          `[[prepared_statement_reuses_plan]]` would report it.
+      out_prepared:
+        type: prepared_statement
+        indirection: 1
+        kind: OUT
+        description: On success, receives the new prepared statement. Owned by the caller; destroy via `[[prepared_statement_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Execution
+  #---------------------------------------------------------------------------------------------------------------------
+  prepared_statement_execute:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Executes a prepared statement, streaming its result. Non-consuming.
+
+      Returns a result without executing anything: execution happens incrementally as the result is stepped or
+      drained, exactly as with `[[statement_execute]]`. The handle returned is an ordinary result, with identical
+      behaviour throughout -- streaming, draining, the changed-row count of a DML statement, the output schema, the
+      statement type, and the result type.
+
+      `parameter_values` binds the statement's parameters as constants for this execution. Binding is positional by
+      default ($1 = element 0); supply `parameter_names` to bind by name instead, where a non-empty entry binds its
+      value to that named parameter ($name, matched case-insensitively) and a {NULL, 0} entry stays positional. Pass
+      NULL for both arrays, or a count of 0, for a statement without parameters. Both arrays are borrowed and copied
+      in, so the caller still owns and destroys them. A key set that does not match the statement's parameters is
+      rejected with `ERROR_INPUT_INVALID`, with one exception: a named parameter left without a value reads the
+      session variable of the same name (`SET VARIABLE`) when one exists.
+
+      Not consumed: execute the same handle again, with the same values or different ones, as often as you like.
+      Values are bound per execution and nothing carries over between them. A catalog change since the statement was
+      prepared, or a parameter type that differs from the one the cached plan assumed, triggers a re-bind that is
+      invisible apart from its cost.
+
+      Refuses with `ERROR_RESOURCE_IN_USE` while the connection has a live result; drain, destroy, or interrupt it
+      first, or execute on another connection. A failed execution, at any stage, leaves the prepared statement usable.
+      `*out_result` is set to NULL on failure.
+    role: method
+    belongs_to: prepared_statement
+    parameters:
+      prepared:
+        type: prepared_statement
+        description: The prepared statement to execute. Borrowed; not consumed.
+      parameter_names:
+        type: identifier
+        indirection: 1
+        const: true
+        description: |
+          Optional. An array of `parameter_count` parameter names; a non-empty entry binds its value to the named
+          parameter ($name, case-insensitive), a {NULL, 0} entry keeps it positional ($1 = element 0). Pass NULL to
+          bind everything positionally.
+      parameter_values:
+        type: value
+        indirection: 1
+        const: true
+        description: |
+          Optional. An array of `parameter_count` values. Each binds by name when `parameter_names` supplies one, and
+          positionally ($1 = element 0) otherwise. Borrowed and copied in. Pass NULL for a statement without
+          parameters.
+      parameter_count:
+        type: idx
+        description: The number of entries in `parameter_names` and `parameter_values`. Pass 0 for a statement without parameters.
+      out_result:
+        type: result
+        indirection: 1
+        kind: OUT
+        description: On success, receives the new result. Owned by the caller; destroy via `[[result_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Introspection
+  #---------------------------------------------------------------------------------------------------------------------
+  prepared_statement_reuses_plan:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Reports whether the prepared statement reuses its compiled plan across executions.
+
+      True when executions reuse the plan built at prepare time, provided the supplied values match the planned
+      parameter types and nothing the plan depends on has changed; false when the statement re-binds on every
+      execution, making it no faster than `[[statement_execute]]`. A plan is reused only when all parameter types
+      were resolved at prepare time and the plan is cacheable: `SELECT 42` reuses, `SELECT $1::INTEGER + 1` reuses,
+      a statement reading a base table does not (it re-binds so a catalog change is picked up), and `SELECT $1 + $2`
+      does not (the types are unknown until values arrive).
+
+      A static property of the built plan, fixed when the statement was prepared and independent of the values later
+      passed to `[[prepared_statement_execute]]`.
+    role: getter
+    belongs_to: prepared_statement
+    parameters:
+      prepared:
+        type: prepared_statement
+        description: The prepared statement to inspect.
+      out_reuses:
+        type: bool
+        indirection: 1
+        kind: OUT
+        description: Receives true when the compiled plan is reused across executions, false when the statement re-binds each time.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destructor
+  #---------------------------------------------------------------------------------------------------------------------
+  prepared_statement_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-03" ]
+    description: |
+      Destroys a prepared statement.
+
+      Null-safe: passing NULL, or a slot already set to NULL, is a no-op. A result produced by
+      `[[prepared_statement_execute]]` is independently owned and keeps the session alive itself, so the prepared
+      statement may be destroyed while results made from it are still live. On success the slot is set to NULL.
+    role: destructor
+    belongs_to: prepared_statement
+    parameters:
+      prepared:
+        type: prepared_statement
+        indirection: 1
+        description: The prepared statement to destroy.
+    return_type: ERROR

--- a/api_spec/v2/qname/qname.yaml
+++ b/api_spec/v2/qname/qname.yaml
@@ -1,0 +1,263 @@
+module: qname
+#
+# A qualified name: the ordered path of identifiers that names a database
+# object. The path is the whole representation -- partial qualification is
+# expressed by path length (["t"], ["s","t"], ["c","s","t"]), never by empty
+# placeholder parts, and the last part is always the object itself. Deciding
+# whether a two-part name means catalog.object or schema.object belongs to
+# resolution, not to the name.
+#
+# Names are handed out as owned handles rather than borrowed views because the
+# engine spells them several different ways internally, and several of those
+# are mutable in place; an owned handle is a snapshot the caller keeps for as
+# long as it likes, with no lifetime tied to whatever produced it.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Handles
+#-----------------------------------------------------------------------------------------------------------------------
+handles:
+  qname:
+    description: |
+      An owned qualified name: an ordered path of one to three non-empty identifier parts whose last element is the
+      object name. Construct with `[[qname_parse]]` or `[[qname_create]]`, read with `[[qname_get_part_count]]` and
+      `[[qname_get_part]]`, render back to SQL with `[[qname_render]]`, compare with `[[qname_equals]]`, and destroy
+      with `[[qname_destroy]]`. Two handles are compared with `[[qname_equals]]`, never by pointer.
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------------------------------------
+functions:
+  #---------------------------------------------------------------------------------------------------------------------
+  # Constructors
+  #---------------------------------------------------------------------------------------------------------------------
+  qname_parse:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Parses SQL text into a qualified name.
+
+      Applies the engine's qualified-name rules: dots separate parts, and a double-quoted part may contain dots and
+      doubled interior quotes. More than three parts and an unterminated quote are rejected with the parser's own
+      error; text without at least one non-empty part is rejected with `ERROR_INPUT_INVALID`. When the parts are
+      already separate, build the name with `[[qname_create]]` rather than joining them and parsing the result.
+    role: constructor
+    belongs_to: qname
+    parameters:
+      text:
+        type: str
+        description: The name text to parse. Borrowed for the call only.
+      name:
+        type: qname
+        indirection: 1
+        kind: OUT
+        description: On success, receives the qualified name. Owned by the caller; destroy via `[[qname_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  qname_create:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Creates a qualified name from its parts.
+
+      The parts are ordered outermost first, so the last one is the object name. Between one and three parts are
+      accepted -- the engine qualifies at most catalog.schema.name today -- and every part must be non-empty:
+      partial qualification is expressed by passing fewer parts, never by empty placeholders. Zero parts, more than
+      three, and an empty part are all rejected with `ERROR_INPUT_INVALID`. The parts are borrowed and copied.
+    role: constructor
+    belongs_to: qname
+    parameters:
+      parts:
+        type: identifier
+        indirection: 1
+        const: true
+        description: An array of `part_count` non-empty identifier views, outermost first.
+      part_count:
+        type: idx
+        description: The number of parts, between one and three.
+      name:
+        type: qname
+        indirection: 1
+        kind: OUT
+        description: On success, receives the qualified name. Owned by the caller; destroy via `[[qname_destroy]]`.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Inspection
+  #---------------------------------------------------------------------------------------------------------------------
+  qname_get_part_count:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Returns how many parts the qualified name has.
+
+      Always at least one. Valid indices for `[[qname_get_part]]` are [0, count), and the object name is the part at
+      count - 1.
+    role: getter
+    belongs_to: qname
+    parameters:
+      name:
+        type: qname
+        description: The qualified name.
+      count:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the number of parts.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  qname_get_part:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Borrows one part of the qualified name.
+
+      Parts are ordered outermost first, so the object name is the part at `[[qname_get_part_count]]` - 1. The view
+      is valid until the qualified name is destroyed. An index outside [0, count) is rejected with
+      `ERROR_INPUT_OUT_OF_RANGE`.
+    role: getter
+    belongs_to: qname
+    parameters:
+      name:
+        type: qname
+        description: The qualified name.
+      index:
+        type: idx
+        description: Zero-based part index.
+      part:
+        type: identifier
+        indirection: 1
+        kind: OUT_BORROW
+        description: Receives a borrowed view of the part, valid until the qualified name is destroyed.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  qname_render:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Renders the qualified name as SQL text.
+
+      Joins the parts with dots, quoting and escaping each one only where the identifier requires it, so the result
+      parses back through `[[qname_parse]]` to an equal name.
+
+      Writes into a caller-supplied buffer, so nothing is allocated on the caller's behalf and nothing has to be
+      freed. Pass out_text = NULL to size the buffer without rendering into it: out_length then receives the length,
+      and out_capacity is ignored. With out_text != NULL, out_capacity must be at least out_length + 1, or the call
+      returns ERROR_INPUT_OBJECT_SIZE with out_length set to the required length and out_text left untouched.
+
+      out_length never counts the terminator, but a successful write always appends one, so the buffer is usable as
+      a C string.
+    role: getter
+    belongs_to: qname
+    parameters:
+      name:
+        type: qname
+        description: The qualified name to render.
+      out_text:
+        type: char
+        indirection: 1
+        kind: OUT
+        description: Caller-owned buffer receiving the text plus a null terminator, or NULL to only report the required length in out_length.
+      out_capacity:
+        type: idx
+        description: Bytes available in out_text, terminator included. Ignored when out_text is NULL.
+      out_length:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the text length excluding the null terminator — written on success and on ERROR_INPUT_OBJECT_SIZE.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  qname_equals:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Compares two qualified names.
+
+      True when both have the same number of parts and every part matches case-insensitively, which is the engine's
+      own identifier equality: casing never distinguishes two names. This is the only way to compare names; two
+      handles holding equal names are still distinct pointers.
+    role: getter
+    belongs_to: qname
+    parameters:
+      left:
+        type: qname
+        description: The first qualified name.
+      right:
+        type: qname
+        description: The second qualified name.
+      result:
+        type: bool
+        indirection: 1
+        kind: OUT
+        description: Receives whether the two names are equal.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  qname_hash:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Hashes a qualified name.
+
+      Consistent with `[[qname_equals]]`: names that compare equal hash equal, casing differences included. The value
+      is not stable across processes or library versions, so use it for in-process lookup tables only and never
+      persist it.
+    role: getter
+    belongs_to: qname
+    parameters:
+      name:
+        type: qname
+        description: The qualified name to hash.
+      hash:
+        type: u64
+        indirection: 1
+        kind: OUT
+        description: Receives the hash value.
+      err:
+        type: error_info
+        indirection: 1
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via `[[error_info_destroy]]`.
+    return_type: ERROR
+
+  #---------------------------------------------------------------------------------------------------------------------
+  # Destroy
+  #---------------------------------------------------------------------------------------------------------------------
+  qname_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-02" ]
+    description: |
+      Destroys the qualified name, releasing its resources.
+
+      Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+      double-destruction. Any part views borrowed from it become dangling.
+    role: destructor
+    belongs_to: qname
+    parameters:
+      name:
+        type: qname
+        description: The qualified name to destroy.
+        indirection: 1
+    return_type: ERROR

--- a/scripts/generate_enum_util.py
+++ b/scripts/generate_enum_util.py
@@ -19,6 +19,7 @@ blacklist = [
     "UnavailableReason",
     "VirtualColumnBindingType",
     "Slot",
+    "State",
     "ScheduleMode",
     "MemoryUpdateMode",
     "SchedulePolicy",

--- a/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
+++ b/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
@@ -420,6 +420,14 @@ inline shared_ptr<ConnectionBusySlotV2> GetBusySlot(ClientContext &context) {
 	return context.registered_state->GetOrCreate<ConnectionBusySlotV2>(BUSY_SLOT_STATE_KEY);
 }
 
+//! Runs a prepared statement as a single-statement result, claiming the connection's
+//! live-result slot first. Defined in capi_v2_result.cpp: assembling a result is that
+//! module's business, and the prepared path reaches the same seam the stateless one does.
+//! `context` is the session the result holds on to, so it survives disconnect. Throws
+//! ResourceInUseException when the connection already has a live result.
+auto ExecutePreparedStatementV2(const shared_ptr<ClientContext> &context, PreparedStatement &prepared,
+                                identifier_map_t<BoundParameterData> &values) -> duckdb_v2_result_handle;
+
 //----------------------------------------------------------------------------------------------------------------------
 // Text sinks
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
+++ b/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
@@ -23,6 +23,7 @@
 #include "duckdb/main/parse_iterator.hpp"
 #include "duckdb/main/pending_query_result.hpp"
 #include "duckdb/main/stream_query_result.hpp"
+#include "duckdb/main/table_description.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
@@ -231,6 +232,24 @@ inline auto Convert(duckdb_v2_qname_handle name) -> CV2QualifiedName * {
 }
 inline auto Convert(CV2QualifiedName *name) -> duckdb_v2_qname_handle {
 	return reinterpret_cast<duckdb_v2_qname_handle>(name);
+}
+
+using CV2TableDescription = duckdb::TableDescription;
+
+inline auto Convert(duckdb_v2_table_description_handle desc) -> CV2TableDescription * {
+	return reinterpret_cast<CV2TableDescription *>(desc);
+}
+inline auto Convert(CV2TableDescription *desc) -> duckdb_v2_table_description_handle {
+	return reinterpret_cast<duckdb_v2_table_description_handle>(desc);
+}
+
+using CV2ColumnDescription = duckdb::ColumnDefinition;
+
+inline auto Convert(duckdb_v2_column_description_handle column) -> CV2ColumnDescription * {
+	return reinterpret_cast<CV2ColumnDescription *>(column);
+}
+inline auto Convert(CV2ColumnDescription *column) -> duckdb_v2_column_description_handle {
+	return reinterpret_cast<duckdb_v2_column_description_handle>(column);
 }
 
 using CV2Value = duckdb::Value;

--- a/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
+++ b/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
@@ -23,6 +23,7 @@
 #include "duckdb/main/parse_iterator.hpp"
 #include "duckdb/main/pending_query_result.hpp"
 #include "duckdb/main/stream_query_result.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/parser/sql_statement.hpp"
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/main/db_instance_cache.hpp"
@@ -221,6 +222,15 @@ inline auto Convert(duckdb_v2_logical_type_handle opt) -> CV2LogicalType * {
 }
 inline auto Convert(CV2LogicalType *opt) -> duckdb_v2_logical_type_handle {
 	return reinterpret_cast<duckdb_v2_logical_type_handle>(opt);
+}
+
+using CV2QualifiedName = duckdb::QualifiedName;
+
+inline auto Convert(duckdb_v2_qname_handle name) -> CV2QualifiedName * {
+	return reinterpret_cast<CV2QualifiedName *>(name);
+}
+inline auto Convert(CV2QualifiedName *name) -> duckdb_v2_qname_handle {
+	return reinterpret_cast<duckdb_v2_qname_handle>(name);
 }
 
 using CV2Value = duckdb::Value;

--- a/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
+++ b/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
@@ -26,6 +26,7 @@
 #include "duckdb/main/table_description.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/parser/sql_statement.hpp"
+#include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/main/db_instance_cache.hpp"
 
@@ -260,6 +261,16 @@ inline auto Convert(duckdb_v2_value_handle val) -> CV2Value * {
 
 inline auto Convert(CV2Value *val) -> duckdb_v2_value_handle {
 	return reinterpret_cast<duckdb_v2_value_handle>(val);
+}
+
+using CV2Expression = duckdb::Expression;
+
+inline auto Convert(duckdb_v2_expression_handle expression) -> CV2Expression * {
+	return reinterpret_cast<CV2Expression *>(expression);
+}
+
+inline auto Convert(CV2Expression *expression) -> duckdb_v2_expression_handle {
+	return reinterpret_cast<duckdb_v2_expression_handle>(expression);
 }
 
 using CV2DataChunk = duckdb::DataChunk;

--- a/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
+++ b/src/include/duckdb/main/capi_v2/capi_v2_internal.hpp
@@ -420,14 +420,6 @@ inline shared_ptr<ConnectionBusySlotV2> GetBusySlot(ClientContext &context) {
 	return context.registered_state->GetOrCreate<ConnectionBusySlotV2>(BUSY_SLOT_STATE_KEY);
 }
 
-//! Runs a prepared statement as a single-statement result, claiming the connection's
-//! live-result slot first. Defined in capi_v2_result.cpp: assembling a result is that
-//! module's business, and the prepared path reaches the same seam the stateless one does.
-//! `context` is the session the result holds on to, so it survives disconnect. Throws
-//! ResourceInUseException when the connection already has a live result.
-auto ExecutePreparedStatementV2(const shared_ptr<ClientContext> &context, PreparedStatement &prepared,
-                                identifier_map_t<BoundParameterData> &values) -> duckdb_v2_result_handle;
-
 //----------------------------------------------------------------------------------------------------------------------
 // Text sinks
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/include/duckdb/main/capi_v2/capi_v2_result_internal.hpp
+++ b/src/include/duckdb/main/capi_v2/capi_v2_result_internal.hpp
@@ -1,0 +1,165 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/capi_v2/capi_v2_result_internal.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+
+//! The result state machine, shared by the modules that build a result or consume one wholesale.
+//! Not part of any public surface: only the V2 bridge's own translation units include this.
+//! `capi_v2_result.cpp` owns it and defines the members declared here; `capi_v2_prepared_statement.cpp`
+//! and `capi_v2_arrow.cpp` are the other consumers.
+
+namespace duckdb::capiv2 {
+
+struct ResultWrapperV2 {
+	enum class State : uint8_t { PENDING, STREAMING, FINISHED, CANCELLED, ERRORED };
+
+	~ResultWrapperV2() {
+		// Finalize() (engine cleanup) runs in duckdb_v2_result_destroy, not here:
+		// a destructor must not drive locked engine state behind a catch-all.
+		pending.reset();
+		result.reset();
+		ReleaseBusySlot();
+	}
+
+	State state = State::PENDING;
+	//! Live while state == PENDING.
+	unique_ptr<PendingQueryResult> pending;
+	//! Live while state == STREAMING.
+	unique_ptr<QueryResult> result;
+
+	//! Keeps the ClientContext alive for starting subsequent fragments and
+	//! preserves the guarantee that an undrained result survives disconnect:
+	//! the connection handle (a bare Connection *) may be destroyed while a
+	//! result is live, but the context it shared with us stays alive here.
+	shared_ptr<ClientContext> context;
+	//! The preprocessed statement group; fragment_index points at the next
+	//! fragment to start, fragment_count remembers the group size after
+	//! fragments is cleared on terminal transitions.
+	vector<unique_ptr<SQLStatement>> fragments;
+	idx_t fragment_index = 0;
+	idx_t fragment_count = 0;
+	//! Positional parameter values for this execution, keyed by binding identifier
+	//! ("1".."N"). Empty for an unparameterized statement (StartNextFragment takes
+	//! the no-values path). Applied only to the first fragment (a parameterized
+	//! statement does not expand into a group).
+	identifier_map_t<BoundParameterData> param_values;
+	//! True while the currently executing fragment is the principal one
+	//! (its chunks are surfaced; other fragments' output is discarded).
+	bool principal_active = false;
+	//! True once a row-producing fragment has been selected as principal.
+	bool principal_seen = false;
+	//! True once the principal fragment's metadata has been captured.
+	bool metadata_available = false;
+	//! True when statement_execute injected its own wrapping transaction for
+	//! this group (autocommit input that preprocessing expanded and wrapped
+	//! in BEGIN ... COMMIT). Distinguishes a bridge-owned transaction, which
+	//! must be rolled back on incomplete destroy, from a user-managed one,
+	//! which must not be touched. Captured at query time because the engine's
+	//! auto_rollback flag is not reliably observable from the bridge's
+	//! fragment execution path.
+	bool owns_wrapping_transaction = false;
+
+	//! The owning connection's busy slot; released on terminal transition
+	//! or destroy, whichever comes first.
+	shared_ptr<ConnectionBusySlotV2> busy_slot;
+
+	//! Principal fragment's metadata, valid once metadata_available.
+	vector<LogicalType> types;
+	vector<Identifier> names;
+	StatementType statement_type = StatementType::INVALID_STATEMENT;
+	StatementProperties properties;
+
+	//! Sticky error, recorded when state == ERRORED.
+	ErrorData error;
+
+	//! Mirrors ClientContext::Query's error handling for expanded groups
+	//! (client_context.cpp, chain-append loop): when the group cannot
+	//! complete, roll back the transaction statement_execute injected to wrap
+	//! it. A no-op for non-expanded statements, for groups that ran inside a
+	//! user-managed transaction (which the bridge never wraps), and when the
+	//! transaction is already gone.
+	void RollbackIncompleteGroup() {
+		if (!owns_wrapping_transaction || !context) {
+			return;
+		}
+		if (context->transaction.HasActiveTransaction()) {
+			// Mirrors Connection::Rollback (Query("ROLLBACK") + throw on error),
+			// driven through the retained context so it works after disconnect.
+			auto result = context->Query("ROLLBACK", QueryResultOutputType::FORCE_MATERIALIZED);
+			if (result->HasError()) {
+				result->ThrowError();
+			}
+		}
+	}
+
+	//! Close() the live engine result so an abandoned active query is cleaned
+	//! up (freeing the executor, which breaks the ClientContext ref cycle),
+	//! then roll back an injected group transaction. May throw; the terminal
+	//! states leave pending/result null, so this is then a no-op.
+	void Finalize() {
+		if (pending) {
+			pending->Close();
+		} else if (result && result->GetResultType() == QueryResultType::STREAM_RESULT) {
+			result->Cast<StreamQueryResult>().Close();
+		}
+		RollbackIncompleteGroup();
+	}
+
+	//! Frees the connection for its next query. Only the current owner can
+	//! release the slot, so a release after the connection moved on is a
+	//! no-op.
+	void ReleaseBusySlot() {
+		if (busy_slot) {
+			void *expected = this;
+			busy_slot->owner.compare_exchange_strong(expected, nullptr);
+			busy_slot.reset();
+		}
+	}
+
+	// State-machine entry points; defined in query_result-v2.cpp. All of
+	// them throw DuckDB exceptions on failure (callers wrap in
+	// WithErrorHandler) and record sticky errors before throwing.
+
+	//! Adopts an already-produced pending query into the state machine: the single
+	//! seam both the stateless (fragment) and prepared paths reach. When is_principal,
+	//! captures its metadata and surfaces its chunks. Throws on a pending prepare error.
+	void BeginPending(unique_ptr<PendingQueryResult> pending, bool is_principal);
+	//! Starts the pending query for the next fragment, selecting it as
+	//! principal per the engine-mirrored rule and adopting it via BeginPending.
+	//! Throws on prepare errors.
+	void StartNextFragment();
+	//! Drives one unit of work; never blocks. On CHUNK, out_chunk holds the
+	//! produced chunk; on every other status it is reset.
+	DUCKDB_V2_RESULT_STEP_STATUS Step(unique_ptr<DataChunk> &out_chunk);
+	//! Blocks until Step can make progress. No-op on terminal states.
+	void Wait();
+	//! Blocking convenience: steps/waits until a chunk is produced (returned)
+	//! or the stream ends (nullptr). Cancellation throws InterruptException.
+	unique_ptr<DataChunk> FetchChunkBlocking();
+	//! Throws unless the principal fragment's metadata is available.
+	void RequireMetadata() const;
+
+private:
+	//! Shared error sink: interrupts become the sticky CANCELLED state
+	//! (returned as a status), everything else becomes the sticky ERRORED
+	//! state and throws.
+	DUCKDB_V2_RESULT_STEP_STATUS HandleExecutionError(ErrorData error_data);
+};
+
+auto Convert(ResultWrapperV2 *wrapper) -> duckdb_v2_result_handle;
+auto Convert(duckdb_v2_result_handle handle) -> ResultWrapperV2 *;
+
+//! Runs a prepared statement as a single-statement result, claiming the connection's
+//! live-result slot first. `context` is the session the result holds on to, so it survives
+//! disconnect. Throws ResourceInUseException when the connection already has a live result.
+auto ExecutePreparedStatementV2(const shared_ptr<ClientContext> &context, PreparedStatement &prepared,
+                                identifier_map_t<BoundParameterData> &values) -> duckdb_v2_result_handle;
+
+} // namespace duckdb::capiv2

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -771,13 +771,6 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_set_cardinality)
 	(duckdb_v2_table_function_bind_info_handle info, idx_t cardinality, bool is_exact,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_get_bind_data)
-	(duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_get_user_data)
-	(duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_set_cardinality)
-	(duckdb_v2_table_function_cardinality_info_handle info, idx_t cardinality, bool is_exact,
-	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_create_with_connection)
 	(duckdb_v2_connection_handle connection, duckdb_v2_table_function_handle *function,
 	 duckdb_v2_error_info_handle *err);
@@ -826,9 +819,6 @@ typedef struct {
 	(duckdb_v2_table_function_handle function, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_bind_callback)
 	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_bind_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_cardinality_callback)
-	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_cardinality_callback_fn callback,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_exec_callback)
 	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_exec_callback_fn callback,
@@ -997,87 +987,170 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_next_chunk)
 	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_data_chunk_handle *out_chunk,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_bind_data)
-	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_init_data)
-	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_user_data)
-	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_set_batch_data)
-	(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_get_bind_data)
-	(duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_get_user_data)
-	(duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_set_target)
-	(duckdb_v2_copy_function_batch_size_info_handle info, idx_t rows, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_take_input)
-	(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_column_data_collection_handle *collection,
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_count)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_name)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_count)
-	(duckdb_v2_copy_function_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_name)
-	(duckdb_v2_copy_function_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_type)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_type)
-	(duckdb_v2_copy_function_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_file_path)
+	(duckdb_v2_copy_from_bind_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_option_count)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_option_name)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_user_data)
-	(duckdb_v2_copy_function_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_set_bind_data)
-	(duckdb_v2_copy_function_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_option_value)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t index, duckdb_v2_value_handle *value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_user_data)
+	(duckdb_v2_copy_from_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_set_bind_data)
+	(duckdb_v2_copy_from_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_set_cardinality)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t cardinality, bool is_exact, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_bind_data)
+	(duckdb_v2_copy_from_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_global_state)
+	(duckdb_v2_copy_from_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_local_state)
+	(duckdb_v2_copy_from_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_output_chunk)
+	(duckdb_v2_copy_from_exec_info_handle info, duckdb_v2_data_chunk_handle *chunk, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_user_data)
+	(duckdb_v2_copy_from_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_global_get_bind_data)
+	(duckdb_v2_copy_from_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_global_get_user_data)
+	(duckdb_v2_copy_from_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_global_set_global_state)
+	(duckdb_v2_copy_from_init_global_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_global_set_max_threads)
+	(duckdb_v2_copy_from_init_global_info_handle info, idx_t max_threads, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_local_get_bind_data)
+	(duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_local_get_global_state)
+	(duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_local_get_user_data)
+	(duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_local_set_local_state)
+	(duckdb_v2_copy_from_init_local_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_progress_get_bind_data)
+	(duckdb_v2_copy_from_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_progress_get_global_state)
+	(duckdb_v2_copy_from_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_progress_get_user_data)
+	(duckdb_v2_copy_from_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_progress_set_progress)
+	(duckdb_v2_copy_from_progress_info_handle info, double progress, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_bind_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_bind_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_exec_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_exec_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_init_global_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_init_global_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_init_local_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_init_local_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_progress_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_progress_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_create_with_connection)
 	(duckdb_v2_connection_handle connection, duckdb_v2_copy_function_handle *function,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_create_with_extension)
 	(duckdb_v2_extension_handle extension, duckdb_v2_copy_function_handle *function, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR (*duckdb_v2_copy_function_destroy)(duckdb_v2_copy_function_handle *function);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_bind_data)
-	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_init_data)
-	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_user_data)
-	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_batch_data)
-	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_bind_data)
-	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_init_data)
-	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_user_data)
-	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_bind_data)
-	(duckdb_v2_copy_function_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_file_path)
-	(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_user_data)
-	(duckdb_v2_copy_function_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_set_init_data)
-	(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_register)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_batch_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_batch_size_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_size_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_bind_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_bind_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_finalize_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_finalize_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_flush_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_flush_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_init_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_init_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_name)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_user_data)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_get_bind_data)
+	(duckdb_v2_copy_to_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_get_init_data)
+	(duckdb_v2_copy_to_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_get_user_data)
+	(duckdb_v2_copy_to_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_set_batch_data)
+	(duckdb_v2_copy_to_batch_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_size_get_bind_data)
+	(duckdb_v2_copy_to_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_size_get_user_data)
+	(duckdb_v2_copy_to_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_size_set_target)
+	(duckdb_v2_copy_to_batch_size_info_handle info, idx_t rows, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_take_input)
+	(duckdb_v2_copy_to_batch_info_handle info, duckdb_v2_column_data_collection_handle *collection,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_column_count)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_column_name)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_column_type)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_file_path)
+	(duckdb_v2_copy_to_bind_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_option_count)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_option_name)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_option_value)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t index, duckdb_v2_value_handle *value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_user_data)
+	(duckdb_v2_copy_to_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_set_bind_data)
+	(duckdb_v2_copy_to_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_finalize_get_bind_data)
+	(duckdb_v2_copy_to_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_finalize_get_init_data)
+	(duckdb_v2_copy_to_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_finalize_get_user_data)
+	(duckdb_v2_copy_to_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_flush_get_batch_data)
+	(duckdb_v2_copy_to_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_flush_get_bind_data)
+	(duckdb_v2_copy_to_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_flush_get_init_data)
+	(duckdb_v2_copy_to_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_flush_get_user_data)
+	(duckdb_v2_copy_to_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_init_get_bind_data)
+	(duckdb_v2_copy_to_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_init_get_file_path)
+	(duckdb_v2_copy_to_init_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_init_get_user_data)
+	(duckdb_v2_copy_to_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_init_set_init_data)
+	(duckdb_v2_copy_to_init_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_batch_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_batch_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_batch_size_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_batch_size_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_bind_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_bind_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_finalize_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_finalize_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_flush_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_flush_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_init_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_init_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1421,9 +1494,6 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_table_function_bind_get_user_data = duckdb_v2_table_function_bind_get_user_data;
 	result.duckdb_v2_table_function_bind_set_bind_data = duckdb_v2_table_function_bind_set_bind_data;
 	result.duckdb_v2_table_function_bind_set_cardinality = duckdb_v2_table_function_bind_set_cardinality;
-	result.duckdb_v2_table_function_cardinality_get_bind_data = duckdb_v2_table_function_cardinality_get_bind_data;
-	result.duckdb_v2_table_function_cardinality_get_user_data = duckdb_v2_table_function_cardinality_get_user_data;
-	result.duckdb_v2_table_function_cardinality_set_cardinality = duckdb_v2_table_function_cardinality_set_cardinality;
 	result.duckdb_v2_table_function_create_with_connection = duckdb_v2_table_function_create_with_connection;
 	result.duckdb_v2_table_function_create_with_extension = duckdb_v2_table_function_create_with_extension;
 	result.duckdb_v2_table_function_destroy = duckdb_v2_table_function_destroy;
@@ -1448,7 +1518,6 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_table_function_progress_set_progress = duckdb_v2_table_function_progress_set_progress;
 	result.duckdb_v2_table_function_register = duckdb_v2_table_function_register;
 	result.duckdb_v2_table_function_set_bind_callback = duckdb_v2_table_function_set_bind_callback;
-	result.duckdb_v2_table_function_set_cardinality_callback = duckdb_v2_table_function_set_cardinality_callback;
 	result.duckdb_v2_table_function_set_exec_callback = duckdb_v2_table_function_set_exec_callback;
 	result.duckdb_v2_table_function_set_init_global_callback = duckdb_v2_table_function_set_init_global_callback;
 	result.duckdb_v2_table_function_set_init_local_callback = duckdb_v2_table_function_set_init_local_callback;
@@ -1526,42 +1595,78 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_arrow_importer_destroy = duckdb_v2_arrow_importer_destroy;
 	result.duckdb_v2_arrow_importer_get_schema = duckdb_v2_arrow_importer_get_schema;
 	result.duckdb_v2_arrow_importer_next_chunk = duckdb_v2_arrow_importer_next_chunk;
-	result.duckdb_v2_copy_function_batch_get_bind_data = duckdb_v2_copy_function_batch_get_bind_data;
-	result.duckdb_v2_copy_function_batch_get_init_data = duckdb_v2_copy_function_batch_get_init_data;
-	result.duckdb_v2_copy_function_batch_get_user_data = duckdb_v2_copy_function_batch_get_user_data;
-	result.duckdb_v2_copy_function_batch_set_batch_data = duckdb_v2_copy_function_batch_set_batch_data;
-	result.duckdb_v2_copy_function_batch_size_get_bind_data = duckdb_v2_copy_function_batch_size_get_bind_data;
-	result.duckdb_v2_copy_function_batch_size_get_user_data = duckdb_v2_copy_function_batch_size_get_user_data;
-	result.duckdb_v2_copy_function_batch_size_set_target = duckdb_v2_copy_function_batch_size_set_target;
-	result.duckdb_v2_copy_function_batch_take_input = duckdb_v2_copy_function_batch_take_input;
-	result.duckdb_v2_copy_function_bind_get_column_count = duckdb_v2_copy_function_bind_get_column_count;
-	result.duckdb_v2_copy_function_bind_get_column_name = duckdb_v2_copy_function_bind_get_column_name;
-	result.duckdb_v2_copy_function_bind_get_column_type = duckdb_v2_copy_function_bind_get_column_type;
-	result.duckdb_v2_copy_function_bind_get_user_data = duckdb_v2_copy_function_bind_get_user_data;
-	result.duckdb_v2_copy_function_bind_set_bind_data = duckdb_v2_copy_function_bind_set_bind_data;
+	result.duckdb_v2_copy_from_bind_get_column_count = duckdb_v2_copy_from_bind_get_column_count;
+	result.duckdb_v2_copy_from_bind_get_column_name = duckdb_v2_copy_from_bind_get_column_name;
+	result.duckdb_v2_copy_from_bind_get_column_type = duckdb_v2_copy_from_bind_get_column_type;
+	result.duckdb_v2_copy_from_bind_get_file_path = duckdb_v2_copy_from_bind_get_file_path;
+	result.duckdb_v2_copy_from_bind_get_option_count = duckdb_v2_copy_from_bind_get_option_count;
+	result.duckdb_v2_copy_from_bind_get_option_name = duckdb_v2_copy_from_bind_get_option_name;
+	result.duckdb_v2_copy_from_bind_get_option_value = duckdb_v2_copy_from_bind_get_option_value;
+	result.duckdb_v2_copy_from_bind_get_user_data = duckdb_v2_copy_from_bind_get_user_data;
+	result.duckdb_v2_copy_from_bind_set_bind_data = duckdb_v2_copy_from_bind_set_bind_data;
+	result.duckdb_v2_copy_from_bind_set_cardinality = duckdb_v2_copy_from_bind_set_cardinality;
+	result.duckdb_v2_copy_from_exec_get_bind_data = duckdb_v2_copy_from_exec_get_bind_data;
+	result.duckdb_v2_copy_from_exec_get_global_state = duckdb_v2_copy_from_exec_get_global_state;
+	result.duckdb_v2_copy_from_exec_get_local_state = duckdb_v2_copy_from_exec_get_local_state;
+	result.duckdb_v2_copy_from_exec_get_output_chunk = duckdb_v2_copy_from_exec_get_output_chunk;
+	result.duckdb_v2_copy_from_exec_get_user_data = duckdb_v2_copy_from_exec_get_user_data;
+	result.duckdb_v2_copy_from_init_global_get_bind_data = duckdb_v2_copy_from_init_global_get_bind_data;
+	result.duckdb_v2_copy_from_init_global_get_user_data = duckdb_v2_copy_from_init_global_get_user_data;
+	result.duckdb_v2_copy_from_init_global_set_global_state = duckdb_v2_copy_from_init_global_set_global_state;
+	result.duckdb_v2_copy_from_init_global_set_max_threads = duckdb_v2_copy_from_init_global_set_max_threads;
+	result.duckdb_v2_copy_from_init_local_get_bind_data = duckdb_v2_copy_from_init_local_get_bind_data;
+	result.duckdb_v2_copy_from_init_local_get_global_state = duckdb_v2_copy_from_init_local_get_global_state;
+	result.duckdb_v2_copy_from_init_local_get_user_data = duckdb_v2_copy_from_init_local_get_user_data;
+	result.duckdb_v2_copy_from_init_local_set_local_state = duckdb_v2_copy_from_init_local_set_local_state;
+	result.duckdb_v2_copy_from_progress_get_bind_data = duckdb_v2_copy_from_progress_get_bind_data;
+	result.duckdb_v2_copy_from_progress_get_global_state = duckdb_v2_copy_from_progress_get_global_state;
+	result.duckdb_v2_copy_from_progress_get_user_data = duckdb_v2_copy_from_progress_get_user_data;
+	result.duckdb_v2_copy_from_progress_set_progress = duckdb_v2_copy_from_progress_set_progress;
+	result.duckdb_v2_copy_from_set_bind_callback = duckdb_v2_copy_from_set_bind_callback;
+	result.duckdb_v2_copy_from_set_exec_callback = duckdb_v2_copy_from_set_exec_callback;
+	result.duckdb_v2_copy_from_set_init_global_callback = duckdb_v2_copy_from_set_init_global_callback;
+	result.duckdb_v2_copy_from_set_init_local_callback = duckdb_v2_copy_from_set_init_local_callback;
+	result.duckdb_v2_copy_from_set_progress_callback = duckdb_v2_copy_from_set_progress_callback;
 	result.duckdb_v2_copy_function_create_with_connection = duckdb_v2_copy_function_create_with_connection;
 	result.duckdb_v2_copy_function_create_with_extension = duckdb_v2_copy_function_create_with_extension;
 	result.duckdb_v2_copy_function_destroy = duckdb_v2_copy_function_destroy;
-	result.duckdb_v2_copy_function_finalize_get_bind_data = duckdb_v2_copy_function_finalize_get_bind_data;
-	result.duckdb_v2_copy_function_finalize_get_init_data = duckdb_v2_copy_function_finalize_get_init_data;
-	result.duckdb_v2_copy_function_finalize_get_user_data = duckdb_v2_copy_function_finalize_get_user_data;
-	result.duckdb_v2_copy_function_flush_get_batch_data = duckdb_v2_copy_function_flush_get_batch_data;
-	result.duckdb_v2_copy_function_flush_get_bind_data = duckdb_v2_copy_function_flush_get_bind_data;
-	result.duckdb_v2_copy_function_flush_get_init_data = duckdb_v2_copy_function_flush_get_init_data;
-	result.duckdb_v2_copy_function_flush_get_user_data = duckdb_v2_copy_function_flush_get_user_data;
-	result.duckdb_v2_copy_function_init_get_bind_data = duckdb_v2_copy_function_init_get_bind_data;
-	result.duckdb_v2_copy_function_init_get_file_path = duckdb_v2_copy_function_init_get_file_path;
-	result.duckdb_v2_copy_function_init_get_user_data = duckdb_v2_copy_function_init_get_user_data;
-	result.duckdb_v2_copy_function_init_set_init_data = duckdb_v2_copy_function_init_set_init_data;
 	result.duckdb_v2_copy_function_register = duckdb_v2_copy_function_register;
-	result.duckdb_v2_copy_function_set_batch_callback = duckdb_v2_copy_function_set_batch_callback;
-	result.duckdb_v2_copy_function_set_batch_size_callback = duckdb_v2_copy_function_set_batch_size_callback;
-	result.duckdb_v2_copy_function_set_bind_callback = duckdb_v2_copy_function_set_bind_callback;
-	result.duckdb_v2_copy_function_set_finalize_callback = duckdb_v2_copy_function_set_finalize_callback;
-	result.duckdb_v2_copy_function_set_flush_callback = duckdb_v2_copy_function_set_flush_callback;
-	result.duckdb_v2_copy_function_set_init_callback = duckdb_v2_copy_function_set_init_callback;
 	result.duckdb_v2_copy_function_set_name = duckdb_v2_copy_function_set_name;
 	result.duckdb_v2_copy_function_set_user_data = duckdb_v2_copy_function_set_user_data;
+	result.duckdb_v2_copy_to_batch_get_bind_data = duckdb_v2_copy_to_batch_get_bind_data;
+	result.duckdb_v2_copy_to_batch_get_init_data = duckdb_v2_copy_to_batch_get_init_data;
+	result.duckdb_v2_copy_to_batch_get_user_data = duckdb_v2_copy_to_batch_get_user_data;
+	result.duckdb_v2_copy_to_batch_set_batch_data = duckdb_v2_copy_to_batch_set_batch_data;
+	result.duckdb_v2_copy_to_batch_size_get_bind_data = duckdb_v2_copy_to_batch_size_get_bind_data;
+	result.duckdb_v2_copy_to_batch_size_get_user_data = duckdb_v2_copy_to_batch_size_get_user_data;
+	result.duckdb_v2_copy_to_batch_size_set_target = duckdb_v2_copy_to_batch_size_set_target;
+	result.duckdb_v2_copy_to_batch_take_input = duckdb_v2_copy_to_batch_take_input;
+	result.duckdb_v2_copy_to_bind_get_column_count = duckdb_v2_copy_to_bind_get_column_count;
+	result.duckdb_v2_copy_to_bind_get_column_name = duckdb_v2_copy_to_bind_get_column_name;
+	result.duckdb_v2_copy_to_bind_get_column_type = duckdb_v2_copy_to_bind_get_column_type;
+	result.duckdb_v2_copy_to_bind_get_file_path = duckdb_v2_copy_to_bind_get_file_path;
+	result.duckdb_v2_copy_to_bind_get_option_count = duckdb_v2_copy_to_bind_get_option_count;
+	result.duckdb_v2_copy_to_bind_get_option_name = duckdb_v2_copy_to_bind_get_option_name;
+	result.duckdb_v2_copy_to_bind_get_option_value = duckdb_v2_copy_to_bind_get_option_value;
+	result.duckdb_v2_copy_to_bind_get_user_data = duckdb_v2_copy_to_bind_get_user_data;
+	result.duckdb_v2_copy_to_bind_set_bind_data = duckdb_v2_copy_to_bind_set_bind_data;
+	result.duckdb_v2_copy_to_finalize_get_bind_data = duckdb_v2_copy_to_finalize_get_bind_data;
+	result.duckdb_v2_copy_to_finalize_get_init_data = duckdb_v2_copy_to_finalize_get_init_data;
+	result.duckdb_v2_copy_to_finalize_get_user_data = duckdb_v2_copy_to_finalize_get_user_data;
+	result.duckdb_v2_copy_to_flush_get_batch_data = duckdb_v2_copy_to_flush_get_batch_data;
+	result.duckdb_v2_copy_to_flush_get_bind_data = duckdb_v2_copy_to_flush_get_bind_data;
+	result.duckdb_v2_copy_to_flush_get_init_data = duckdb_v2_copy_to_flush_get_init_data;
+	result.duckdb_v2_copy_to_flush_get_user_data = duckdb_v2_copy_to_flush_get_user_data;
+	result.duckdb_v2_copy_to_init_get_bind_data = duckdb_v2_copy_to_init_get_bind_data;
+	result.duckdb_v2_copy_to_init_get_file_path = duckdb_v2_copy_to_init_get_file_path;
+	result.duckdb_v2_copy_to_init_get_user_data = duckdb_v2_copy_to_init_get_user_data;
+	result.duckdb_v2_copy_to_init_set_init_data = duckdb_v2_copy_to_init_set_init_data;
+	result.duckdb_v2_copy_to_set_batch_callback = duckdb_v2_copy_to_set_batch_callback;
+	result.duckdb_v2_copy_to_set_batch_size_callback = duckdb_v2_copy_to_set_batch_size_callback;
+	result.duckdb_v2_copy_to_set_bind_callback = duckdb_v2_copy_to_set_bind_callback;
+	result.duckdb_v2_copy_to_set_finalize_callback = duckdb_v2_copy_to_set_finalize_callback;
+	result.duckdb_v2_copy_to_set_flush_callback = duckdb_v2_copy_to_set_flush_callback;
+	result.duckdb_v2_copy_to_set_init_callback = duckdb_v2_copy_to_set_init_callback;
 	result.duckdb_v2_prepared_statement_create = duckdb_v2_prepared_statement_create;
 	result.duckdb_v2_prepared_statement_destroy = duckdb_v2_prepared_statement_destroy;
 	result.duckdb_v2_prepared_statement_execute = duckdb_v2_prepared_statement_execute;

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -1151,6 +1151,9 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_init_callback)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_init_callback_fn callback,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_identifier_render_quoted)
+	(duckdb_v2_identifier_t name, char *out_text, idx_t out_capacity, idx_t *out_length,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1667,6 +1670,7 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_copy_to_set_finalize_callback = duckdb_v2_copy_to_set_finalize_callback;
 	result.duckdb_v2_copy_to_set_flush_callback = duckdb_v2_copy_to_set_flush_callback;
 	result.duckdb_v2_copy_to_set_init_callback = duckdb_v2_copy_to_set_init_callback;
+	result.duckdb_v2_identifier_render_quoted = duckdb_v2_identifier_render_quoted;
 	result.duckdb_v2_prepared_statement_create = duckdb_v2_prepared_statement_create;
 	result.duckdb_v2_prepared_statement_destroy = duckdb_v2_prepared_statement_destroy;
 	result.duckdb_v2_prepared_statement_execute = duckdb_v2_prepared_statement_execute;

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -997,6 +997,87 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_next_chunk)
 	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_data_chunk_handle *out_chunk,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_bind_data)
+	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_init_data)
+	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_user_data)
+	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_set_batch_data)
+	(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_get_bind_data)
+	(duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_get_user_data)
+	(duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_set_target)
+	(duckdb_v2_copy_function_batch_size_info_handle info, idx_t rows, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_take_input)
+	(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_column_data_collection_handle *collection,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_count)
+	(duckdb_v2_copy_function_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_name)
+	(duckdb_v2_copy_function_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_type)
+	(duckdb_v2_copy_function_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_user_data)
+	(duckdb_v2_copy_function_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_set_bind_data)
+	(duckdb_v2_copy_function_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_copy_function_handle *function,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_copy_function_handle *function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_copy_function_destroy)(duckdb_v2_copy_function_handle *function);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_bind_data)
+	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_init_data)
+	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_user_data)
+	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_batch_data)
+	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_bind_data)
+	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_init_data)
+	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_user_data)
+	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_bind_data)
+	(duckdb_v2_copy_function_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_file_path)
+	(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_user_data)
+	(duckdb_v2_copy_function_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_set_init_data)
+	(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_register)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_batch_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_batch_size_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_size_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_bind_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_bind_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_finalize_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_finalize_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_flush_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_flush_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_init_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_init_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_name)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_user_data)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1445,6 +1526,42 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_arrow_importer_destroy = duckdb_v2_arrow_importer_destroy;
 	result.duckdb_v2_arrow_importer_get_schema = duckdb_v2_arrow_importer_get_schema;
 	result.duckdb_v2_arrow_importer_next_chunk = duckdb_v2_arrow_importer_next_chunk;
+	result.duckdb_v2_copy_function_batch_get_bind_data = duckdb_v2_copy_function_batch_get_bind_data;
+	result.duckdb_v2_copy_function_batch_get_init_data = duckdb_v2_copy_function_batch_get_init_data;
+	result.duckdb_v2_copy_function_batch_get_user_data = duckdb_v2_copy_function_batch_get_user_data;
+	result.duckdb_v2_copy_function_batch_set_batch_data = duckdb_v2_copy_function_batch_set_batch_data;
+	result.duckdb_v2_copy_function_batch_size_get_bind_data = duckdb_v2_copy_function_batch_size_get_bind_data;
+	result.duckdb_v2_copy_function_batch_size_get_user_data = duckdb_v2_copy_function_batch_size_get_user_data;
+	result.duckdb_v2_copy_function_batch_size_set_target = duckdb_v2_copy_function_batch_size_set_target;
+	result.duckdb_v2_copy_function_batch_take_input = duckdb_v2_copy_function_batch_take_input;
+	result.duckdb_v2_copy_function_bind_get_column_count = duckdb_v2_copy_function_bind_get_column_count;
+	result.duckdb_v2_copy_function_bind_get_column_name = duckdb_v2_copy_function_bind_get_column_name;
+	result.duckdb_v2_copy_function_bind_get_column_type = duckdb_v2_copy_function_bind_get_column_type;
+	result.duckdb_v2_copy_function_bind_get_user_data = duckdb_v2_copy_function_bind_get_user_data;
+	result.duckdb_v2_copy_function_bind_set_bind_data = duckdb_v2_copy_function_bind_set_bind_data;
+	result.duckdb_v2_copy_function_create_with_connection = duckdb_v2_copy_function_create_with_connection;
+	result.duckdb_v2_copy_function_create_with_extension = duckdb_v2_copy_function_create_with_extension;
+	result.duckdb_v2_copy_function_destroy = duckdb_v2_copy_function_destroy;
+	result.duckdb_v2_copy_function_finalize_get_bind_data = duckdb_v2_copy_function_finalize_get_bind_data;
+	result.duckdb_v2_copy_function_finalize_get_init_data = duckdb_v2_copy_function_finalize_get_init_data;
+	result.duckdb_v2_copy_function_finalize_get_user_data = duckdb_v2_copy_function_finalize_get_user_data;
+	result.duckdb_v2_copy_function_flush_get_batch_data = duckdb_v2_copy_function_flush_get_batch_data;
+	result.duckdb_v2_copy_function_flush_get_bind_data = duckdb_v2_copy_function_flush_get_bind_data;
+	result.duckdb_v2_copy_function_flush_get_init_data = duckdb_v2_copy_function_flush_get_init_data;
+	result.duckdb_v2_copy_function_flush_get_user_data = duckdb_v2_copy_function_flush_get_user_data;
+	result.duckdb_v2_copy_function_init_get_bind_data = duckdb_v2_copy_function_init_get_bind_data;
+	result.duckdb_v2_copy_function_init_get_file_path = duckdb_v2_copy_function_init_get_file_path;
+	result.duckdb_v2_copy_function_init_get_user_data = duckdb_v2_copy_function_init_get_user_data;
+	result.duckdb_v2_copy_function_init_set_init_data = duckdb_v2_copy_function_init_set_init_data;
+	result.duckdb_v2_copy_function_register = duckdb_v2_copy_function_register;
+	result.duckdb_v2_copy_function_set_batch_callback = duckdb_v2_copy_function_set_batch_callback;
+	result.duckdb_v2_copy_function_set_batch_size_callback = duckdb_v2_copy_function_set_batch_size_callback;
+	result.duckdb_v2_copy_function_set_bind_callback = duckdb_v2_copy_function_set_bind_callback;
+	result.duckdb_v2_copy_function_set_finalize_callback = duckdb_v2_copy_function_set_finalize_callback;
+	result.duckdb_v2_copy_function_set_flush_callback = duckdb_v2_copy_function_set_flush_callback;
+	result.duckdb_v2_copy_function_set_init_callback = duckdb_v2_copy_function_set_init_callback;
+	result.duckdb_v2_copy_function_set_name = duckdb_v2_copy_function_set_name;
+	result.duckdb_v2_copy_function_set_user_data = duckdb_v2_copy_function_set_user_data;
 	result.duckdb_v2_prepared_statement_create = duckdb_v2_prepared_statement_create;
 	result.duckdb_v2_prepared_statement_destroy = duckdb_v2_prepared_statement_destroy;
 	result.duckdb_v2_prepared_statement_execute = duckdb_v2_prepared_statement_execute;

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -60,7 +60,7 @@ typedef struct {
 	 const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_connection_create_type_from_name)
-	(duckdb_v2_connection_handle conn, duckdb_v2_identifier_t name, const duckdb_v2_identifier_t *param_names,
+	(duckdb_v2_connection_handle conn, duckdb_v2_qname_handle name, const duckdb_v2_identifier_t *param_names,
 	 const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_connection_create_type_from_text)
@@ -89,7 +89,7 @@ typedef struct {
 	 const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_context_create_type_from_name)
-	(duckdb_v2_context_handle ctx, duckdb_v2_identifier_t name, const duckdb_v2_identifier_t *param_names,
+	(duckdb_v2_context_handle ctx, duckdb_v2_qname_handle name, const duckdb_v2_identifier_t *param_names,
 	 const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_context_create_type_from_text)
@@ -890,6 +890,23 @@ typedef struct {
 	(duckdb_v2_custom_type_handle type, duckdb_v2_logical_type_handle base_type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_name)
 	(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_create)
+	(const duckdb_v2_identifier_t *parts, idx_t part_count, duckdb_v2_qname_handle *name,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_qname_destroy)(duckdb_v2_qname_handle *name);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_equals)
+	(duckdb_v2_qname_handle left, duckdb_v2_qname_handle right, bool *result, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_get_part)
+	(duckdb_v2_qname_handle name, idx_t index, duckdb_v2_identifier_t *part, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_get_part_count)
+	(duckdb_v2_qname_handle name, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_hash)
+	(duckdb_v2_qname_handle name, uint64_t *hash, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_parse)
+	(duckdb_v2_str text, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_render)
+	(duckdb_v2_qname_handle name, char *out_text, idx_t out_capacity, idx_t *out_length,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_add_argument)
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_value_handle value, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_add_named_argument)
@@ -902,12 +919,8 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_create_with_extension)
 	(duckdb_v2_extension_handle extension, duckdb_v2_replacement_scan_handle *scan, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR (*duckdb_v2_replacement_scan_destroy)(duckdb_v2_replacement_scan_handle *scan);
-	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_catalog_name)
-	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_schema_name)
-	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_table_name)
-	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_user_data)
 	(duckdb_v2_replacement_scan_info_handle info, void **data, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_register)
@@ -921,7 +934,7 @@ typedef struct {
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_column_data_collection_handle collection,
 	 const duckdb_v2_identifier_t *column_names, idx_t column_count, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_function_name)
-	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_qname_handle name, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_subquery)
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
@@ -1311,15 +1324,21 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_custom_type_register = duckdb_v2_custom_type_register;
 	result.duckdb_v2_custom_type_set_base_type = duckdb_v2_custom_type_set_base_type;
 	result.duckdb_v2_custom_type_set_name = duckdb_v2_custom_type_set_name;
+	result.duckdb_v2_qname_create = duckdb_v2_qname_create;
+	result.duckdb_v2_qname_destroy = duckdb_v2_qname_destroy;
+	result.duckdb_v2_qname_equals = duckdb_v2_qname_equals;
+	result.duckdb_v2_qname_get_part = duckdb_v2_qname_get_part;
+	result.duckdb_v2_qname_get_part_count = duckdb_v2_qname_get_part_count;
+	result.duckdb_v2_qname_hash = duckdb_v2_qname_hash;
+	result.duckdb_v2_qname_parse = duckdb_v2_qname_parse;
+	result.duckdb_v2_qname_render = duckdb_v2_qname_render;
 	result.duckdb_v2_replacement_scan_add_argument = duckdb_v2_replacement_scan_add_argument;
 	result.duckdb_v2_replacement_scan_add_named_argument = duckdb_v2_replacement_scan_add_named_argument;
 	result.duckdb_v2_replacement_scan_create_with_connection = duckdb_v2_replacement_scan_create_with_connection;
 	result.duckdb_v2_replacement_scan_create_with_database = duckdb_v2_replacement_scan_create_with_database;
 	result.duckdb_v2_replacement_scan_create_with_extension = duckdb_v2_replacement_scan_create_with_extension;
 	result.duckdb_v2_replacement_scan_destroy = duckdb_v2_replacement_scan_destroy;
-	result.duckdb_v2_replacement_scan_get_catalog_name = duckdb_v2_replacement_scan_get_catalog_name;
-	result.duckdb_v2_replacement_scan_get_schema_name = duckdb_v2_replacement_scan_get_schema_name;
-	result.duckdb_v2_replacement_scan_get_table_name = duckdb_v2_replacement_scan_get_table_name;
+	result.duckdb_v2_replacement_scan_get_name = duckdb_v2_replacement_scan_get_name;
 	result.duckdb_v2_replacement_scan_get_user_data = duckdb_v2_replacement_scan_get_user_data;
 	result.duckdb_v2_replacement_scan_register = duckdb_v2_replacement_scan_register;
 	result.duckdb_v2_replacement_scan_set_alias = duckdb_v2_replacement_scan_set_alias;

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -974,6 +974,16 @@ typedef struct {
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
 	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
+	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
+	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_prepared_statement_destroy)(duckdb_v2_prepared_statement_handle *prepared);
+	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_execute)
+	(duckdb_v2_prepared_statement_handle prepared, const duckdb_v2_identifier_t *parameter_names,
+	 const duckdb_v2_value_handle *parameter_values, idx_t parameter_count, duckdb_v2_result_handle *out_result,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_reuses_plan)
+	(duckdb_v2_prepared_statement_handle prepared, bool *out_reuses, duckdb_v2_error_info_handle *err);
 } duckdb_ext_api_v2;
 
 //===--------------------------------------------------------------------===//
@@ -1399,6 +1409,10 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_replacement_scan_set_function_name = duckdb_v2_replacement_scan_set_function_name;
 	result.duckdb_v2_replacement_scan_set_subquery = duckdb_v2_replacement_scan_set_subquery;
 	result.duckdb_v2_replacement_scan_set_user_data = duckdb_v2_replacement_scan_set_user_data;
+	result.duckdb_v2_prepared_statement_create = duckdb_v2_prepared_statement_create;
+	result.duckdb_v2_prepared_statement_destroy = duckdb_v2_prepared_statement_destroy;
+	result.duckdb_v2_prepared_statement_execute = duckdb_v2_prepared_statement_execute;
+	result.duckdb_v2_prepared_statement_reuses_plan = duckdb_v2_prepared_statement_reuses_plan;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -877,6 +877,8 @@ typedef struct {
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_user_data)
 	(duckdb_v2_cast_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_data_collection_clear)
+	(duckdb_v2_column_data_collection_handle collection, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_create_with_connection)
 	(duckdb_v2_connection_handle connection, duckdb_v2_custom_type_handle *type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_create_with_extension)
@@ -888,6 +890,42 @@ typedef struct {
 	(duckdb_v2_custom_type_handle type, duckdb_v2_logical_type_handle base_type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_name)
 	(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_add_argument)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_value_handle value, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_add_named_argument)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_value_handle value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_replacement_scan_handle *scan, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_create_with_database)
+	(duckdb_v2_database_handle database, duckdb_v2_replacement_scan_handle *scan, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_replacement_scan_handle *scan, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_replacement_scan_destroy)(duckdb_v2_replacement_scan_handle *scan);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_catalog_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_schema_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_table_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_user_data)
+	(duckdb_v2_replacement_scan_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_register)
+	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_alias)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t alias, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_callback)
+	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_replacement_scan_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_collection)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_column_data_collection_handle collection,
+	 const duckdb_v2_identifier_t *column_names, idx_t column_count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_function_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_subquery)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
+	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
 } duckdb_ext_api_v2;
 
 //===--------------------------------------------------------------------===//
@@ -1266,12 +1304,30 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_cast_function_set_source_type = duckdb_v2_cast_function_set_source_type;
 	result.duckdb_v2_cast_function_set_target_type = duckdb_v2_cast_function_set_target_type;
 	result.duckdb_v2_cast_function_set_user_data = duckdb_v2_cast_function_set_user_data;
+	result.duckdb_v2_column_data_collection_clear = duckdb_v2_column_data_collection_clear;
 	result.duckdb_v2_custom_type_create_with_connection = duckdb_v2_custom_type_create_with_connection;
 	result.duckdb_v2_custom_type_create_with_extension = duckdb_v2_custom_type_create_with_extension;
 	result.duckdb_v2_custom_type_destroy = duckdb_v2_custom_type_destroy;
 	result.duckdb_v2_custom_type_register = duckdb_v2_custom_type_register;
 	result.duckdb_v2_custom_type_set_base_type = duckdb_v2_custom_type_set_base_type;
 	result.duckdb_v2_custom_type_set_name = duckdb_v2_custom_type_set_name;
+	result.duckdb_v2_replacement_scan_add_argument = duckdb_v2_replacement_scan_add_argument;
+	result.duckdb_v2_replacement_scan_add_named_argument = duckdb_v2_replacement_scan_add_named_argument;
+	result.duckdb_v2_replacement_scan_create_with_connection = duckdb_v2_replacement_scan_create_with_connection;
+	result.duckdb_v2_replacement_scan_create_with_database = duckdb_v2_replacement_scan_create_with_database;
+	result.duckdb_v2_replacement_scan_create_with_extension = duckdb_v2_replacement_scan_create_with_extension;
+	result.duckdb_v2_replacement_scan_destroy = duckdb_v2_replacement_scan_destroy;
+	result.duckdb_v2_replacement_scan_get_catalog_name = duckdb_v2_replacement_scan_get_catalog_name;
+	result.duckdb_v2_replacement_scan_get_schema_name = duckdb_v2_replacement_scan_get_schema_name;
+	result.duckdb_v2_replacement_scan_get_table_name = duckdb_v2_replacement_scan_get_table_name;
+	result.duckdb_v2_replacement_scan_get_user_data = duckdb_v2_replacement_scan_get_user_data;
+	result.duckdb_v2_replacement_scan_register = duckdb_v2_replacement_scan_register;
+	result.duckdb_v2_replacement_scan_set_alias = duckdb_v2_replacement_scan_set_alias;
+	result.duckdb_v2_replacement_scan_set_callback = duckdb_v2_replacement_scan_set_callback;
+	result.duckdb_v2_replacement_scan_set_collection = duckdb_v2_replacement_scan_set_collection;
+	result.duckdb_v2_replacement_scan_set_function_name = duckdb_v2_replacement_scan_set_function_name;
+	result.duckdb_v2_replacement_scan_set_subquery = duckdb_v2_replacement_scan_set_subquery;
+	result.duckdb_v2_replacement_scan_set_user_data = duckdb_v2_replacement_scan_set_user_data;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -1163,6 +1163,25 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_init_callback)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_init_callback_fn callback,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_cast_get_mode)
+	(duckdb_v2_expression_handle expression, DUCKDB_V2_CAST_MODE *mode, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_column_ref_get_index)
+	(duckdb_v2_expression_handle expression, idx_t *index, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_constant_get_value)
+	(duckdb_v2_expression_handle expression, duckdb_v2_value_handle *value, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_function_get_name)
+	(duckdb_v2_expression_handle expression, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_function_get_qname)
+	(duckdb_v2_expression_handle expression, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_get_child)
+	(duckdb_v2_expression_handle expression, idx_t index, duckdb_v2_expression_handle *child,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_get_child_count)
+	(duckdb_v2_expression_handle expression, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_get_return_type)
+	(duckdb_v2_expression_handle expression, duckdb_v2_logical_type_handle *type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_get_type)
+	(duckdb_v2_expression_handle expression, DUCKDB_V2_EXPRESSION_TYPE *type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_identifier_render_quoted)
 	(duckdb_v2_identifier_t name, char *out_text, idx_t out_capacity, idx_t *out_length,
 	 duckdb_v2_error_info_handle *err);
@@ -1189,6 +1208,42 @@ typedef struct {
 	(duckdb_v2_table_description_handle desc, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_description_is_readonly)
 	(duckdb_v2_table_description_handle desc, bool *readonly, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_column_count)
+	(duckdb_v2_table_function_exec_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_column_index)
+	(duckdb_v2_table_function_exec_info_handle info, idx_t index, idx_t *column_index,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_accept)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_bind_data)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_column_count)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_column_index)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, idx_t *column_index,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_filter)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, duckdb_v2_expression_handle *filter,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_filter_count)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_user_data)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_get_column_count)
+	(duckdb_v2_table_function_init_global_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_get_column_index)
+	(duckdb_v2_table_function_init_global_info_handle info, idx_t index, idx_t *column_index,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_column_count)
+	(duckdb_v2_table_function_init_local_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_column_index)
+	(duckdb_v2_table_function_init_local_info_handle info, idx_t index, idx_t *column_index,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_filter_pushdown_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_filter_pushdown_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_projection_pushdown)
+	(duckdb_v2_table_function_handle function, bool enable, duckdb_v2_error_info_handle *err);
 } duckdb_ext_api_v2;
 
 //===--------------------------------------------------------------------===//
@@ -1698,6 +1753,15 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_copy_to_set_finalize_callback = duckdb_v2_copy_to_set_finalize_callback;
 	result.duckdb_v2_copy_to_set_flush_callback = duckdb_v2_copy_to_set_flush_callback;
 	result.duckdb_v2_copy_to_set_init_callback = duckdb_v2_copy_to_set_init_callback;
+	result.duckdb_v2_expression_cast_get_mode = duckdb_v2_expression_cast_get_mode;
+	result.duckdb_v2_expression_column_ref_get_index = duckdb_v2_expression_column_ref_get_index;
+	result.duckdb_v2_expression_constant_get_value = duckdb_v2_expression_constant_get_value;
+	result.duckdb_v2_expression_function_get_name = duckdb_v2_expression_function_get_name;
+	result.duckdb_v2_expression_function_get_qname = duckdb_v2_expression_function_get_qname;
+	result.duckdb_v2_expression_get_child = duckdb_v2_expression_get_child;
+	result.duckdb_v2_expression_get_child_count = duckdb_v2_expression_get_child_count;
+	result.duckdb_v2_expression_get_return_type = duckdb_v2_expression_get_return_type;
+	result.duckdb_v2_expression_get_type = duckdb_v2_expression_get_type;
 	result.duckdb_v2_identifier_render_quoted = duckdb_v2_identifier_render_quoted;
 	result.duckdb_v2_prepared_statement_create = duckdb_v2_prepared_statement_create;
 	result.duckdb_v2_prepared_statement_destroy = duckdb_v2_prepared_statement_destroy;
@@ -1709,6 +1773,29 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_table_description_get_column_count = duckdb_v2_table_description_get_column_count;
 	result.duckdb_v2_table_description_get_qname = duckdb_v2_table_description_get_qname;
 	result.duckdb_v2_table_description_is_readonly = duckdb_v2_table_description_is_readonly;
+	result.duckdb_v2_table_function_exec_get_column_count = duckdb_v2_table_function_exec_get_column_count;
+	result.duckdb_v2_table_function_exec_get_column_index = duckdb_v2_table_function_exec_get_column_index;
+	result.duckdb_v2_table_function_filter_pushdown_accept = duckdb_v2_table_function_filter_pushdown_accept;
+	result.duckdb_v2_table_function_filter_pushdown_get_bind_data =
+	    duckdb_v2_table_function_filter_pushdown_get_bind_data;
+	result.duckdb_v2_table_function_filter_pushdown_get_column_count =
+	    duckdb_v2_table_function_filter_pushdown_get_column_count;
+	result.duckdb_v2_table_function_filter_pushdown_get_column_index =
+	    duckdb_v2_table_function_filter_pushdown_get_column_index;
+	result.duckdb_v2_table_function_filter_pushdown_get_filter = duckdb_v2_table_function_filter_pushdown_get_filter;
+	result.duckdb_v2_table_function_filter_pushdown_get_filter_count =
+	    duckdb_v2_table_function_filter_pushdown_get_filter_count;
+	result.duckdb_v2_table_function_filter_pushdown_get_user_data =
+	    duckdb_v2_table_function_filter_pushdown_get_user_data;
+	result.duckdb_v2_table_function_init_global_get_column_count =
+	    duckdb_v2_table_function_init_global_get_column_count;
+	result.duckdb_v2_table_function_init_global_get_column_index =
+	    duckdb_v2_table_function_init_global_get_column_index;
+	result.duckdb_v2_table_function_init_local_get_column_count = duckdb_v2_table_function_init_local_get_column_count;
+	result.duckdb_v2_table_function_init_local_get_column_index = duckdb_v2_table_function_init_local_get_column_index;
+	result.duckdb_v2_table_function_set_filter_pushdown_callback =
+	    duckdb_v2_table_function_set_filter_pushdown_callback;
+	result.duckdb_v2_table_function_set_projection_pushdown = duckdb_v2_table_function_set_projection_pushdown;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -987,6 +987,18 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_next_chunk)
 	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_data_chunk_handle *out_chunk,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_column_description_destroy)(duckdb_v2_column_description_handle *column);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_description_get_name)
+	(duckdb_v2_column_description_handle column, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_description_get_type)
+	(duckdb_v2_column_description_handle column, duckdb_v2_logical_type_handle *type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_description_has_default)
+	(duckdb_v2_column_description_handle column, bool *has_default, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_description_has_generated)
+	(duckdb_v2_column_description_handle column, bool *has_generated, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_connection_describe_table)
+	(duckdb_v2_connection_handle conn, duckdb_v2_qname_handle name, duckdb_v2_table_description_handle *desc,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_count)
 	(duckdb_v2_copy_from_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_name)
@@ -1167,6 +1179,16 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_result_to_arrow_stream)
 	(duckdb_v2_result_handle *result, idx_t batch_size, struct ArrowArrayStream *out_stream,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_table_description_destroy)(duckdb_v2_table_description_handle *desc);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_description_get_column)
+	(duckdb_v2_table_description_handle desc, idx_t index, duckdb_v2_column_description_handle *column,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_description_get_column_count)
+	(duckdb_v2_table_description_handle desc, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_description_get_qname)
+	(duckdb_v2_table_description_handle desc, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_description_is_readonly)
+	(duckdb_v2_table_description_handle desc, bool *readonly, duckdb_v2_error_info_handle *err);
 } duckdb_ext_api_v2;
 
 //===--------------------------------------------------------------------===//
@@ -1598,6 +1620,12 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_arrow_importer_destroy = duckdb_v2_arrow_importer_destroy;
 	result.duckdb_v2_arrow_importer_get_schema = duckdb_v2_arrow_importer_get_schema;
 	result.duckdb_v2_arrow_importer_next_chunk = duckdb_v2_arrow_importer_next_chunk;
+	result.duckdb_v2_column_description_destroy = duckdb_v2_column_description_destroy;
+	result.duckdb_v2_column_description_get_name = duckdb_v2_column_description_get_name;
+	result.duckdb_v2_column_description_get_type = duckdb_v2_column_description_get_type;
+	result.duckdb_v2_column_description_has_default = duckdb_v2_column_description_has_default;
+	result.duckdb_v2_column_description_has_generated = duckdb_v2_column_description_has_generated;
+	result.duckdb_v2_connection_describe_table = duckdb_v2_connection_describe_table;
 	result.duckdb_v2_copy_from_bind_get_column_count = duckdb_v2_copy_from_bind_get_column_count;
 	result.duckdb_v2_copy_from_bind_get_column_name = duckdb_v2_copy_from_bind_get_column_name;
 	result.duckdb_v2_copy_from_bind_get_column_type = duckdb_v2_copy_from_bind_get_column_type;
@@ -1676,6 +1704,11 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_prepared_statement_execute = duckdb_v2_prepared_statement_execute;
 	result.duckdb_v2_prepared_statement_reuses_plan = duckdb_v2_prepared_statement_reuses_plan;
 	result.duckdb_v2_result_to_arrow_stream = duckdb_v2_result_to_arrow_stream;
+	result.duckdb_v2_table_description_destroy = duckdb_v2_table_description_destroy;
+	result.duckdb_v2_table_description_get_column = duckdb_v2_table_description_get_column;
+	result.duckdb_v2_table_description_get_column_count = duckdb_v2_table_description_get_column_count;
+	result.duckdb_v2_table_description_get_qname = duckdb_v2_table_description_get_qname;
+	result.duckdb_v2_table_description_is_readonly = duckdb_v2_table_description_is_readonly;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -753,6 +753,99 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_scalar_function_set_property)
 	(duckdb_v2_scalar_function_handle function, DUCKDB_V2_FUNCTION_PROPERTY_KEY key,
 	 DUCKDB_V2_FUNCTION_PROPERTY_VALUE value, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_add_result_column)
+	(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_logical_type_handle type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_get_arg_count)
+	(duckdb_v2_table_function_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_get_arg_type)
+	(duckdb_v2_table_function_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_get_arg_value)
+	(duckdb_v2_table_function_bind_info_handle info, idx_t index, duckdb_v2_value_handle *value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_get_user_data)
+	(duckdb_v2_table_function_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_set_bind_data)
+	(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_set_cardinality)
+	(duckdb_v2_table_function_bind_info_handle info, idx_t cardinality, bool is_exact,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_get_bind_data)
+	(duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_get_user_data)
+	(duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_set_cardinality)
+	(duckdb_v2_table_function_cardinality_info_handle info, idx_t cardinality, bool is_exact,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_table_function_handle *function,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_table_function_handle *function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_table_function_destroy)(duckdb_v2_table_function_handle *function);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_bind_data)
+	(duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_global_state)
+	(duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_local_state)
+	(duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_output_chunk)
+	(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_data_chunk_handle *chunk,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_user_data)
+	(duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_get_signature)
+	(duckdb_v2_table_function_handle function, duckdb_v2_function_signature_handle *sig,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_get_bind_data)
+	(duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_get_user_data)
+	(duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_set_global_state)
+	(duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_set_max_threads)
+	(duckdb_v2_table_function_init_global_info_handle info, idx_t max_threads, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_bind_data)
+	(duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_global_state)
+	(duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_user_data)
+	(duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_set_local_state)
+	(duckdb_v2_table_function_init_local_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_progress_get_bind_data)
+	(duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_progress_get_global_state)
+	(duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_progress_get_user_data)
+	(duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_progress_set_progress)
+	(duckdb_v2_table_function_progress_info_handle info, double progress, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_register)
+	(duckdb_v2_table_function_handle function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_bind_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_bind_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_cardinality_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_cardinality_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_exec_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_exec_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_init_global_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_global_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_init_local_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_local_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_name)
+	(duckdb_v2_table_function_handle function, duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_progress_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_progress_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_user_data)
+	(duckdb_v2_table_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
 } duckdb_ext_api_v2;
 
 //===--------------------------------------------------------------------===//
@@ -1076,6 +1169,47 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_aggregate_function_update_get_user_data = duckdb_v2_aggregate_function_update_get_user_data;
 	result.duckdb_v2_aggregate_function_set_property = duckdb_v2_aggregate_function_set_property;
 	result.duckdb_v2_scalar_function_set_property = duckdb_v2_scalar_function_set_property;
+	result.duckdb_v2_table_function_bind_add_result_column = duckdb_v2_table_function_bind_add_result_column;
+	result.duckdb_v2_table_function_bind_get_arg_count = duckdb_v2_table_function_bind_get_arg_count;
+	result.duckdb_v2_table_function_bind_get_arg_type = duckdb_v2_table_function_bind_get_arg_type;
+	result.duckdb_v2_table_function_bind_get_arg_value = duckdb_v2_table_function_bind_get_arg_value;
+	result.duckdb_v2_table_function_bind_get_user_data = duckdb_v2_table_function_bind_get_user_data;
+	result.duckdb_v2_table_function_bind_set_bind_data = duckdb_v2_table_function_bind_set_bind_data;
+	result.duckdb_v2_table_function_bind_set_cardinality = duckdb_v2_table_function_bind_set_cardinality;
+	result.duckdb_v2_table_function_cardinality_get_bind_data = duckdb_v2_table_function_cardinality_get_bind_data;
+	result.duckdb_v2_table_function_cardinality_get_user_data = duckdb_v2_table_function_cardinality_get_user_data;
+	result.duckdb_v2_table_function_cardinality_set_cardinality = duckdb_v2_table_function_cardinality_set_cardinality;
+	result.duckdb_v2_table_function_create_with_connection = duckdb_v2_table_function_create_with_connection;
+	result.duckdb_v2_table_function_create_with_extension = duckdb_v2_table_function_create_with_extension;
+	result.duckdb_v2_table_function_destroy = duckdb_v2_table_function_destroy;
+	result.duckdb_v2_table_function_exec_get_bind_data = duckdb_v2_table_function_exec_get_bind_data;
+	result.duckdb_v2_table_function_exec_get_global_state = duckdb_v2_table_function_exec_get_global_state;
+	result.duckdb_v2_table_function_exec_get_local_state = duckdb_v2_table_function_exec_get_local_state;
+	result.duckdb_v2_table_function_exec_get_output_chunk = duckdb_v2_table_function_exec_get_output_chunk;
+	result.duckdb_v2_table_function_exec_get_user_data = duckdb_v2_table_function_exec_get_user_data;
+	result.duckdb_v2_table_function_get_signature = duckdb_v2_table_function_get_signature;
+	result.duckdb_v2_table_function_init_global_get_bind_data = duckdb_v2_table_function_init_global_get_bind_data;
+	result.duckdb_v2_table_function_init_global_get_user_data = duckdb_v2_table_function_init_global_get_user_data;
+	result.duckdb_v2_table_function_init_global_set_global_state =
+	    duckdb_v2_table_function_init_global_set_global_state;
+	result.duckdb_v2_table_function_init_global_set_max_threads = duckdb_v2_table_function_init_global_set_max_threads;
+	result.duckdb_v2_table_function_init_local_get_bind_data = duckdb_v2_table_function_init_local_get_bind_data;
+	result.duckdb_v2_table_function_init_local_get_global_state = duckdb_v2_table_function_init_local_get_global_state;
+	result.duckdb_v2_table_function_init_local_get_user_data = duckdb_v2_table_function_init_local_get_user_data;
+	result.duckdb_v2_table_function_init_local_set_local_state = duckdb_v2_table_function_init_local_set_local_state;
+	result.duckdb_v2_table_function_progress_get_bind_data = duckdb_v2_table_function_progress_get_bind_data;
+	result.duckdb_v2_table_function_progress_get_global_state = duckdb_v2_table_function_progress_get_global_state;
+	result.duckdb_v2_table_function_progress_get_user_data = duckdb_v2_table_function_progress_get_user_data;
+	result.duckdb_v2_table_function_progress_set_progress = duckdb_v2_table_function_progress_set_progress;
+	result.duckdb_v2_table_function_register = duckdb_v2_table_function_register;
+	result.duckdb_v2_table_function_set_bind_callback = duckdb_v2_table_function_set_bind_callback;
+	result.duckdb_v2_table_function_set_cardinality_callback = duckdb_v2_table_function_set_cardinality_callback;
+	result.duckdb_v2_table_function_set_exec_callback = duckdb_v2_table_function_set_exec_callback;
+	result.duckdb_v2_table_function_set_init_global_callback = duckdb_v2_table_function_set_init_global_callback;
+	result.duckdb_v2_table_function_set_init_local_callback = duckdb_v2_table_function_set_init_local_callback;
+	result.duckdb_v2_table_function_set_name = duckdb_v2_table_function_set_name;
+	result.duckdb_v2_table_function_set_progress_callback = duckdb_v2_table_function_set_progress_callback;
+	result.duckdb_v2_table_function_set_user_data = duckdb_v2_table_function_set_user_data;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -846,6 +846,48 @@ typedef struct {
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_user_data)
 	(duckdb_v2_table_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_cast_function_handle *function,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_cast_function_handle *function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_cast_function_destroy)(duckdb_v2_cast_function_handle *function);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_input)
+	(duckdb_v2_cast_function_exec_info_handle info, duckdb_v2_vector_handle *vector, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_mode)
+	(duckdb_v2_cast_function_exec_info_handle info, DUCKDB_V2_CAST_MODE *mode, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_output)
+	(duckdb_v2_cast_function_exec_info_handle info, duckdb_v2_vector_handle *vector, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_row_count)
+	(duckdb_v2_cast_function_exec_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_user_data)
+	(duckdb_v2_cast_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_register)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_exec_callback)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_cast_function_exec_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_implicit_cast_cost)
+	(duckdb_v2_cast_function_handle function, int64_t cost, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_source_type)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_logical_type_handle source_type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_target_type)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_logical_type_handle target_type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_user_data)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_custom_type_handle *type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_custom_type_handle *type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_custom_type_destroy)(duckdb_v2_custom_type_handle *type);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_register)
+	(duckdb_v2_custom_type_handle type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_base_type)
+	(duckdb_v2_custom_type_handle type, duckdb_v2_logical_type_handle base_type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_name)
+	(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
 } duckdb_ext_api_v2;
 
 //===--------------------------------------------------------------------===//
@@ -1210,6 +1252,26 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_table_function_set_name = duckdb_v2_table_function_set_name;
 	result.duckdb_v2_table_function_set_progress_callback = duckdb_v2_table_function_set_progress_callback;
 	result.duckdb_v2_table_function_set_user_data = duckdb_v2_table_function_set_user_data;
+	result.duckdb_v2_cast_function_create_with_connection = duckdb_v2_cast_function_create_with_connection;
+	result.duckdb_v2_cast_function_create_with_extension = duckdb_v2_cast_function_create_with_extension;
+	result.duckdb_v2_cast_function_destroy = duckdb_v2_cast_function_destroy;
+	result.duckdb_v2_cast_function_exec_get_input = duckdb_v2_cast_function_exec_get_input;
+	result.duckdb_v2_cast_function_exec_get_mode = duckdb_v2_cast_function_exec_get_mode;
+	result.duckdb_v2_cast_function_exec_get_output = duckdb_v2_cast_function_exec_get_output;
+	result.duckdb_v2_cast_function_exec_get_row_count = duckdb_v2_cast_function_exec_get_row_count;
+	result.duckdb_v2_cast_function_exec_get_user_data = duckdb_v2_cast_function_exec_get_user_data;
+	result.duckdb_v2_cast_function_register = duckdb_v2_cast_function_register;
+	result.duckdb_v2_cast_function_set_exec_callback = duckdb_v2_cast_function_set_exec_callback;
+	result.duckdb_v2_cast_function_set_implicit_cast_cost = duckdb_v2_cast_function_set_implicit_cast_cost;
+	result.duckdb_v2_cast_function_set_source_type = duckdb_v2_cast_function_set_source_type;
+	result.duckdb_v2_cast_function_set_target_type = duckdb_v2_cast_function_set_target_type;
+	result.duckdb_v2_cast_function_set_user_data = duckdb_v2_cast_function_set_user_data;
+	result.duckdb_v2_custom_type_create_with_connection = duckdb_v2_custom_type_create_with_connection;
+	result.duckdb_v2_custom_type_create_with_extension = duckdb_v2_custom_type_create_with_extension;
+	result.duckdb_v2_custom_type_destroy = duckdb_v2_custom_type_destroy;
+	result.duckdb_v2_custom_type_register = duckdb_v2_custom_type_register;
+	result.duckdb_v2_custom_type_set_base_type = duckdb_v2_custom_type_set_base_type;
+	result.duckdb_v2_custom_type_set_name = duckdb_v2_custom_type_set_name;
 	return result;
 }
 

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -890,6 +890,41 @@ typedef struct {
 	(duckdb_v2_custom_type_handle type, duckdb_v2_logical_type_handle base_type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_name)
 	(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_close)(duckdb_v2_file_handle file, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_destroy)(duckdb_v2_file_handle *file);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_open_options_create)
+	(duckdb_v2_file_system_handle file_system, duckdb_v2_file_open_options_handle *options,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_open_options_destroy)(duckdb_v2_file_open_options_handle *options);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_open_options_set_flag)
+	(duckdb_v2_file_open_options_handle options, DUCKDB_V2_FILE_FLAG flag, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_open_options_set_value)
+	(duckdb_v2_file_open_options_handle options, duckdb_v2_str name, duckdb_v2_value_handle value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_read)
+	(duckdb_v2_file_handle file, void *buffer, idx_t buffer_size, idx_t *bytes_read, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_read_at)
+	(duckdb_v2_file_handle file, void *buffer, idx_t buffer_size, idx_t location, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_seek)
+	(duckdb_v2_file_handle file, idx_t position, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_size)(duckdb_v2_file_handle file, idx_t *size, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_sync)(duckdb_v2_file_handle file, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_system_get_from_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_file_system_handle *file_system,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_system_get_from_context)
+	(duckdb_v2_context_handle context, duckdb_v2_file_system_handle *file_system, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_system_open)
+	(duckdb_v2_file_system_handle file_system, duckdb_v2_str file_path, duckdb_v2_file_open_options_handle options,
+	 duckdb_v2_file_handle *file, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_tell)
+	(duckdb_v2_file_handle file, idx_t *position, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_write)
+	(duckdb_v2_file_handle file, const void *buffer, idx_t buffer_size, idx_t *bytes_written,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_write_at)
+	(duckdb_v2_file_handle file, const void *buffer, idx_t buffer_size, idx_t location,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_qname_create)
 	(const duckdb_v2_identifier_t *parts, idx_t part_count, duckdb_v2_qname_handle *name,
 	 duckdb_v2_error_info_handle *err);
@@ -1324,6 +1359,23 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_custom_type_register = duckdb_v2_custom_type_register;
 	result.duckdb_v2_custom_type_set_base_type = duckdb_v2_custom_type_set_base_type;
 	result.duckdb_v2_custom_type_set_name = duckdb_v2_custom_type_set_name;
+	result.duckdb_v2_file_close = duckdb_v2_file_close;
+	result.duckdb_v2_file_destroy = duckdb_v2_file_destroy;
+	result.duckdb_v2_file_open_options_create = duckdb_v2_file_open_options_create;
+	result.duckdb_v2_file_open_options_destroy = duckdb_v2_file_open_options_destroy;
+	result.duckdb_v2_file_open_options_set_flag = duckdb_v2_file_open_options_set_flag;
+	result.duckdb_v2_file_open_options_set_value = duckdb_v2_file_open_options_set_value;
+	result.duckdb_v2_file_read = duckdb_v2_file_read;
+	result.duckdb_v2_file_read_at = duckdb_v2_file_read_at;
+	result.duckdb_v2_file_seek = duckdb_v2_file_seek;
+	result.duckdb_v2_file_size = duckdb_v2_file_size;
+	result.duckdb_v2_file_sync = duckdb_v2_file_sync;
+	result.duckdb_v2_file_system_get_from_connection = duckdb_v2_file_system_get_from_connection;
+	result.duckdb_v2_file_system_get_from_context = duckdb_v2_file_system_get_from_context;
+	result.duckdb_v2_file_system_open = duckdb_v2_file_system_open;
+	result.duckdb_v2_file_tell = duckdb_v2_file_tell;
+	result.duckdb_v2_file_write = duckdb_v2_file_write;
+	result.duckdb_v2_file_write_at = duckdb_v2_file_write_at;
 	result.duckdb_v2_qname_create = duckdb_v2_qname_create;
 	result.duckdb_v2_qname_destroy = duckdb_v2_qname_destroy;
 	result.duckdb_v2_qname_equals = duckdb_v2_qname_equals;

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -974,21 +974,29 @@ typedef struct {
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
 	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_array_to_chunk)
-	(duckdb_v2_context_handle context, struct ArrowArray *array, duckdb_v2_arrow_converter_handle converter,
-	 duckdb_v2_data_chunk_handle *out_chunk, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_create)
-	(duckdb_v2_context_handle context, struct ArrowSchema *schema, duckdb_v2_arrow_converter_handle *out_converter,
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_exporter_append)
+	(duckdb_v2_arrow_exporter_handle exporter, duckdb_v2_data_chunk_handle *chunk, bool consume, bool flush,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR (*duckdb_v2_arrow_converter_destroy)(duckdb_v2_arrow_converter_handle *converter);
-	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_get_schema)
-	(duckdb_v2_arrow_converter_handle converter, duckdb_v2_schema_handle *out_schema, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_data_chunk_to_arrow_array)
-	(duckdb_v2_context_handle context, duckdb_v2_data_chunk_handle chunk, struct ArrowArray *out_array,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_logical_types_to_arrow_schema)
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_exporter_create)
 	(duckdb_v2_context_handle context, const duckdb_v2_logical_type_handle *types, const duckdb_v2_str *names,
-	 idx_t count, struct ArrowSchema *out_schema, duckdb_v2_error_info_handle *err);
+	 idx_t count, idx_t batch_size, duckdb_v2_arrow_exporter_handle *out_exporter, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_arrow_exporter_destroy)(duckdb_v2_arrow_exporter_handle *exporter);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_exporter_get_schema)
+	(duckdb_v2_arrow_exporter_handle exporter, struct ArrowSchema *out_schema, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_exporter_next_array)
+	(duckdb_v2_arrow_exporter_handle exporter, struct ArrowArray *out_array, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_append)
+	(duckdb_v2_arrow_importer_handle importer, struct ArrowArray *array, bool consume, bool flush,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_create)
+	(duckdb_v2_context_handle context, struct ArrowSchema *schema, idx_t batch_size,
+	 duckdb_v2_arrow_importer_handle *out_importer, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_arrow_importer_destroy)(duckdb_v2_arrow_importer_handle *importer);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_get_schema)
+	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_schema_handle *out_schema, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_next_chunk)
+	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_data_chunk_handle *out_chunk,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1427,12 +1435,16 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_replacement_scan_set_function_name = duckdb_v2_replacement_scan_set_function_name;
 	result.duckdb_v2_replacement_scan_set_subquery = duckdb_v2_replacement_scan_set_subquery;
 	result.duckdb_v2_replacement_scan_set_user_data = duckdb_v2_replacement_scan_set_user_data;
-	result.duckdb_v2_arrow_converter_array_to_chunk = duckdb_v2_arrow_converter_array_to_chunk;
-	result.duckdb_v2_arrow_converter_create = duckdb_v2_arrow_converter_create;
-	result.duckdb_v2_arrow_converter_destroy = duckdb_v2_arrow_converter_destroy;
-	result.duckdb_v2_arrow_converter_get_schema = duckdb_v2_arrow_converter_get_schema;
-	result.duckdb_v2_data_chunk_to_arrow_array = duckdb_v2_data_chunk_to_arrow_array;
-	result.duckdb_v2_logical_types_to_arrow_schema = duckdb_v2_logical_types_to_arrow_schema;
+	result.duckdb_v2_arrow_exporter_append = duckdb_v2_arrow_exporter_append;
+	result.duckdb_v2_arrow_exporter_create = duckdb_v2_arrow_exporter_create;
+	result.duckdb_v2_arrow_exporter_destroy = duckdb_v2_arrow_exporter_destroy;
+	result.duckdb_v2_arrow_exporter_get_schema = duckdb_v2_arrow_exporter_get_schema;
+	result.duckdb_v2_arrow_exporter_next_array = duckdb_v2_arrow_exporter_next_array;
+	result.duckdb_v2_arrow_importer_append = duckdb_v2_arrow_importer_append;
+	result.duckdb_v2_arrow_importer_create = duckdb_v2_arrow_importer_create;
+	result.duckdb_v2_arrow_importer_destroy = duckdb_v2_arrow_importer_destroy;
+	result.duckdb_v2_arrow_importer_get_schema = duckdb_v2_arrow_importer_get_schema;
+	result.duckdb_v2_arrow_importer_next_chunk = duckdb_v2_arrow_importer_next_chunk;
 	result.duckdb_v2_prepared_statement_create = duckdb_v2_prepared_statement_create;
 	result.duckdb_v2_prepared_statement_destroy = duckdb_v2_prepared_statement_destroy;
 	result.duckdb_v2_prepared_statement_execute = duckdb_v2_prepared_statement_execute;

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -974,6 +974,21 @@ typedef struct {
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
 	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_array_to_chunk)
+	(duckdb_v2_context_handle context, struct ArrowArray *array, duckdb_v2_arrow_converter_handle converter,
+	 duckdb_v2_data_chunk_handle *out_chunk, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_create)
+	(duckdb_v2_context_handle context, struct ArrowSchema *schema, duckdb_v2_arrow_converter_handle *out_converter,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_arrow_converter_destroy)(duckdb_v2_arrow_converter_handle *converter);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_get_schema)
+	(duckdb_v2_arrow_converter_handle converter, duckdb_v2_schema_handle *out_schema, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_data_chunk_to_arrow_array)
+	(duckdb_v2_context_handle context, duckdb_v2_data_chunk_handle chunk, struct ArrowArray *out_array,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_logical_types_to_arrow_schema)
+	(duckdb_v2_context_handle context, const duckdb_v2_logical_type_handle *types, const duckdb_v2_str *names,
+	 idx_t count, struct ArrowSchema *out_schema, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -984,6 +999,9 @@ typedef struct {
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_reuses_plan)
 	(duckdb_v2_prepared_statement_handle prepared, bool *out_reuses, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_result_to_arrow_stream)
+	(duckdb_v2_result_handle *result, idx_t batch_size, struct ArrowArrayStream *out_stream,
+	 duckdb_v2_error_info_handle *err);
 } duckdb_ext_api_v2;
 
 //===--------------------------------------------------------------------===//
@@ -1409,10 +1427,17 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_replacement_scan_set_function_name = duckdb_v2_replacement_scan_set_function_name;
 	result.duckdb_v2_replacement_scan_set_subquery = duckdb_v2_replacement_scan_set_subquery;
 	result.duckdb_v2_replacement_scan_set_user_data = duckdb_v2_replacement_scan_set_user_data;
+	result.duckdb_v2_arrow_converter_array_to_chunk = duckdb_v2_arrow_converter_array_to_chunk;
+	result.duckdb_v2_arrow_converter_create = duckdb_v2_arrow_converter_create;
+	result.duckdb_v2_arrow_converter_destroy = duckdb_v2_arrow_converter_destroy;
+	result.duckdb_v2_arrow_converter_get_schema = duckdb_v2_arrow_converter_get_schema;
+	result.duckdb_v2_data_chunk_to_arrow_array = duckdb_v2_data_chunk_to_arrow_array;
+	result.duckdb_v2_logical_types_to_arrow_schema = duckdb_v2_logical_types_to_arrow_schema;
 	result.duckdb_v2_prepared_statement_create = duckdb_v2_prepared_statement_create;
 	result.duckdb_v2_prepared_statement_destroy = duckdb_v2_prepared_statement_destroy;
 	result.duckdb_v2_prepared_statement_execute = duckdb_v2_prepared_statement_execute;
 	result.duckdb_v2_prepared_statement_reuses_plan = duckdb_v2_prepared_statement_reuses_plan;
+	result.duckdb_v2_result_to_arrow_stream = duckdb_v2_result_to_arrow_stream;
 	return result;
 }
 

--- a/src/include/duckdb/main/client_config.hpp
+++ b/src/include/duckdb/main/client_config.hpp
@@ -24,6 +24,7 @@ class ClientContext;
 class PhysicalResultCollector;
 class PreparedStatementData;
 struct CompiledGrammar;
+struct ReplacementScan;
 
 typedef std::function<unique_ptr<PhysicalOperator>(ClientContext &context, PreparedStatementData &data)>
     get_result_collector_t;
@@ -58,6 +59,9 @@ struct ClientConfig {
 	//! If this context should also try to use the available replacement scans
 	//! True by default
 	bool use_replacement_scans = true;
+	//! Replacement scans visible only to this connection, consulted before the database-wide ones in DBConfig.
+	//! Held by pointer so that copying a ClientConfig stays possible; a ReplacementScan owns its data uniquely.
+	vector<shared_ptr<ReplacementScan>> replacement_scans;
 
 	//! The maximum amount of memory to keep buffered in a streaming query result. Default: 1mb.
 	idx_t streaming_buffer_size = 1000000;

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1039,6 +1039,21 @@ typedef struct {
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
 	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_array_to_chunk)
+	(duckdb_v2_context_handle context, struct ArrowArray *array, duckdb_v2_arrow_converter_handle converter,
+	 duckdb_v2_data_chunk_handle *out_chunk, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_create)
+	(duckdb_v2_context_handle context, struct ArrowSchema *schema, duckdb_v2_arrow_converter_handle *out_converter,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_arrow_converter_destroy)(duckdb_v2_arrow_converter_handle *converter);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_get_schema)
+	(duckdb_v2_arrow_converter_handle converter, duckdb_v2_schema_handle *out_schema, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_data_chunk_to_arrow_array)
+	(duckdb_v2_context_handle context, duckdb_v2_data_chunk_handle chunk, struct ArrowArray *out_array,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_logical_types_to_arrow_schema)
+	(duckdb_v2_context_handle context, const duckdb_v2_logical_type_handle *types, const duckdb_v2_str *names,
+	 idx_t count, struct ArrowSchema *out_schema, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1049,6 +1064,9 @@ typedef struct {
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_reuses_plan)
 	(duckdb_v2_prepared_statement_handle prepared, bool *out_reuses, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_result_to_arrow_stream)
+	(duckdb_v2_result_handle *result, idx_t batch_size, struct ArrowArrayStream *out_stream,
+	 duckdb_v2_error_info_handle *err);
 	// capigen:end appended
 } duckdb_ext_api_v2;
 
@@ -1519,10 +1537,17 @@ typedef struct {
 #define duckdb_v2_replacement_scan_set_function_name     duckdb_ext_api.duckdb_v2_replacement_scan_set_function_name
 #define duckdb_v2_replacement_scan_set_subquery          duckdb_ext_api.duckdb_v2_replacement_scan_set_subquery
 #define duckdb_v2_replacement_scan_set_user_data         duckdb_ext_api.duckdb_v2_replacement_scan_set_user_data
+#define duckdb_v2_arrow_converter_array_to_chunk         duckdb_ext_api.duckdb_v2_arrow_converter_array_to_chunk
+#define duckdb_v2_arrow_converter_create                 duckdb_ext_api.duckdb_v2_arrow_converter_create
+#define duckdb_v2_arrow_converter_destroy                duckdb_ext_api.duckdb_v2_arrow_converter_destroy
+#define duckdb_v2_arrow_converter_get_schema             duckdb_ext_api.duckdb_v2_arrow_converter_get_schema
+#define duckdb_v2_data_chunk_to_arrow_array              duckdb_ext_api.duckdb_v2_data_chunk_to_arrow_array
+#define duckdb_v2_logical_types_to_arrow_schema          duckdb_ext_api.duckdb_v2_logical_types_to_arrow_schema
 #define duckdb_v2_prepared_statement_create              duckdb_ext_api.duckdb_v2_prepared_statement_create
 #define duckdb_v2_prepared_statement_destroy             duckdb_ext_api.duckdb_v2_prepared_statement_destroy
 #define duckdb_v2_prepared_statement_execute             duckdb_ext_api.duckdb_v2_prepared_statement_execute
 #define duckdb_v2_prepared_statement_reuses_plan         duckdb_ext_api.duckdb_v2_prepared_statement_reuses_plan
+#define duckdb_v2_result_to_arrow_stream                 duckdb_ext_api.duckdb_v2_result_to_arrow_stream
 // capigen:end appended
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -955,6 +955,41 @@ typedef struct {
 	(duckdb_v2_custom_type_handle type, duckdb_v2_logical_type_handle base_type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_name)
 	(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_close)(duckdb_v2_file_handle file, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_destroy)(duckdb_v2_file_handle *file);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_open_options_create)
+	(duckdb_v2_file_system_handle file_system, duckdb_v2_file_open_options_handle *options,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_open_options_destroy)(duckdb_v2_file_open_options_handle *options);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_open_options_set_flag)
+	(duckdb_v2_file_open_options_handle options, DUCKDB_V2_FILE_FLAG flag, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_open_options_set_value)
+	(duckdb_v2_file_open_options_handle options, duckdb_v2_str name, duckdb_v2_value_handle value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_read)
+	(duckdb_v2_file_handle file, void *buffer, idx_t buffer_size, idx_t *bytes_read, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_read_at)
+	(duckdb_v2_file_handle file, void *buffer, idx_t buffer_size, idx_t location, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_seek)
+	(duckdb_v2_file_handle file, idx_t position, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_size)(duckdb_v2_file_handle file, idx_t *size, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_file_sync)(duckdb_v2_file_handle file, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_system_get_from_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_file_system_handle *file_system,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_system_get_from_context)
+	(duckdb_v2_context_handle context, duckdb_v2_file_system_handle *file_system, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_system_open)
+	(duckdb_v2_file_system_handle file_system, duckdb_v2_str file_path, duckdb_v2_file_open_options_handle options,
+	 duckdb_v2_file_handle *file, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_tell)
+	(duckdb_v2_file_handle file, idx_t *position, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_write)
+	(duckdb_v2_file_handle file, const void *buffer, idx_t buffer_size, idx_t *bytes_written,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_file_write_at)
+	(duckdb_v2_file_handle file, const void *buffer, idx_t buffer_size, idx_t location,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_qname_create)
 	(const duckdb_v2_identifier_t *parts, idx_t part_count, duckdb_v2_qname_handle *name,
 	 duckdb_v2_error_info_handle *err);
@@ -1433,6 +1468,23 @@ typedef struct {
 #define duckdb_v2_custom_type_register                   duckdb_ext_api.duckdb_v2_custom_type_register
 #define duckdb_v2_custom_type_set_base_type              duckdb_ext_api.duckdb_v2_custom_type_set_base_type
 #define duckdb_v2_custom_type_set_name                   duckdb_ext_api.duckdb_v2_custom_type_set_name
+#define duckdb_v2_file_close                             duckdb_ext_api.duckdb_v2_file_close
+#define duckdb_v2_file_destroy                           duckdb_ext_api.duckdb_v2_file_destroy
+#define duckdb_v2_file_open_options_create               duckdb_ext_api.duckdb_v2_file_open_options_create
+#define duckdb_v2_file_open_options_destroy              duckdb_ext_api.duckdb_v2_file_open_options_destroy
+#define duckdb_v2_file_open_options_set_flag             duckdb_ext_api.duckdb_v2_file_open_options_set_flag
+#define duckdb_v2_file_open_options_set_value            duckdb_ext_api.duckdb_v2_file_open_options_set_value
+#define duckdb_v2_file_read                              duckdb_ext_api.duckdb_v2_file_read
+#define duckdb_v2_file_read_at                           duckdb_ext_api.duckdb_v2_file_read_at
+#define duckdb_v2_file_seek                              duckdb_ext_api.duckdb_v2_file_seek
+#define duckdb_v2_file_size                              duckdb_ext_api.duckdb_v2_file_size
+#define duckdb_v2_file_sync                              duckdb_ext_api.duckdb_v2_file_sync
+#define duckdb_v2_file_system_get_from_connection        duckdb_ext_api.duckdb_v2_file_system_get_from_connection
+#define duckdb_v2_file_system_get_from_context           duckdb_ext_api.duckdb_v2_file_system_get_from_context
+#define duckdb_v2_file_system_open                       duckdb_ext_api.duckdb_v2_file_system_open
+#define duckdb_v2_file_tell                              duckdb_ext_api.duckdb_v2_file_tell
+#define duckdb_v2_file_write                             duckdb_ext_api.duckdb_v2_file_write
+#define duckdb_v2_file_write_at                          duckdb_ext_api.duckdb_v2_file_write_at
 #define duckdb_v2_qname_create                           duckdb_ext_api.duckdb_v2_qname_create
 #define duckdb_v2_qname_destroy                          duckdb_ext_api.duckdb_v2_qname_destroy
 #define duckdb_v2_qname_equals                           duckdb_ext_api.duckdb_v2_qname_equals

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1052,6 +1052,18 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_next_chunk)
 	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_data_chunk_handle *out_chunk,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_column_description_destroy)(duckdb_v2_column_description_handle *column);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_description_get_name)
+	(duckdb_v2_column_description_handle column, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_description_get_type)
+	(duckdb_v2_column_description_handle column, duckdb_v2_logical_type_handle *type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_description_has_default)
+	(duckdb_v2_column_description_handle column, bool *has_default, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_description_has_generated)
+	(duckdb_v2_column_description_handle column, bool *has_generated, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_connection_describe_table)
+	(duckdb_v2_connection_handle conn, duckdb_v2_qname_handle name, duckdb_v2_table_description_handle *desc,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_count)
 	(duckdb_v2_copy_from_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_name)
@@ -1232,6 +1244,16 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_result_to_arrow_stream)
 	(duckdb_v2_result_handle *result, idx_t batch_size, struct ArrowArrayStream *out_stream,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_table_description_destroy)(duckdb_v2_table_description_handle *desc);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_description_get_column)
+	(duckdb_v2_table_description_handle desc, idx_t index, duckdb_v2_column_description_handle *column,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_description_get_column_count)
+	(duckdb_v2_table_description_handle desc, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_description_get_qname)
+	(duckdb_v2_table_description_handle desc, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_description_is_readonly)
+	(duckdb_v2_table_description_handle desc, bool *readonly, duckdb_v2_error_info_handle *err);
 	// capigen:end appended
 } duckdb_ext_api_v2;
 
@@ -1704,6 +1726,12 @@ typedef struct {
 #define duckdb_v2_arrow_importer_destroy                 duckdb_ext_api.duckdb_v2_arrow_importer_destroy
 #define duckdb_v2_arrow_importer_get_schema              duckdb_ext_api.duckdb_v2_arrow_importer_get_schema
 #define duckdb_v2_arrow_importer_next_chunk              duckdb_ext_api.duckdb_v2_arrow_importer_next_chunk
+#define duckdb_v2_column_description_destroy             duckdb_ext_api.duckdb_v2_column_description_destroy
+#define duckdb_v2_column_description_get_name            duckdb_ext_api.duckdb_v2_column_description_get_name
+#define duckdb_v2_column_description_get_type            duckdb_ext_api.duckdb_v2_column_description_get_type
+#define duckdb_v2_column_description_has_default         duckdb_ext_api.duckdb_v2_column_description_has_default
+#define duckdb_v2_column_description_has_generated       duckdb_ext_api.duckdb_v2_column_description_has_generated
+#define duckdb_v2_connection_describe_table              duckdb_ext_api.duckdb_v2_connection_describe_table
 #define duckdb_v2_copy_from_bind_get_column_count        duckdb_ext_api.duckdb_v2_copy_from_bind_get_column_count
 #define duckdb_v2_copy_from_bind_get_column_name         duckdb_ext_api.duckdb_v2_copy_from_bind_get_column_name
 #define duckdb_v2_copy_from_bind_get_column_type         duckdb_ext_api.duckdb_v2_copy_from_bind_get_column_type
@@ -1782,6 +1810,11 @@ typedef struct {
 #define duckdb_v2_prepared_statement_execute             duckdb_ext_api.duckdb_v2_prepared_statement_execute
 #define duckdb_v2_prepared_statement_reuses_plan         duckdb_ext_api.duckdb_v2_prepared_statement_reuses_plan
 #define duckdb_v2_result_to_arrow_stream                 duckdb_ext_api.duckdb_v2_result_to_arrow_stream
+#define duckdb_v2_table_description_destroy              duckdb_ext_api.duckdb_v2_table_description_destroy
+#define duckdb_v2_table_description_get_column           duckdb_ext_api.duckdb_v2_table_description_get_column
+#define duckdb_v2_table_description_get_column_count     duckdb_ext_api.duckdb_v2_table_description_get_column_count
+#define duckdb_v2_table_description_get_qname            duckdb_ext_api.duckdb_v2_table_description_get_qname
+#define duckdb_v2_table_description_is_readonly          duckdb_ext_api.duckdb_v2_table_description_is_readonly
 // capigen:end appended
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1062,6 +1062,87 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_next_chunk)
 	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_data_chunk_handle *out_chunk,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_bind_data)
+	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_init_data)
+	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_user_data)
+	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_set_batch_data)
+	(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_get_bind_data)
+	(duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_get_user_data)
+	(duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_set_target)
+	(duckdb_v2_copy_function_batch_size_info_handle info, idx_t rows, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_take_input)
+	(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_column_data_collection_handle *collection,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_count)
+	(duckdb_v2_copy_function_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_name)
+	(duckdb_v2_copy_function_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_type)
+	(duckdb_v2_copy_function_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_user_data)
+	(duckdb_v2_copy_function_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_set_bind_data)
+	(duckdb_v2_copy_function_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_copy_function_handle *function,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_copy_function_handle *function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_copy_function_destroy)(duckdb_v2_copy_function_handle *function);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_bind_data)
+	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_init_data)
+	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_user_data)
+	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_batch_data)
+	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_bind_data)
+	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_init_data)
+	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_user_data)
+	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_bind_data)
+	(duckdb_v2_copy_function_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_file_path)
+	(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_user_data)
+	(duckdb_v2_copy_function_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_set_init_data)
+	(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_register)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_batch_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_batch_size_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_size_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_bind_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_bind_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_finalize_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_finalize_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_flush_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_flush_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_init_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_init_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_name)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_user_data)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1555,6 +1636,42 @@ typedef struct {
 #define duckdb_v2_arrow_importer_destroy                 duckdb_ext_api.duckdb_v2_arrow_importer_destroy
 #define duckdb_v2_arrow_importer_get_schema              duckdb_ext_api.duckdb_v2_arrow_importer_get_schema
 #define duckdb_v2_arrow_importer_next_chunk              duckdb_ext_api.duckdb_v2_arrow_importer_next_chunk
+#define duckdb_v2_copy_function_batch_get_bind_data      duckdb_ext_api.duckdb_v2_copy_function_batch_get_bind_data
+#define duckdb_v2_copy_function_batch_get_init_data      duckdb_ext_api.duckdb_v2_copy_function_batch_get_init_data
+#define duckdb_v2_copy_function_batch_get_user_data      duckdb_ext_api.duckdb_v2_copy_function_batch_get_user_data
+#define duckdb_v2_copy_function_batch_set_batch_data     duckdb_ext_api.duckdb_v2_copy_function_batch_set_batch_data
+#define duckdb_v2_copy_function_batch_size_get_bind_data duckdb_ext_api.duckdb_v2_copy_function_batch_size_get_bind_data
+#define duckdb_v2_copy_function_batch_size_get_user_data duckdb_ext_api.duckdb_v2_copy_function_batch_size_get_user_data
+#define duckdb_v2_copy_function_batch_size_set_target    duckdb_ext_api.duckdb_v2_copy_function_batch_size_set_target
+#define duckdb_v2_copy_function_batch_take_input         duckdb_ext_api.duckdb_v2_copy_function_batch_take_input
+#define duckdb_v2_copy_function_bind_get_column_count    duckdb_ext_api.duckdb_v2_copy_function_bind_get_column_count
+#define duckdb_v2_copy_function_bind_get_column_name     duckdb_ext_api.duckdb_v2_copy_function_bind_get_column_name
+#define duckdb_v2_copy_function_bind_get_column_type     duckdb_ext_api.duckdb_v2_copy_function_bind_get_column_type
+#define duckdb_v2_copy_function_bind_get_user_data       duckdb_ext_api.duckdb_v2_copy_function_bind_get_user_data
+#define duckdb_v2_copy_function_bind_set_bind_data       duckdb_ext_api.duckdb_v2_copy_function_bind_set_bind_data
+#define duckdb_v2_copy_function_create_with_connection   duckdb_ext_api.duckdb_v2_copy_function_create_with_connection
+#define duckdb_v2_copy_function_create_with_extension    duckdb_ext_api.duckdb_v2_copy_function_create_with_extension
+#define duckdb_v2_copy_function_destroy                  duckdb_ext_api.duckdb_v2_copy_function_destroy
+#define duckdb_v2_copy_function_finalize_get_bind_data   duckdb_ext_api.duckdb_v2_copy_function_finalize_get_bind_data
+#define duckdb_v2_copy_function_finalize_get_init_data   duckdb_ext_api.duckdb_v2_copy_function_finalize_get_init_data
+#define duckdb_v2_copy_function_finalize_get_user_data   duckdb_ext_api.duckdb_v2_copy_function_finalize_get_user_data
+#define duckdb_v2_copy_function_flush_get_batch_data     duckdb_ext_api.duckdb_v2_copy_function_flush_get_batch_data
+#define duckdb_v2_copy_function_flush_get_bind_data      duckdb_ext_api.duckdb_v2_copy_function_flush_get_bind_data
+#define duckdb_v2_copy_function_flush_get_init_data      duckdb_ext_api.duckdb_v2_copy_function_flush_get_init_data
+#define duckdb_v2_copy_function_flush_get_user_data      duckdb_ext_api.duckdb_v2_copy_function_flush_get_user_data
+#define duckdb_v2_copy_function_init_get_bind_data       duckdb_ext_api.duckdb_v2_copy_function_init_get_bind_data
+#define duckdb_v2_copy_function_init_get_file_path       duckdb_ext_api.duckdb_v2_copy_function_init_get_file_path
+#define duckdb_v2_copy_function_init_get_user_data       duckdb_ext_api.duckdb_v2_copy_function_init_get_user_data
+#define duckdb_v2_copy_function_init_set_init_data       duckdb_ext_api.duckdb_v2_copy_function_init_set_init_data
+#define duckdb_v2_copy_function_register                 duckdb_ext_api.duckdb_v2_copy_function_register
+#define duckdb_v2_copy_function_set_batch_callback       duckdb_ext_api.duckdb_v2_copy_function_set_batch_callback
+#define duckdb_v2_copy_function_set_batch_size_callback  duckdb_ext_api.duckdb_v2_copy_function_set_batch_size_callback
+#define duckdb_v2_copy_function_set_bind_callback        duckdb_ext_api.duckdb_v2_copy_function_set_bind_callback
+#define duckdb_v2_copy_function_set_finalize_callback    duckdb_ext_api.duckdb_v2_copy_function_set_finalize_callback
+#define duckdb_v2_copy_function_set_flush_callback       duckdb_ext_api.duckdb_v2_copy_function_set_flush_callback
+#define duckdb_v2_copy_function_set_init_callback        duckdb_ext_api.duckdb_v2_copy_function_set_init_callback
+#define duckdb_v2_copy_function_set_name                 duckdb_ext_api.duckdb_v2_copy_function_set_name
+#define duckdb_v2_copy_function_set_user_data            duckdb_ext_api.duckdb_v2_copy_function_set_user_data
 #define duckdb_v2_prepared_statement_create              duckdb_ext_api.duckdb_v2_prepared_statement_create
 #define duckdb_v2_prepared_statement_destroy             duckdb_ext_api.duckdb_v2_prepared_statement_destroy
 #define duckdb_v2_prepared_statement_execute             duckdb_ext_api.duckdb_v2_prepared_statement_execute

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1228,6 +1228,25 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_init_callback)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_init_callback_fn callback,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_cast_get_mode)
+	(duckdb_v2_expression_handle expression, DUCKDB_V2_CAST_MODE *mode, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_column_ref_get_index)
+	(duckdb_v2_expression_handle expression, idx_t *index, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_constant_get_value)
+	(duckdb_v2_expression_handle expression, duckdb_v2_value_handle *value, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_function_get_name)
+	(duckdb_v2_expression_handle expression, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_function_get_qname)
+	(duckdb_v2_expression_handle expression, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_get_child)
+	(duckdb_v2_expression_handle expression, idx_t index, duckdb_v2_expression_handle *child,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_get_child_count)
+	(duckdb_v2_expression_handle expression, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_get_return_type)
+	(duckdb_v2_expression_handle expression, duckdb_v2_logical_type_handle *type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_expression_get_type)
+	(duckdb_v2_expression_handle expression, DUCKDB_V2_EXPRESSION_TYPE *type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_identifier_render_quoted)
 	(duckdb_v2_identifier_t name, char *out_text, idx_t out_capacity, idx_t *out_length,
 	 duckdb_v2_error_info_handle *err);
@@ -1254,6 +1273,42 @@ typedef struct {
 	(duckdb_v2_table_description_handle desc, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_description_is_readonly)
 	(duckdb_v2_table_description_handle desc, bool *readonly, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_column_count)
+	(duckdb_v2_table_function_exec_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_column_index)
+	(duckdb_v2_table_function_exec_info_handle info, idx_t index, idx_t *column_index,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_accept)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_bind_data)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_column_count)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_column_index)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, idx_t *column_index,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_filter)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, duckdb_v2_expression_handle *filter,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_filter_count)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_filter_pushdown_get_user_data)
+	(duckdb_v2_table_function_filter_pushdown_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_get_column_count)
+	(duckdb_v2_table_function_init_global_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_get_column_index)
+	(duckdb_v2_table_function_init_global_info_handle info, idx_t index, idx_t *column_index,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_column_count)
+	(duckdb_v2_table_function_init_local_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_column_index)
+	(duckdb_v2_table_function_init_local_info_handle info, idx_t index, idx_t *column_index,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_filter_pushdown_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_filter_pushdown_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_projection_pushdown)
+	(duckdb_v2_table_function_handle function, bool enable, duckdb_v2_error_info_handle *err);
 	// capigen:end appended
 } duckdb_ext_api_v2;
 
@@ -1804,6 +1859,15 @@ typedef struct {
 #define duckdb_v2_copy_to_set_finalize_callback          duckdb_ext_api.duckdb_v2_copy_to_set_finalize_callback
 #define duckdb_v2_copy_to_set_flush_callback             duckdb_ext_api.duckdb_v2_copy_to_set_flush_callback
 #define duckdb_v2_copy_to_set_init_callback              duckdb_ext_api.duckdb_v2_copy_to_set_init_callback
+#define duckdb_v2_expression_cast_get_mode               duckdb_ext_api.duckdb_v2_expression_cast_get_mode
+#define duckdb_v2_expression_column_ref_get_index        duckdb_ext_api.duckdb_v2_expression_column_ref_get_index
+#define duckdb_v2_expression_constant_get_value          duckdb_ext_api.duckdb_v2_expression_constant_get_value
+#define duckdb_v2_expression_function_get_name           duckdb_ext_api.duckdb_v2_expression_function_get_name
+#define duckdb_v2_expression_function_get_qname          duckdb_ext_api.duckdb_v2_expression_function_get_qname
+#define duckdb_v2_expression_get_child                   duckdb_ext_api.duckdb_v2_expression_get_child
+#define duckdb_v2_expression_get_child_count             duckdb_ext_api.duckdb_v2_expression_get_child_count
+#define duckdb_v2_expression_get_return_type             duckdb_ext_api.duckdb_v2_expression_get_return_type
+#define duckdb_v2_expression_get_type                    duckdb_ext_api.duckdb_v2_expression_get_type
 #define duckdb_v2_identifier_render_quoted               duckdb_ext_api.duckdb_v2_identifier_render_quoted
 #define duckdb_v2_prepared_statement_create              duckdb_ext_api.duckdb_v2_prepared_statement_create
 #define duckdb_v2_prepared_statement_destroy             duckdb_ext_api.duckdb_v2_prepared_statement_destroy
@@ -1815,6 +1879,32 @@ typedef struct {
 #define duckdb_v2_table_description_get_column_count     duckdb_ext_api.duckdb_v2_table_description_get_column_count
 #define duckdb_v2_table_description_get_qname            duckdb_ext_api.duckdb_v2_table_description_get_qname
 #define duckdb_v2_table_description_is_readonly          duckdb_ext_api.duckdb_v2_table_description_is_readonly
+#define duckdb_v2_table_function_exec_get_column_count   duckdb_ext_api.duckdb_v2_table_function_exec_get_column_count
+#define duckdb_v2_table_function_exec_get_column_index   duckdb_ext_api.duckdb_v2_table_function_exec_get_column_index
+#define duckdb_v2_table_function_filter_pushdown_accept  duckdb_ext_api.duckdb_v2_table_function_filter_pushdown_accept
+#define duckdb_v2_table_function_filter_pushdown_get_bind_data                                                         \
+	duckdb_ext_api.duckdb_v2_table_function_filter_pushdown_get_bind_data
+#define duckdb_v2_table_function_filter_pushdown_get_column_count                                                      \
+	duckdb_ext_api.duckdb_v2_table_function_filter_pushdown_get_column_count
+#define duckdb_v2_table_function_filter_pushdown_get_column_index                                                      \
+	duckdb_ext_api.duckdb_v2_table_function_filter_pushdown_get_column_index
+#define duckdb_v2_table_function_filter_pushdown_get_filter                                                            \
+	duckdb_ext_api.duckdb_v2_table_function_filter_pushdown_get_filter
+#define duckdb_v2_table_function_filter_pushdown_get_filter_count                                                      \
+	duckdb_ext_api.duckdb_v2_table_function_filter_pushdown_get_filter_count
+#define duckdb_v2_table_function_filter_pushdown_get_user_data                                                         \
+	duckdb_ext_api.duckdb_v2_table_function_filter_pushdown_get_user_data
+#define duckdb_v2_table_function_init_global_get_column_count                                                          \
+	duckdb_ext_api.duckdb_v2_table_function_init_global_get_column_count
+#define duckdb_v2_table_function_init_global_get_column_index                                                          \
+	duckdb_ext_api.duckdb_v2_table_function_init_global_get_column_index
+#define duckdb_v2_table_function_init_local_get_column_count                                                           \
+	duckdb_ext_api.duckdb_v2_table_function_init_local_get_column_count
+#define duckdb_v2_table_function_init_local_get_column_index                                                           \
+	duckdb_ext_api.duckdb_v2_table_function_init_local_get_column_index
+#define duckdb_v2_table_function_set_filter_pushdown_callback                                                          \
+	duckdb_ext_api.duckdb_v2_table_function_set_filter_pushdown_callback
+#define duckdb_v2_table_function_set_projection_pushdown duckdb_ext_api.duckdb_v2_table_function_set_projection_pushdown
 // capigen:end appended
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1039,6 +1039,16 @@ typedef struct {
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
 	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
+	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
+	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_prepared_statement_destroy)(duckdb_v2_prepared_statement_handle *prepared);
+	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_execute)
+	(duckdb_v2_prepared_statement_handle prepared, const duckdb_v2_identifier_t *parameter_names,
+	 const duckdb_v2_value_handle *parameter_values, idx_t parameter_count, duckdb_v2_result_handle *out_result,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_reuses_plan)
+	(duckdb_v2_prepared_statement_handle prepared, bool *out_reuses, duckdb_v2_error_info_handle *err);
 	// capigen:end appended
 } duckdb_ext_api_v2;
 
@@ -1509,6 +1519,10 @@ typedef struct {
 #define duckdb_v2_replacement_scan_set_function_name     duckdb_ext_api.duckdb_v2_replacement_scan_set_function_name
 #define duckdb_v2_replacement_scan_set_subquery          duckdb_ext_api.duckdb_v2_replacement_scan_set_subquery
 #define duckdb_v2_replacement_scan_set_user_data         duckdb_ext_api.duckdb_v2_replacement_scan_set_user_data
+#define duckdb_v2_prepared_statement_create              duckdb_ext_api.duckdb_v2_prepared_statement_create
+#define duckdb_v2_prepared_statement_destroy             duckdb_ext_api.duckdb_v2_prepared_statement_destroy
+#define duckdb_v2_prepared_statement_execute             duckdb_ext_api.duckdb_v2_prepared_statement_execute
+#define duckdb_v2_prepared_statement_reuses_plan         duckdb_ext_api.duckdb_v2_prepared_statement_reuses_plan
 // capigen:end appended
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -818,6 +818,99 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_scalar_function_set_property)
 	(duckdb_v2_scalar_function_handle function, DUCKDB_V2_FUNCTION_PROPERTY_KEY key,
 	 DUCKDB_V2_FUNCTION_PROPERTY_VALUE value, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_add_result_column)
+	(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_logical_type_handle type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_get_arg_count)
+	(duckdb_v2_table_function_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_get_arg_type)
+	(duckdb_v2_table_function_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_get_arg_value)
+	(duckdb_v2_table_function_bind_info_handle info, idx_t index, duckdb_v2_value_handle *value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_get_user_data)
+	(duckdb_v2_table_function_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_set_bind_data)
+	(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_set_cardinality)
+	(duckdb_v2_table_function_bind_info_handle info, idx_t cardinality, bool is_exact,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_get_bind_data)
+	(duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_get_user_data)
+	(duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_set_cardinality)
+	(duckdb_v2_table_function_cardinality_info_handle info, idx_t cardinality, bool is_exact,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_table_function_handle *function,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_table_function_handle *function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_table_function_destroy)(duckdb_v2_table_function_handle *function);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_bind_data)
+	(duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_global_state)
+	(duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_local_state)
+	(duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_output_chunk)
+	(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_data_chunk_handle *chunk,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_exec_get_user_data)
+	(duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_get_signature)
+	(duckdb_v2_table_function_handle function, duckdb_v2_function_signature_handle *sig,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_get_bind_data)
+	(duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_get_user_data)
+	(duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_set_global_state)
+	(duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_global_set_max_threads)
+	(duckdb_v2_table_function_init_global_info_handle info, idx_t max_threads, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_bind_data)
+	(duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_global_state)
+	(duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_get_user_data)
+	(duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_init_local_set_local_state)
+	(duckdb_v2_table_function_init_local_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_progress_get_bind_data)
+	(duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_progress_get_global_state)
+	(duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_progress_get_user_data)
+	(duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_progress_set_progress)
+	(duckdb_v2_table_function_progress_info_handle info, double progress, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_register)
+	(duckdb_v2_table_function_handle function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_bind_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_bind_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_cardinality_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_cardinality_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_exec_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_exec_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_init_global_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_global_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_init_local_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_local_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_name)
+	(duckdb_v2_table_function_handle function, duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_progress_callback)
+	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_progress_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_user_data)
+	(duckdb_v2_table_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
 	// capigen:end appended
 } duckdb_ext_api_v2;
 
@@ -1170,8 +1263,62 @@ typedef struct {
 #define duckdb_v2_aggregate_function_update_get_states duckdb_ext_api.duckdb_v2_aggregate_function_update_get_states
 #define duckdb_v2_aggregate_function_update_get_user_data                                                              \
 	duckdb_ext_api.duckdb_v2_aggregate_function_update_get_user_data
-#define duckdb_v2_aggregate_function_set_property duckdb_ext_api.duckdb_v2_aggregate_function_set_property
-#define duckdb_v2_scalar_function_set_property    duckdb_ext_api.duckdb_v2_scalar_function_set_property
+#define duckdb_v2_aggregate_function_set_property       duckdb_ext_api.duckdb_v2_aggregate_function_set_property
+#define duckdb_v2_scalar_function_set_property          duckdb_ext_api.duckdb_v2_scalar_function_set_property
+#define duckdb_v2_table_function_bind_add_result_column duckdb_ext_api.duckdb_v2_table_function_bind_add_result_column
+#define duckdb_v2_table_function_bind_get_arg_count     duckdb_ext_api.duckdb_v2_table_function_bind_get_arg_count
+#define duckdb_v2_table_function_bind_get_arg_type      duckdb_ext_api.duckdb_v2_table_function_bind_get_arg_type
+#define duckdb_v2_table_function_bind_get_arg_value     duckdb_ext_api.duckdb_v2_table_function_bind_get_arg_value
+#define duckdb_v2_table_function_bind_get_user_data     duckdb_ext_api.duckdb_v2_table_function_bind_get_user_data
+#define duckdb_v2_table_function_bind_set_bind_data     duckdb_ext_api.duckdb_v2_table_function_bind_set_bind_data
+#define duckdb_v2_table_function_bind_set_cardinality   duckdb_ext_api.duckdb_v2_table_function_bind_set_cardinality
+#define duckdb_v2_table_function_cardinality_get_bind_data                                                             \
+	duckdb_ext_api.duckdb_v2_table_function_cardinality_get_bind_data
+#define duckdb_v2_table_function_cardinality_get_user_data                                                             \
+	duckdb_ext_api.duckdb_v2_table_function_cardinality_get_user_data
+#define duckdb_v2_table_function_cardinality_set_cardinality                                                           \
+	duckdb_ext_api.duckdb_v2_table_function_cardinality_set_cardinality
+#define duckdb_v2_table_function_create_with_connection duckdb_ext_api.duckdb_v2_table_function_create_with_connection
+#define duckdb_v2_table_function_create_with_extension  duckdb_ext_api.duckdb_v2_table_function_create_with_extension
+#define duckdb_v2_table_function_destroy                duckdb_ext_api.duckdb_v2_table_function_destroy
+#define duckdb_v2_table_function_exec_get_bind_data     duckdb_ext_api.duckdb_v2_table_function_exec_get_bind_data
+#define duckdb_v2_table_function_exec_get_global_state  duckdb_ext_api.duckdb_v2_table_function_exec_get_global_state
+#define duckdb_v2_table_function_exec_get_local_state   duckdb_ext_api.duckdb_v2_table_function_exec_get_local_state
+#define duckdb_v2_table_function_exec_get_output_chunk  duckdb_ext_api.duckdb_v2_table_function_exec_get_output_chunk
+#define duckdb_v2_table_function_exec_get_user_data     duckdb_ext_api.duckdb_v2_table_function_exec_get_user_data
+#define duckdb_v2_table_function_get_signature          duckdb_ext_api.duckdb_v2_table_function_get_signature
+#define duckdb_v2_table_function_init_global_get_bind_data                                                             \
+	duckdb_ext_api.duckdb_v2_table_function_init_global_get_bind_data
+#define duckdb_v2_table_function_init_global_get_user_data                                                             \
+	duckdb_ext_api.duckdb_v2_table_function_init_global_get_user_data
+#define duckdb_v2_table_function_init_global_set_global_state                                                          \
+	duckdb_ext_api.duckdb_v2_table_function_init_global_set_global_state
+#define duckdb_v2_table_function_init_global_set_max_threads                                                           \
+	duckdb_ext_api.duckdb_v2_table_function_init_global_set_max_threads
+#define duckdb_v2_table_function_init_local_get_bind_data                                                              \
+	duckdb_ext_api.duckdb_v2_table_function_init_local_get_bind_data
+#define duckdb_v2_table_function_init_local_get_global_state                                                           \
+	duckdb_ext_api.duckdb_v2_table_function_init_local_get_global_state
+#define duckdb_v2_table_function_init_local_get_user_data                                                              \
+	duckdb_ext_api.duckdb_v2_table_function_init_local_get_user_data
+#define duckdb_v2_table_function_init_local_set_local_state                                                            \
+	duckdb_ext_api.duckdb_v2_table_function_init_local_set_local_state
+#define duckdb_v2_table_function_progress_get_bind_data duckdb_ext_api.duckdb_v2_table_function_progress_get_bind_data
+#define duckdb_v2_table_function_progress_get_global_state                                                             \
+	duckdb_ext_api.duckdb_v2_table_function_progress_get_global_state
+#define duckdb_v2_table_function_progress_get_user_data duckdb_ext_api.duckdb_v2_table_function_progress_get_user_data
+#define duckdb_v2_table_function_progress_set_progress  duckdb_ext_api.duckdb_v2_table_function_progress_set_progress
+#define duckdb_v2_table_function_register               duckdb_ext_api.duckdb_v2_table_function_register
+#define duckdb_v2_table_function_set_bind_callback      duckdb_ext_api.duckdb_v2_table_function_set_bind_callback
+#define duckdb_v2_table_function_set_cardinality_callback                                                              \
+	duckdb_ext_api.duckdb_v2_table_function_set_cardinality_callback
+#define duckdb_v2_table_function_set_exec_callback duckdb_ext_api.duckdb_v2_table_function_set_exec_callback
+#define duckdb_v2_table_function_set_init_global_callback                                                              \
+	duckdb_ext_api.duckdb_v2_table_function_set_init_global_callback
+#define duckdb_v2_table_function_set_init_local_callback duckdb_ext_api.duckdb_v2_table_function_set_init_local_callback
+#define duckdb_v2_table_function_set_name                duckdb_ext_api.duckdb_v2_table_function_set_name
+#define duckdb_v2_table_function_set_progress_callback   duckdb_ext_api.duckdb_v2_table_function_set_progress_callback
+#define duckdb_v2_table_function_set_user_data           duckdb_ext_api.duckdb_v2_table_function_set_user_data
 // capigen:end appended
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -125,7 +125,7 @@ typedef struct {
 	 const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_connection_create_type_from_name)
-	(duckdb_v2_connection_handle conn, duckdb_v2_identifier_t name, const duckdb_v2_identifier_t *param_names,
+	(duckdb_v2_connection_handle conn, duckdb_v2_qname_handle name, const duckdb_v2_identifier_t *param_names,
 	 const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_connection_create_type_from_text)
@@ -154,7 +154,7 @@ typedef struct {
 	 const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_context_create_type_from_name)
-	(duckdb_v2_context_handle ctx, duckdb_v2_identifier_t name, const duckdb_v2_identifier_t *param_names,
+	(duckdb_v2_context_handle ctx, duckdb_v2_qname_handle name, const duckdb_v2_identifier_t *param_names,
 	 const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_context_create_type_from_text)
@@ -955,6 +955,23 @@ typedef struct {
 	(duckdb_v2_custom_type_handle type, duckdb_v2_logical_type_handle base_type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_name)
 	(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_create)
+	(const duckdb_v2_identifier_t *parts, idx_t part_count, duckdb_v2_qname_handle *name,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_qname_destroy)(duckdb_v2_qname_handle *name);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_equals)
+	(duckdb_v2_qname_handle left, duckdb_v2_qname_handle right, bool *result, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_get_part)
+	(duckdb_v2_qname_handle name, idx_t index, duckdb_v2_identifier_t *part, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_get_part_count)
+	(duckdb_v2_qname_handle name, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_hash)
+	(duckdb_v2_qname_handle name, uint64_t *hash, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_parse)
+	(duckdb_v2_str text, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_qname_render)
+	(duckdb_v2_qname_handle name, char *out_text, idx_t out_capacity, idx_t *out_length,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_add_argument)
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_value_handle value, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_add_named_argument)
@@ -967,12 +984,8 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_create_with_extension)
 	(duckdb_v2_extension_handle extension, duckdb_v2_replacement_scan_handle *scan, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR (*duckdb_v2_replacement_scan_destroy)(duckdb_v2_replacement_scan_handle *scan);
-	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_catalog_name)
-	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_schema_name)
-	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_table_name)
-	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_user_data)
 	(duckdb_v2_replacement_scan_info_handle info, void **data, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_register)
@@ -986,7 +999,7 @@ typedef struct {
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_column_data_collection_handle collection,
 	 const duckdb_v2_identifier_t *column_names, idx_t column_count, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_function_name)
-	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_qname_handle name, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_subquery)
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
@@ -1420,6 +1433,14 @@ typedef struct {
 #define duckdb_v2_custom_type_register                   duckdb_ext_api.duckdb_v2_custom_type_register
 #define duckdb_v2_custom_type_set_base_type              duckdb_ext_api.duckdb_v2_custom_type_set_base_type
 #define duckdb_v2_custom_type_set_name                   duckdb_ext_api.duckdb_v2_custom_type_set_name
+#define duckdb_v2_qname_create                           duckdb_ext_api.duckdb_v2_qname_create
+#define duckdb_v2_qname_destroy                          duckdb_ext_api.duckdb_v2_qname_destroy
+#define duckdb_v2_qname_equals                           duckdb_ext_api.duckdb_v2_qname_equals
+#define duckdb_v2_qname_get_part                         duckdb_ext_api.duckdb_v2_qname_get_part
+#define duckdb_v2_qname_get_part_count                   duckdb_ext_api.duckdb_v2_qname_get_part_count
+#define duckdb_v2_qname_hash                             duckdb_ext_api.duckdb_v2_qname_hash
+#define duckdb_v2_qname_parse                            duckdb_ext_api.duckdb_v2_qname_parse
+#define duckdb_v2_qname_render                           duckdb_ext_api.duckdb_v2_qname_render
 #define duckdb_v2_replacement_scan_add_argument          duckdb_ext_api.duckdb_v2_replacement_scan_add_argument
 #define duckdb_v2_replacement_scan_add_named_argument    duckdb_ext_api.duckdb_v2_replacement_scan_add_named_argument
 #define duckdb_v2_replacement_scan_create_with_connection                                                              \
@@ -1427,9 +1448,7 @@ typedef struct {
 #define duckdb_v2_replacement_scan_create_with_database  duckdb_ext_api.duckdb_v2_replacement_scan_create_with_database
 #define duckdb_v2_replacement_scan_create_with_extension duckdb_ext_api.duckdb_v2_replacement_scan_create_with_extension
 #define duckdb_v2_replacement_scan_destroy               duckdb_ext_api.duckdb_v2_replacement_scan_destroy
-#define duckdb_v2_replacement_scan_get_catalog_name      duckdb_ext_api.duckdb_v2_replacement_scan_get_catalog_name
-#define duckdb_v2_replacement_scan_get_schema_name       duckdb_ext_api.duckdb_v2_replacement_scan_get_schema_name
-#define duckdb_v2_replacement_scan_get_table_name        duckdb_ext_api.duckdb_v2_replacement_scan_get_table_name
+#define duckdb_v2_replacement_scan_get_name              duckdb_ext_api.duckdb_v2_replacement_scan_get_name
 #define duckdb_v2_replacement_scan_get_user_data         duckdb_ext_api.duckdb_v2_replacement_scan_get_user_data
 #define duckdb_v2_replacement_scan_register              duckdb_ext_api.duckdb_v2_replacement_scan_register
 #define duckdb_v2_replacement_scan_set_alias             duckdb_ext_api.duckdb_v2_replacement_scan_set_alias

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -911,6 +911,48 @@ typedef struct {
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_user_data)
 	(duckdb_v2_table_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_cast_function_handle *function,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_cast_function_handle *function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_cast_function_destroy)(duckdb_v2_cast_function_handle *function);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_input)
+	(duckdb_v2_cast_function_exec_info_handle info, duckdb_v2_vector_handle *vector, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_mode)
+	(duckdb_v2_cast_function_exec_info_handle info, DUCKDB_V2_CAST_MODE *mode, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_output)
+	(duckdb_v2_cast_function_exec_info_handle info, duckdb_v2_vector_handle *vector, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_row_count)
+	(duckdb_v2_cast_function_exec_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_exec_get_user_data)
+	(duckdb_v2_cast_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_register)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_exec_callback)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_cast_function_exec_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_implicit_cast_cost)
+	(duckdb_v2_cast_function_handle function, int64_t cost, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_source_type)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_logical_type_handle source_type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_target_type)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_logical_type_handle target_type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_user_data)
+	(duckdb_v2_cast_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_custom_type_handle *type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_custom_type_handle *type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_custom_type_destroy)(duckdb_v2_custom_type_handle *type);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_register)
+	(duckdb_v2_custom_type_handle type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_base_type)
+	(duckdb_v2_custom_type_handle type, duckdb_v2_logical_type_handle base_type, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_name)
+	(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
 	// capigen:end appended
 } duckdb_ext_api_v2;
 
@@ -1319,6 +1361,26 @@ typedef struct {
 #define duckdb_v2_table_function_set_name                duckdb_ext_api.duckdb_v2_table_function_set_name
 #define duckdb_v2_table_function_set_progress_callback   duckdb_ext_api.duckdb_v2_table_function_set_progress_callback
 #define duckdb_v2_table_function_set_user_data           duckdb_ext_api.duckdb_v2_table_function_set_user_data
+#define duckdb_v2_cast_function_create_with_connection   duckdb_ext_api.duckdb_v2_cast_function_create_with_connection
+#define duckdb_v2_cast_function_create_with_extension    duckdb_ext_api.duckdb_v2_cast_function_create_with_extension
+#define duckdb_v2_cast_function_destroy                  duckdb_ext_api.duckdb_v2_cast_function_destroy
+#define duckdb_v2_cast_function_exec_get_input           duckdb_ext_api.duckdb_v2_cast_function_exec_get_input
+#define duckdb_v2_cast_function_exec_get_mode            duckdb_ext_api.duckdb_v2_cast_function_exec_get_mode
+#define duckdb_v2_cast_function_exec_get_output          duckdb_ext_api.duckdb_v2_cast_function_exec_get_output
+#define duckdb_v2_cast_function_exec_get_row_count       duckdb_ext_api.duckdb_v2_cast_function_exec_get_row_count
+#define duckdb_v2_cast_function_exec_get_user_data       duckdb_ext_api.duckdb_v2_cast_function_exec_get_user_data
+#define duckdb_v2_cast_function_register                 duckdb_ext_api.duckdb_v2_cast_function_register
+#define duckdb_v2_cast_function_set_exec_callback        duckdb_ext_api.duckdb_v2_cast_function_set_exec_callback
+#define duckdb_v2_cast_function_set_implicit_cast_cost   duckdb_ext_api.duckdb_v2_cast_function_set_implicit_cast_cost
+#define duckdb_v2_cast_function_set_source_type          duckdb_ext_api.duckdb_v2_cast_function_set_source_type
+#define duckdb_v2_cast_function_set_target_type          duckdb_ext_api.duckdb_v2_cast_function_set_target_type
+#define duckdb_v2_cast_function_set_user_data            duckdb_ext_api.duckdb_v2_cast_function_set_user_data
+#define duckdb_v2_custom_type_create_with_connection     duckdb_ext_api.duckdb_v2_custom_type_create_with_connection
+#define duckdb_v2_custom_type_create_with_extension      duckdb_ext_api.duckdb_v2_custom_type_create_with_extension
+#define duckdb_v2_custom_type_destroy                    duckdb_ext_api.duckdb_v2_custom_type_destroy
+#define duckdb_v2_custom_type_register                   duckdb_ext_api.duckdb_v2_custom_type_register
+#define duckdb_v2_custom_type_set_base_type              duckdb_ext_api.duckdb_v2_custom_type_set_base_type
+#define duckdb_v2_custom_type_set_name                   duckdb_ext_api.duckdb_v2_custom_type_set_name
 // capigen:end appended
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -942,6 +942,8 @@ typedef struct {
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_cast_function_set_user_data)
 	(duckdb_v2_cast_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_column_data_collection_clear)
+	(duckdb_v2_column_data_collection_handle collection, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_create_with_connection)
 	(duckdb_v2_connection_handle connection, duckdb_v2_custom_type_handle *type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_create_with_extension)
@@ -953,6 +955,42 @@ typedef struct {
 	(duckdb_v2_custom_type_handle type, duckdb_v2_logical_type_handle base_type, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_custom_type_set_name)
 	(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_add_argument)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_value_handle value, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_add_named_argument)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_value_handle value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_create_with_connection)
+	(duckdb_v2_connection_handle connection, duckdb_v2_replacement_scan_handle *scan, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_create_with_database)
+	(duckdb_v2_database_handle database, duckdb_v2_replacement_scan_handle *scan, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_create_with_extension)
+	(duckdb_v2_extension_handle extension, duckdb_v2_replacement_scan_handle *scan, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_replacement_scan_destroy)(duckdb_v2_replacement_scan_handle *scan);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_catalog_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_schema_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_table_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_get_user_data)
+	(duckdb_v2_replacement_scan_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_register)
+	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_alias)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t alias, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_callback)
+	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_replacement_scan_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_collection)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_column_data_collection_handle collection,
+	 const duckdb_v2_identifier_t *column_names, idx_t column_count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_function_name)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_subquery)
+	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
+	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
 	// capigen:end appended
 } duckdb_ext_api_v2;
 
@@ -1375,12 +1413,31 @@ typedef struct {
 #define duckdb_v2_cast_function_set_source_type          duckdb_ext_api.duckdb_v2_cast_function_set_source_type
 #define duckdb_v2_cast_function_set_target_type          duckdb_ext_api.duckdb_v2_cast_function_set_target_type
 #define duckdb_v2_cast_function_set_user_data            duckdb_ext_api.duckdb_v2_cast_function_set_user_data
+#define duckdb_v2_column_data_collection_clear           duckdb_ext_api.duckdb_v2_column_data_collection_clear
 #define duckdb_v2_custom_type_create_with_connection     duckdb_ext_api.duckdb_v2_custom_type_create_with_connection
 #define duckdb_v2_custom_type_create_with_extension      duckdb_ext_api.duckdb_v2_custom_type_create_with_extension
 #define duckdb_v2_custom_type_destroy                    duckdb_ext_api.duckdb_v2_custom_type_destroy
 #define duckdb_v2_custom_type_register                   duckdb_ext_api.duckdb_v2_custom_type_register
 #define duckdb_v2_custom_type_set_base_type              duckdb_ext_api.duckdb_v2_custom_type_set_base_type
 #define duckdb_v2_custom_type_set_name                   duckdb_ext_api.duckdb_v2_custom_type_set_name
+#define duckdb_v2_replacement_scan_add_argument          duckdb_ext_api.duckdb_v2_replacement_scan_add_argument
+#define duckdb_v2_replacement_scan_add_named_argument    duckdb_ext_api.duckdb_v2_replacement_scan_add_named_argument
+#define duckdb_v2_replacement_scan_create_with_connection                                                              \
+	duckdb_ext_api.duckdb_v2_replacement_scan_create_with_connection
+#define duckdb_v2_replacement_scan_create_with_database  duckdb_ext_api.duckdb_v2_replacement_scan_create_with_database
+#define duckdb_v2_replacement_scan_create_with_extension duckdb_ext_api.duckdb_v2_replacement_scan_create_with_extension
+#define duckdb_v2_replacement_scan_destroy               duckdb_ext_api.duckdb_v2_replacement_scan_destroy
+#define duckdb_v2_replacement_scan_get_catalog_name      duckdb_ext_api.duckdb_v2_replacement_scan_get_catalog_name
+#define duckdb_v2_replacement_scan_get_schema_name       duckdb_ext_api.duckdb_v2_replacement_scan_get_schema_name
+#define duckdb_v2_replacement_scan_get_table_name        duckdb_ext_api.duckdb_v2_replacement_scan_get_table_name
+#define duckdb_v2_replacement_scan_get_user_data         duckdb_ext_api.duckdb_v2_replacement_scan_get_user_data
+#define duckdb_v2_replacement_scan_register              duckdb_ext_api.duckdb_v2_replacement_scan_register
+#define duckdb_v2_replacement_scan_set_alias             duckdb_ext_api.duckdb_v2_replacement_scan_set_alias
+#define duckdb_v2_replacement_scan_set_callback          duckdb_ext_api.duckdb_v2_replacement_scan_set_callback
+#define duckdb_v2_replacement_scan_set_collection        duckdb_ext_api.duckdb_v2_replacement_scan_set_collection
+#define duckdb_v2_replacement_scan_set_function_name     duckdb_ext_api.duckdb_v2_replacement_scan_set_function_name
+#define duckdb_v2_replacement_scan_set_subquery          duckdb_ext_api.duckdb_v2_replacement_scan_set_subquery
+#define duckdb_v2_replacement_scan_set_user_data         duckdb_ext_api.duckdb_v2_replacement_scan_set_user_data
 // capigen:end appended
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -836,13 +836,6 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_bind_set_cardinality)
 	(duckdb_v2_table_function_bind_info_handle info, idx_t cardinality, bool is_exact,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_get_bind_data)
-	(duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_get_user_data)
-	(duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_table_function_cardinality_set_cardinality)
-	(duckdb_v2_table_function_cardinality_info_handle info, idx_t cardinality, bool is_exact,
-	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_create_with_connection)
 	(duckdb_v2_connection_handle connection, duckdb_v2_table_function_handle *function,
 	 duckdb_v2_error_info_handle *err);
@@ -891,9 +884,6 @@ typedef struct {
 	(duckdb_v2_table_function_handle function, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_bind_callback)
 	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_bind_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_cardinality_callback)
-	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_cardinality_callback_fn callback,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_exec_callback)
 	(duckdb_v2_table_function_handle function, duckdb_v2_table_function_exec_callback_fn callback,
@@ -1062,87 +1052,170 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_next_chunk)
 	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_data_chunk_handle *out_chunk,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_bind_data)
-	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_init_data)
-	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_get_user_data)
-	(duckdb_v2_copy_function_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_set_batch_data)
-	(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_get_bind_data)
-	(duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_get_user_data)
-	(duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_size_set_target)
-	(duckdb_v2_copy_function_batch_size_info_handle info, idx_t rows, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_batch_take_input)
-	(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_column_data_collection_handle *collection,
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_count)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_name)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_count)
-	(duckdb_v2_copy_function_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_name)
-	(duckdb_v2_copy_function_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_column_type)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_column_type)
-	(duckdb_v2_copy_function_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_file_path)
+	(duckdb_v2_copy_from_bind_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_option_count)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_option_name)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_get_user_data)
-	(duckdb_v2_copy_function_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_bind_set_bind_data)
-	(duckdb_v2_copy_function_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_option_value)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t index, duckdb_v2_value_handle *value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_get_user_data)
+	(duckdb_v2_copy_from_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_set_bind_data)
+	(duckdb_v2_copy_from_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_bind_set_cardinality)
+	(duckdb_v2_copy_from_bind_info_handle info, idx_t cardinality, bool is_exact, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_bind_data)
+	(duckdb_v2_copy_from_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_global_state)
+	(duckdb_v2_copy_from_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_local_state)
+	(duckdb_v2_copy_from_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_output_chunk)
+	(duckdb_v2_copy_from_exec_info_handle info, duckdb_v2_data_chunk_handle *chunk, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_exec_get_user_data)
+	(duckdb_v2_copy_from_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_global_get_bind_data)
+	(duckdb_v2_copy_from_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_global_get_user_data)
+	(duckdb_v2_copy_from_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_global_set_global_state)
+	(duckdb_v2_copy_from_init_global_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_global_set_max_threads)
+	(duckdb_v2_copy_from_init_global_info_handle info, idx_t max_threads, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_local_get_bind_data)
+	(duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_local_get_global_state)
+	(duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_local_get_user_data)
+	(duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_init_local_set_local_state)
+	(duckdb_v2_copy_from_init_local_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_progress_get_bind_data)
+	(duckdb_v2_copy_from_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_progress_get_global_state)
+	(duckdb_v2_copy_from_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_progress_get_user_data)
+	(duckdb_v2_copy_from_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_progress_set_progress)
+	(duckdb_v2_copy_from_progress_info_handle info, double progress, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_bind_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_bind_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_exec_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_exec_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_init_global_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_init_global_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_init_local_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_init_local_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_from_set_progress_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_progress_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_create_with_connection)
 	(duckdb_v2_connection_handle connection, duckdb_v2_copy_function_handle *function,
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_create_with_extension)
 	(duckdb_v2_extension_handle extension, duckdb_v2_copy_function_handle *function, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR (*duckdb_v2_copy_function_destroy)(duckdb_v2_copy_function_handle *function);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_bind_data)
-	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_init_data)
-	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_finalize_get_user_data)
-	(duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_batch_data)
-	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_bind_data)
-	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_init_data)
-	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_flush_get_user_data)
-	(duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_bind_data)
-	(duckdb_v2_copy_function_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_file_path)
-	(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_get_user_data)
-	(duckdb_v2_copy_function_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_init_set_init_data)
-	(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_register)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_batch_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_batch_size_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_size_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_bind_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_bind_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_finalize_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_finalize_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_flush_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_flush_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_init_callback)
-	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_init_callback_fn callback,
-	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_name)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_function_set_user_data)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_get_bind_data)
+	(duckdb_v2_copy_to_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_get_init_data)
+	(duckdb_v2_copy_to_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_get_user_data)
+	(duckdb_v2_copy_to_batch_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_set_batch_data)
+	(duckdb_v2_copy_to_batch_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_size_get_bind_data)
+	(duckdb_v2_copy_to_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_size_get_user_data)
+	(duckdb_v2_copy_to_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_size_set_target)
+	(duckdb_v2_copy_to_batch_size_info_handle info, idx_t rows, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_batch_take_input)
+	(duckdb_v2_copy_to_batch_info_handle info, duckdb_v2_column_data_collection_handle *collection,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_column_count)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_column_name)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_column_type)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t index, duckdb_v2_logical_type_handle *type,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_file_path)
+	(duckdb_v2_copy_to_bind_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_option_count)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_option_name)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t index, duckdb_v2_identifier_t *name,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_option_value)
+	(duckdb_v2_copy_to_bind_info_handle info, idx_t index, duckdb_v2_value_handle *value,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_get_user_data)
+	(duckdb_v2_copy_to_bind_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_bind_set_bind_data)
+	(duckdb_v2_copy_to_bind_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_finalize_get_bind_data)
+	(duckdb_v2_copy_to_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_finalize_get_init_data)
+	(duckdb_v2_copy_to_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_finalize_get_user_data)
+	(duckdb_v2_copy_to_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_flush_get_batch_data)
+	(duckdb_v2_copy_to_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_flush_get_bind_data)
+	(duckdb_v2_copy_to_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_flush_get_init_data)
+	(duckdb_v2_copy_to_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_flush_get_user_data)
+	(duckdb_v2_copy_to_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_init_get_bind_data)
+	(duckdb_v2_copy_to_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_init_get_file_path)
+	(duckdb_v2_copy_to_init_info_handle info, duckdb_v2_str *path, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_init_get_user_data)
+	(duckdb_v2_copy_to_init_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_init_set_init_data)
+	(duckdb_v2_copy_to_init_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_batch_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_batch_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_batch_size_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_batch_size_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_bind_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_bind_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_finalize_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_finalize_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_flush_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_flush_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_init_callback)
+	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_init_callback_fn callback,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1517,12 +1590,6 @@ typedef struct {
 #define duckdb_v2_table_function_bind_get_user_data     duckdb_ext_api.duckdb_v2_table_function_bind_get_user_data
 #define duckdb_v2_table_function_bind_set_bind_data     duckdb_ext_api.duckdb_v2_table_function_bind_set_bind_data
 #define duckdb_v2_table_function_bind_set_cardinality   duckdb_ext_api.duckdb_v2_table_function_bind_set_cardinality
-#define duckdb_v2_table_function_cardinality_get_bind_data                                                             \
-	duckdb_ext_api.duckdb_v2_table_function_cardinality_get_bind_data
-#define duckdb_v2_table_function_cardinality_get_user_data                                                             \
-	duckdb_ext_api.duckdb_v2_table_function_cardinality_get_user_data
-#define duckdb_v2_table_function_cardinality_set_cardinality                                                           \
-	duckdb_ext_api.duckdb_v2_table_function_cardinality_set_cardinality
 #define duckdb_v2_table_function_create_with_connection duckdb_ext_api.duckdb_v2_table_function_create_with_connection
 #define duckdb_v2_table_function_create_with_extension  duckdb_ext_api.duckdb_v2_table_function_create_with_extension
 #define duckdb_v2_table_function_destroy                duckdb_ext_api.duckdb_v2_table_function_destroy
@@ -1555,9 +1622,7 @@ typedef struct {
 #define duckdb_v2_table_function_progress_set_progress  duckdb_ext_api.duckdb_v2_table_function_progress_set_progress
 #define duckdb_v2_table_function_register               duckdb_ext_api.duckdb_v2_table_function_register
 #define duckdb_v2_table_function_set_bind_callback      duckdb_ext_api.duckdb_v2_table_function_set_bind_callback
-#define duckdb_v2_table_function_set_cardinality_callback                                                              \
-	duckdb_ext_api.duckdb_v2_table_function_set_cardinality_callback
-#define duckdb_v2_table_function_set_exec_callback duckdb_ext_api.duckdb_v2_table_function_set_exec_callback
+#define duckdb_v2_table_function_set_exec_callback      duckdb_ext_api.duckdb_v2_table_function_set_exec_callback
 #define duckdb_v2_table_function_set_init_global_callback                                                              \
 	duckdb_ext_api.duckdb_v2_table_function_set_init_global_callback
 #define duckdb_v2_table_function_set_init_local_callback duckdb_ext_api.duckdb_v2_table_function_set_init_local_callback
@@ -1636,42 +1701,78 @@ typedef struct {
 #define duckdb_v2_arrow_importer_destroy                 duckdb_ext_api.duckdb_v2_arrow_importer_destroy
 #define duckdb_v2_arrow_importer_get_schema              duckdb_ext_api.duckdb_v2_arrow_importer_get_schema
 #define duckdb_v2_arrow_importer_next_chunk              duckdb_ext_api.duckdb_v2_arrow_importer_next_chunk
-#define duckdb_v2_copy_function_batch_get_bind_data      duckdb_ext_api.duckdb_v2_copy_function_batch_get_bind_data
-#define duckdb_v2_copy_function_batch_get_init_data      duckdb_ext_api.duckdb_v2_copy_function_batch_get_init_data
-#define duckdb_v2_copy_function_batch_get_user_data      duckdb_ext_api.duckdb_v2_copy_function_batch_get_user_data
-#define duckdb_v2_copy_function_batch_set_batch_data     duckdb_ext_api.duckdb_v2_copy_function_batch_set_batch_data
-#define duckdb_v2_copy_function_batch_size_get_bind_data duckdb_ext_api.duckdb_v2_copy_function_batch_size_get_bind_data
-#define duckdb_v2_copy_function_batch_size_get_user_data duckdb_ext_api.duckdb_v2_copy_function_batch_size_get_user_data
-#define duckdb_v2_copy_function_batch_size_set_target    duckdb_ext_api.duckdb_v2_copy_function_batch_size_set_target
-#define duckdb_v2_copy_function_batch_take_input         duckdb_ext_api.duckdb_v2_copy_function_batch_take_input
-#define duckdb_v2_copy_function_bind_get_column_count    duckdb_ext_api.duckdb_v2_copy_function_bind_get_column_count
-#define duckdb_v2_copy_function_bind_get_column_name     duckdb_ext_api.duckdb_v2_copy_function_bind_get_column_name
-#define duckdb_v2_copy_function_bind_get_column_type     duckdb_ext_api.duckdb_v2_copy_function_bind_get_column_type
-#define duckdb_v2_copy_function_bind_get_user_data       duckdb_ext_api.duckdb_v2_copy_function_bind_get_user_data
-#define duckdb_v2_copy_function_bind_set_bind_data       duckdb_ext_api.duckdb_v2_copy_function_bind_set_bind_data
+#define duckdb_v2_copy_from_bind_get_column_count        duckdb_ext_api.duckdb_v2_copy_from_bind_get_column_count
+#define duckdb_v2_copy_from_bind_get_column_name         duckdb_ext_api.duckdb_v2_copy_from_bind_get_column_name
+#define duckdb_v2_copy_from_bind_get_column_type         duckdb_ext_api.duckdb_v2_copy_from_bind_get_column_type
+#define duckdb_v2_copy_from_bind_get_file_path           duckdb_ext_api.duckdb_v2_copy_from_bind_get_file_path
+#define duckdb_v2_copy_from_bind_get_option_count        duckdb_ext_api.duckdb_v2_copy_from_bind_get_option_count
+#define duckdb_v2_copy_from_bind_get_option_name         duckdb_ext_api.duckdb_v2_copy_from_bind_get_option_name
+#define duckdb_v2_copy_from_bind_get_option_value        duckdb_ext_api.duckdb_v2_copy_from_bind_get_option_value
+#define duckdb_v2_copy_from_bind_get_user_data           duckdb_ext_api.duckdb_v2_copy_from_bind_get_user_data
+#define duckdb_v2_copy_from_bind_set_bind_data           duckdb_ext_api.duckdb_v2_copy_from_bind_set_bind_data
+#define duckdb_v2_copy_from_bind_set_cardinality         duckdb_ext_api.duckdb_v2_copy_from_bind_set_cardinality
+#define duckdb_v2_copy_from_exec_get_bind_data           duckdb_ext_api.duckdb_v2_copy_from_exec_get_bind_data
+#define duckdb_v2_copy_from_exec_get_global_state        duckdb_ext_api.duckdb_v2_copy_from_exec_get_global_state
+#define duckdb_v2_copy_from_exec_get_local_state         duckdb_ext_api.duckdb_v2_copy_from_exec_get_local_state
+#define duckdb_v2_copy_from_exec_get_output_chunk        duckdb_ext_api.duckdb_v2_copy_from_exec_get_output_chunk
+#define duckdb_v2_copy_from_exec_get_user_data           duckdb_ext_api.duckdb_v2_copy_from_exec_get_user_data
+#define duckdb_v2_copy_from_init_global_get_bind_data    duckdb_ext_api.duckdb_v2_copy_from_init_global_get_bind_data
+#define duckdb_v2_copy_from_init_global_get_user_data    duckdb_ext_api.duckdb_v2_copy_from_init_global_get_user_data
+#define duckdb_v2_copy_from_init_global_set_global_state duckdb_ext_api.duckdb_v2_copy_from_init_global_set_global_state
+#define duckdb_v2_copy_from_init_global_set_max_threads  duckdb_ext_api.duckdb_v2_copy_from_init_global_set_max_threads
+#define duckdb_v2_copy_from_init_local_get_bind_data     duckdb_ext_api.duckdb_v2_copy_from_init_local_get_bind_data
+#define duckdb_v2_copy_from_init_local_get_global_state  duckdb_ext_api.duckdb_v2_copy_from_init_local_get_global_state
+#define duckdb_v2_copy_from_init_local_get_user_data     duckdb_ext_api.duckdb_v2_copy_from_init_local_get_user_data
+#define duckdb_v2_copy_from_init_local_set_local_state   duckdb_ext_api.duckdb_v2_copy_from_init_local_set_local_state
+#define duckdb_v2_copy_from_progress_get_bind_data       duckdb_ext_api.duckdb_v2_copy_from_progress_get_bind_data
+#define duckdb_v2_copy_from_progress_get_global_state    duckdb_ext_api.duckdb_v2_copy_from_progress_get_global_state
+#define duckdb_v2_copy_from_progress_get_user_data       duckdb_ext_api.duckdb_v2_copy_from_progress_get_user_data
+#define duckdb_v2_copy_from_progress_set_progress        duckdb_ext_api.duckdb_v2_copy_from_progress_set_progress
+#define duckdb_v2_copy_from_set_bind_callback            duckdb_ext_api.duckdb_v2_copy_from_set_bind_callback
+#define duckdb_v2_copy_from_set_exec_callback            duckdb_ext_api.duckdb_v2_copy_from_set_exec_callback
+#define duckdb_v2_copy_from_set_init_global_callback     duckdb_ext_api.duckdb_v2_copy_from_set_init_global_callback
+#define duckdb_v2_copy_from_set_init_local_callback      duckdb_ext_api.duckdb_v2_copy_from_set_init_local_callback
+#define duckdb_v2_copy_from_set_progress_callback        duckdb_ext_api.duckdb_v2_copy_from_set_progress_callback
 #define duckdb_v2_copy_function_create_with_connection   duckdb_ext_api.duckdb_v2_copy_function_create_with_connection
 #define duckdb_v2_copy_function_create_with_extension    duckdb_ext_api.duckdb_v2_copy_function_create_with_extension
 #define duckdb_v2_copy_function_destroy                  duckdb_ext_api.duckdb_v2_copy_function_destroy
-#define duckdb_v2_copy_function_finalize_get_bind_data   duckdb_ext_api.duckdb_v2_copy_function_finalize_get_bind_data
-#define duckdb_v2_copy_function_finalize_get_init_data   duckdb_ext_api.duckdb_v2_copy_function_finalize_get_init_data
-#define duckdb_v2_copy_function_finalize_get_user_data   duckdb_ext_api.duckdb_v2_copy_function_finalize_get_user_data
-#define duckdb_v2_copy_function_flush_get_batch_data     duckdb_ext_api.duckdb_v2_copy_function_flush_get_batch_data
-#define duckdb_v2_copy_function_flush_get_bind_data      duckdb_ext_api.duckdb_v2_copy_function_flush_get_bind_data
-#define duckdb_v2_copy_function_flush_get_init_data      duckdb_ext_api.duckdb_v2_copy_function_flush_get_init_data
-#define duckdb_v2_copy_function_flush_get_user_data      duckdb_ext_api.duckdb_v2_copy_function_flush_get_user_data
-#define duckdb_v2_copy_function_init_get_bind_data       duckdb_ext_api.duckdb_v2_copy_function_init_get_bind_data
-#define duckdb_v2_copy_function_init_get_file_path       duckdb_ext_api.duckdb_v2_copy_function_init_get_file_path
-#define duckdb_v2_copy_function_init_get_user_data       duckdb_ext_api.duckdb_v2_copy_function_init_get_user_data
-#define duckdb_v2_copy_function_init_set_init_data       duckdb_ext_api.duckdb_v2_copy_function_init_set_init_data
 #define duckdb_v2_copy_function_register                 duckdb_ext_api.duckdb_v2_copy_function_register
-#define duckdb_v2_copy_function_set_batch_callback       duckdb_ext_api.duckdb_v2_copy_function_set_batch_callback
-#define duckdb_v2_copy_function_set_batch_size_callback  duckdb_ext_api.duckdb_v2_copy_function_set_batch_size_callback
-#define duckdb_v2_copy_function_set_bind_callback        duckdb_ext_api.duckdb_v2_copy_function_set_bind_callback
-#define duckdb_v2_copy_function_set_finalize_callback    duckdb_ext_api.duckdb_v2_copy_function_set_finalize_callback
-#define duckdb_v2_copy_function_set_flush_callback       duckdb_ext_api.duckdb_v2_copy_function_set_flush_callback
-#define duckdb_v2_copy_function_set_init_callback        duckdb_ext_api.duckdb_v2_copy_function_set_init_callback
 #define duckdb_v2_copy_function_set_name                 duckdb_ext_api.duckdb_v2_copy_function_set_name
 #define duckdb_v2_copy_function_set_user_data            duckdb_ext_api.duckdb_v2_copy_function_set_user_data
+#define duckdb_v2_copy_to_batch_get_bind_data            duckdb_ext_api.duckdb_v2_copy_to_batch_get_bind_data
+#define duckdb_v2_copy_to_batch_get_init_data            duckdb_ext_api.duckdb_v2_copy_to_batch_get_init_data
+#define duckdb_v2_copy_to_batch_get_user_data            duckdb_ext_api.duckdb_v2_copy_to_batch_get_user_data
+#define duckdb_v2_copy_to_batch_set_batch_data           duckdb_ext_api.duckdb_v2_copy_to_batch_set_batch_data
+#define duckdb_v2_copy_to_batch_size_get_bind_data       duckdb_ext_api.duckdb_v2_copy_to_batch_size_get_bind_data
+#define duckdb_v2_copy_to_batch_size_get_user_data       duckdb_ext_api.duckdb_v2_copy_to_batch_size_get_user_data
+#define duckdb_v2_copy_to_batch_size_set_target          duckdb_ext_api.duckdb_v2_copy_to_batch_size_set_target
+#define duckdb_v2_copy_to_batch_take_input               duckdb_ext_api.duckdb_v2_copy_to_batch_take_input
+#define duckdb_v2_copy_to_bind_get_column_count          duckdb_ext_api.duckdb_v2_copy_to_bind_get_column_count
+#define duckdb_v2_copy_to_bind_get_column_name           duckdb_ext_api.duckdb_v2_copy_to_bind_get_column_name
+#define duckdb_v2_copy_to_bind_get_column_type           duckdb_ext_api.duckdb_v2_copy_to_bind_get_column_type
+#define duckdb_v2_copy_to_bind_get_file_path             duckdb_ext_api.duckdb_v2_copy_to_bind_get_file_path
+#define duckdb_v2_copy_to_bind_get_option_count          duckdb_ext_api.duckdb_v2_copy_to_bind_get_option_count
+#define duckdb_v2_copy_to_bind_get_option_name           duckdb_ext_api.duckdb_v2_copy_to_bind_get_option_name
+#define duckdb_v2_copy_to_bind_get_option_value          duckdb_ext_api.duckdb_v2_copy_to_bind_get_option_value
+#define duckdb_v2_copy_to_bind_get_user_data             duckdb_ext_api.duckdb_v2_copy_to_bind_get_user_data
+#define duckdb_v2_copy_to_bind_set_bind_data             duckdb_ext_api.duckdb_v2_copy_to_bind_set_bind_data
+#define duckdb_v2_copy_to_finalize_get_bind_data         duckdb_ext_api.duckdb_v2_copy_to_finalize_get_bind_data
+#define duckdb_v2_copy_to_finalize_get_init_data         duckdb_ext_api.duckdb_v2_copy_to_finalize_get_init_data
+#define duckdb_v2_copy_to_finalize_get_user_data         duckdb_ext_api.duckdb_v2_copy_to_finalize_get_user_data
+#define duckdb_v2_copy_to_flush_get_batch_data           duckdb_ext_api.duckdb_v2_copy_to_flush_get_batch_data
+#define duckdb_v2_copy_to_flush_get_bind_data            duckdb_ext_api.duckdb_v2_copy_to_flush_get_bind_data
+#define duckdb_v2_copy_to_flush_get_init_data            duckdb_ext_api.duckdb_v2_copy_to_flush_get_init_data
+#define duckdb_v2_copy_to_flush_get_user_data            duckdb_ext_api.duckdb_v2_copy_to_flush_get_user_data
+#define duckdb_v2_copy_to_init_get_bind_data             duckdb_ext_api.duckdb_v2_copy_to_init_get_bind_data
+#define duckdb_v2_copy_to_init_get_file_path             duckdb_ext_api.duckdb_v2_copy_to_init_get_file_path
+#define duckdb_v2_copy_to_init_get_user_data             duckdb_ext_api.duckdb_v2_copy_to_init_get_user_data
+#define duckdb_v2_copy_to_init_set_init_data             duckdb_ext_api.duckdb_v2_copy_to_init_set_init_data
+#define duckdb_v2_copy_to_set_batch_callback             duckdb_ext_api.duckdb_v2_copy_to_set_batch_callback
+#define duckdb_v2_copy_to_set_batch_size_callback        duckdb_ext_api.duckdb_v2_copy_to_set_batch_size_callback
+#define duckdb_v2_copy_to_set_bind_callback              duckdb_ext_api.duckdb_v2_copy_to_set_bind_callback
+#define duckdb_v2_copy_to_set_finalize_callback          duckdb_ext_api.duckdb_v2_copy_to_set_finalize_callback
+#define duckdb_v2_copy_to_set_flush_callback             duckdb_ext_api.duckdb_v2_copy_to_set_flush_callback
+#define duckdb_v2_copy_to_set_init_callback              duckdb_ext_api.duckdb_v2_copy_to_set_init_callback
 #define duckdb_v2_prepared_statement_create              duckdb_ext_api.duckdb_v2_prepared_statement_create
 #define duckdb_v2_prepared_statement_destroy             duckdb_ext_api.duckdb_v2_prepared_statement_destroy
 #define duckdb_v2_prepared_statement_execute             duckdb_ext_api.duckdb_v2_prepared_statement_execute

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1216,6 +1216,9 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_copy_to_set_init_callback)
 	(duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_init_callback_fn callback,
 	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_identifier_render_quoted)
+	(duckdb_v2_identifier_t name, char *out_text, idx_t out_capacity, idx_t *out_length,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1773,6 +1776,7 @@ typedef struct {
 #define duckdb_v2_copy_to_set_finalize_callback          duckdb_ext_api.duckdb_v2_copy_to_set_finalize_callback
 #define duckdb_v2_copy_to_set_flush_callback             duckdb_ext_api.duckdb_v2_copy_to_set_flush_callback
 #define duckdb_v2_copy_to_set_init_callback              duckdb_ext_api.duckdb_v2_copy_to_set_init_callback
+#define duckdb_v2_identifier_render_quoted               duckdb_ext_api.duckdb_v2_identifier_render_quoted
 #define duckdb_v2_prepared_statement_create              duckdb_ext_api.duckdb_v2_prepared_statement_create
 #define duckdb_v2_prepared_statement_destroy             duckdb_ext_api.duckdb_v2_prepared_statement_destroy
 #define duckdb_v2_prepared_statement_execute             duckdb_ext_api.duckdb_v2_prepared_statement_execute

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1039,21 +1039,29 @@ typedef struct {
 	(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_replacement_scan_set_user_data)
 	(duckdb_v2_replacement_scan_handle scan, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_array_to_chunk)
-	(duckdb_v2_context_handle context, struct ArrowArray *array, duckdb_v2_arrow_converter_handle converter,
-	 duckdb_v2_data_chunk_handle *out_chunk, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_create)
-	(duckdb_v2_context_handle context, struct ArrowSchema *schema, duckdb_v2_arrow_converter_handle *out_converter,
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_exporter_append)
+	(duckdb_v2_arrow_exporter_handle exporter, duckdb_v2_data_chunk_handle *chunk, bool consume, bool flush,
 	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR (*duckdb_v2_arrow_converter_destroy)(duckdb_v2_arrow_converter_handle *converter);
-	DUCKDB_V2_ERROR(*duckdb_v2_arrow_converter_get_schema)
-	(duckdb_v2_arrow_converter_handle converter, duckdb_v2_schema_handle *out_schema, duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_data_chunk_to_arrow_array)
-	(duckdb_v2_context_handle context, duckdb_v2_data_chunk_handle chunk, struct ArrowArray *out_array,
-	 duckdb_v2_error_info_handle *err);
-	DUCKDB_V2_ERROR(*duckdb_v2_logical_types_to_arrow_schema)
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_exporter_create)
 	(duckdb_v2_context_handle context, const duckdb_v2_logical_type_handle *types, const duckdb_v2_str *names,
-	 idx_t count, struct ArrowSchema *out_schema, duckdb_v2_error_info_handle *err);
+	 idx_t count, idx_t batch_size, duckdb_v2_arrow_exporter_handle *out_exporter, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_arrow_exporter_destroy)(duckdb_v2_arrow_exporter_handle *exporter);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_exporter_get_schema)
+	(duckdb_v2_arrow_exporter_handle exporter, struct ArrowSchema *out_schema, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_exporter_next_array)
+	(duckdb_v2_arrow_exporter_handle exporter, struct ArrowArray *out_array, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_append)
+	(duckdb_v2_arrow_importer_handle importer, struct ArrowArray *array, bool consume, bool flush,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_create)
+	(duckdb_v2_context_handle context, struct ArrowSchema *schema, idx_t batch_size,
+	 duckdb_v2_arrow_importer_handle *out_importer, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_arrow_importer_destroy)(duckdb_v2_arrow_importer_handle *importer);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_get_schema)
+	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_schema_handle *out_schema, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_arrow_importer_next_chunk)
+	(duckdb_v2_arrow_importer_handle importer, duckdb_v2_data_chunk_handle *out_chunk,
+	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_prepared_statement_create)
 	(duckdb_v2_connection_handle conn, duckdb_v2_sql_statement_handle statement, bool require_cacheable,
 	 duckdb_v2_prepared_statement_handle *out_prepared, duckdb_v2_error_info_handle *err);
@@ -1537,12 +1545,16 @@ typedef struct {
 #define duckdb_v2_replacement_scan_set_function_name     duckdb_ext_api.duckdb_v2_replacement_scan_set_function_name
 #define duckdb_v2_replacement_scan_set_subquery          duckdb_ext_api.duckdb_v2_replacement_scan_set_subquery
 #define duckdb_v2_replacement_scan_set_user_data         duckdb_ext_api.duckdb_v2_replacement_scan_set_user_data
-#define duckdb_v2_arrow_converter_array_to_chunk         duckdb_ext_api.duckdb_v2_arrow_converter_array_to_chunk
-#define duckdb_v2_arrow_converter_create                 duckdb_ext_api.duckdb_v2_arrow_converter_create
-#define duckdb_v2_arrow_converter_destroy                duckdb_ext_api.duckdb_v2_arrow_converter_destroy
-#define duckdb_v2_arrow_converter_get_schema             duckdb_ext_api.duckdb_v2_arrow_converter_get_schema
-#define duckdb_v2_data_chunk_to_arrow_array              duckdb_ext_api.duckdb_v2_data_chunk_to_arrow_array
-#define duckdb_v2_logical_types_to_arrow_schema          duckdb_ext_api.duckdb_v2_logical_types_to_arrow_schema
+#define duckdb_v2_arrow_exporter_append                  duckdb_ext_api.duckdb_v2_arrow_exporter_append
+#define duckdb_v2_arrow_exporter_create                  duckdb_ext_api.duckdb_v2_arrow_exporter_create
+#define duckdb_v2_arrow_exporter_destroy                 duckdb_ext_api.duckdb_v2_arrow_exporter_destroy
+#define duckdb_v2_arrow_exporter_get_schema              duckdb_ext_api.duckdb_v2_arrow_exporter_get_schema
+#define duckdb_v2_arrow_exporter_next_array              duckdb_ext_api.duckdb_v2_arrow_exporter_next_array
+#define duckdb_v2_arrow_importer_append                  duckdb_ext_api.duckdb_v2_arrow_importer_append
+#define duckdb_v2_arrow_importer_create                  duckdb_ext_api.duckdb_v2_arrow_importer_create
+#define duckdb_v2_arrow_importer_destroy                 duckdb_ext_api.duckdb_v2_arrow_importer_destroy
+#define duckdb_v2_arrow_importer_get_schema              duckdb_ext_api.duckdb_v2_arrow_importer_get_schema
+#define duckdb_v2_arrow_importer_next_chunk              duckdb_ext_api.duckdb_v2_arrow_importer_next_chunk
 #define duckdb_v2_prepared_statement_create              duckdb_ext_api.duckdb_v2_prepared_statement_create
 #define duckdb_v2_prepared_statement_destroy             duckdb_ext_api.duckdb_v2_prepared_statement_destroy
 #define duckdb_v2_prepared_statement_execute             duckdb_ext_api.duckdb_v2_prepared_statement_execute

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -5087,6 +5087,248 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_destroy(duckdb_v2_arrow_ex
 /* --- Struct definitions for arrow --- */
 
 /* ============================================================================
+ * MODULE: catalog
+ * ============================================================================ */
+
+/* --- Enums for catalog --- */
+
+/* --- Struct forward declarations for catalog --- */
+
+/* --- Types for catalog --- */
+
+/*!
+ * An owned snapshot of one base table taken at creation: where the name resolved, the table's columns, and per-column
+ * catalog facts. Later DDL does not update it. Create with `duckdb_v2_connection_describe_table()`, read the resolved
+ * location via `duckdb_v2_table_description_get_qname()`, and the columns via
+ * `duckdb_v2_table_description_get_column_count()` and `duckdb_v2_table_description_get_column()`. Destroy via
+ * `duckdb_v2_table_description_destroy()`.
+ */
+typedef struct _duckdb_v2_table_description {
+	void *internal_ptr;
+} * duckdb_v2_table_description_handle;
+
+/*!
+ * An owned snapshot of one column of a described table: its name, type, and catalog facts. Obtain with
+ * `duckdb_v2_table_description_get_column()`, read with `duckdb_v2_column_description_get_name()`,
+ * `duckdb_v2_column_description_get_type()`, `duckdb_v2_column_description_has_default()` and
+ * `duckdb_v2_column_description_has_generated()`, and destroy with `duckdb_v2_column_description_destroy()`.
+ * Independent of the table description it came from, so it may outlive it.
+ */
+typedef struct _duckdb_v2_column_description {
+	void *internal_ptr;
+} * duckdb_v2_column_description_handle;
+
+/* --- Constants for catalog --- */
+
+/* --- Function pointer typedefs for catalog --- */
+
+/* --- Functions for catalog --- */
+
+/*!
+ * Resolves a table name and snapshots its description.
+ *
+ * Resolves name in the connection's catalogs and returns an owned description of the table it names. name may be
+ * partial: an unqualified or schema-qualified name resolves through the connection's search path, exactly as the same
+ * name resolves in SQL. A two-part name tries the first part as a schema and as an attached database, as SQL does, and
+ * is rejected when both readings exist. A name that resolves to nothing is rejected with the engine's missing-table
+ * error; a name that resolves to a view is rejected with the engine's not-a-table error, since a description snapshots
+ * a base table.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param conn The connection whose catalogs and search path resolve the name.
+ * @param name The possibly partial table name to resolve. Borrowed for the call only.
+ * @param desc On success, receives the owned description. Destroy via `duckdb_v2_table_description_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_describe_table(duckdb_v2_connection_handle conn,
+                                                                 duckdb_v2_qname_handle name,
+                                                                 duckdb_v2_table_description_handle *desc,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the resolved qualified name of the described table.
+ *
+ * Returns an owned copy of the fully resolved name: the catalog, schema, and table the lookup landed on, with the
+ * casing the table was created with, never an echo of the requested name. Rendering it produces SQL that pins the
+ * described table regardless of search path.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param desc The description.
+ * @param name Receives the owned resolved name. Destroy via `duckdb_v2_qname_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_description_get_qname(duckdb_v2_table_description_handle desc,
+                                                                   duckdb_v2_qname_handle *name,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns whether the described table's catalog is read-only.
+ *
+ * True when the catalog the name resolved into was attached read-only, in which case no write to the table can succeed.
+ * False does not by itself prove a write will succeed; it clears the catalog-level check only.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param desc The description.
+ * @param readonly Receives whether the catalog is read-only.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_description_is_readonly(duckdb_v2_table_description_handle desc,
+                                                                     bool *readonly, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of columns of the described table.
+ *
+ * Counts every column in declared order, generated columns included. Valid indices for
+ * `duckdb_v2_table_description_get_column()` are [0, count).
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param desc The description.
+ * @param count Receives the column count.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_description_get_column_count(duckdb_v2_table_description_handle desc,
+                                                                          idx_t *count,
+                                                                          duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns an owned description of the column at index.
+ *
+ * Columns are numbered in declared order, generated columns included. An out-of-range index is rejected with
+ * `ERROR_INPUT_OUT_OF_RANGE`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param desc The description.
+ * @param index Zero-based column index.
+ * @param column Receives the owned column description. Destroy via `duckdb_v2_column_description_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_description_get_column(duckdb_v2_table_description_handle desc,
+                                                                    idx_t index,
+                                                                    duckdb_v2_column_description_handle *column,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the table description, releasing its resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Column descriptions obtained from it are independent and stay valid.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param desc The description to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_description_destroy(duckdb_v2_table_description_handle *desc);
+
+/*!
+ * Borrows the name of the column.
+ *
+ * The name carries the casing the column was declared with.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param column The column description.
+ * @param name Receives a borrowed view of the column name. Valid until the column description is destroyed.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_description_get_name(duckdb_v2_column_description_handle column,
+                                                                   duckdb_v2_identifier_t *name,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Borrows the type of the column.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param column The column description.
+ * @param type Receives the borrowed column type. Valid until the column description is destroyed; do not destroy it.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_description_get_type(duckdb_v2_column_description_handle column,
+                                                                   duckdb_v2_logical_type_handle *type,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns whether the column has a default value.
+ *
+ * True when the column declares a default expression; the engine evaluates it for rows that omit the column. Generated
+ * columns report false.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param column The column description.
+ * @param has_default Receives whether the column has a default value.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_description_has_default(duckdb_v2_column_description_handle column,
+                                                                      bool *has_default,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns whether the column is generated.
+ *
+ * True when the column is a generated column, computed by the engine from a generation expression and not writable.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param column The column description.
+ * @param has_generated Receives whether the column is generated.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_description_has_generated(duckdb_v2_column_description_handle column,
+                                                                        bool *has_generated,
+                                                                        duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the column description, releasing its resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Any name or type borrowed from it becomes dangling.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param column The column description to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_description_destroy(duckdb_v2_column_description_handle *column);
+
+/* --- Struct definitions for catalog --- */
+
+/* ============================================================================
  * MODULE: connection
  * ============================================================================ */
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -5277,6 +5277,751 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_query_progress_destroy(duckdb_v2_query_pr
 /* --- Struct definitions for connection --- */
 
 /* ============================================================================
+ * MODULE: copy
+ * ============================================================================ */
+
+/* --- Enums for copy --- */
+
+/* --- Struct forward declarations for copy --- */
+
+/* --- Types for copy --- */
+
+/*!
+ * An owned opaque handle to a custom copy function being built. Created with
+ * `duckdb_v2_copy_function_create_with_connection()` or `duckdb_v2_copy_function_create_with_extension()`, configured
+ * with the setter functions (e.g. `duckdb_v2_copy_function_set_name()`, `duckdb_v2_copy_function_set_batch_callback()`,
+ * etc.), made available with `duckdb_v2_copy_function_register()`, and destroyed with
+ * `duckdb_v2_copy_function_destroy()`.
+ */
+typedef struct _duckdb_v2_copy_function {
+	void *internal_ptr;
+} * duckdb_v2_copy_function_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the query preparation "bind" phase. The
+ * "bind" callback receives this handle and can use it to e.g. inspect the names and types of the columns being copied
+ * and initialize some constant state.
+ */
+typedef struct _duckdb_v2_copy_function_bind_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_function_bind_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the per-file "init" phase. The "init"
+ * callback receives this handle and can use it to e.g. read the path of the file being written and set up the state
+ * shared by every batch written to that file.
+ */
+typedef struct _duckdb_v2_copy_function_init_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_function_init_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the "batch" phase. The "batch" callback
+ * receives this handle and can use it to take ownership of the rows of the batch and to set the prepared form of the
+ * batch handed to the "flush" callback.
+ */
+typedef struct _duckdb_v2_copy_function_batch_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_function_batch_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the "flush" phase. The "flush" callback
+ * receives this handle and can use it to access the prepared batch and write it to the output.
+ */
+typedef struct _duckdb_v2_copy_function_flush_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_function_flush_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the "batch size" phase. The "batch size"
+ * callback receives this handle and must use it to report how many rows a batch should carry.
+ */
+typedef struct _duckdb_v2_copy_function_batch_size_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_function_batch_size_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the per-file "finalize" phase. The
+ * "finalize" callback receives this handle and can use it to e.g. close the file after every batch has been flushed to
+ * it.
+ */
+typedef struct _duckdb_v2_copy_function_finalize_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_function_finalize_info_handle;
+
+/* --- Constants for copy --- */
+
+/* --- Function pointer typedefs for copy --- */
+
+typedef void (*duckdb_v2_copy_function_bind_callback_fn)(duckdb_v2_copy_function_bind_info_handle info,
+                                                         duckdb_v2_context_handle context,
+                                                         duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_function_init_callback_fn)(duckdb_v2_copy_function_init_info_handle info,
+                                                         duckdb_v2_context_handle context,
+                                                         duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_function_batch_callback_fn)(duckdb_v2_copy_function_batch_info_handle info,
+                                                          duckdb_v2_context_handle context,
+                                                          duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_function_flush_callback_fn)(duckdb_v2_copy_function_flush_info_handle info,
+                                                          duckdb_v2_context_handle context,
+                                                          duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_function_batch_size_callback_fn)(duckdb_v2_copy_function_batch_size_info_handle info,
+                                                               duckdb_v2_context_handle context,
+                                                               duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_function_finalize_callback_fn)(duckdb_v2_copy_function_finalize_info_handle info,
+                                                             duckdb_v2_context_handle context,
+                                                             duckdb_v2_error_info_handle *err);
+
+/* --- Functions for copy --- */
+
+/*!
+ * Creates a new copy function that will be registered on the connection's database.
+ *
+ * A copy function implements an output format for `COPY ... TO`: once registered, SQL reaches it with `COPY ... TO
+ * 'path' (FORMAT name)`. The function starts out empty: configure it with the setter functions (e.g.
+ * `duckdb_v2_copy_function_set_name()`, `duckdb_v2_copy_function_set_batch_callback()`, etc.), then make it available
+ * with `duckdb_v2_copy_function_register()`. The caller owns the returned handle and must destroy it with
+ * `duckdb_v2_copy_function_destroy()`, also after registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param connection The connection to create the function in.
+ * @param function On success, receives the newly created copy function. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_create_with_connection(duckdb_v2_connection_handle connection,
+                                                                            duckdb_v2_copy_function_handle *function,
+                                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a new copy function that will be registered on the loading extension's database.
+ *
+ * Use this from an extension load callback, where an extension handle is available. The function starts out empty:
+ * configure it with the setter functions (e.g. `duckdb_v2_copy_function_set_name()`,
+ * `duckdb_v2_copy_function_set_batch_callback()`, etc.), then make it available with
+ * `duckdb_v2_copy_function_register()`. The caller owns the returned handle and must destroy it with
+ * `duckdb_v2_copy_function_destroy()`, also after registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param extension The extension to create the function in.
+ * @param function On success, receives the newly created copy function. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_create_with_extension(duckdb_v2_extension_handle extension,
+                                                                           duckdb_v2_copy_function_handle *function,
+                                                                           duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the name of the copy function.
+ *
+ * The name is the format SQL selects the function with: `COPY ... TO 'path' (FORMAT name)`. It is borrowed and copied.
+ * Calling this again replaces the previous name. A name must be set before registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the name of.
+ * @param name The name to set. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_name(duckdb_v2_copy_function_handle function,
+                                                              duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets arbitrary user data on the copy function.
+ *
+ * Associates an opaque pointer with the function, retrievable from each callback via its user data accessor (e.g.
+ * `duckdb_v2_copy_function_bind_get_user_data()`, `duckdb_v2_copy_function_batch_get_user_data()`, etc.). The opaque
+ * handle bundles the pointer with an optional destructor, invoked when the data is no longer needed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the user data of.
+ * @param data Opaque handle bundling the user data pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_user_data(duckdb_v2_copy_function_handle function,
+                                                                   duckdb_v2_opaque *data,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional batch size callback of the copy function.
+ *
+ * The batch size callback is invoked during query planning, after the bind callback, for each `COPY ... TO` statement
+ * that does not set `BATCH_SIZE` itself. It must report how many rows a batch should carry via
+ * `duckdb_v2_copy_function_batch_size_set_target()`; the engine then cuts the rows being copied into batches of that
+ * size and hands each to the batch callback. Without a batch size from either the statement or the callback, a batch is
+ * cut for every chunk of rows sunk, i.e. a vector at a time. A batch may still be smaller than the reported size (the
+ * last one of a file, or when `BATCH_SIZE_BYTES` cuts it first).
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the batch size callback of.
+ * @param callback The batch size callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_batch_size_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_size_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional bind callback of the copy function.
+ *
+ * The bind callback is invoked during query planning for each `COPY ... TO` statement that uses the function. It can
+ * inspect the names and types of the columns being copied and set "bind data" that is shared with the other callbacks.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the bind callback of.
+ * @param callback The bind callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_bind_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_bind_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional init callback of the copy function.
+ *
+ * The init callback is invoked once per output file, before any batch destined for that file is prepared. It can read
+ * the path of the file via `duckdb_v2_copy_function_init_get_file_path()`, which is only available here, and set "init
+ * data" that is shared with the batch, flush and finalize callbacks of that file. A statement may write several files,
+ * e.g. when its output is partitioned; each gets its own init data.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the init callback of.
+ * @param callback The init callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_init_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_init_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the batch callback of the copy function.
+ *
+ * The batch callback is invoked during query execution with a batch of the rows being copied, taken via
+ * `duckdb_v2_copy_function_batch_take_input()`. It prepares the batch for writing, e.g. by encoding it into the output
+ * format, and sets "batch data" via `duckdb_v2_copy_function_batch_set_batch_data()` that is handed to the flush
+ * callback. Batches may be prepared by several threads at once, so the callback must synchronize its own access to the
+ * init data. A batch callback must be set before registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the batch callback of.
+ * @param callback The batch callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_batch_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the flush callback of the copy function.
+ *
+ * The flush callback is invoked once per prepared batch to write its batch data, available via
+ * `duckdb_v2_copy_function_flush_get_batch_data()`, to the output. Flushes of the same file never run concurrently. A
+ * flush callback must be set before registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the flush callback of.
+ * @param callback The flush callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_flush_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_flush_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional finalize callback of the copy function.
+ *
+ * The finalize callback is invoked once per output file after the last batch destined for that file has been flushed.
+ * It can e.g. write a footer and close the file.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the finalize callback of.
+ * @param callback The finalize callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_finalize_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_finalize_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_user_data(duckdb_v2_copy_function_bind_info_handle info,
+                                                                        void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's "bind data" from the bind callback.
+ *
+ * The bind data is stored with the bound statement and retrievable from the other callbacks. The opaque handle bundles
+ * the pointer with an optional destructor, invoked when the bind data is no longer needed, and an optional equality
+ * callback used when comparing two bound statements; without one, pointer equality is used.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param data Opaque handle bundling the bind data pointer plus optional destructor and equality callbacks.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_set_bind_data(duckdb_v2_copy_function_bind_info_handle info,
+                                                                        duckdb_v2_opaque *data,
+                                                                        duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of columns being copied.
+ *
+ * This is the number of columns of the rows every batch carries. Valid indices for
+ * `duckdb_v2_copy_function_bind_get_column_type()` and `duckdb_v2_copy_function_bind_get_column_name()` are [0, count).
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param count Receives the number of columns.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_count(
+    duckdb_v2_copy_function_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the type of the column at the given index.
+ *
+ * Fails if the index is out of bounds. The returned type is owned by the caller and must be destroyed via
+ * `duckdb_v2_logical_type_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the column to get the type of.
+ * @param type Receives the column type. Owned by the caller; destroy via `duckdb_v2_logical_type_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_type(duckdb_v2_copy_function_bind_info_handle info,
+                                                                          idx_t index,
+                                                                          duckdb_v2_logical_type_handle *type,
+                                                                          duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the name of the column at the given index.
+ *
+ * Fails if the index is out of bounds. The name is borrowed and valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the column to get the name of.
+ * @param name Receives a borrowed view of the column name. Valid only for the duration of the callback.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_name(duckdb_v2_copy_function_bind_info_handle info,
+                                                                          idx_t index, duckdb_v2_identifier_t *name,
+                                                                          duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The batch size info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_user_data(
+    duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The batch size info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_bind_data(
+    duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the number of rows a batch should carry, as the target the engine cuts batches at. The batch size callback must
+ * set this to a value greater than 0; the statement fails otherwise.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The batch size info handle.
+ * @param rows The number of rows a batch should carry. Must be greater than 0.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_set_target(
+    duckdb_v2_copy_function_batch_size_info_handle info, idx_t rows, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The init info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_user_data(duckdb_v2_copy_function_init_info_handle info,
+                                                                        void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The init info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_bind_data(duckdb_v2_copy_function_init_info_handle info,
+                                                                        void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the path of the file the init callback is preparing.
+ *
+ * This is the path the batches of this file are to be written to, after the engine has applied its own rewrites (e.g. a
+ * temporary name while the file is being written, or a per-partition path). The path is borrowed and valid only for the
+ * duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The init info handle.
+ * @param path Receives a borrowed view of the file path. Valid only for the duration of the callback.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_file_path(duckdb_v2_copy_function_init_info_handle info,
+                                                                        duckdb_v2_str *path,
+                                                                        duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's "init data" from the init callback.
+ *
+ * The init data lives for the duration of the file being written and is retrievable from the batch, flush and finalize
+ * callbacks of that file. Batches may be prepared by several threads at once, so the function must synchronize its own
+ * access to it from the batch callback. The opaque handle bundles the pointer with an optional destructor, invoked when
+ * the file is done with the data.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The init info handle.
+ * @param data Opaque handle bundling the init data pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_set_init_data(duckdb_v2_copy_function_init_info_handle info,
+                                                                        duckdb_v2_opaque *data,
+                                                                        duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The batch info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_user_data(duckdb_v2_copy_function_batch_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The batch info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_bind_data(duckdb_v2_copy_function_batch_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the init data set by the function's init callback for the file this batch belongs to.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The batch info handle.
+ * @param data Receives the init data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_init_data(duckdb_v2_copy_function_batch_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Takes ownership of the rows of the batch to prepare.
+ *
+ * The collection holds one column per column reported by `duckdb_v2_copy_function_bind_get_column_count()`, in the same
+ * order, and can be scanned with `duckdb_v2_column_data_collection_scan()`. The batch can only be taken once: a second
+ * call fails. Once taken, the caller owns the collection and must destroy it via
+ * `duckdb_v2_column_data_collection_destroy()`, e.g. by keeping it as the batch data with that destructor. A batch that
+ * is never taken is destroyed when the callback returns.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The batch info handle.
+ * @param collection Receives the collection holding the rows of the batch. Owned by the caller; destroy via
+ * `duckdb_v2_column_data_collection_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_take_input(
+    duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_column_data_collection_handle *collection,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the prepared "batch data" from the batch callback.
+ *
+ * The batch data is the prepared form of the batch and is handed to the flush callback via
+ * `duckdb_v2_copy_function_flush_get_batch_data()`. The opaque handle bundles the pointer with an optional destructor,
+ * invoked once the batch has been flushed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The batch info handle.
+ * @param data Opaque handle bundling the batch data pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_set_batch_data(
+    duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The flush info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_user_data(duckdb_v2_copy_function_flush_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The flush info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_bind_data(duckdb_v2_copy_function_flush_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the init data set by the function's init callback for the file this batch belongs to.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The flush info handle.
+ * @param data Receives the init data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_init_data(duckdb_v2_copy_function_flush_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the batch data set by the function's batch callback for the batch being flushed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The flush info handle.
+ * @param data Receives the batch data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_batch_data(
+    duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The finalize info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_user_data(
+    duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The finalize info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_bind_data(
+    duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the init data set by the function's init callback for the file being finalized.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The finalize info handle.
+ * @param data Receives the init data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_init_data(
+    duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Registers the copy function, making it available as a `COPY ... TO` format.
+ *
+ * The function is registered on the target given at creation: the connection's database or the loading extension.
+ * Registration requires a name and the batch and flush callbacks. The caller still owns the handle after registration
+ * and must destroy it with `duckdb_v2_copy_function_destroy()`, which does not affect the registered function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to register.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_register(duckdb_v2_copy_function_handle function,
+                                                              duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the copy function, releasing its resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Destroying the handle after registration does not affect the registered function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_destroy(duckdb_v2_copy_function_handle *function);
+
+/* --- Struct definitions for copy --- */
+
+/* ============================================================================
  * MODULE: logical_type
  * ============================================================================ */
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -5725,9 +5725,15 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_add_named_argument(duckd
  * Claims the reference by naming a column data collection to read instead.
  *
  * The collection is borrowed, not copied: the caller keeps ownership and must keep it alive, and must not clear, reset
- * or destroy it, for as long as any result reading it is live, since the result scans its buffers directly. A prepared
- * statement holds on to the collection it was bound against, so destroy such statements before releasing the
- * collection.
+ * or destroy it, for as long as any result reading it is live, since the result scans its buffers directly.
+ *
+ * A prepared statement extends that lifetime well beyond its own results. Preparing a statement over a claimed name
+ * captures the borrow in the plan, and since a collection claim reads no database there is nothing to invalidate that
+ * plan: `duckdb_v2_prepared_statement_reuses_plan()` reports true, and every later execution reuses the captured borrow
+ * without consulting the callback again. So dropping the name from whatever the callback resolves against does not
+ * release the collection, and releasing it while such a statement is live leaves the next execution reading freed
+ * memory. Destroy every prepared statement over a claimed name before clearing, resetting or destroying the collection
+ * behind it.
  *
  * By default the collection's columns are named col1..colN. Pass `column_names` to name them instead. When supplied,
  * `column_count` must equal the collection's column count and no name may be empty; pass NULL and 0 for the default
@@ -9639,6 +9645,162 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_value_to_string(duckdb_v2_value_handle va
                                                        duckdb_v2_error_info_handle *err);
 
 /* --- Struct definitions for value --- */
+
+/* ============================================================================
+ * MODULE: prepared_statement
+ * ============================================================================ */
+
+/* --- Enums for prepared_statement --- */
+
+/* --- Struct forward declarations for prepared_statement --- */
+
+/* --- Types for prepared_statement --- */
+
+/*!
+ * An owned handle to a statement bound and planned once, executable repeatedly via
+ * `duckdb_v2_prepared_statement_execute()`. Construct with `duckdb_v2_prepared_statement_create()` and destroy with
+ * `duckdb_v2_prepared_statement_destroy()`. It keeps its connection's session alive, so it stays usable across
+ * executions and even after the connection is disconnected.
+ */
+typedef struct _duckdb_v2_prepared_statement {
+	void *internal_ptr;
+} * duckdb_v2_prepared_statement_handle;
+
+/* --- Constants for prepared_statement --- */
+
+/* --- Function pointer typedefs for prepared_statement --- */
+
+/* --- Functions for prepared_statement --- */
+
+/*!
+ * Prepares a parsed statement into a reusable handle. Non-consuming.
+ *
+ * Copies the statement's AST, then binds and plans it once. Binder and catalog errors surface here, exactly as they
+ * would from `duckdb_v2_statement_execute()`. The statement is borrowed rather than consumed, since a copy is what gets
+ * prepared, so it can be prepared again or executed directly; the caller destroys it with
+ * `duckdb_v2_sql_statement_destroy()`.
+ *
+ * By default this succeeds for any preparable statement, whether or not its plan will be reused; ask
+ * `duckdb_v2_prepared_statement_reuses_plan()` which one you got. Setting `require_cacheable` instead fails with
+ * `ERROR_INPUT_INVALID` when the plan would not be reused, so a caller who wants the handle only for the speedup finds
+ * out here rather than after silently taking the slow path.
+ *
+ * Refuses with `ERROR_RESOURCE_IN_USE` while the connection has a live result. Drain, destroy, or interrupt that result
+ * first, or prepare on another connection. `*out_prepared` is set to NULL on failure.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param conn The connection supplying the catalog, transaction, and parser state. The prepared statement belongs to
+ * it.
+ * @param statement The statement to prepare. Borrowed and copied, not consumed; destroy it with
+ * `duckdb_v2_sql_statement_destroy()`.
+ * @param require_cacheable When true, fail with `ERROR_INPUT_INVALID` unless the prepared plan will be reused across
+ * executions, as `duckdb_v2_prepared_statement_reuses_plan()` would report it.
+ * @param out_prepared On success, receives the new prepared statement. Owned by the caller; destroy via
+ * `duckdb_v2_prepared_statement_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_prepared_statement_create(duckdb_v2_connection_handle conn,
+                                                                 duckdb_v2_sql_statement_handle statement,
+                                                                 bool require_cacheable,
+                                                                 duckdb_v2_prepared_statement_handle *out_prepared,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Executes a prepared statement, streaming its result. Non-consuming.
+ *
+ * Returns a result without executing anything: execution happens incrementally as the result is stepped or drained,
+ * exactly as with `duckdb_v2_statement_execute()`. The handle returned is an ordinary result, with identical behaviour
+ * throughout -- streaming, draining, the changed-row count of a DML statement, the output schema, the statement type,
+ * and the result type.
+ *
+ * `parameter_values` binds the statement's parameters as constants for this execution. Binding is positional by default
+ * ($1 = element 0); supply `parameter_names` to bind by name instead, where a non-empty entry binds its value to that
+ * named parameter ($name, matched case-insensitively) and a {NULL, 0} entry stays positional. Pass NULL for both
+ * arrays, or a count of 0, for a statement without parameters. Both arrays are borrowed and copied in, so the caller
+ * still owns and destroys them. A key set that does not match the statement's parameters is rejected with
+ * `ERROR_INPUT_INVALID`, with one exception: a named parameter left without a value reads the session variable of the
+ * same name (`SET VARIABLE`) when one exists.
+ *
+ * Not consumed: execute the same handle again, with the same values or different ones, as often as you like. Values are
+ * bound per execution and nothing carries over between them. A catalog change since the statement was prepared, or a
+ * parameter type that differs from the one the cached plan assumed, triggers a re-bind that is invisible apart from its
+ * cost.
+ *
+ * Refuses with `ERROR_RESOURCE_IN_USE` while the connection has a live result; drain, destroy, or interrupt it first,
+ * or execute on another connection. A failed execution, at any stage, leaves the prepared statement usable.
+ * `*out_result` is set to NULL on failure.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param prepared The prepared statement to execute. Borrowed; not consumed.
+ * @param parameter_names Optional. An array of `parameter_count` parameter names; a non-empty entry binds its value to
+ * the named parameter ($name, case-insensitive), a {NULL, 0} entry keeps it positional ($1 = element 0). Pass NULL to
+ * bind everything positionally.
+ * @param parameter_values Optional. An array of `parameter_count` values. Each binds by name when `parameter_names`
+ * supplies one, and positionally ($1 = element 0) otherwise. Borrowed and copied in. Pass NULL for a statement without
+ * parameters.
+ * @param parameter_count The number of entries in `parameter_names` and `parameter_values`. Pass 0 for a statement
+ * without parameters.
+ * @param out_result On success, receives the new result. Owned by the caller; destroy via `duckdb_v2_result_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_prepared_statement_execute(duckdb_v2_prepared_statement_handle prepared,
+                                                                  const duckdb_v2_identifier_t *parameter_names,
+                                                                  const duckdb_v2_value_handle *parameter_values,
+                                                                  idx_t parameter_count,
+                                                                  duckdb_v2_result_handle *out_result,
+                                                                  duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reports whether the prepared statement reuses its compiled plan across executions.
+ *
+ * True when executions reuse the plan built at prepare time, provided the supplied values match the planned parameter
+ * types and nothing the plan depends on has changed; false when the statement re-binds on every execution, making it no
+ * faster than `duckdb_v2_statement_execute()`. A plan is reused only when all parameter types were resolved at prepare
+ * time and the plan is cacheable: `SELECT 42` reuses, `SELECT $1::INTEGER + 1` reuses, a statement reading a base table
+ * does not (it re-binds so a catalog change is picked up), and `SELECT $1 + $2` does not (the types are unknown until
+ * values arrive).
+ *
+ * A static property of the built plan, fixed when the statement was prepared and independent of the values later passed
+ * to `duckdb_v2_prepared_statement_execute()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param prepared The prepared statement to inspect.
+ * @param out_reuses Receives true when the compiled plan is reused across executions, false when the statement re-binds
+ * each time.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_prepared_statement_reuses_plan(duckdb_v2_prepared_statement_handle prepared,
+                                                                      bool *out_reuses,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys a prepared statement.
+ *
+ * Null-safe: passing NULL, or a slot already set to NULL, is a no-op. A result produced by
+ * `duckdb_v2_prepared_statement_execute()` is independently owned and keeps the session alive itself, so the prepared
+ * statement may be destroyed while results made from it are still live. On success the slot is set to NULL.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param prepared The prepared statement to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_prepared_statement_destroy(duckdb_v2_prepared_statement_handle *prepared);
+
+/* --- Struct definitions for prepared_statement --- */
 
 /* ============================================================================
  * MODULE: query_result

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -754,6 +754,333 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arena_allocate(duckdb_v2_arena_handle are
 /* --- Struct definitions for arena --- */
 
 /* ============================================================================
+ * MODULE: cast
+ * ============================================================================ */
+
+/* --- Enums for cast --- */
+
+/*!
+ * The mode a cast is being executed in. A normal cast must either succeed for every row or report an error, which
+ * aborts the query. A "try" cast (SQL TRY_CAST, and implicit casts the engine probes speculatively) tolerates per-row
+ * failures: the callback writes NULL for the rows it could not convert instead of aborting. Read with
+ * `duckdb_v2_cast_function_exec_get_mode()`.
+ */
+typedef enum DUCKDB_V2_CAST_MODE {
+	//! A regular cast. A conversion failure reported through the error slot aborts the query.
+	DUCKDB_V2_CAST_MODE_NORMAL = 0,
+
+	/*!
+	 * A "try" cast. Conversion failures should be written as NULLs into the output vector; an error reported through
+	 * the slot is swallowed and the affected rows are left NULL.
+	 */
+	DUCKDB_V2_CAST_MODE_TRY = 1,
+	DUCKDB_V2_CAST_MODE_MAX_ENUM = 0x7FFFFFFF,
+} DUCKDB_V2_CAST_MODE;
+
+/* --- Struct forward declarations for cast --- */
+
+/* --- Types for cast --- */
+
+/*!
+ * An owned opaque handle to a cast function being built. Created with
+ * `duckdb_v2_cast_function_create_with_connection()` or `duckdb_v2_cast_function_create_with_extension()`, configured
+ * with the setter functions (e.g. `duckdb_v2_cast_function_set_source_type()`,
+ * `duckdb_v2_cast_function_set_exec_callback()`, etc.), made available with `duckdb_v2_cast_function_register()`, and
+ * destroyed with `duckdb_v2_cast_function_destroy()`.
+ */
+typedef struct _duckdb_v2_cast_function {
+	void *internal_ptr;
+} * duckdb_v2_cast_function_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a cast function during the execution "exec" phase. The "exec"
+ * callback receives this handle and can use it to access the input vector, the output vector to write into, the number
+ * of rows to convert, and the mode the cast is running in.
+ */
+typedef struct _duckdb_v2_cast_function_exec_info {
+	void *internal_ptr;
+} * duckdb_v2_cast_function_exec_info_handle;
+
+/* --- Constants for cast --- */
+
+/* --- Function pointer typedefs for cast --- */
+
+typedef void (*duckdb_v2_cast_function_exec_callback_fn)(duckdb_v2_cast_function_exec_info_handle info,
+                                                         duckdb_v2_context_handle context,
+                                                         duckdb_v2_error_info_handle *err);
+
+/* --- Functions for cast --- */
+
+/*!
+ * Creates a new cast function that will be registered on the connection's database.
+ *
+ * The function starts out empty: configure it with the setter functions (e.g.
+ * `duckdb_v2_cast_function_set_source_type()`, `duckdb_v2_cast_function_set_exec_callback()`, etc.), then make it
+ * available with `duckdb_v2_cast_function_register()`. The caller owns the returned handle and must destroy it with
+ * `duckdb_v2_cast_function_destroy()`, also after registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param connection The connection to create the function in.
+ * @param function On success, receives the newly created cast function. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_create_with_connection(duckdb_v2_connection_handle connection,
+                                                                            duckdb_v2_cast_function_handle *function,
+                                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a new cast function that will be registered on the loading extension's database.
+ *
+ * Use this from an extension load callback, where an extension handle is available. The function starts out empty:
+ * configure it with the setter functions (e.g. `duckdb_v2_cast_function_set_source_type()`,
+ * `duckdb_v2_cast_function_set_exec_callback()`, etc.), then make it available with
+ * `duckdb_v2_cast_function_register()`. The caller owns the returned handle and must destroy it with
+ * `duckdb_v2_cast_function_destroy()`, also after registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param extension The extension to create the function in.
+ * @param function On success, receives the newly created cast function. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_create_with_extension(duckdb_v2_extension_handle extension,
+                                                                           duckdb_v2_cast_function_handle *function,
+                                                                           duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the type the cast converts from.
+ *
+ * The type is borrowed and copied. Calling this again replaces the previous source type. A source type must be set
+ * before registration, and it must be a fully defined concrete type.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the source type of.
+ * @param source_type The type to cast from. Borrowed for the call only.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_set_source_type(duckdb_v2_cast_function_handle function,
+                                                                     duckdb_v2_logical_type_handle source_type,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the type the cast converts to.
+ *
+ * The type is borrowed and copied. Calling this again replaces the previous target type. A target type must be set
+ * before registration, and it must be a fully defined concrete type.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the target type of.
+ * @param target_type The type to cast to. Borrowed for the call only.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_set_target_type(duckdb_v2_cast_function_handle function,
+                                                                     duckdb_v2_logical_type_handle target_type,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets what it costs to apply this cast implicitly.
+ *
+ * The binder uses the cost to choose between candidate implicit casts: a lower non-negative cost makes the cast more
+ * likely to be picked, a higher one less likely. Built-in widening casts sit in the [0, 20] range, so a cost above 100
+ * effectively puts this cast last. A negative cost -- the default -- means the cast is never applied implicitly and is
+ * reached only through an explicit CAST or TRY_CAST.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the implicit cast cost of.
+ * @param cost The cost. Negative disables implicit casting.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_set_implicit_cast_cost(duckdb_v2_cast_function_handle function,
+                                                                            int64_t cost,
+                                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets arbitrary user data on the cast function.
+ *
+ * Associates an opaque pointer with the function, retrievable from the exec callback via
+ * `duckdb_v2_cast_function_exec_get_user_data()`. The opaque handle bundles the pointer with an optional destructor,
+ * invoked when the data is no longer needed. The data is read-only during execution: the same pointer is shared by
+ * every thread running the cast.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the user data of.
+ * @param data Opaque handle bundling the user data pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_set_user_data(duckdb_v2_cast_function_handle function,
+                                                                   duckdb_v2_opaque *data,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the exec callback of the cast function.
+ *
+ * The exec callback implements the conversion: it is invoked during query execution with a batch of input values and
+ * must fill the output vector. An exec callback must be set before registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the exec callback of.
+ * @param callback The exec callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_set_exec_callback(
+    duckdb_v2_cast_function_handle function, duckdb_v2_cast_function_exec_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_cast_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_user_data(duckdb_v2_cast_function_exec_info_handle info,
+                                                                        void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns how many rows this execution must convert.
+ *
+ * The number of rows held by the input vector, and the number of entries the callback must write to the output vector.
+ * Note that this may be less than a full vector: a constant input is converted as a single row and the result is
+ * expanded by the engine.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param count Receives the number of rows.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_row_count(duckdb_v2_cast_function_exec_info_handle info,
+                                                                        idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the input vector holding the values to convert.
+ *
+ * The vector holds the source type's values for the current batch; use `duckdb_v2_cast_function_exec_get_row_count()`
+ * for the number of rows. Borrowed; valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param vector Receives the borrowed input vector.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_input(duckdb_v2_cast_function_exec_info_handle info,
+                                                                    duckdb_v2_vector_handle *vector,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the output vector the exec callback must write into.
+ *
+ * The callback must write one entry per input row; use `duckdb_v2_cast_function_exec_get_row_count()` for the number of
+ * rows. Borrowed; valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param vector Receives the borrowed output vector to write into.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_output(duckdb_v2_cast_function_exec_info_handle info,
+                                                                     duckdb_v2_vector_handle *vector,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the mode the cast is being executed in.
+ *
+ * In `CAST_MODE_TRY` a conversion failure should be written as a NULL into the output vector rather than reported
+ * through the error slot, since the engine discards the error and keeps whatever the callback left in the output.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param mode Receives the cast mode.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_mode(duckdb_v2_cast_function_exec_info_handle info,
+                                                                   DUCKDB_V2_CAST_MODE *mode,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Registers the cast function, making it available to CAST and TRY_CAST.
+ *
+ * The function is registered on the target given at creation: the connection's database or the loading extension.
+ * Registration requires a source type, a target type and an exec callback; both types must be fully defined concrete
+ * types. Registering a cast for a pair that already has one replaces it. The caller still owns the handle after
+ * registration and must destroy it with `duckdb_v2_cast_function_destroy()`, which does not affect the registered
+ * function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to register.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_register(duckdb_v2_cast_function_handle function,
+                                                              duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the cast function, releasing its resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Destroying the handle after registration does not affect the registered function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_cast_function_destroy(duckdb_v2_cast_function_handle *function);
+
+/* --- Struct definitions for cast --- */
+
+/* ============================================================================
  * MODULE: column_data_collection
  * ============================================================================ */
 
@@ -1291,6 +1618,147 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_option_get_alias(duckdb_v2_option_handle 
                                                         duckdb_v2_error_info_handle *err);
 
 /* --- Struct definitions for configuration --- */
+
+/* ============================================================================
+ * MODULE: custom type
+ * ============================================================================ */
+
+/* --- Enums for custom type --- */
+
+/* --- Struct forward declarations for custom type --- */
+
+/* --- Types for custom type --- */
+
+/*!
+ * An owned opaque handle to a custom type being built. Created with `duckdb_v2_custom_type_create_with_connection()` or
+ * `duckdb_v2_custom_type_create_with_extension()`, configured with `duckdb_v2_custom_type_set_name()` and
+ * `duckdb_v2_custom_type_set_base_type()`, made available with `duckdb_v2_custom_type_register()`, and destroyed with
+ * `duckdb_v2_custom_type_destroy()`.
+ */
+typedef struct _duckdb_v2_custom_type {
+	void *internal_ptr;
+} * duckdb_v2_custom_type_handle;
+
+/* --- Constants for custom type --- */
+
+/* --- Function pointer typedefs for custom type --- */
+
+/* --- Functions for custom type --- */
+
+/*!
+ * Creates a new custom type that will be registered on the connection's database.
+ *
+ * The type starts out empty: configure it with `duckdb_v2_custom_type_set_name()` and
+ * `duckdb_v2_custom_type_set_base_type()`, then make it available with `duckdb_v2_custom_type_register()`. The caller
+ * owns the returned handle and must destroy it with `duckdb_v2_custom_type_destroy()`, also after registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param connection The connection to create the type in.
+ * @param type On success, receives the newly created custom type. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_custom_type_create_with_connection(duckdb_v2_connection_handle connection,
+                                                                          duckdb_v2_custom_type_handle *type,
+                                                                          duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a new custom type that will be registered on the loading extension's database.
+ *
+ * Use this from an extension load callback, where an extension handle is available. The type starts out empty:
+ * configure it with `duckdb_v2_custom_type_set_name()` and `duckdb_v2_custom_type_set_base_type()`, then make it
+ * available with `duckdb_v2_custom_type_register()`. The caller owns the returned handle and must destroy it with
+ * `duckdb_v2_custom_type_destroy()`, also after registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param extension The extension to create the type in.
+ * @param type On success, receives the newly created custom type. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_custom_type_create_with_extension(duckdb_v2_extension_handle extension,
+                                                                         duckdb_v2_custom_type_handle *type,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the name of the custom type.
+ *
+ * This is the name the type is referred to by in SQL, and the alias carried by every logical type instance of it. The
+ * name is borrowed and copied. Calling this again replaces the previous name. A name must be set before registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The type to set the name of.
+ * @param name The name to set. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_custom_type_set_name(duckdb_v2_custom_type_handle type,
+                                                            duckdb_v2_identifier_t name,
+                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the base type of the custom type.
+ *
+ * The custom type shares the base type's internal representation but is logically distinct, so it can carry its own
+ * cast functions. The type is borrowed and copied. Calling this again replaces the previous base type. A base type must
+ * be set before registration, and it must be a fully defined concrete type -- ANY is a signature wildcard, not
+ * something a registered type can be built on.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The type to set the base type of.
+ * @param base_type The logical type to base the custom type on. Borrowed for the call only.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_custom_type_set_base_type(duckdb_v2_custom_type_handle type,
+                                                                 duckdb_v2_logical_type_handle base_type,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Registers the custom type, making it available for use in SQL queries.
+ *
+ * The type is registered on the target given at creation: the connection's database or the loading extension.
+ * Registration requires a name and a complete base type. The caller still owns the handle after registration and must
+ * destroy it with `duckdb_v2_custom_type_destroy()`, which does not affect the registered type.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The type to register.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_custom_type_register(duckdb_v2_custom_type_handle type,
+                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the custom type, releasing its resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Destroying the handle after registration does not affect the registered type.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The type to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_custom_type_destroy(duckdb_v2_custom_type_handle *type);
+
+/* --- Struct definitions for custom type --- */
 
 /* ============================================================================
  * MODULE: data_chunk

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -5112,7 +5112,6 @@ typedef struct _duckdb_v2_table_description {
  * `duckdb_v2_table_description_get_column()`, read with `duckdb_v2_column_description_get_name()`,
  * `duckdb_v2_column_description_get_type()`, `duckdb_v2_column_description_has_default()` and
  * `duckdb_v2_column_description_has_generated()`, and destroy with `duckdb_v2_column_description_destroy()`.
- * Independent of the table description it came from, so it may outlive it.
  */
 typedef struct _duckdb_v2_column_description {
 	void *internal_ptr;
@@ -7043,6 +7042,298 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_destroy(duckdb_v2_copy_func
 /* --- Struct definitions for copy --- */
 
 /* ============================================================================
+ * MODULE: expression
+ * ============================================================================ */
+
+/* --- Enums for expression --- */
+
+/*!
+ * The type of a bound expression node. The values mirror the engine's own expression types, restricted to the node
+ * types a filter predicate can contain; every other node type is reported as `EXPRESSION_TYPE_INVALID`.
+ *
+ * Comparisons, `BETWEEN` and casts are regular scalar function calls once bound: they have the function's children and
+ * name, and only their type tells them apart from any other function. A `CAST` therefore has one child, the value being
+ * cast, and its target type is the node's return type.
+ */
+typedef enum DUCKDB_V2_EXPRESSION_TYPE {
+	//! A node type this API does not model. Its children can still be walked.
+	DUCKDB_V2_EXPRESSION_TYPE_INVALID = 0,
+
+	/*!
+	 * A cast. One child; the target type is the node's return type and `duckdb_v2_expression_cast_get_mode()` tells a
+	 * `TRY_CAST` apart.
+	 */
+	DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_CAST = 12,
+
+	//! Logical `NOT`. One child.
+	DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_NOT = 13,
+
+	//! `IS NULL`. One child.
+	DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_IS_NULL = 14,
+
+	//! `IS NOT NULL`. One child.
+	DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_IS_NOT_NULL = 15,
+
+	//! `=`. Two children.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_EQUAL = 25,
+
+	//! `<>`. Two children.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_NOTEQUAL = 26,
+
+	//! `<`. Two children.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_LESSTHAN = 27,
+
+	//! `>`. Two children.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_GREATERTHAN = 28,
+
+	//! `<=`. Two children.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO = 29,
+
+	//! `>=`. Two children.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO = 30,
+
+	//! `IN`. The first child is the value tested, the remaining children are the candidates.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_IN = 35,
+
+	//! `NOT IN`. The first child is the value tested, the remaining children are the candidates.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_NOT_IN = 36,
+
+	//! `IS DISTINCT FROM`. Two children.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_DISTINCT_FROM = 37,
+
+	//! `BETWEEN`. Three children: the value tested, the lower bound and the upper bound.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_BETWEEN = 38,
+
+	//! `IS NOT DISTINCT FROM`. Two children.
+	DUCKDB_V2_EXPRESSION_TYPE_COMPARE_NOT_DISTINCT_FROM = 40,
+
+	//! Logical `AND`. Two or more children.
+	DUCKDB_V2_EXPRESSION_TYPE_CONJUNCTION_AND = 50,
+
+	//! Logical `OR`. Two or more children.
+	DUCKDB_V2_EXPRESSION_TYPE_CONJUNCTION_OR = 51,
+
+	//! A constant. No children; read it with `duckdb_v2_expression_constant_get_value()`.
+	DUCKDB_V2_EXPRESSION_TYPE_VALUE_CONSTANT = 75,
+
+	//! A prepared statement parameter whose value is not known yet. No children.
+	DUCKDB_V2_EXPRESSION_TYPE_VALUE_PARAMETER = 76,
+
+	/*!
+	 * A call to a scalar function other than the ones listed above. The children are its arguments; read the name with
+	 * `duckdb_v2_expression_function_get_name()`.
+	 */
+	DUCKDB_V2_EXPRESSION_TYPE_BOUND_FUNCTION = 141,
+
+	//! A `CASE` expression. The children are each `WHEN` condition followed by its `THEN` result, then the `ELSE`
+	//! result.
+	DUCKDB_V2_EXPRESSION_TYPE_CASE_EXPR = 150,
+
+	//! `COALESCE`. One or more children.
+	DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_COALESCE = 152,
+
+	//! A reference to a column. No children; read it with `duckdb_v2_expression_column_ref_get_index()`.
+	DUCKDB_V2_EXPRESSION_TYPE_BOUND_COLUMN_REF = 228,
+	DUCKDB_V2_EXPRESSION_TYPE_MAX_ENUM = 0x7FFFFFFF,
+} DUCKDB_V2_EXPRESSION_TYPE;
+
+/* --- Struct forward declarations for expression --- */
+
+/* --- Types for expression --- */
+
+/*!
+ * A borrowed opaque handle to a node of a bound expression tree. Read-only and owned by the engine: valid only for the
+ * duration of the callback that handed it out, and never destroyed by the caller. Child nodes borrowed via
+ * `duckdb_v2_expression_get_child()` share their parent's lifetime.
+ */
+typedef struct _duckdb_v2_expression {
+	void *internal_ptr;
+} * duckdb_v2_expression_handle;
+
+/* --- Constants for expression --- */
+
+/* --- Function pointer typedefs for expression --- */
+
+/* --- Functions for expression --- */
+
+/*!
+ * Returns the type of an expression node.
+ *
+ * The type decides which of the type-specific accessors apply, and what the node's children mean; see
+ * `EXPRESSION_TYPE`. A node of a type this API does not model reports `EXPRESSION_TYPE_INVALID`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The expression node.
+ * @param type Receives the node type.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_get_type(duckdb_v2_expression_handle expression,
+                                                           DUCKDB_V2_EXPRESSION_TYPE *type,
+                                                           duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the logical type the expression node evaluates to.
+ *
+ * For a cast this is the target type. The returned type is owned by the caller and must be destroyed via
+ * `duckdb_v2_logical_type_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The expression node.
+ * @param type Receives the owned logical type.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_get_return_type(duckdb_v2_expression_handle expression,
+                                                                  duckdb_v2_logical_type_handle *type,
+                                                                  duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of child nodes of an expression node.
+ *
+ * Works for every node type, including `EXPRESSION_TYPE_INVALID`. Constants, parameters and column references have no
+ * children.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The expression node.
+ * @param count Receives the number of children.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_get_child_count(duckdb_v2_expression_handle expression, idx_t *count,
+                                                                  duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves a child node of an expression node by index.
+ *
+ * Fails if the index is out of bounds. Children are ordered as the node type describes (see `EXPRESSION_TYPE`). The
+ * child is borrowed and shares the lifetime of its parent.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The expression node.
+ * @param index The index of the child to retrieve.
+ * @param child Receives the borrowed child node.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_get_child(duckdb_v2_expression_handle expression, idx_t index,
+                                                            duckdb_v2_expression_handle *child,
+                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the value of a constant node.
+ *
+ * Fails if the node is not of type `EXPRESSION_TYPE_VALUE_CONSTANT`. The returned value is owned by the caller and must
+ * be destroyed via `duckdb_v2_value_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The constant node.
+ * @param value Receives the owned constant value.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_constant_get_value(duckdb_v2_expression_handle expression,
+                                                                     duckdb_v2_value_handle *value,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the column a column reference node points at.
+ *
+ * Fails if the node is not of type `EXPRESSION_TYPE_BOUND_COLUMN_REF`. The index counts the columns of the operator the
+ * predicate is evaluated against, which is not necessarily the full set of columns that operator can produce: a
+ * callback resolves it through whatever handed it the expression, e.g.
+ * `duckdb_v2_table_function_filter_pushdown_get_column_index()` for a filter offered to a table function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The column reference node.
+ * @param index Receives the column index.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_column_ref_get_index(duckdb_v2_expression_handle expression,
+                                                                       idx_t *index, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the name of the scalar function a function node calls.
+ *
+ * Applies to `EXPRESSION_TYPE_BOUND_FUNCTION` and to the node types that are function calls underneath: the
+ * comparisons, `EXPRESSION_TYPE_COMPARE_BETWEEN` and `EXPRESSION_TYPE_OPERATOR_CAST`. Fails for any other node type.
+ * For a comparison the name is its operator, e.g. `<`; for `BETWEEN` and casts it is an internal name, so dispatch on
+ * the type rather than the name for those. The name is borrowed and shares the lifetime of the node.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The function node.
+ * @param name Receives a borrowed view of the function name.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_function_get_name(duckdb_v2_expression_handle expression,
+                                                                    duckdb_v2_identifier_t *name,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the qualified name of the scalar function a function node calls.
+ *
+ * Applies to the same node types as `duckdb_v2_expression_function_get_name()`, and fails for any other. The name is
+ * qualified with the catalog and schema the function was resolved in, where known. The returned name is owned by the
+ * caller and must be destroyed via `duckdb_v2_qname_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The function node.
+ * @param name Receives the owned qualified name.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_function_get_qname(duckdb_v2_expression_handle expression,
+                                                                     duckdb_v2_qname_handle *name,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns whether a cast node is a regular `CAST` or a `TRY_CAST`.
+ *
+ * Fails if the node is not of type `EXPRESSION_TYPE_OPERATOR_CAST`. A `TRY_CAST` yields NULL for a value it cannot
+ * convert where a regular `CAST` would fail the query.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param expression The cast node.
+ * @param mode Receives the cast mode.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_expression_cast_get_mode(duckdb_v2_expression_handle expression,
+                                                                DUCKDB_V2_CAST_MODE *mode,
+                                                                duckdb_v2_error_info_handle *err);
+
+/* --- Struct definitions for expression --- */
+
+/* ============================================================================
  * MODULE: logical_type
  * ============================================================================ */
 
@@ -8665,767 +8956,6 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_sql_statement_destroy(duckdb_v2_sql_state
 DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_statement_iterator_destroy(duckdb_v2_statement_iterator_handle *iterator);
 
 /* --- Struct definitions for sql_statement --- */
-
-/* ============================================================================
- * MODULE: table
- * ============================================================================ */
-
-/* --- Enums for table --- */
-
-/* --- Struct forward declarations for table --- */
-
-/* --- Types for table --- */
-
-/*!
- * An owned opaque handle to a custom table function being built. Created with
- * `duckdb_v2_table_function_create_with_connection()` or `duckdb_v2_table_function_create_with_extension()`, configured
- * with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
- * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
- * `duckdb_v2_table_function_get_signature()`, made available with `duckdb_v2_table_function_register()`, and destroyed
- * with `duckdb_v2_table_function_destroy()`.
- */
-typedef struct _duckdb_v2_table_function {
-	void *internal_ptr;
-} * duckdb_v2_table_function_handle;
-
-/*!
- * A borrowed opaque handle to the arguments supplied to a table function during the query preparation "bind" phase. The
- * "bind" callback receives this handle and must use it to declare the columns the function returns; it can also inspect
- * the arguments given to the function, initialize some constant state and hint at the number of rows the scan will
- * produce.
- */
-typedef struct _duckdb_v2_table_function_bind_info {
-	void *internal_ptr;
-} * duckdb_v2_table_function_bind_info_handle;
-
-/*!
- * A borrowed opaque handle to the arguments supplied to a table function during the global state initialization "init
- * global" phase. The "init global" callback receives this handle and can use it to e.g. set up the state shared by
- * every thread scanning the function, and to declare how many threads may scan it.
- */
-typedef struct _duckdb_v2_table_function_init_global_info {
-	void *internal_ptr;
-} * duckdb_v2_table_function_init_global_info_handle;
-
-/*!
- * A borrowed opaque handle to the arguments supplied to a table function during the local state initialization "init
- * local" phase. The "init local" callback receives this handle and can use it to e.g. set up worker-local state,
- * typically by claiming work from the shared global state.
- */
-typedef struct _duckdb_v2_table_function_init_local_info {
-	void *internal_ptr;
-} * duckdb_v2_table_function_init_local_info_handle;
-
-/*!
- * A borrowed opaque handle to the arguments supplied to a table function during the execution "exec" phase. The "exec"
- * callback receives this handle and can use it to e.g. access the global and local state and write the next batch of
- * rows to the output chunk.
- */
-typedef struct _duckdb_v2_table_function_exec_info {
-	void *internal_ptr;
-} * duckdb_v2_table_function_exec_info_handle;
-
-/*!
- * A borrowed opaque handle to the arguments supplied to a table function during the "progress" phase. The "progress"
- * callback receives this handle and can use it to report how far the scan has advanced.
- */
-typedef struct _duckdb_v2_table_function_progress_info {
-	void *internal_ptr;
-} * duckdb_v2_table_function_progress_info_handle;
-
-/* --- Constants for table --- */
-
-/* --- Function pointer typedefs for table --- */
-
-typedef void (*duckdb_v2_table_function_bind_callback_fn)(duckdb_v2_table_function_bind_info_handle info,
-                                                          duckdb_v2_context_handle context,
-                                                          duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_table_function_init_global_callback_fn)(duckdb_v2_table_function_init_global_info_handle info,
-                                                                 duckdb_v2_context_handle context,
-                                                                 duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_table_function_init_local_callback_fn)(duckdb_v2_table_function_init_local_info_handle info,
-                                                                duckdb_v2_context_handle context,
-                                                                duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_table_function_exec_callback_fn)(duckdb_v2_table_function_exec_info_handle info,
-                                                          duckdb_v2_context_handle context,
-                                                          duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_table_function_progress_callback_fn)(duckdb_v2_table_function_progress_info_handle info,
-                                                              duckdb_v2_context_handle context,
-                                                              duckdb_v2_error_info_handle *err);
-
-/* --- Functions for table --- */
-
-/*!
- * Creates a new table function that will be registered on the connection's database.
- *
- * The function starts out empty: configure it with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
- * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
- * `duckdb_v2_table_function_get_signature()`, then make it available with `duckdb_v2_table_function_register()`. The
- * caller owns the returned handle and must destroy it with `duckdb_v2_table_function_destroy()`, also after
- * registration.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param connection The connection to create the function in.
- * @param function On success, receives the newly created table function. Owned by the caller.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_create_with_connection(duckdb_v2_connection_handle connection,
-                                                                             duckdb_v2_table_function_handle *function,
-                                                                             duckdb_v2_error_info_handle *err);
-
-/*!
- * Creates a new table function that will be registered on the loading extension's database.
- *
- * Use this from an extension load callback, where an extension handle is available. The function starts out empty:
- * configure it with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
- * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
- * `duckdb_v2_table_function_get_signature()`, then make it available with `duckdb_v2_table_function_register()`. The
- * caller owns the returned handle and must destroy it with `duckdb_v2_table_function_destroy()`, also after
- * registration.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param extension The extension to create the function in.
- * @param function On success, receives the newly created table function. Owned by the caller.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_create_with_extension(duckdb_v2_extension_handle extension,
-                                                                            duckdb_v2_table_function_handle *function,
-                                                                            duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the name of the table function.
- *
- * The name is borrowed and copied. Calling this again replaces the previous name. A name must be set before
- * registration.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the name of.
- * @param name The name to set. Borrowed and copied.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_name(duckdb_v2_table_function_handle function,
-                                                               duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
-
-/*!
- * Returns the function's signature so it can be configured.
- *
- * Add parameters with `duckdb_v2_function_signature_add_parameter()` and set a variadic tail with
- * `duckdb_v2_function_signature_set_varargs()`. The signature is modified in place. A table function maps the signature
- * onto the two ways SQL passes arguments to a table function: a parameter without a default value becomes a required
- * positional argument, a parameter with a default value becomes a named argument the caller may omit. The variadic tail
- * extends the positional arguments. A table function declares the columns it returns from its bind callback instead of
- * through a return type, so registration rejects a signature whose return type was set with
- * `duckdb_v2_function_signature_set_return_type()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to get the signature of.
- * @param sig The returned signature. Borrowed and valid for the lifetime of the function handle.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_get_signature(duckdb_v2_table_function_handle function,
-                                                                    duckdb_v2_function_signature_handle *sig,
-                                                                    duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets arbitrary user data on the table function.
- *
- * Associates an opaque pointer with the function, retrievable from the callbacks via
- * `duckdb_v2_table_function_bind_get_user_data()`, `duckdb_v2_table_function_init_global_get_user_data()`,
- * `duckdb_v2_table_function_exec_get_user_data()` and their counterparts on the other phases. The opaque handle bundles
- * the pointer with an optional destructor, invoked when the data is no longer needed.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the user data of.
- * @param data Opaque handle bundling the user data pointer plus an optional destructor.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_user_data(duckdb_v2_table_function_handle function,
-                                                                    duckdb_v2_opaque *data,
-                                                                    duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the bind callback of the table function.
- *
- * The bind callback is invoked during query planning for each call site of the function. It must declare the columns
- * the function returns via `duckdb_v2_table_function_bind_add_result_column()`. It can also inspect the constant
- * argument values and set "bind data" that is shared with all later callbacks. A bind callback must be set before
- * registration.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the bind callback of.
- * @param callback The bind callback to set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_bind_callback(
-    duckdb_v2_table_function_handle function, duckdb_v2_table_function_bind_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the optional global init callback of the table function.
- *
- * The global init callback is invoked once per scan, at the start of execution. It can set "global state" shared by
- * every thread scanning the function, and declare how many threads may scan it in parallel via
- * `duckdb_v2_table_function_init_global_set_max_threads()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the global init callback of.
- * @param callback The global init callback to set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_init_global_callback(
-    duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_global_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the optional local init callback of the table function.
- *
- * The local init callback is invoked once per thread that will scan the function. It can set worker-local "local
- * state", retrievable from the exec callback, typically derived from the shared global state.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the local init callback of.
- * @param callback The local init callback to set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_init_local_callback(
-    duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_local_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the exec callback of the table function.
- *
- * The exec callback implements the function's logic: it is invoked repeatedly during query execution and writes the
- * next batch of rows to the output chunk, until it produces an empty batch to signal the end of the scan. An exec
- * callback must be set before registration.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the exec callback of.
- * @param callback The exec callback to set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_exec_callback(
-    duckdb_v2_table_function_handle function, duckdb_v2_table_function_exec_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the optional progress callback of the table function.
- *
- * The progress callback is invoked on demand during execution to report how far the scan has advanced, which the engine
- * surfaces as the query's progress. It is invoked concurrently with the exec callback, so it must read the global state
- * in a thread-safe way.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the progress callback of.
- * @param callback The progress callback to set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_progress_callback(
-    duckdb_v2_table_function_handle function, duckdb_v2_table_function_progress_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The bind info handle.
- * @param data Receives the user data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_user_data(duckdb_v2_table_function_bind_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the function's "bind data" from the bind callback.
- *
- * The bind data is stored with the bound call site and retrievable from every later callback. The opaque handle bundles
- * the pointer with an optional destructor, invoked when the bind data is no longer needed, and an optional equality
- * callback used when comparing two bound call sites; without one, pointer equality is used.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The bind info handle.
- * @param data Opaque handle bundling the bind data pointer plus optional destructor and equality callbacks.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_set_bind_data(duckdb_v2_table_function_bind_info_handle info,
-                                                                         duckdb_v2_opaque *data,
-                                                                         duckdb_v2_error_info_handle *err);
-
-/*!
- * Returns the number of arguments of the call site being bound.
- *
- * The arguments are presented in signature order: one for every parameter declared with
- * `duckdb_v2_function_signature_add_parameter()`, followed by any variadic tail arguments. A parameter the call site
- * omitted is still present, carrying the default value declared for it, so the count only varies with the length of the
- * variadic tail. Valid indices for `duckdb_v2_table_function_bind_get_arg_type()` and
- * `duckdb_v2_table_function_bind_get_arg_value()` are [0, count).
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The bind info handle.
- * @param count Receives the number of arguments.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_count(duckdb_v2_table_function_bind_info_handle info,
-                                                                         idx_t *count,
-                                                                         duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the type of the argument at the given index.
- *
- * Fails if the index is out of bounds. The returned type is owned by the caller and must be destroyed via
- * `duckdb_v2_logical_type_destroy()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The bind info handle.
- * @param index The index of the argument to get the type of.
- * @param type Receives the argument type. Owned by the caller; destroy via `duckdb_v2_logical_type_destroy()`.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_type(duckdb_v2_table_function_bind_info_handle info,
-                                                                        idx_t index,
-                                                                        duckdb_v2_logical_type_handle *type,
-                                                                        duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the constant value of the argument at the given index.
- *
- * The arguments of a table function are always constants, folded before the bind callback runs, so this never fails for
- * an index in bounds; it does fail when the index is out of bounds. The value may be NULL. The returned value is owned
- * by the caller and must be destroyed via `duckdb_v2_value_destroy()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The bind info handle.
- * @param index The index of the argument to get the value of.
- * @param value Receives the constant value. Owned by the caller; destroy via `duckdb_v2_value_destroy()`.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_value(duckdb_v2_table_function_bind_info_handle info,
-                                                                         idx_t index, duckdb_v2_value_handle *value,
-                                                                         duckdb_v2_error_info_handle *err);
-
-/*!
- * Declares one of the columns the function returns.
- *
- * Call this once per column, in order: the columns declared here are the columns of the table the function produces,
- * and the vectors of the output chunk the exec callback fills follow the same order. At least one column must be
- * declared. The type must be a fully defined concrete type; ANY is rejected, as a result column carries data. The name
- * and type are borrowed and copied.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The bind info handle.
- * @param name The name of the column. Borrowed and copied.
- * @param type The type of the column. Borrowed and copied.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_add_result_column(
-    duckdb_v2_table_function_bind_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_logical_type_handle type,
-    duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the estimated number of rows the scan will produce.
- *
- * The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error. Without
- * it, the optimizer falls back on its own defaults.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The bind info handle.
- * @param cardinality The estimated number of rows.
- * @param is_exact Whether the estimate is exact, which also makes it an upper bound on the row count.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_set_cardinality(
-    duckdb_v2_table_function_bind_info_handle info, idx_t cardinality, bool is_exact, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The global init info handle.
- * @param data Receives the user data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_get_user_data(
-    duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the bind data set by the function's bind callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The global init info handle.
- * @param data Receives the bind data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_get_bind_data(
-    duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the function's "global state" from the global init callback.
- *
- * The global state lives for the duration of the scan and is retrievable from the local init, exec and progress
- * callbacks. Every thread scanning the function shares it, so the function must synchronize its own access to it. The
- * opaque handle bundles the pointer with an optional destructor, invoked when the scan is done with the state.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The global init info handle.
- * @param data Opaque handle bundling the global state pointer plus an optional destructor.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_set_global_state(
-    duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets how many threads may scan the function in parallel.
- *
- * Defaults to 1, a single-threaded scan. The engine creates at most this many local states, and therefore runs at most
- * this many exec callbacks concurrently. It is an upper bound, not a request: the engine may use fewer threads.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The global init info handle.
- * @param max_threads The maximum number of threads. Must be at least 1.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_set_max_threads(
-    duckdb_v2_table_function_init_global_info_handle info, idx_t max_threads, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The local init info handle.
- * @param data Receives the user data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_user_data(
-    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the bind data set by the function's bind callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The local init info handle.
- * @param data Receives the bind data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_bind_data(
-    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the global state set by the function's global init callback.
- *
- * Shared with every other thread scanning the function; access to it must be synchronized by the function.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The local init info handle.
- * @param data Receives the global state pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_global_state(
-    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the function's worker-local "local state" from the local init callback.
- *
- * The local state is associated with the executing thread for the duration of the scan and retrievable from the exec
- * callback via `duckdb_v2_table_function_exec_get_local_state()`. No other thread observes it, so it needs no
- * synchronization. The opaque handle bundles the pointer with an optional destructor, invoked when the local state is
- * no longer needed.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The local init info handle.
- * @param data Opaque handle bundling the local state pointer plus an optional destructor.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_set_local_state(
-    duckdb_v2_table_function_init_local_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The exec info handle.
- * @param data Receives the user data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_user_data(duckdb_v2_table_function_exec_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the bind data set by the function's bind callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The exec info handle.
- * @param data Receives the bind data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_bind_data(duckdb_v2_table_function_exec_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the global state set by the function's global init callback.
- *
- * Shared with every other thread scanning the function; access to it must be synchronized by the function.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The exec info handle.
- * @param data Receives the global state pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_global_state(
-    duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the worker-local local state set by the function's local init callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The exec info handle.
- * @param data Receives the local state pointer for the executing thread, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_local_state(
-    duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the output chunk the exec callback must write the next batch of rows into.
- *
- * The chunk holds one vector per column declared with `duckdb_v2_table_function_bind_add_result_column()`, in the same
- * order; reach them with `duckdb_v2_data_chunk_get_vector()`. The chunk starts out empty on every invocation: write the
- * rows, then declare how many there are with `duckdb_v2_vector_set_size()` on the first vector, which the engine takes
- * as the batch's row count and propagates to the other vectors. Producing an empty batch signals the end of the scan,
- * after which the callback is not invoked again on that thread. Borrowed; valid only for the duration of the callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The exec info handle.
- * @param chunk Receives the borrowed output chunk to write into.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR
-duckdb_v2_table_function_exec_get_output_chunk(duckdb_v2_table_function_exec_info_handle info,
-                                               duckdb_v2_data_chunk_handle *chunk, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The progress info handle.
- * @param data Receives the user data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_user_data(
-    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the bind data set by the function's bind callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The progress info handle.
- * @param data Receives the bind data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_bind_data(
-    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the global state set by the function's global init callback.
- *
- * The progress callback runs concurrently with the exec callbacks scanning the function, so it must read the global
- * state in a thread-safe way.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The progress info handle.
- * @param data Receives the global state pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_global_state(
-    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Reports how far the scan has advanced.
- *
- * A fraction between 0.0 (nothing scanned yet) and 1.0 (done); values outside that range are clamped. A progress
- * callback that returns without calling this reports no progress.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The progress info handle.
- * @param progress The fraction of the scan that is complete, in [0.0, 1.0].
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_set_progress(
-    duckdb_v2_table_function_progress_info_handle info, double progress, duckdb_v2_error_info_handle *err);
-
-/*!
- * Registers the table function, making it available for use in SQL queries.
- *
- * The function is registered on the target given at creation: the connection's database or the loading extension.
- * Registration requires a name, a bind callback and an exec callback, and rejects a signature that declares a return
- * type, since a table function declares the columns it returns from its bind callback. The caller still owns the handle
- * after registration and must destroy it with `duckdb_v2_table_function_destroy()`, which does not affect the
- * registered function.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to register.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_register(duckdb_v2_table_function_handle function,
-                                                               duckdb_v2_error_info_handle *err);
-
-/*!
- * Destroys the table function, releasing its resources.
- *
- * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
- * double-destruction. Destroying the handle after registration does not affect the registered function.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_destroy(duckdb_v2_table_function_handle *function);
-
-/* --- Struct definitions for table --- */
 
 /* ============================================================================
  * MODULE: value
@@ -12200,6 +11730,1081 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_result_get_schema(duckdb_v2_result_handle
                                                          duckdb_v2_error_info_handle *err);
 
 /* --- Struct definitions for query_result --- */
+
+/* ============================================================================
+ * MODULE: table
+ * ============================================================================ */
+
+/* --- Enums for table --- */
+
+/* --- Struct forward declarations for table --- */
+
+/* --- Types for table --- */
+
+/*!
+ * An owned opaque handle to a custom table function being built. Created with
+ * `duckdb_v2_table_function_create_with_connection()` or `duckdb_v2_table_function_create_with_extension()`, configured
+ * with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
+ * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
+ * `duckdb_v2_table_function_get_signature()`, made available with `duckdb_v2_table_function_register()`, and destroyed
+ * with `duckdb_v2_table_function_destroy()`.
+ */
+typedef struct _duckdb_v2_table_function {
+	void *internal_ptr;
+} * duckdb_v2_table_function_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the query preparation "bind" phase. The
+ * "bind" callback receives this handle and must use it to declare the columns the function returns; it can also inspect
+ * the arguments given to the function, initialize some constant state and hint at the number of rows the scan will
+ * produce.
+ */
+typedef struct _duckdb_v2_table_function_bind_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_bind_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the global state initialization "init
+ * global" phase. The "init global" callback receives this handle and can use it to e.g. set up the state shared by
+ * every thread scanning the function, and to declare how many threads may scan it.
+ */
+typedef struct _duckdb_v2_table_function_init_global_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_init_global_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the local state initialization "init
+ * local" phase. The "init local" callback receives this handle and can use it to e.g. set up worker-local state,
+ * typically by claiming work from the shared global state.
+ */
+typedef struct _duckdb_v2_table_function_init_local_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_init_local_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the execution "exec" phase. The "exec"
+ * callback receives this handle and can use it to e.g. access the global and local state and write the next batch of
+ * rows to the output chunk.
+ */
+typedef struct _duckdb_v2_table_function_exec_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_exec_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the "progress" phase. The "progress"
+ * callback receives this handle and can use it to report how far the scan has advanced.
+ */
+typedef struct _duckdb_v2_table_function_progress_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_progress_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the "filter pushdown" phase of query
+ * optimization. The "filter pushdown" callback receives this handle and can use it to inspect the filter predicates the
+ * query applies to the function's rows, and to accept the ones it will apply itself.
+ */
+typedef struct _duckdb_v2_table_function_filter_pushdown_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_filter_pushdown_info_handle;
+
+/* --- Constants for table --- */
+
+/* --- Function pointer typedefs for table --- */
+
+typedef void (*duckdb_v2_table_function_bind_callback_fn)(duckdb_v2_table_function_bind_info_handle info,
+                                                          duckdb_v2_context_handle context,
+                                                          duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_init_global_callback_fn)(duckdb_v2_table_function_init_global_info_handle info,
+                                                                 duckdb_v2_context_handle context,
+                                                                 duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_init_local_callback_fn)(duckdb_v2_table_function_init_local_info_handle info,
+                                                                duckdb_v2_context_handle context,
+                                                                duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_exec_callback_fn)(duckdb_v2_table_function_exec_info_handle info,
+                                                          duckdb_v2_context_handle context,
+                                                          duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_progress_callback_fn)(duckdb_v2_table_function_progress_info_handle info,
+                                                              duckdb_v2_context_handle context,
+                                                              duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_filter_pushdown_callback_fn)(
+    duckdb_v2_table_function_filter_pushdown_info_handle info, duckdb_v2_context_handle context,
+    duckdb_v2_error_info_handle *err);
+
+/* --- Functions for table --- */
+
+/*!
+ * Creates a new table function that will be registered on the connection's database.
+ *
+ * The function starts out empty: configure it with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
+ * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
+ * `duckdb_v2_table_function_get_signature()`, then make it available with `duckdb_v2_table_function_register()`. The
+ * caller owns the returned handle and must destroy it with `duckdb_v2_table_function_destroy()`, also after
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param connection The connection to create the function in.
+ * @param function On success, receives the newly created table function. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_create_with_connection(duckdb_v2_connection_handle connection,
+                                                                             duckdb_v2_table_function_handle *function,
+                                                                             duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a new table function that will be registered on the loading extension's database.
+ *
+ * Use this from an extension load callback, where an extension handle is available. The function starts out empty:
+ * configure it with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
+ * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
+ * `duckdb_v2_table_function_get_signature()`, then make it available with `duckdb_v2_table_function_register()`. The
+ * caller owns the returned handle and must destroy it with `duckdb_v2_table_function_destroy()`, also after
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param extension The extension to create the function in.
+ * @param function On success, receives the newly created table function. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_create_with_extension(duckdb_v2_extension_handle extension,
+                                                                            duckdb_v2_table_function_handle *function,
+                                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the name of the table function.
+ *
+ * The name is borrowed and copied. Calling this again replaces the previous name. A name must be set before
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the name of.
+ * @param name The name to set. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_name(duckdb_v2_table_function_handle function,
+                                                               duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the function's signature so it can be configured.
+ *
+ * Add parameters with `duckdb_v2_function_signature_add_parameter()` and set a variadic tail with
+ * `duckdb_v2_function_signature_set_varargs()`. The signature is modified in place. A table function maps the signature
+ * onto the two ways SQL passes arguments to a table function: a parameter without a default value becomes a required
+ * positional argument, a parameter with a default value becomes a named argument the caller may omit. The variadic tail
+ * extends the positional arguments. A table function declares the columns it returns from its bind callback instead of
+ * through a return type, so registration rejects a signature whose return type was set with
+ * `duckdb_v2_function_signature_set_return_type()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to get the signature of.
+ * @param sig The returned signature. Borrowed and valid for the lifetime of the function handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_get_signature(duckdb_v2_table_function_handle function,
+                                                                    duckdb_v2_function_signature_handle *sig,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets arbitrary user data on the table function.
+ *
+ * Associates an opaque pointer with the function, retrievable from the callbacks via
+ * `duckdb_v2_table_function_bind_get_user_data()`, `duckdb_v2_table_function_init_global_get_user_data()`,
+ * `duckdb_v2_table_function_exec_get_user_data()` and their counterparts on the other phases. The opaque handle bundles
+ * the pointer with an optional destructor, invoked when the data is no longer needed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the user data of.
+ * @param data Opaque handle bundling the user data pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_user_data(duckdb_v2_table_function_handle function,
+                                                                    duckdb_v2_opaque *data,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the bind callback of the table function.
+ *
+ * The bind callback is invoked during query planning for each call site of the function. It must declare the columns
+ * the function returns via `duckdb_v2_table_function_bind_add_result_column()`. It can also inspect the constant
+ * argument values and set "bind data" that is shared with all later callbacks. A bind callback must be set before
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the bind callback of.
+ * @param callback The bind callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_bind_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_bind_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional global init callback of the table function.
+ *
+ * The global init callback is invoked once per scan, at the start of execution. It can set "global state" shared by
+ * every thread scanning the function, and declare how many threads may scan it in parallel via
+ * `duckdb_v2_table_function_init_global_set_max_threads()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the global init callback of.
+ * @param callback The global init callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_init_global_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_global_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional local init callback of the table function.
+ *
+ * The local init callback is invoked once per thread that will scan the function. It can set worker-local "local
+ * state", retrievable from the exec callback, typically derived from the shared global state.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the local init callback of.
+ * @param callback The local init callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_init_local_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_local_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the exec callback of the table function.
+ *
+ * The exec callback implements the function's logic: it is invoked repeatedly during query execution and writes the
+ * next batch of rows to the output chunk, until it produces an empty batch to signal the end of the scan. An exec
+ * callback must be set before registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the exec callback of.
+ * @param callback The exec callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_exec_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_exec_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional progress callback of the table function.
+ *
+ * The progress callback is invoked on demand during execution to report how far the scan has advanced, which the engine
+ * surfaces as the query's progress. It is invoked concurrently with the exec callback, so it must read the global state
+ * in a thread-safe way.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the progress callback of.
+ * @param callback The progress callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_progress_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_progress_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets whether the table function supports projection pushdown. Defaults to false.
+ *
+ * With projection pushdown, the engine asks the function for only the columns a query actually uses: the exec
+ * callback's output chunk holds one vector per requested column rather than one per column declared in bind, and the
+ * global init, local init and exec callbacks can look up which declared column each vector stands for via e.g.
+ * `duckdb_v2_table_function_exec_get_column_index()`. Without it the output chunk always holds every declared column,
+ * and the engine drops the unused ones itself.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to configure.
+ * @param enable Whether the function supports projection pushdown.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_projection_pushdown(duckdb_v2_table_function_handle function,
+                                                                              bool enable,
+                                                                              duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional filter pushdown callback of the table function.
+ *
+ * The filter pushdown callback is invoked while the query is optimized, after the bind callback and before any init
+ * callback, with the filter predicates the query applies to the function's rows. Each predicate is a bound expression
+ * the callback can inspect with the `expression` functions; the callback accepts the predicates it will apply itself
+ * via `duckdb_v2_table_function_filter_pushdown_accept()`, typically after recording what they select in the bind data.
+ * The engine then stops applying the accepted predicates and keeps applying the rest above the scan, so accepting a
+ * predicate is a promise to filter the rows exactly as it would have. The optimizer may invoke the callback more than
+ * once for the same query, each time with the predicates not yet accepted; it is not invoked when there are none.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the filter pushdown callback of.
+ * @param callback The filter pushdown callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_filter_pushdown_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_filter_pushdown_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_user_data(duckdb_v2_table_function_bind_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's "bind data" from the bind callback.
+ *
+ * The bind data is stored with the bound call site and retrievable from every later callback. The opaque handle bundles
+ * the pointer with an optional destructor, invoked when the bind data is no longer needed, and an optional equality
+ * callback used when comparing two bound call sites; without one, pointer equality is used.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param data Opaque handle bundling the bind data pointer plus optional destructor and equality callbacks.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_set_bind_data(duckdb_v2_table_function_bind_info_handle info,
+                                                                         duckdb_v2_opaque *data,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of arguments of the call site being bound.
+ *
+ * The arguments are presented in signature order: one for every parameter declared with
+ * `duckdb_v2_function_signature_add_parameter()`, followed by any variadic tail arguments. A parameter the call site
+ * omitted is still present, carrying the default value declared for it, so the count only varies with the length of the
+ * variadic tail. Valid indices for `duckdb_v2_table_function_bind_get_arg_type()` and
+ * `duckdb_v2_table_function_bind_get_arg_value()` are [0, count).
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param count Receives the number of arguments.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_count(duckdb_v2_table_function_bind_info_handle info,
+                                                                         idx_t *count,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the type of the argument at the given index.
+ *
+ * Fails if the index is out of bounds. The returned type is owned by the caller and must be destroyed via
+ * `duckdb_v2_logical_type_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the argument to get the type of.
+ * @param type Receives the argument type. Owned by the caller; destroy via `duckdb_v2_logical_type_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_type(duckdb_v2_table_function_bind_info_handle info,
+                                                                        idx_t index,
+                                                                        duckdb_v2_logical_type_handle *type,
+                                                                        duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the constant value of the argument at the given index.
+ *
+ * The arguments of a table function are always constants, folded before the bind callback runs, so this never fails for
+ * an index in bounds; it does fail when the index is out of bounds. The value may be NULL. The returned value is owned
+ * by the caller and must be destroyed via `duckdb_v2_value_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the argument to get the value of.
+ * @param value Receives the constant value. Owned by the caller; destroy via `duckdb_v2_value_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_value(duckdb_v2_table_function_bind_info_handle info,
+                                                                         idx_t index, duckdb_v2_value_handle *value,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Declares one of the columns the function returns.
+ *
+ * Call this once per column, in order: the columns declared here are the columns of the table the function produces,
+ * and the vectors of the output chunk the exec callback fills follow the same order. At least one column must be
+ * declared. The type must be a fully defined concrete type; ANY is rejected, as a result column carries data. The name
+ * and type are borrowed and copied.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param name The name of the column. Borrowed and copied.
+ * @param type The type of the column. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_add_result_column(
+    duckdb_v2_table_function_bind_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_logical_type_handle type,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the estimated number of rows the scan will produce.
+ *
+ * The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error. Without
+ * it, the optimizer falls back on its own defaults.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param cardinality The estimated number of rows.
+ * @param is_exact Whether the estimate is exact, which also makes it an upper bound on the row count.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_set_cardinality(
+    duckdb_v2_table_function_bind_info_handle info, idx_t cardinality, bool is_exact, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_get_user_data(
+    duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_get_bind_data(
+    duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's "global state" from the global init callback.
+ *
+ * The global state lives for the duration of the scan and is retrievable from the local init, exec and progress
+ * callbacks. Every thread scanning the function shares it, so the function must synchronize its own access to it. The
+ * opaque handle bundles the pointer with an optional destructor, invoked when the scan is done with the state.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Opaque handle bundling the global state pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_set_global_state(
+    duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets how many threads may scan the function in parallel.
+ *
+ * Defaults to 1, a single-threaded scan. The engine creates at most this many local states, and therefore runs at most
+ * this many exec callbacks concurrently. It is an upper bound, not a request: the engine may use fewer threads.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param max_threads The maximum number of threads. Must be at least 1.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_set_max_threads(
+    duckdb_v2_table_function_init_global_info_handle info, idx_t max_threads, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of columns the scan produces.
+ *
+ * With projection pushdown (see `duckdb_v2_table_function_set_projection_pushdown()`) this is the number of columns the
+ * query uses, which is the number of vectors in the exec callback's output chunk; without it, it is the number of
+ * columns declared in bind. Valid indices for `duckdb_v2_table_function_init_global_get_column_index()` are `0` up to
+ * (but excluding) this count.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param count Receives the number of columns the scan produces.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_get_column_count(
+    duckdb_v2_table_function_init_global_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns which declared column the scan's column at the given index stands for.
+ *
+ * The result indexes the columns declared with `duckdb_v2_table_function_bind_add_result_column()`, in declaration
+ * order: the exec callback fills the output chunk's vector at `index` with that column's data. Without projection
+ * pushdown the mapping is the identity. Fails if the index is out of bounds.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param index The index of the column in the scan's output.
+ * @param column_index Receives the index of the declared column.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_get_column_index(
+    duckdb_v2_table_function_init_global_info_handle info, idx_t index, idx_t *column_index,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_user_data(
+    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_bind_data(
+    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * Shared with every other thread scanning the function; access to it must be synchronized by the function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_global_state(
+    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's worker-local "local state" from the local init callback.
+ *
+ * The local state is associated with the executing thread for the duration of the scan and retrievable from the exec
+ * callback via `duckdb_v2_table_function_exec_get_local_state()`. No other thread observes it, so it needs no
+ * synchronization. The opaque handle bundles the pointer with an optional destructor, invoked when the local state is
+ * no longer needed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Opaque handle bundling the local state pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_set_local_state(
+    duckdb_v2_table_function_init_local_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of columns the scan produces.
+ *
+ * With projection pushdown (see `duckdb_v2_table_function_set_projection_pushdown()`) this is the number of columns the
+ * query uses, which is the number of vectors in the exec callback's output chunk; without it, it is the number of
+ * columns declared in bind. Valid indices for `duckdb_v2_table_function_init_local_get_column_index()` are `0` up to
+ * (but excluding) this count.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param count Receives the number of columns the scan produces.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_column_count(
+    duckdb_v2_table_function_init_local_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns which declared column the scan's column at the given index stands for.
+ *
+ * The result indexes the columns declared with `duckdb_v2_table_function_bind_add_result_column()`, in declaration
+ * order: the exec callback fills the output chunk's vector at `index` with that column's data. Without projection
+ * pushdown the mapping is the identity. Fails if the index is out of bounds.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param index The index of the column in the scan's output.
+ * @param column_index Receives the index of the declared column.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_local_get_column_index(duckdb_v2_table_function_init_local_info_handle info, idx_t index,
+                                                     idx_t *column_index, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_user_data(duckdb_v2_table_function_exec_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_bind_data(duckdb_v2_table_function_exec_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * Shared with every other thread scanning the function; access to it must be synchronized by the function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_global_state(
+    duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the worker-local local state set by the function's local init callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the local state pointer for the executing thread, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_local_state(
+    duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the output chunk the exec callback must write the next batch of rows into.
+ *
+ * The chunk holds one vector per column declared with `duckdb_v2_table_function_bind_add_result_column()`, in the same
+ * order; reach them with `duckdb_v2_data_chunk_get_vector()`. The chunk starts out empty on every invocation: write the
+ * rows, then declare how many there are with `duckdb_v2_vector_set_size()` on the first vector, which the engine takes
+ * as the batch's row count and propagates to the other vectors. Producing an empty batch signals the end of the scan,
+ * after which the callback is not invoked again on that thread. Borrowed; valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param chunk Receives the borrowed output chunk to write into.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR
+duckdb_v2_table_function_exec_get_output_chunk(duckdb_v2_table_function_exec_info_handle info,
+                                               duckdb_v2_data_chunk_handle *chunk, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of columns the scan produces.
+ *
+ * With projection pushdown (see `duckdb_v2_table_function_set_projection_pushdown()`) this is the number of columns the
+ * query uses, which is the number of vectors in the exec callback's output chunk; without it, it is the number of
+ * columns declared in bind. Valid indices for `duckdb_v2_table_function_exec_get_column_index()` are `0` up to (but
+ * excluding) this count.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param count Receives the number of columns the scan produces.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_column_count(
+    duckdb_v2_table_function_exec_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns which declared column the scan's column at the given index stands for.
+ *
+ * The result indexes the columns declared with `duckdb_v2_table_function_bind_add_result_column()`, in declaration
+ * order: the exec callback fills the output chunk's vector at `index` with that column's data. Without projection
+ * pushdown the mapping is the identity. Fails if the index is out of bounds.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param index The index of the column in the scan's output.
+ * @param column_index Receives the index of the declared column.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_column_index(
+    duckdb_v2_table_function_exec_info_handle info, idx_t index, idx_t *column_index, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_user_data(
+    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_bind_data(
+    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * The progress callback runs concurrently with the exec callbacks scanning the function, so it must read the global
+ * state in a thread-safe way.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_global_state(
+    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reports how far the scan has advanced.
+ *
+ * A fraction between 0.0 (nothing scanned yet) and 1.0 (done); values outside that range are clamped. A progress
+ * callback that returns without calling this reports no progress.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param progress The fraction of the scan that is complete, in [0.0, 1.0].
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_set_progress(
+    duckdb_v2_table_function_progress_info_handle info, double progress, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`, or null if none was set.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The filter pushdown info handle.
+ * @param data Receives the user data pointer.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_filter_pushdown_get_user_data(
+    duckdb_v2_table_function_filter_pushdown_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set via `duckdb_v2_table_function_bind_set_bind_data()`, or null if none was set.
+ *
+ * This is the same object the init and exec callbacks later receive, so a predicate the callback accepts can be
+ * recorded in it for the scan to apply.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The filter pushdown info handle.
+ * @param data Receives the bind data pointer.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_filter_pushdown_get_bind_data(
+    duckdb_v2_table_function_filter_pushdown_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of filter predicates offered to the function.
+ *
+ * The predicates are combined with `AND`: every row the scan produces must satisfy all of them. Valid indices for
+ * `duckdb_v2_table_function_filter_pushdown_get_filter()` and `duckdb_v2_table_function_filter_pushdown_accept()` are
+ * `0` up to (but excluding) this count.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The filter pushdown info handle.
+ * @param count Receives the number of predicates.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_filter_pushdown_get_filter_count(
+    duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the filter predicate at the given index.
+ *
+ * Fails if the index is out of bounds. The predicate is a bound expression evaluating to `BOOLEAN`; inspect it with
+ * `duckdb_v2_expression_get_type()` and the other `expression` functions, and resolve the column references it contains
+ * via `duckdb_v2_table_function_filter_pushdown_get_column_index()`. Borrowed; valid only for the duration of the
+ * callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The filter pushdown info handle.
+ * @param index The index of the predicate to retrieve.
+ * @param filter Receives the borrowed predicate.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_filter_pushdown_get_filter(
+    duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, duckdb_v2_expression_handle *filter,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Accepts the filter predicate at the given index: the function will apply it itself.
+ *
+ * The engine stops applying an accepted predicate, so the scan must produce only rows that satisfy it, or the query
+ * returns rows it should not. Predicates left unaccepted are applied by the engine as usual, so a callback that
+ * recognizes nothing can simply return. Fails if the index is out of bounds.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The filter pushdown info handle.
+ * @param index The index of the predicate to accept.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_filter_pushdown_accept(
+    duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of columns the predicates can refer to.
+ *
+ * A column reference inside a predicate (`duckdb_v2_expression_column_ref_get_index()`) indexes the columns the query
+ * reads from the function, not the columns declared in bind. Valid indices for
+ * `duckdb_v2_table_function_filter_pushdown_get_column_index()` are `0` up to (but excluding) this count.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The filter pushdown info handle.
+ * @param count Receives the number of referable columns.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_filter_pushdown_get_column_count(
+    duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Resolves a column reference found in a predicate to the declared column it refers to.
+ *
+ * Takes the index a `EXPRESSION_TYPE_BOUND_COLUMN_REF` node reports and returns the index of the column among the ones
+ * declared with `duckdb_v2_table_function_bind_add_result_column()`, in declaration order. Fails if the index is out of
+ * bounds.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The filter pushdown info handle.
+ * @param index The column index reported by a column reference node.
+ * @param column_index Receives the index of the declared column.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_filter_pushdown_get_column_index(
+    duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index, idx_t *column_index,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Registers the table function, making it available for use in SQL queries.
+ *
+ * The function is registered on the target given at creation: the connection's database or the loading extension.
+ * Registration requires a name, a bind callback and an exec callback, and rejects a signature that declares a return
+ * type, since a table function declares the columns it returns from its bind callback. The caller still owns the handle
+ * after registration and must destroy it with `duckdb_v2_table_function_destroy()`, which does not affect the
+ * registered function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to register.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_register(duckdb_v2_table_function_handle function,
+                                                               duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the table function, releasing its resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Destroying the handle after registration does not affect the registered function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_destroy(duckdb_v2_table_function_handle *function);
+
+/* --- Struct definitions for table --- */
 
 #ifdef __cplusplus
 }

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -5056,6 +5056,853 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_statement_iterator_destroy(duckdb_v2_stat
 /* --- Struct definitions for sql_statement --- */
 
 /* ============================================================================
+ * MODULE: table
+ * ============================================================================ */
+
+/* --- Enums for table --- */
+
+/* --- Struct forward declarations for table --- */
+
+/* --- Types for table --- */
+
+/*!
+ * An owned opaque handle to a custom table function being built. Created with
+ * `duckdb_v2_table_function_create_with_connection()` or `duckdb_v2_table_function_create_with_extension()`, configured
+ * with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
+ * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
+ * `duckdb_v2_table_function_get_signature()`, made available with `duckdb_v2_table_function_register()`, and destroyed
+ * with `duckdb_v2_table_function_destroy()`.
+ */
+typedef struct _duckdb_v2_table_function {
+	void *internal_ptr;
+} * duckdb_v2_table_function_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the query preparation "bind" phase. The
+ * "bind" callback receives this handle and must use it to declare the columns the function returns; it can also inspect
+ * the arguments given to the function, initialize some constant state and hint at the number of rows the scan will
+ * produce.
+ */
+typedef struct _duckdb_v2_table_function_bind_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_bind_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the global state initialization "init
+ * global" phase. The "init global" callback receives this handle and can use it to e.g. set up the state shared by
+ * every thread scanning the function, and to declare how many threads may scan it.
+ */
+typedef struct _duckdb_v2_table_function_init_global_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_init_global_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the local state initialization "init
+ * local" phase. The "init local" callback receives this handle and can use it to e.g. set up worker-local state,
+ * typically by claiming work from the shared global state.
+ */
+typedef struct _duckdb_v2_table_function_init_local_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_init_local_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the execution "exec" phase. The "exec"
+ * callback receives this handle and can use it to e.g. access the global and local state and write the next batch of
+ * rows to the output chunk.
+ */
+typedef struct _duckdb_v2_table_function_exec_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_exec_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the "cardinality" estimation phase. The
+ * "cardinality" callback receives this handle and can use it to report how many rows the scan is expected to produce.
+ */
+typedef struct _duckdb_v2_table_function_cardinality_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_cardinality_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a table function during the "progress" phase. The "progress"
+ * callback receives this handle and can use it to report how far the scan has advanced.
+ */
+typedef struct _duckdb_v2_table_function_progress_info {
+	void *internal_ptr;
+} * duckdb_v2_table_function_progress_info_handle;
+
+/* --- Constants for table --- */
+
+/* --- Function pointer typedefs for table --- */
+
+typedef void (*duckdb_v2_table_function_bind_callback_fn)(duckdb_v2_table_function_bind_info_handle info,
+                                                          duckdb_v2_context_handle context,
+                                                          duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_init_global_callback_fn)(duckdb_v2_table_function_init_global_info_handle info,
+                                                                 duckdb_v2_context_handle context,
+                                                                 duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_init_local_callback_fn)(duckdb_v2_table_function_init_local_info_handle info,
+                                                                duckdb_v2_context_handle context,
+                                                                duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_exec_callback_fn)(duckdb_v2_table_function_exec_info_handle info,
+                                                          duckdb_v2_context_handle context,
+                                                          duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_cardinality_callback_fn)(duckdb_v2_table_function_cardinality_info_handle info,
+                                                                 duckdb_v2_context_handle context,
+                                                                 duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_table_function_progress_callback_fn)(duckdb_v2_table_function_progress_info_handle info,
+                                                              duckdb_v2_context_handle context,
+                                                              duckdb_v2_error_info_handle *err);
+
+/* --- Functions for table --- */
+
+/*!
+ * Creates a new table function that will be registered on the connection's database.
+ *
+ * The function starts out empty: configure it with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
+ * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
+ * `duckdb_v2_table_function_get_signature()`, then make it available with `duckdb_v2_table_function_register()`. The
+ * caller owns the returned handle and must destroy it with `duckdb_v2_table_function_destroy()`, also after
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param connection The connection to create the function in.
+ * @param function On success, receives the newly created table function. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_create_with_connection(duckdb_v2_connection_handle connection,
+                                                                             duckdb_v2_table_function_handle *function,
+                                                                             duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a new table function that will be registered on the loading extension's database.
+ *
+ * Use this from an extension load callback, where an extension handle is available. The function starts out empty:
+ * configure it with the setter functions (e.g. `duckdb_v2_table_function_set_name()`,
+ * `duckdb_v2_table_function_set_exec_callback()`, etc.) and the signature obtained via
+ * `duckdb_v2_table_function_get_signature()`, then make it available with `duckdb_v2_table_function_register()`. The
+ * caller owns the returned handle and must destroy it with `duckdb_v2_table_function_destroy()`, also after
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param extension The extension to create the function in.
+ * @param function On success, receives the newly created table function. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_create_with_extension(duckdb_v2_extension_handle extension,
+                                                                            duckdb_v2_table_function_handle *function,
+                                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the name of the table function.
+ *
+ * The name is borrowed and copied. Calling this again replaces the previous name. A name must be set before
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the name of.
+ * @param name The name to set. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_name(duckdb_v2_table_function_handle function,
+                                                               duckdb_v2_str *name, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the function's signature so it can be configured.
+ *
+ * Add parameters with `duckdb_v2_function_signature_add_parameter()` and set a variadic tail with
+ * `duckdb_v2_function_signature_set_varargs()`. The signature is modified in place. A table function maps the signature
+ * onto the two ways SQL passes arguments to a table function: a parameter without a default value becomes a required
+ * positional argument, a parameter with a default value becomes a named argument the caller may omit. The variadic tail
+ * extends the positional arguments. A table function declares the columns it returns from its bind callback instead of
+ * through a return type, so registration rejects a signature whose return type was set with
+ * `duckdb_v2_function_signature_set_return_type()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to get the signature of.
+ * @param sig The returned signature. Borrowed and valid for the lifetime of the function handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_get_signature(duckdb_v2_table_function_handle function,
+                                                                    duckdb_v2_function_signature_handle *sig,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets arbitrary user data on the table function.
+ *
+ * Associates an opaque pointer with the function, retrievable from the callbacks via
+ * `duckdb_v2_table_function_bind_get_user_data()`, `duckdb_v2_table_function_init_global_get_user_data()`,
+ * `duckdb_v2_table_function_exec_get_user_data()` and their counterparts on the other phases. The opaque handle bundles
+ * the pointer with an optional destructor, invoked when the data is no longer needed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the user data of.
+ * @param data Opaque handle bundling the user data pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_user_data(duckdb_v2_table_function_handle function,
+                                                                    duckdb_v2_opaque *data,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the bind callback of the table function.
+ *
+ * The bind callback is invoked during query planning for each call site of the function. It must declare the columns
+ * the function returns via `duckdb_v2_table_function_bind_add_result_column()`. It can also inspect the constant
+ * argument values and set "bind data" that is shared with all later callbacks. A bind callback must be set before
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the bind callback of.
+ * @param callback The bind callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_bind_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_bind_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional global init callback of the table function.
+ *
+ * The global init callback is invoked once per scan, at the start of execution. It can set "global state" shared by
+ * every thread scanning the function, and declare how many threads may scan it in parallel via
+ * `duckdb_v2_table_function_init_global_set_max_threads()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the global init callback of.
+ * @param callback The global init callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_init_global_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_global_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional local init callback of the table function.
+ *
+ * The local init callback is invoked once per thread that will scan the function. It can set worker-local "local
+ * state", retrievable from the exec callback, typically derived from the shared global state.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the local init callback of.
+ * @param callback The local init callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_init_local_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_init_local_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the exec callback of the table function.
+ *
+ * The exec callback implements the function's logic: it is invoked repeatedly during query execution and writes the
+ * next batch of rows to the output chunk, until it produces an empty batch to signal the end of the scan. An exec
+ * callback must be set before registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the exec callback of.
+ * @param callback The exec callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_exec_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_exec_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional cardinality callback of the table function.
+ *
+ * The cardinality callback is invoked during query optimization to estimate how many rows the scan will produce, which
+ * the optimizer uses for cost-based decisions such as join ordering. It may be invoked more than once per plan, so it
+ * should be cheap and free of side effects. Use `duckdb_v2_table_function_bind_set_cardinality()` instead when the row
+ * count is already known at bind time; the callback takes precedence when both are provided.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the cardinality callback of.
+ * @param callback The cardinality callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_cardinality_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_cardinality_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional progress callback of the table function.
+ *
+ * The progress callback is invoked on demand during execution to report how far the scan has advanced, which the engine
+ * surfaces as the query's progress. It is invoked concurrently with the exec callback, so it must read the global state
+ * in a thread-safe way.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the progress callback of.
+ * @param callback The progress callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_progress_callback(
+    duckdb_v2_table_function_handle function, duckdb_v2_table_function_progress_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_user_data(duckdb_v2_table_function_bind_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's "bind data" from the bind callback.
+ *
+ * The bind data is stored with the bound call site and retrievable from every later callback. The opaque handle bundles
+ * the pointer with an optional destructor, invoked when the bind data is no longer needed, and an optional equality
+ * callback used when comparing two bound call sites; without one, pointer equality is used.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param data Opaque handle bundling the bind data pointer plus optional destructor and equality callbacks.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_set_bind_data(duckdb_v2_table_function_bind_info_handle info,
+                                                                         duckdb_v2_opaque *data,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of arguments of the call site being bound.
+ *
+ * The arguments are presented in signature order: one for every parameter declared with
+ * `duckdb_v2_function_signature_add_parameter()`, followed by any variadic tail arguments. A parameter the call site
+ * omitted is still present, carrying the default value declared for it, so the count only varies with the length of the
+ * variadic tail. Valid indices for `duckdb_v2_table_function_bind_get_arg_type()` and
+ * `duckdb_v2_table_function_bind_get_arg_value()` are [0, count).
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param count Receives the number of arguments.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_count(duckdb_v2_table_function_bind_info_handle info,
+                                                                         idx_t *count,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the type of the argument at the given index.
+ *
+ * Fails if the index is out of bounds. The returned type is owned by the caller and must be destroyed via
+ * `duckdb_v2_logical_type_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the argument to get the type of.
+ * @param type Receives the argument type. Owned by the caller; destroy via `duckdb_v2_logical_type_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_type(duckdb_v2_table_function_bind_info_handle info,
+                                                                        idx_t index,
+                                                                        duckdb_v2_logical_type_handle *type,
+                                                                        duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the constant value of the argument at the given index.
+ *
+ * The arguments of a table function are always constants, folded before the bind callback runs, so this never fails for
+ * an index in bounds; it does fail when the index is out of bounds. The value may be NULL. The returned value is owned
+ * by the caller and must be destroyed via `duckdb_v2_value_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the argument to get the value of.
+ * @param value Receives the constant value. Owned by the caller; destroy via `duckdb_v2_value_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_value(duckdb_v2_table_function_bind_info_handle info,
+                                                                         idx_t index, duckdb_v2_value_handle *value,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Declares one of the columns the function returns.
+ *
+ * Call this once per column, in order: the columns declared here are the columns of the table the function produces,
+ * and the vectors of the output chunk the exec callback fills follow the same order. At least one column must be
+ * declared. The type must be a fully defined concrete type; ANY is rejected, as a result column carries data. The name
+ * and type are borrowed and copied.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param name The name of the column. Borrowed and copied.
+ * @param type The type of the column. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_add_result_column(
+    duckdb_v2_table_function_bind_info_handle info, duckdb_v2_identifier_t name, duckdb_v2_logical_type_handle type,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the estimated number of rows the scan will produce.
+ *
+ * A convenience for the common case where the row count is already known at bind time; use
+ * `duckdb_v2_table_function_set_cardinality_callback()` instead when the estimate depends on state only available
+ * later. The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error.
+ * When both are provided the callback takes precedence.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param cardinality The estimated number of rows.
+ * @param is_exact Whether the estimate is exact, which also makes it an upper bound on the row count.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_set_cardinality(
+    duckdb_v2_table_function_bind_info_handle info, idx_t cardinality, bool is_exact, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_get_user_data(
+    duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_get_bind_data(
+    duckdb_v2_table_function_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's "global state" from the global init callback.
+ *
+ * The global state lives for the duration of the scan and is retrievable from the local init, exec and progress
+ * callbacks. Every thread scanning the function shares it, so the function must synchronize its own access to it. The
+ * opaque handle bundles the pointer with an optional destructor, invoked when the scan is done with the state.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Opaque handle bundling the global state pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_set_global_state(
+    duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets how many threads may scan the function in parallel.
+ *
+ * Defaults to 1, a single-threaded scan. The engine creates at most this many local states, and therefore runs at most
+ * this many exec callbacks concurrently. It is an upper bound, not a request: the engine may use fewer threads.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param max_threads The maximum number of threads. Must be at least 1.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_global_set_max_threads(
+    duckdb_v2_table_function_init_global_info_handle info, idx_t max_threads, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_user_data(
+    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_bind_data(
+    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * Shared with every other thread scanning the function; access to it must be synchronized by the function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_global_state(
+    duckdb_v2_table_function_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's worker-local "local state" from the local init callback.
+ *
+ * The local state is associated with the executing thread for the duration of the scan and retrievable from the exec
+ * callback via `duckdb_v2_table_function_exec_get_local_state()`. No other thread observes it, so it needs no
+ * synchronization. The opaque handle bundles the pointer with an optional destructor, invoked when the local state is
+ * no longer needed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Opaque handle bundling the local state pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_set_local_state(
+    duckdb_v2_table_function_init_local_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_user_data(duckdb_v2_table_function_exec_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_bind_data(duckdb_v2_table_function_exec_info_handle info,
+                                                                         void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * Shared with every other thread scanning the function; access to it must be synchronized by the function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_global_state(
+    duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the worker-local local state set by the function's local init callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the local state pointer for the executing thread, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_local_state(
+    duckdb_v2_table_function_exec_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the output chunk the exec callback must write the next batch of rows into.
+ *
+ * The chunk holds one vector per column declared with `duckdb_v2_table_function_bind_add_result_column()`, in the same
+ * order; reach them with `duckdb_v2_data_chunk_get_vector()`. The chunk starts out empty on every invocation: write the
+ * rows, then declare how many there are with `duckdb_v2_vector_set_size()` on the first vector, which the engine takes
+ * as the batch's row count and propagates to the other vectors. Producing an empty batch signals the end of the scan,
+ * after which the callback is not invoked again on that thread. Borrowed; valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param chunk Receives the borrowed output chunk to write into.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR
+duckdb_v2_table_function_exec_get_output_chunk(duckdb_v2_table_function_exec_info_handle info,
+                                               duckdb_v2_data_chunk_handle *chunk, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The cardinality info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_cardinality_get_user_data(
+    duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The cardinality info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_cardinality_get_bind_data(
+    duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reports the estimated number of rows the scan will produce.
+ *
+ * The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error. A
+ * cardinality callback that returns without calling this reports no estimate at all, leaving the optimizer to fall back
+ * on its own defaults.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The cardinality info handle.
+ * @param cardinality The estimated number of rows.
+ * @param is_exact Whether the estimate is exact, which also makes it an upper bound on the row count.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_cardinality_set_cardinality(
+    duckdb_v2_table_function_cardinality_info_handle info, idx_t cardinality, bool is_exact,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_user_data(
+    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_bind_data(
+    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * The progress callback runs concurrently with the exec callbacks scanning the function, so it must read the global
+ * state in a thread-safe way.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_global_state(
+    duckdb_v2_table_function_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reports how far the scan has advanced.
+ *
+ * A fraction between 0.0 (nothing scanned yet) and 1.0 (done); values outside that range are clamped. A progress
+ * callback that returns without calling this reports no progress.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param progress The fraction of the scan that is complete, in [0.0, 1.0].
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_progress_set_progress(
+    duckdb_v2_table_function_progress_info_handle info, double progress, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Registers the table function, making it available for use in SQL queries.
+ *
+ * The function is registered on the target given at creation: the connection's database or the loading extension.
+ * Registration requires a name, a bind callback and an exec callback, and rejects a signature that declares a return
+ * type, since a table function declares the columns it returns from its bind callback. The caller still owns the handle
+ * after registration and must destroy it with `duckdb_v2_table_function_destroy()`, which does not affect the
+ * registered function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to register.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_register(duckdb_v2_table_function_handle function,
+                                                               duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the table function, releasing its resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Destroying the handle after registration does not affect the registered function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_destroy(duckdb_v2_table_function_handle *function);
+
+/* --- Struct definitions for table --- */
+
+/* ============================================================================
  * MODULE: value
  * ============================================================================ */
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -5287,106 +5287,171 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_query_progress_destroy(duckdb_v2_query_pr
 /* --- Types for copy --- */
 
 /*!
- * An owned opaque handle to a custom copy function being built. Created with
- * `duckdb_v2_copy_function_create_with_connection()` or `duckdb_v2_copy_function_create_with_extension()`, configured
- * with the setter functions (e.g. `duckdb_v2_copy_function_set_name()`, `duckdb_v2_copy_function_set_batch_callback()`,
- * etc.), made available with `duckdb_v2_copy_function_register()`, and destroyed with
- * `duckdb_v2_copy_function_destroy()`.
+ * An owned opaque handle to a custom copy function being built: an output format for `COPY ... TO`, an input format for
+ * `COPY ... FROM`, or both. Created with `duckdb_v2_copy_function_create_with_connection()` or
+ * `duckdb_v2_copy_function_create_with_extension()`, configured with the setter functions (e.g.
+ * `duckdb_v2_copy_function_set_name()`, `duckdb_v2_copy_to_set_batch_callback()`,
+ * `duckdb_v2_copy_from_set_exec_callback()`, etc.), made available with `duckdb_v2_copy_function_register()`, and
+ * destroyed with `duckdb_v2_copy_function_destroy()`.
  */
 typedef struct _duckdb_v2_copy_function {
 	void *internal_ptr;
 } * duckdb_v2_copy_function_handle;
 
 /*!
- * A borrowed opaque handle to the arguments supplied to a copy function during the query preparation "bind" phase. The
- * "bind" callback receives this handle and can use it to e.g. inspect the names and types of the columns being copied
- * and initialize some constant state.
+ * A borrowed opaque handle to the arguments supplied to a copy function during the query preparation "bind" phase of a
+ * `COPY ... TO` statement. The "bind" callback receives this handle and can use it to e.g. inspect the names and types
+ * of the columns being written, read the statement's options and initialize some constant state.
  */
-typedef struct _duckdb_v2_copy_function_bind_info {
+typedef struct _duckdb_v2_copy_to_bind_info {
 	void *internal_ptr;
-} * duckdb_v2_copy_function_bind_info_handle;
+} * duckdb_v2_copy_to_bind_info_handle;
 
 /*!
- * A borrowed opaque handle to the arguments supplied to a copy function during the per-file "init" phase. The "init"
- * callback receives this handle and can use it to e.g. read the path of the file being written and set up the state
- * shared by every batch written to that file.
+ * A borrowed opaque handle to the arguments supplied to a copy function during the "batch size" phase of a `COPY ...
+ * TO` statement. The "batch size" callback receives this handle and must use it to report how many rows a batch should
+ * carry.
  */
-typedef struct _duckdb_v2_copy_function_init_info {
+typedef struct _duckdb_v2_copy_to_batch_size_info {
 	void *internal_ptr;
-} * duckdb_v2_copy_function_init_info_handle;
+} * duckdb_v2_copy_to_batch_size_info_handle;
 
 /*!
- * A borrowed opaque handle to the arguments supplied to a copy function during the "batch" phase. The "batch" callback
- * receives this handle and can use it to take ownership of the rows of the batch and to set the prepared form of the
- * batch handed to the "flush" callback.
+ * A borrowed opaque handle to the arguments supplied to a copy function during the per-file "init" phase of a `COPY ...
+ * TO` statement. The "init" callback receives this handle and can use it to e.g. read the path of the file being
+ * written and set up the state shared by every batch written to that file.
  */
-typedef struct _duckdb_v2_copy_function_batch_info {
+typedef struct _duckdb_v2_copy_to_init_info {
 	void *internal_ptr;
-} * duckdb_v2_copy_function_batch_info_handle;
+} * duckdb_v2_copy_to_init_info_handle;
 
 /*!
- * A borrowed opaque handle to the arguments supplied to a copy function during the "flush" phase. The "flush" callback
- * receives this handle and can use it to access the prepared batch and write it to the output.
+ * A borrowed opaque handle to the arguments supplied to a copy function during the "batch" phase of a `COPY ... TO`
+ * statement. The "batch" callback receives this handle and can use it to take ownership of the rows of the batch and to
+ * set the prepared form of the batch handed to the "flush" callback.
  */
-typedef struct _duckdb_v2_copy_function_flush_info {
+typedef struct _duckdb_v2_copy_to_batch_info {
 	void *internal_ptr;
-} * duckdb_v2_copy_function_flush_info_handle;
+} * duckdb_v2_copy_to_batch_info_handle;
 
 /*!
- * A borrowed opaque handle to the arguments supplied to a copy function during the "batch size" phase. The "batch size"
- * callback receives this handle and must use it to report how many rows a batch should carry.
+ * A borrowed opaque handle to the arguments supplied to a copy function during the "flush" phase of a `COPY ... TO`
+ * statement. The "flush" callback receives this handle and can use it to access the prepared batch and write it to the
+ * output.
  */
-typedef struct _duckdb_v2_copy_function_batch_size_info {
+typedef struct _duckdb_v2_copy_to_flush_info {
 	void *internal_ptr;
-} * duckdb_v2_copy_function_batch_size_info_handle;
+} * duckdb_v2_copy_to_flush_info_handle;
 
 /*!
- * A borrowed opaque handle to the arguments supplied to a copy function during the per-file "finalize" phase. The
- * "finalize" callback receives this handle and can use it to e.g. close the file after every batch has been flushed to
- * it.
+ * A borrowed opaque handle to the arguments supplied to a copy function during the per-file "finalize" phase of a `COPY
+ * ... TO` statement. The "finalize" callback receives this handle and can use it to e.g. close the file after every
+ * batch has been flushed to it.
  */
-typedef struct _duckdb_v2_copy_function_finalize_info {
+typedef struct _duckdb_v2_copy_to_finalize_info {
 	void *internal_ptr;
-} * duckdb_v2_copy_function_finalize_info_handle;
+} * duckdb_v2_copy_to_finalize_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the query preparation "bind" phase of a
+ * `COPY ... FROM` statement. The "bind" callback receives this handle and can use it to e.g. read the path of the file
+ * to read, inspect the names and types of the columns the target table expects, read the statement's options, hint at
+ * the number of rows the read will produce and initialize some constant state.
+ */
+typedef struct _duckdb_v2_copy_from_bind_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_from_bind_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the global state initialization "init
+ * global" phase of a `COPY ... FROM` statement. The "init global" callback receives this handle and can use it to e.g.
+ * set up the state shared by every thread reading the file, and to declare how many threads may read it.
+ */
+typedef struct _duckdb_v2_copy_from_init_global_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_from_init_global_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the local state initialization "init
+ * local" phase of a `COPY ... FROM` statement. The "init local" callback receives this handle and can use it to e.g.
+ * set up worker-local state, typically by claiming work from the shared global state.
+ */
+typedef struct _duckdb_v2_copy_from_init_local_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_from_init_local_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the execution "exec" phase of a `COPY
+ * ... FROM` statement. The "exec" callback receives this handle and can use it to e.g. access the global and local
+ * state and write the next batch of rows to the output chunk.
+ */
+typedef struct _duckdb_v2_copy_from_exec_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_from_exec_info_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a copy function during the "progress" phase of a `COPY ...
+ * FROM` statement. The "progress" callback receives this handle and can use it to report how far the read has advanced.
+ */
+typedef struct _duckdb_v2_copy_from_progress_info {
+	void *internal_ptr;
+} * duckdb_v2_copy_from_progress_info_handle;
 
 /* --- Constants for copy --- */
 
 /* --- Function pointer typedefs for copy --- */
 
-typedef void (*duckdb_v2_copy_function_bind_callback_fn)(duckdb_v2_copy_function_bind_info_handle info,
+typedef void (*duckdb_v2_copy_to_bind_callback_fn)(duckdb_v2_copy_to_bind_info_handle info,
+                                                   duckdb_v2_context_handle context, duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_to_batch_size_callback_fn)(duckdb_v2_copy_to_batch_size_info_handle info,
                                                          duckdb_v2_context_handle context,
                                                          duckdb_v2_error_info_handle *err);
 
-typedef void (*duckdb_v2_copy_function_init_callback_fn)(duckdb_v2_copy_function_init_info_handle info,
+typedef void (*duckdb_v2_copy_to_init_callback_fn)(duckdb_v2_copy_to_init_info_handle info,
+                                                   duckdb_v2_context_handle context, duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_to_batch_callback_fn)(duckdb_v2_copy_to_batch_info_handle info,
+                                                    duckdb_v2_context_handle context, duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_to_flush_callback_fn)(duckdb_v2_copy_to_flush_info_handle info,
+                                                    duckdb_v2_context_handle context, duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_to_finalize_callback_fn)(duckdb_v2_copy_to_finalize_info_handle info,
+                                                       duckdb_v2_context_handle context,
+                                                       duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_from_bind_callback_fn)(duckdb_v2_copy_from_bind_info_handle info,
+                                                     duckdb_v2_context_handle context,
+                                                     duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_from_init_global_callback_fn)(duckdb_v2_copy_from_init_global_info_handle info,
+                                                            duckdb_v2_context_handle context,
+                                                            duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_from_init_local_callback_fn)(duckdb_v2_copy_from_init_local_info_handle info,
+                                                           duckdb_v2_context_handle context,
+                                                           duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_from_exec_callback_fn)(duckdb_v2_copy_from_exec_info_handle info,
+                                                     duckdb_v2_context_handle context,
+                                                     duckdb_v2_error_info_handle *err);
+
+typedef void (*duckdb_v2_copy_from_progress_callback_fn)(duckdb_v2_copy_from_progress_info_handle info,
                                                          duckdb_v2_context_handle context,
                                                          duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_copy_function_batch_callback_fn)(duckdb_v2_copy_function_batch_info_handle info,
-                                                          duckdb_v2_context_handle context,
-                                                          duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_copy_function_flush_callback_fn)(duckdb_v2_copy_function_flush_info_handle info,
-                                                          duckdb_v2_context_handle context,
-                                                          duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_copy_function_batch_size_callback_fn)(duckdb_v2_copy_function_batch_size_info_handle info,
-                                                               duckdb_v2_context_handle context,
-                                                               duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_copy_function_finalize_callback_fn)(duckdb_v2_copy_function_finalize_info_handle info,
-                                                             duckdb_v2_context_handle context,
-                                                             duckdb_v2_error_info_handle *err);
 
 /* --- Functions for copy --- */
 
 /*!
  * Creates a new copy function that will be registered on the connection's database.
  *
- * A copy function implements an output format for `COPY ... TO`: once registered, SQL reaches it with `COPY ... TO
- * 'path' (FORMAT name)`. The function starts out empty: configure it with the setter functions (e.g.
- * `duckdb_v2_copy_function_set_name()`, `duckdb_v2_copy_function_set_batch_callback()`, etc.), then make it available
- * with `duckdb_v2_copy_function_register()`. The caller owns the returned handle and must destroy it with
- * `duckdb_v2_copy_function_destroy()`, also after registration.
+ * A copy function implements a file format for `COPY`: once registered, SQL reaches it with `COPY ... TO 'path' (FORMAT
+ * name)` and `COPY table FROM 'path' (FORMAT name)`. The function starts out empty: configure it with the setter
+ * functions (e.g. `duckdb_v2_copy_function_set_name()`, the `copy_to_set_*` callbacks for writing, the
+ * `copy_from_set_*` callbacks for reading, or both), then make it available with `duckdb_v2_copy_function_register()`.
+ * The caller owns the returned handle and must destroy it with `duckdb_v2_copy_function_destroy()`, also after
+ * registration.
  *
  * history:
  * - stable: v2.0.0
@@ -5404,11 +5469,12 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_create_with_connection(duck
 /*!
  * Creates a new copy function that will be registered on the loading extension's database.
  *
- * Use this from an extension load callback, where an extension handle is available. The function starts out empty:
- * configure it with the setter functions (e.g. `duckdb_v2_copy_function_set_name()`,
- * `duckdb_v2_copy_function_set_batch_callback()`, etc.), then make it available with
- * `duckdb_v2_copy_function_register()`. The caller owns the returned handle and must destroy it with
- * `duckdb_v2_copy_function_destroy()`, also after registration.
+ * A copy function implements a file format for `COPY`: once registered, SQL reaches it with `COPY ... TO 'path' (FORMAT
+ * name)` and `COPY table FROM 'path' (FORMAT name)`. Use this from an extension load callback, where an extension
+ * handle is available. The function starts out empty: configure it with the setter functions (e.g.
+ * `duckdb_v2_copy_function_set_name()`, the `copy_to_set_*` callbacks for writing, the `copy_from_set_*` callbacks for
+ * reading, or both), then make it available with `duckdb_v2_copy_function_register()`. The caller owns the returned
+ * handle and must destroy it with `duckdb_v2_copy_function_destroy()`, also after registration.
  *
  * history:
  * - stable: v2.0.0
@@ -5426,8 +5492,9 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_create_with_extension(duckd
 /*!
  * Sets the name of the copy function.
  *
- * The name is the format SQL selects the function with: `COPY ... TO 'path' (FORMAT name)`. It is borrowed and copied.
- * Calling this again replaces the previous name. A name must be set before registration.
+ * The name is the format SQL selects the function with: `COPY ... TO 'path' (FORMAT name)` or `COPY table FROM 'path'
+ * (FORMAT name)`. It is borrowed and copied. Calling this again replaces the previous name. A name must be set before
+ * registration.
  *
  * history:
  * - stable: v2.0.0
@@ -5444,9 +5511,9 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_name(duckdb_v2_copy_fun
 /*!
  * Sets arbitrary user data on the copy function.
  *
- * Associates an opaque pointer with the function, retrievable from each callback via its user data accessor (e.g.
- * `duckdb_v2_copy_function_bind_get_user_data()`, `duckdb_v2_copy_function_batch_get_user_data()`, etc.). The opaque
- * handle bundles the pointer with an optional destructor, invoked when the data is no longer needed.
+ * Associates an opaque pointer with the function, retrievable from each callback of either side via its user data
+ * accessor (e.g. `duckdb_v2_copy_to_bind_get_user_data()`, `duckdb_v2_copy_from_exec_get_user_data()`, etc.). The
+ * opaque handle bundles the pointer with an optional destructor, invoked when the data is no longer needed.
  *
  * history:
  * - stable: v2.0.0
@@ -5462,112 +5529,113 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_user_data(duckdb_v2_cop
                                                                    duckdb_v2_error_info_handle *err);
 
 /*!
- * Sets the optional batch size callback of the copy function.
+ * Sets the optional bind callback of the `COPY ... TO` side.
+ *
+ * The bind callback is invoked during query planning for each `COPY ... TO` statement that uses the function. It can
+ * inspect the names and types of the columns being written, read the statement's options and set "bind data" that is
+ * shared with the other `COPY ... TO` callbacks.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_set_bind_callback(duckdb_v2_copy_function_handle function,
+                                                                 duckdb_v2_copy_to_bind_callback_fn callback,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional batch size callback of the `COPY ... TO` side.
  *
  * The batch size callback is invoked during query planning, after the bind callback, for each `COPY ... TO` statement
  * that does not set `BATCH_SIZE` itself. It must report how many rows a batch should carry via
- * `duckdb_v2_copy_function_batch_size_set_target()`; the engine then cuts the rows being copied into batches of that
- * size and hands each to the batch callback. Without a batch size from either the statement or the callback, a batch is
- * cut for every chunk of rows sunk, i.e. a vector at a time. A batch may still be smaller than the reported size (the
- * last one of a file, or when `BATCH_SIZE_BYTES` cuts it first).
+ * `duckdb_v2_copy_to_batch_size_set_target()`; the engine then cuts the rows being written into batches of that size
+ * and hands each to the batch callback. Without a batch size from either the statement or the callback, a batch is cut
+ * for every chunk of rows sunk, i.e. a vector at a time. A batch may still be smaller than the reported size (the last
+ * one of a file, or when `BATCH_SIZE_BYTES` cuts it first).
  *
  * history:
  * - stable: v2.0.0
  *
- * @param function The function to set the batch size callback of.
- * @param callback The batch size callback to set.
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_batch_size_callback(
-    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_size_callback_fn callback,
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_set_batch_size_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_to_batch_size_callback_fn callback,
     duckdb_v2_error_info_handle *err);
 
 /*!
- * Sets the optional bind callback of the copy function.
- *
- * The bind callback is invoked during query planning for each `COPY ... TO` statement that uses the function. It can
- * inspect the names and types of the columns being copied and set "bind data" that is shared with the other callbacks.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the bind callback of.
- * @param callback The bind callback to set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_bind_callback(
-    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_bind_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
-
-/*!
- * Sets the optional init callback of the copy function.
+ * Sets the optional init callback of the `COPY ... TO` side.
  *
  * The init callback is invoked once per output file, before any batch destined for that file is prepared. It can read
- * the path of the file via `duckdb_v2_copy_function_init_get_file_path()`, which is only available here, and set "init
- * data" that is shared with the batch, flush and finalize callbacks of that file. A statement may write several files,
- * e.g. when its output is partitioned; each gets its own init data.
+ * the path of the file via `duckdb_v2_copy_to_init_get_file_path()` and set "init data" that is shared with the batch,
+ * flush and finalize callbacks of that file. A statement may write several files, e.g. when its output is partitioned;
+ * each gets its own init data.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param function The function to set the init callback of.
- * @param callback The init callback to set.
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_init_callback(
-    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_init_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_set_init_callback(duckdb_v2_copy_function_handle function,
+                                                                 duckdb_v2_copy_to_init_callback_fn callback,
+                                                                 duckdb_v2_error_info_handle *err);
 
 /*!
- * Sets the batch callback of the copy function.
+ * Sets the batch callback of the `COPY ... TO` side.
  *
- * The batch callback is invoked during query execution with a batch of the rows being copied, taken via
- * `duckdb_v2_copy_function_batch_take_input()`. It prepares the batch for writing, e.g. by encoding it into the output
- * format, and sets "batch data" via `duckdb_v2_copy_function_batch_set_batch_data()` that is handed to the flush
- * callback. Batches may be prepared by several threads at once, so the callback must synchronize its own access to the
- * init data. A batch callback must be set before registration.
+ * The batch callback is invoked during query execution with a batch of the rows being written, taken via
+ * `duckdb_v2_copy_to_batch_take_input()`. It prepares the batch for writing, e.g. by encoding it into the output
+ * format, and sets "batch data" via `duckdb_v2_copy_to_batch_set_batch_data()` that is handed to the flush callback.
+ * Batches may be prepared by several threads at once, so the callback must synchronize its own access to the init data.
+ * A batch callback must be set for the `COPY ... TO` side to be registered.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param function The function to set the batch callback of.
- * @param callback The batch callback to set.
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_batch_callback(
-    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_batch_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_set_batch_callback(duckdb_v2_copy_function_handle function,
+                                                                  duckdb_v2_copy_to_batch_callback_fn callback,
+                                                                  duckdb_v2_error_info_handle *err);
 
 /*!
- * Sets the flush callback of the copy function.
+ * Sets the flush callback of the `COPY ... TO` side.
  *
  * The flush callback is invoked once per prepared batch to write its batch data, available via
- * `duckdb_v2_copy_function_flush_get_batch_data()`, to the output. Flushes of the same file never run concurrently. A
- * flush callback must be set before registration.
+ * `duckdb_v2_copy_to_flush_get_batch_data()`, to the output. Flushes of the same file never run concurrently. A flush
+ * callback must be set for the `COPY ... TO` side to be registered.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param function The function to set the flush callback of.
- * @param callback The flush callback to set.
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_flush_callback(
-    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_flush_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_set_flush_callback(duckdb_v2_copy_function_handle function,
+                                                                  duckdb_v2_copy_to_flush_callback_fn callback,
+                                                                  duckdb_v2_error_info_handle *err);
 
 /*!
- * Sets the optional finalize callback of the copy function.
+ * Sets the optional finalize callback of the `COPY ... TO` side.
  *
  * The finalize callback is invoked once per output file after the last batch destined for that file has been flushed.
  * It can e.g. write a footer and close the file.
@@ -5575,15 +5643,15 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_flush_callback(
  * history:
  * - stable: v2.0.0
  *
- * @param function The function to set the finalize callback of.
- * @param callback The finalize callback to set.
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_finalize_callback(
-    duckdb_v2_copy_function_handle function, duckdb_v2_copy_function_finalize_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_set_finalize_callback(duckdb_v2_copy_function_handle function,
+                                                                     duckdb_v2_copy_to_finalize_callback_fn callback,
+                                                                     duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
@@ -5597,15 +5665,15 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_set_finalize_callback(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_user_data(duckdb_v2_copy_function_bind_info_handle info,
-                                                                        void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_user_data(duckdb_v2_copy_to_bind_info_handle info, void **data,
+                                                                  duckdb_v2_error_info_handle *err);
 
 /*!
  * Sets the function's "bind data" from the bind callback.
  *
- * The bind data is stored with the bound statement and retrievable from the other callbacks. The opaque handle bundles
- * the pointer with an optional destructor, invoked when the bind data is no longer needed, and an optional equality
- * callback used when comparing two bound statements; without one, pointer equality is used.
+ * The bind data is stored with the bound statement and retrievable from the other callbacks of the same side. The
+ * opaque handle bundles the pointer with an optional destructor, invoked when the bind data is no longer needed, and an
+ * optional equality callback used when comparing two bound statements; without one, pointer equality is used.
  *
  * history:
  * - stable: v2.0.0
@@ -5616,15 +5684,35 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_user_data(duckdb_v
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_set_bind_data(duckdb_v2_copy_function_bind_info_handle info,
-                                                                        duckdb_v2_opaque *data,
-                                                                        duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_set_bind_data(duckdb_v2_copy_to_bind_info_handle info,
+                                                                  duckdb_v2_opaque *data,
+                                                                  duckdb_v2_error_info_handle *err);
 
 /*!
- * Returns the number of columns being copied.
+ * Retrieves the path the `COPY ... TO` statement writes to, as written in the statement.
  *
- * This is the number of columns of the rows every batch carries. Valid indices for
- * `duckdb_v2_copy_function_bind_get_column_type()` and `duckdb_v2_copy_function_bind_get_column_name()` are [0, count).
+ * This is the target before the engine's own rewrites: the path of each file actually being written, e.g. a temporary
+ * name or a per-partition path, is only known to the init callback via `duckdb_v2_copy_to_init_get_file_path()`. The
+ * path is borrowed and valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param path Receives a borrowed view of the file path. Valid only for the duration of the callback.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_file_path(duckdb_v2_copy_to_bind_info_handle info,
+                                                                  duckdb_v2_str *path,
+                                                                  duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of columns being written, i.e. the columns of the rows every batch carries.
+ *
+ * Valid indices for `duckdb_v2_copy_to_bind_get_column_type()` and `duckdb_v2_copy_to_bind_get_column_name()` are [0,
+ * count).
  *
  * history:
  * - stable: v2.0.0
@@ -5635,8 +5723,8 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_set_bind_data(duckdb_v
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_count(
-    duckdb_v2_copy_function_bind_info_handle info, idx_t *count, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_column_count(duckdb_v2_copy_to_bind_info_handle info,
+                                                                     idx_t *count, duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the type of the column at the given index.
@@ -5654,10 +5742,9 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_count(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_type(duckdb_v2_copy_function_bind_info_handle info,
-                                                                          idx_t index,
-                                                                          duckdb_v2_logical_type_handle *type,
-                                                                          duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_column_type(duckdb_v2_copy_to_bind_info_handle info,
+                                                                    idx_t index, duckdb_v2_logical_type_handle *type,
+                                                                    duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the name of the column at the given index.
@@ -5674,9 +5761,70 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_type(duckdb
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_name(duckdb_v2_copy_function_bind_info_handle info,
-                                                                          idx_t index, duckdb_v2_identifier_t *name,
-                                                                          duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_column_name(duckdb_v2_copy_to_bind_info_handle info,
+                                                                    idx_t index, duckdb_v2_identifier_t *name,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of options the `COPY` statement passed to the function.
+ *
+ * The engine's own options (e.g. `USE_TMP_FILE` or `BATCH_SIZE`) are handled before the function sees the statement and
+ * are not included. Valid indices for `duckdb_v2_copy_to_bind_get_option_name()` and
+ * `duckdb_v2_copy_to_bind_get_option_value()` are [0, count). The options are ordered by name.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param count Receives the number of options.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_option_count(duckdb_v2_copy_to_bind_info_handle info,
+                                                                     idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the name of the option at the given index.
+ *
+ * Option names are SQL identifiers, matched case-insensitively. Fails if the index is out of bounds. The name is
+ * borrowed and valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the option to get the name of.
+ * @param name Receives a borrowed view of the option name. Valid only for the duration of the callback.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_option_name(duckdb_v2_copy_to_bind_info_handle info,
+                                                                    idx_t index, duckdb_v2_identifier_t *name,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the value of the option at the given index.
+ *
+ * An option written with a single value (e.g. `DELIM ','`) yields that value. An option written as a bare name (e.g.
+ * `HEADER`) yields the BOOLEAN `true`. An option written with a parenthesized list (e.g. `KEYS (a, b)`) yields a tuple:
+ * an unnamed STRUCT with one field per element, in order. Fails if the index is out of bounds. The returned value is
+ * owned by the caller and must be destroyed via `duckdb_v2_value_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the option.
+ * @param value Receives the option's value. Owned by the caller; destroy via `duckdb_v2_value_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_option_value(duckdb_v2_copy_to_bind_info_handle info,
+                                                                     idx_t index, duckdb_v2_value_handle *value,
+                                                                     duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
@@ -5690,11 +5838,11 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_name(duckdb
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_user_data(
-    duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_size_get_user_data(duckdb_v2_copy_to_batch_size_info_handle info,
+                                                                        void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the bind data set by the function's bind callback.
+ * Retrieves the bind data set by the function's `COPY ... TO` bind callback.
  *
  * history:
  * - stable: v2.0.0
@@ -5705,8 +5853,8 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_user_data(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_bind_data(
-    duckdb_v2_copy_function_batch_size_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_size_get_bind_data(duckdb_v2_copy_to_batch_size_info_handle info,
+                                                                        void **data, duckdb_v2_error_info_handle *err);
 
 /*!
  * Sets the number of rows a batch should carry, as the target the engine cuts batches at. The batch size callback must
@@ -5721,8 +5869,8 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_bind_data(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_set_target(
-    duckdb_v2_copy_function_batch_size_info_handle info, idx_t rows, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_size_set_target(duckdb_v2_copy_to_batch_size_info_handle info,
+                                                                     idx_t rows, duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
@@ -5736,11 +5884,11 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_set_target(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_user_data(duckdb_v2_copy_function_init_info_handle info,
-                                                                        void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_init_get_user_data(duckdb_v2_copy_to_init_info_handle info, void **data,
+                                                                  duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the bind data set by the function's bind callback.
+ * Retrieves the bind data set by the function's `COPY ... TO` bind callback.
  *
  * history:
  * - stable: v2.0.0
@@ -5751,8 +5899,8 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_user_data(duckdb_v
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_bind_data(duckdb_v2_copy_function_init_info_handle info,
-                                                                        void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_init_get_bind_data(duckdb_v2_copy_to_init_info_handle info, void **data,
+                                                                  duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the path of the file the init callback is preparing.
@@ -5770,9 +5918,9 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_bind_data(duckdb_v
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_file_path(duckdb_v2_copy_function_init_info_handle info,
-                                                                        duckdb_v2_str *path,
-                                                                        duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_init_get_file_path(duckdb_v2_copy_to_init_info_handle info,
+                                                                  duckdb_v2_str *path,
+                                                                  duckdb_v2_error_info_handle *err);
 
 /*!
  * Sets the function's "init data" from the init callback.
@@ -5791,9 +5939,9 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_file_path(duckdb_v
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_set_init_data(duckdb_v2_copy_function_init_info_handle info,
-                                                                        duckdb_v2_opaque *data,
-                                                                        duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_init_set_init_data(duckdb_v2_copy_to_init_info_handle info,
+                                                                  duckdb_v2_opaque *data,
+                                                                  duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
@@ -5807,11 +5955,11 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_init_set_init_data(duckdb_v
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_user_data(duckdb_v2_copy_function_batch_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_get_user_data(duckdb_v2_copy_to_batch_info_handle info,
+                                                                   void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the bind data set by the function's bind callback.
+ * Retrieves the bind data set by the function's `COPY ... TO` bind callback.
  *
  * history:
  * - stable: v2.0.0
@@ -5822,11 +5970,11 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_user_data(duckdb_
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_bind_data(duckdb_v2_copy_function_batch_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_get_bind_data(duckdb_v2_copy_to_batch_info_handle info,
+                                                                   void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the init data set by the function's init callback for the file this batch belongs to.
+ * Retrieves the init data set by the function's `COPY ... TO` init callback for the file this batch belongs to.
  *
  * history:
  * - stable: v2.0.0
@@ -5837,13 +5985,13 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_bind_data(duckdb_
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_init_data(duckdb_v2_copy_function_batch_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_get_init_data(duckdb_v2_copy_to_batch_info_handle info,
+                                                                   void **data, duckdb_v2_error_info_handle *err);
 
 /*!
  * Takes ownership of the rows of the batch to prepare.
  *
- * The collection holds one column per column reported by `duckdb_v2_copy_function_bind_get_column_count()`, in the same
+ * The collection holds one column per column reported by `duckdb_v2_copy_to_bind_get_column_count()`, in the same
  * order, and can be scanned with `duckdb_v2_column_data_collection_scan()`. The batch can only be taken once: a second
  * call fails. Once taken, the caller owns the collection and must destroy it via
  * `duckdb_v2_column_data_collection_destroy()`, e.g. by keeping it as the batch data with that destructor. A batch that
@@ -5859,15 +6007,15 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_init_data(duckdb_
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_take_input(
-    duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_column_data_collection_handle *collection,
-    duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_take_input(duckdb_v2_copy_to_batch_info_handle info,
+                                                                duckdb_v2_column_data_collection_handle *collection,
+                                                                duckdb_v2_error_info_handle *err);
 
 /*!
  * Sets the prepared "batch data" from the batch callback.
  *
  * The batch data is the prepared form of the batch and is handed to the flush callback via
- * `duckdb_v2_copy_function_flush_get_batch_data()`. The opaque handle bundles the pointer with an optional destructor,
+ * `duckdb_v2_copy_to_flush_get_batch_data()`. The opaque handle bundles the pointer with an optional destructor,
  * invoked once the batch has been flushed.
  *
  * history:
@@ -5879,8 +6027,9 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_take_input(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_set_batch_data(
-    duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_set_batch_data(duckdb_v2_copy_to_batch_info_handle info,
+                                                                    duckdb_v2_opaque *data,
+                                                                    duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
@@ -5894,11 +6043,11 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_set_batch_data(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_user_data(duckdb_v2_copy_function_flush_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_flush_get_user_data(duckdb_v2_copy_to_flush_info_handle info,
+                                                                   void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the bind data set by the function's bind callback.
+ * Retrieves the bind data set by the function's `COPY ... TO` bind callback.
  *
  * history:
  * - stable: v2.0.0
@@ -5909,11 +6058,11 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_user_data(duckdb_
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_bind_data(duckdb_v2_copy_function_flush_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_flush_get_bind_data(duckdb_v2_copy_to_flush_info_handle info,
+                                                                   void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the init data set by the function's init callback for the file this batch belongs to.
+ * Retrieves the init data set by the function's `COPY ... TO` init callback for the file this batch belongs to.
  *
  * history:
  * - stable: v2.0.0
@@ -5924,8 +6073,8 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_bind_data(duckdb_
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_init_data(duckdb_v2_copy_function_flush_info_handle info,
-                                                                         void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_flush_get_init_data(duckdb_v2_copy_to_flush_info_handle info,
+                                                                   void **data, duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the batch data set by the function's batch callback for the batch being flushed.
@@ -5939,8 +6088,8 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_init_data(duckdb_
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_batch_data(
-    duckdb_v2_copy_function_flush_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_flush_get_batch_data(duckdb_v2_copy_to_flush_info_handle info,
+                                                                    void **data, duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
@@ -5954,11 +6103,11 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_batch_data(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_user_data(
-    duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_finalize_get_user_data(duckdb_v2_copy_to_finalize_info_handle info,
+                                                                      void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the bind data set by the function's bind callback.
+ * Retrieves the bind data set by the function's `COPY ... TO` bind callback.
  *
  * history:
  * - stable: v2.0.0
@@ -5969,11 +6118,11 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_user_data(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_bind_data(
-    duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_finalize_get_bind_data(duckdb_v2_copy_to_finalize_info_handle info,
+                                                                      void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the init data set by the function's init callback for the file being finalized.
+ * Retrieves the init data set by the function's `COPY ... TO` init callback for the file being finalized.
  *
  * history:
  * - stable: v2.0.0
@@ -5984,15 +6133,595 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_bind_data(
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_init_data(
-    duckdb_v2_copy_function_finalize_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_to_finalize_get_init_data(duckdb_v2_copy_to_finalize_info_handle info,
+                                                                      void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Registers the copy function, making it available as a `COPY ... TO` format.
+ * Sets the bind callback of the `COPY ... FROM` side.
+ *
+ * The bind callback is invoked during query planning for each `COPY ... FROM` statement that uses the function. It can
+ * read the path of the file to read and the statement's options, inspect the names and types of the columns the target
+ * table expects, hint at the number of rows the read will produce, and set "bind data" that is shared with the other
+ * `COPY ... FROM` callbacks. The columns are fixed by the target table: the function must produce them as they are. A
+ * bind callback must be set for the `COPY ... FROM` side to be registered.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_set_bind_callback(duckdb_v2_copy_function_handle function,
+                                                                   duckdb_v2_copy_from_bind_callback_fn callback,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional global init callback of the `COPY ... FROM` side.
+ *
+ * The global init callback is invoked once per statement, at the start of execution. It can set "global state" shared
+ * by every thread reading the file, and declare how many threads may read it in parallel via
+ * `duckdb_v2_copy_from_init_global_set_max_threads()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_set_init_global_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_init_global_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional local init callback of the `COPY ... FROM` side.
+ *
+ * The local init callback is invoked once per thread that will read the file. It can set worker-local "local state",
+ * retrievable from the exec callback, typically derived from the shared global state.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_set_init_local_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_init_local_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the exec callback of the `COPY ... FROM` side.
+ *
+ * The exec callback implements the read: it is invoked repeatedly during query execution and writes the next batch of
+ * rows to the output chunk, until it produces an empty batch to signal the end of the read. An exec callback must be
+ * set for the `COPY ... FROM` side to be registered.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_set_exec_callback(duckdb_v2_copy_function_handle function,
+                                                                   duckdb_v2_copy_from_exec_callback_fn callback,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the optional progress callback of the `COPY ... FROM` side.
+ *
+ * The progress callback is invoked on demand during execution to report how far the read has advanced, which the engine
+ * surfaces as the query's progress. It is invoked concurrently with the exec callback, so it must read the global state
+ * in a thread-safe way.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param function The function to set the callback of.
+ * @param callback The callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_set_progress_callback(
+    duckdb_v2_copy_function_handle function, duckdb_v2_copy_from_progress_callback_fn callback,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_user_data(duckdb_v2_copy_from_bind_info_handle info,
+                                                                    void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's "bind data" from the bind callback.
+ *
+ * The bind data is stored with the bound statement and retrievable from the other callbacks of the same side. The
+ * opaque handle bundles the pointer with an optional destructor, invoked when the bind data is no longer needed, and an
+ * optional equality callback used when comparing two bound statements; without one, pointer equality is used.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param data Opaque handle bundling the bind data pointer plus optional destructor and equality callbacks.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_set_bind_data(duckdb_v2_copy_from_bind_info_handle info,
+                                                                    duckdb_v2_opaque *data,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the path the `COPY ... FROM` statement reads from, as written in the statement.
+ *
+ * The engine does not expand globs or check that the file exists; both are left to the function. The path is borrowed
+ * and valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param path Receives a borrowed view of the file path. Valid only for the duration of the callback.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_file_path(duckdb_v2_copy_from_bind_info_handle info,
+                                                                    duckdb_v2_str *path,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of columns the target table expects, i.e. the columns every batch the exec callback produces must
+ * carry, in this order.
+ *
+ * Valid indices for `duckdb_v2_copy_from_bind_get_column_type()` and `duckdb_v2_copy_from_bind_get_column_name()` are
+ * [0, count).
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param count Receives the number of columns.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_column_count(duckdb_v2_copy_from_bind_info_handle info,
+                                                                       idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the type of the column at the given index.
+ *
+ * Fails if the index is out of bounds. The returned type is owned by the caller and must be destroyed via
+ * `duckdb_v2_logical_type_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the column to get the type of.
+ * @param type Receives the column type. Owned by the caller; destroy via `duckdb_v2_logical_type_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_column_type(duckdb_v2_copy_from_bind_info_handle info,
+                                                                      idx_t index, duckdb_v2_logical_type_handle *type,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the name of the column at the given index.
+ *
+ * Fails if the index is out of bounds. The name is borrowed and valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the column to get the name of.
+ * @param name Receives a borrowed view of the column name. Valid only for the duration of the callback.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_column_name(duckdb_v2_copy_from_bind_info_handle info,
+                                                                      idx_t index, duckdb_v2_identifier_t *name,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of options the `COPY` statement passed to the function.
+ *
+ * Every option other than `FORMAT` is included. Valid indices for `duckdb_v2_copy_from_bind_get_option_name()` and
+ * `duckdb_v2_copy_from_bind_get_option_value()` are [0, count). The options are ordered by name.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param count Receives the number of options.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_option_count(duckdb_v2_copy_from_bind_info_handle info,
+                                                                       idx_t *count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the name of the option at the given index.
+ *
+ * Option names are SQL identifiers, matched case-insensitively. Fails if the index is out of bounds. The name is
+ * borrowed and valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the option to get the name of.
+ * @param name Receives a borrowed view of the option name. Valid only for the duration of the callback.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_option_name(duckdb_v2_copy_from_bind_info_handle info,
+                                                                      idx_t index, duckdb_v2_identifier_t *name,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the value of the option at the given index.
+ *
+ * An option written with a single value (e.g. `DELIM ','`) yields that value. An option written as a bare name (e.g.
+ * `HEADER`) yields the BOOLEAN `true`. An option written with a parenthesized list (e.g. `KEYS (a, b)`) yields a tuple:
+ * an unnamed STRUCT with one field per element, in order. Fails if the index is out of bounds. The returned value is
+ * owned by the caller and must be destroyed via `duckdb_v2_value_destroy()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param index The index of the option.
+ * @param value Receives the option's value. Owned by the caller; destroy via `duckdb_v2_value_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_option_value(duckdb_v2_copy_from_bind_info_handle info,
+                                                                       idx_t index, duckdb_v2_value_handle *value,
+                                                                       duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reports the estimated number of rows the read will produce.
+ *
+ * The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error. Without
+ * it, the optimizer falls back on its own defaults.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The bind info handle.
+ * @param cardinality The estimated number of rows.
+ * @param is_exact Whether the estimate is exact, which also makes it an upper bound on the row count.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_set_cardinality(duckdb_v2_copy_from_bind_info_handle info,
+                                                                      idx_t cardinality, bool is_exact,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_init_global_get_user_data(
+    duckdb_v2_copy_from_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's `COPY ... FROM` bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_init_global_get_bind_data(
+    duckdb_v2_copy_from_init_global_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's "global state" from the global init callback.
+ *
+ * The global state lives for the duration of the read and is retrievable from the local init, exec and progress
+ * callbacks. Every thread reading the file shares it, so the function must synchronize its own access to it. The opaque
+ * handle bundles the pointer with an optional destructor, invoked when the read is done with the state.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param data Opaque handle bundling the global state pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_init_global_set_global_state(
+    duckdb_v2_copy_from_init_global_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets how many threads may read the file in parallel.
+ *
+ * Defaults to 1, a single-threaded read. The engine creates at most this many local states, and therefore runs at most
+ * this many exec callbacks concurrently. It is an upper bound, not a request: the engine may use fewer threads.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The global init info handle.
+ * @param max_threads The maximum number of threads. Must be at least 1.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_init_global_set_max_threads(
+    duckdb_v2_copy_from_init_global_info_handle info, idx_t max_threads, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_init_local_get_user_data(
+    duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's `COPY ... FROM` bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_init_local_get_bind_data(
+    duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * Shared with every other thread reading the file; access to it must be synchronized by the function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_init_local_get_global_state(
+    duckdb_v2_copy_from_init_local_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the function's worker-local "local state" from the local init callback.
+ *
+ * The local state is associated with the executing thread for the duration of the read and retrievable from the exec
+ * callback via `duckdb_v2_copy_from_exec_get_local_state()`. No other thread observes it, so it needs no
+ * synchronization. The opaque handle bundles the pointer with an optional destructor, invoked when the local state is
+ * no longer needed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The local init info handle.
+ * @param data Opaque handle bundling the local state pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_init_local_set_local_state(
+    duckdb_v2_copy_from_init_local_info_handle info, duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_user_data(duckdb_v2_copy_from_exec_info_handle info,
+                                                                    void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's `COPY ... FROM` bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_bind_data(duckdb_v2_copy_from_exec_info_handle info,
+                                                                    void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * Shared with every other thread reading the file; access to it must be synchronized by the function.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_global_state(duckdb_v2_copy_from_exec_info_handle info,
+                                                                       void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the worker-local local state set by the function's local init callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param data Receives the local state pointer for the executing thread, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_local_state(duckdb_v2_copy_from_exec_info_handle info,
+                                                                      void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the output chunk the exec callback must write the next batch of rows into.
+ *
+ * The chunk holds one vector per column reported by `duckdb_v2_copy_from_bind_get_column_count()`, in the same order;
+ * reach them with `duckdb_v2_data_chunk_get_vector()`. The chunk starts out empty on every invocation: write the rows,
+ * then declare how many there are with `duckdb_v2_vector_set_size()` on the first vector, which the engine takes as the
+ * batch's row count and propagates to the other vectors. Producing an empty batch signals the end of the read, after
+ * which the callback is not invoked again on that thread. Borrowed; valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The exec info handle.
+ * @param chunk Receives the borrowed output chunk to write into.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_output_chunk(duckdb_v2_copy_from_exec_info_handle info,
+                                                                       duckdb_v2_data_chunk_handle *chunk,
+                                                                       duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_copy_function_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_progress_get_user_data(duckdb_v2_copy_from_progress_info_handle info,
+                                                                        void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the bind data set by the function's `COPY ... FROM` bind callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the bind data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_progress_get_bind_data(duckdb_v2_copy_from_progress_info_handle info,
+                                                                        void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the global state set by the function's global init callback.
+ *
+ * The progress callback runs concurrently with the exec callbacks reading the file, so it must read the global state in
+ * a thread-safe way.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param data Receives the global state pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_progress_get_global_state(
+    duckdb_v2_copy_from_progress_info_handle info, void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reports how far the read has advanced.
+ *
+ * A fraction between 0.0 (nothing read yet) and 1.0 (done); values outside that range are clamped. A progress callback
+ * that returns without calling this reports no progress.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The progress info handle.
+ * @param progress The fraction of the read that is complete, in [0.0, 1.0].
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_copy_from_progress_set_progress(duckdb_v2_copy_from_progress_info_handle info,
+                                                                       double progress,
+                                                                       duckdb_v2_error_info_handle *err);
+
+/*!
+ * Registers the copy function, making it available as a `COPY` format.
  *
  * The function is registered on the target given at creation: the connection's database or the loading extension.
- * Registration requires a name and the batch and flush callbacks. The caller still owns the handle after registration
- * and must destroy it with `duckdb_v2_copy_function_destroy()`, which does not affect the registered function.
+ * Registration requires a name and at least one configured side: a `COPY ... TO` side needs its batch and flush
+ * callbacks, a `COPY ... FROM` side needs its bind and exec callbacks. A statement in a direction the function does not
+ * implement fails with an error. The caller still owns the handle after registration and must destroy it with
+ * `duckdb_v2_copy_function_destroy()`, which does not affect the registered function.
  *
  * history:
  * - stable: v2.0.0
@@ -7705,14 +8434,6 @@ typedef struct _duckdb_v2_table_function_exec_info {
 } * duckdb_v2_table_function_exec_info_handle;
 
 /*!
- * A borrowed opaque handle to the arguments supplied to a table function during the "cardinality" estimation phase. The
- * "cardinality" callback receives this handle and can use it to report how many rows the scan is expected to produce.
- */
-typedef struct _duckdb_v2_table_function_cardinality_info {
-	void *internal_ptr;
-} * duckdb_v2_table_function_cardinality_info_handle;
-
-/*!
  * A borrowed opaque handle to the arguments supplied to a table function during the "progress" phase. The "progress"
  * callback receives this handle and can use it to report how far the scan has advanced.
  */
@@ -7739,10 +8460,6 @@ typedef void (*duckdb_v2_table_function_init_local_callback_fn)(duckdb_v2_table_
 typedef void (*duckdb_v2_table_function_exec_callback_fn)(duckdb_v2_table_function_exec_info_handle info,
                                                           duckdb_v2_context_handle context,
                                                           duckdb_v2_error_info_handle *err);
-
-typedef void (*duckdb_v2_table_function_cardinality_callback_fn)(duckdb_v2_table_function_cardinality_info_handle info,
-                                                                 duckdb_v2_context_handle context,
-                                                                 duckdb_v2_error_info_handle *err);
 
 typedef void (*duckdb_v2_table_function_progress_callback_fn)(duckdb_v2_table_function_progress_info_handle info,
                                                               duckdb_v2_context_handle context,
@@ -7939,27 +8656,6 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_exec_callback(
     duckdb_v2_error_info_handle *err);
 
 /*!
- * Sets the optional cardinality callback of the table function.
- *
- * The cardinality callback is invoked during query optimization to estimate how many rows the scan will produce, which
- * the optimizer uses for cost-based decisions such as join ordering. It may be invoked more than once per plan, so it
- * should be cheap and free of side effects. Use `duckdb_v2_table_function_bind_set_cardinality()` instead when the row
- * count is already known at bind time; the callback takes precedence when both are provided.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param function The function to set the cardinality callback of.
- * @param callback The cardinality callback to set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_set_cardinality_callback(
-    duckdb_v2_table_function_handle function, duckdb_v2_table_function_cardinality_callback_fn callback,
-    duckdb_v2_error_info_handle *err);
-
-/*!
  * Sets the optional progress callback of the table function.
  *
  * The progress callback is invoked on demand during execution to report how far the scan has advanced, which the engine
@@ -8103,10 +8799,8 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_bind_add_result_column(
 /*!
  * Sets the estimated number of rows the scan will produce.
  *
- * A convenience for the common case where the row count is already known at bind time; use
- * `duckdb_v2_table_function_set_cardinality_callback()` instead when the estimate depends on state only available
- * later. The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error.
- * When both are provided the callback takes precedence.
+ * The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error. Without
+ * it, the optimizer falls back on its own defaults.
  *
  * history:
  * - stable: v2.0.0
@@ -8338,57 +9032,6 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_local_state(
 DUCKDB_C_API DUCKDB_V2_ERROR
 duckdb_v2_table_function_exec_get_output_chunk(duckdb_v2_table_function_exec_info_handle info,
                                                duckdb_v2_data_chunk_handle *chunk, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The cardinality info handle.
- * @param data Receives the user data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_cardinality_get_user_data(
-    duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the bind data set by the function's bind callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The cardinality info handle.
- * @param data Receives the bind data pointer, or null if none was set.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_cardinality_get_bind_data(
-    duckdb_v2_table_function_cardinality_info_handle info, void **data, duckdb_v2_error_info_handle *err);
-
-/*!
- * Reports the estimated number of rows the scan will produce.
- *
- * The estimate is a hint for the optimizer, not a limit: producing a different number of rows is not an error. A
- * cardinality callback that returns without calling this reports no estimate at all, leaving the optimizer to fall back
- * on its own defaults.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The cardinality info handle.
- * @param cardinality The estimated number of rows.
- * @param is_exact Whether the estimate is exact, which also makes it an upper bound on the row count.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_table_function_cardinality_set_cardinality(
-    duckdb_v2_table_function_cardinality_info_handle info, idx_t cardinality, bool is_exact,
-    duckdb_v2_error_info_handle *err);
 
 /*!
  * Retrieves the user data set via `duckdb_v2_table_function_set_user_data()`.

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -4697,15 +4697,31 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_aggregate_function_destroy(duckdb_v2_aggr
 /* --- Types for arrow --- */
 
 /*!
- * An owned, resolved interpretation of an ArrowSchema: the DuckDB logical type of every column plus the per-column
- * Arrow type information needed to import an array. Built once from an ArrowSchema with
- * `duckdb_v2_arrow_converter_create()` and reused across many arrays by `duckdb_v2_arrow_converter_array_to_chunk()`,
- * so a table function can resolve the schema at bind time and pay nothing per chunk. Read the resolved names and types
- * back with `duckdb_v2_arrow_converter_get_schema()`, and destroy with `duckdb_v2_arrow_converter_destroy()`.
+ * Converts Arrow arrays into DuckDB data chunks, against one resolved ArrowSchema. Create it with
+ * `duckdb_v2_arrow_importer_create()`, which resolves every column's DuckDB type once, so the same importer serves any
+ * number of arrays of that shape. `duckdb_v2_arrow_importer_get_schema()` reports the resolved DuckDB schema.
+ * `duckdb_v2_arrow_importer_append()` takes an array, `duckdb_v2_arrow_importer_next_chunk()` produces chunks from it,
+ * and `duckdb_v2_arrow_importer_destroy()` frees the importer.
+ *
+ * The importer borrows the context it was created with and must not outlive it. One array is in flight at a time, and
+ * an importer must not be used from two threads at once.
  */
-typedef struct _duckdb_v2_arrow_converter {
+typedef struct _duckdb_v2_arrow_importer {
 	void *internal_ptr;
-} * duckdb_v2_arrow_converter_handle;
+} * duckdb_v2_arrow_importer_handle;
+
+/*!
+ * Converts DuckDB data chunks into Arrow arrays, for one fixed list of columns. Create it with
+ * `duckdb_v2_arrow_exporter_create()`, which captures the session's Arrow settings and resolves the extension types
+ * once. `duckdb_v2_arrow_exporter_get_schema()` reports the Arrow schema. `duckdb_v2_arrow_exporter_append()` takes a
+ * chunk, `duckdb_v2_arrow_exporter_next_array()` produces arrays from it, and `duckdb_v2_arrow_exporter_destroy()`
+ * frees the exporter.
+ *
+ * An exporter must not be used from two threads at once.
+ */
+typedef struct _duckdb_v2_arrow_exporter {
+	void *internal_ptr;
+} * duckdb_v2_arrow_exporter_handle;
 
 /* --- Constants for arrow --- */
 
@@ -4716,33 +4732,31 @@ typedef struct _duckdb_v2_arrow_converter {
 /*!
  * Exports a result as a lazy ArrowArrayStream. Consuming.
  *
- * Takes the result by transfer, setting the slot to NULL, and fills the caller-allocated `out_stream`. The stream owns
- * the result from then on: releasing it does not drain anything, but it does close the query and free the connection's
- * live-result slot exactly as `duckdb_v2_result_destroy()` would, so the connection can run its next query. Release it
- * by calling `out_stream->release(out_stream)`.
+ * Takes ownership of the result, sets the slot to NULL, and fills the caller-allocated `out_stream`. The stream owns
+ * the result from then on. Releasing the stream, with `out_stream->release(out_stream)`, does not drain the result, but
+ * closes the query and frees the connection's live-result slot as `duckdb_v2_result_destroy()` would, so the connection
+ * can run its next query.
  *
- * The stream is lazy. Its `get_next` drives the result, stepping past waiting states internally until a batch is ready,
- * and coalesces DuckDB chunks into one Arrow array of up to `batch_size` rows. Its `get_schema` returns the Arrow
- * schema and never touches the catalog, because both the schema and the extension type map are built and cached while
- * this call still holds the query's transaction. That caching is a correctness requirement rather than an optimization:
- * building the schema can run extension populate-schema callbacks and read ENUM dictionaries, neither of which is
- * available once the transaction is gone.
+ * The stream's `get_next` drives the result, waiting internally until a batch is ready, and gathers DuckDB chunks into
+ * one Arrow array of up to `batch_size` rows. The Arrow schema and the extension type map are built and cached here,
+ * while the query's transaction is still active, because building them can run extension populate-schema callbacks and
+ * read ENUM dictionaries. `get_schema` returns a copy of the cached schema and never touches the catalog.
  *
- * Passing a result that has already yielded some chunks is allowed and produces a stream over what remains.
+ * A result that has already yielded some chunks is allowed and produces a stream over the remaining rows.
  *
- * A statement that expanded into a group whose row-producing fragment has not started yet is stepped far enough here
- * for its schema to be cached, which can block briefly; no rows are lost, since none can be produced before that
+ * If the statement expanded into a group whose row-producing fragment has not started yet, this call steps the result
+ * far enough to cache the schema, which may block briefly. No rows are lost, since none are produced before that
  * fragment is prepared. For an ordinary statement nothing executes here.
  *
  * The result is consumed on every path that reaches the engine, including failures. Only a null-argument rejection
- * leaves it intact, and `out_stream` is untouched unless the call succeeds.
+ * leaves it intact. `out_stream` is untouched unless the call succeeds.
  *
  * history:
  * - stable: v2.0.0
  *
  * @param result The result to export. Consumed and set to NULL, except when the call rejects a null argument.
- * @param batch_size Target rows per Arrow array. Pass 0 for the default of 131072, which is 64 vectors in a default
- * build and matches pyarrow's dataset scanner.
+ * @param batch_size Maximum rows per Arrow array. Pass 0 for the default of 131072, which is 64 vectors in a default
+ * build.
  * @param out_stream Caller-allocated stream the library fills. Release it with `out_stream->release(out_stream)`.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
@@ -4753,156 +4767,272 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_result_to_arrow_stream(duckdb_v2_result_h
                                                               duckdb_v2_error_info_handle *err);
 
 /*!
- * Converts a list of column types and names into an Arrow schema.
+ * Resolves an Arrow schema into a reusable importer.
  *
- * Fills the caller-allocated `out_schema` using the Arrow options carried by `context`. The caller owns the result and
- * releases it with `out_schema->release(out_schema)`.
+ * Works out every column's DuckDB logical type and the Arrow type information the conversion needs, once, so any number
+ * of arrays of that shape can be imported without re-reading the schema. `schema` is read, not consumed: the caller
+ * keeps ownership and still releases it.
  *
- * `types` and `names` are parallel arrays of `count` entries, and may be NULL only when `count` is 0. Building the
- * schema can read the catalog -- extension populate-schema callbacks, ENUM dictionaries -- so `context` must have an
- * active transaction, which a callback context does.
+ * `batch_size` caps the rows per produced chunk. A long array is split across several chunks. Rows left over that do
+ * not fill a batch are held back and joined with the next array, unless the append asked to flush. Pass 0 for no
+ * maximum: each array becomes one chunk, however long it is.
  *
- * history:
- * - stable: v2.0.0
- *
- * @param context The context whose Arrow options and transaction drive the conversion.
- * @param types An array of `count` column types. May be NULL only when `count` is 0.
- * @param names An array of `count` column names, parallel to `types`. May be NULL only when `count` is 0.
- * @param count The number of columns, being the length of both `types` and `names`.
- * @param out_schema Caller-allocated schema the library fills. Release it with `out_schema->release(out_schema)`.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_types_to_arrow_schema(duckdb_v2_context_handle context,
-                                                                     const duckdb_v2_logical_type_handle *types,
-                                                                     const duckdb_v2_str *names, idx_t count,
-                                                                     struct ArrowSchema *out_schema,
-                                                                     duckdb_v2_error_info_handle *err);
-
-/*!
- * Converts a data chunk into an Arrow array.
- *
- * Fills the caller-allocated `out_array`, using the Arrow options and extension type casts resolved from `context`. The
- * caller owns the result and releases it with `out_array->release(out_array)`. The chunk is borrowed, not consumed, and
- * stays valid afterwards.
- *
- * The Arrow schema for the array comes from `duckdb_v2_logical_types_to_arrow_schema()`, given the chunk's column
- * types; this call produces data only.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param context The context whose Arrow options and transaction drive the conversion.
- * @param chunk The chunk to convert. Borrowed; not consumed.
- * @param out_array Caller-allocated array the library fills. Release it with `out_array->release(out_array)`.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_data_chunk_to_arrow_array(duckdb_v2_context_handle context,
-                                                                 duckdb_v2_data_chunk_handle chunk,
-                                                                 struct ArrowArray *out_array,
-                                                                 duckdb_v2_error_info_handle *err);
-
-/*!
- * Resolves an Arrow schema into a reusable converter.
- *
- * Interprets `schema` against `context`, working out each column's DuckDB logical type and the Arrow type information
- * an import needs, and returns a converter that `duckdb_v2_arrow_converter_array_to_chunk()` reuses across every array
- * of that shape. `schema` is read, not consumed: the caller keeps ownership and still releases it.
- *
- * Resolving reads the catalog for extension types, so `context` must have an active transaction. The converter itself
- * captures no context: build it under a bind-time context and use it at execution time under another.
- *
- * `*out_converter` is set to NULL on failure.
+ * Resolving reads the catalog for extension types, so `context` must have an active transaction. The importer keeps
+ * using that context for every conversion and must not outlive it. Within one connection the context is the same
+ * throughout, so an importer created in a bind callback is usable from the matching exec callback. `*out_importer` is
+ * set to NULL on failure.
  *
  * history:
  * - stable: v2.0.0
  *
  * @param context The context used to resolve the Arrow types, extension types included.
  * @param schema The schema to resolve. Read, not consumed; the caller keeps ownership.
- * @param out_converter On success, receives the new converter. Owned by the caller; destroy via
- * `duckdb_v2_arrow_converter_destroy()`.
+ * @param batch_size Maximum rows per produced chunk, or 0 for no maximum.
+ * @param out_importer On success, receives the new importer. Owned by the caller; destroy via
+ * `duckdb_v2_arrow_importer_destroy()`.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_converter_create(duckdb_v2_context_handle context,
-                                                              struct ArrowSchema *schema,
-                                                              duckdb_v2_arrow_converter_handle *out_converter,
-                                                              duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_importer_create(duckdb_v2_context_handle context,
+                                                             struct ArrowSchema *schema, idx_t batch_size,
+                                                             duckdb_v2_arrow_importer_handle *out_importer,
+                                                             duckdb_v2_error_info_handle *err);
 
 /*!
- * Converts an Arrow array into a data chunk, interpreting it through a converter. Consuming.
+ * Returns the resolved DuckDB schema.
  *
- * The chunk adopts the array's buffers zero-copy and `array->release` is set to NULL, so the caller must not release
- * `array` afterwards; destroying the chunk releases the Arrow data. Ownership transfers even on the failure paths that
- * have already taken it, so a caller must never release an array it has passed here.
+ * Writes an owned schema handle with the DuckDB name and logical type of every column the importer resolved. This is
+ * how a caller learns the DuckDB shape of an ArrowSchema, to declare a table function's result columns for instance,
+ * without reimplementing the mapping from Arrow format strings to logical types.
  *
- * The chunk is sized to the array's length, which may exceed the engine's vector size: that is the size of a chunk
- * flowing through a pipeline, not a cap on a chunk that stands alone.
- *
- * An array whose shape disagrees with the converter -- a different child count, a child length that does not match the
- * array's, a null or already-released child -- is rejected with `ERROR_INPUT_INVALID` rather than read. Only the
- * default, dictionary-encoded and run-end-encoded layouts are supported; any other reports
- * `ERROR_QUERY_NOT_IMPLEMENTED`. `*out_chunk` is set to NULL on failure.
+ * The fields were resolved at creation, so this reads no catalog and needs no transaction. `*out_schema` is set to NULL
+ * on failure.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param context The context used during the conversion.
- * @param array The array to convert. Its data is adopted by the chunk and its `release` is set to NULL.
- * @param converter The converter describing the array, from `duckdb_v2_arrow_converter_create()`.
- * @param out_chunk On success, receives the new chunk. Owned by the caller; destroy via
- * `duckdb_v2_data_chunk_destroy()`.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_converter_array_to_chunk(duckdb_v2_context_handle context,
-                                                                      struct ArrowArray *array,
-                                                                      duckdb_v2_arrow_converter_handle converter,
-                                                                      duckdb_v2_data_chunk_handle *out_chunk,
-                                                                      duckdb_v2_error_info_handle *err);
-
-/*!
- * Returns the converter's resolved columns as a schema.
- *
- * Writes an owned schema handle carrying the DuckDB name and logical type of every column the converter resolved. This
- * is how a caller learns the DuckDB shape of an arbitrary ArrowSchema, to declare a table function's result columns for
- * instance: mapping Arrow format strings onto logical types is engine knowledge, not something a binding should
- * reimplement.
- *
- * The fields are copied from what was resolved at creation, so this reads no catalog and needs no transaction.
- * `*out_schema` is set to NULL on failure.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param converter The converter to read.
+ * @param importer The importer to read.
  * @param out_schema On success, receives an owned schema. Destroy via `duckdb_v2_schema_destroy()`.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_converter_get_schema(duckdb_v2_arrow_converter_handle converter,
-                                                                  duckdb_v2_schema_handle *out_schema,
-                                                                  duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_importer_get_schema(duckdb_v2_arrow_importer_handle importer,
+                                                                 duckdb_v2_schema_handle *out_schema,
+                                                                 duckdb_v2_error_info_handle *err);
 
 /*!
- * Destroys an Arrow converter.
+ * Gives the importer one array to convert.
  *
- * Null-safe: passing NULL, or a slot already set to NULL, is a no-op. Chunks already produced through it are
- * independent of the converter and stay valid. On success the slot is set to NULL.
+ * Take the chunks with `duckdb_v2_arrow_importer_next_chunk()` until that returns NULL. Appending while the previous
+ * array still has rows left is rejected with `ERROR_INPUT_INVALID`. An array whose shape does not match the resolved
+ * schema -- a different child count, a child whose length differs from the array's, a null or already-released child --
+ * is rejected the same way, before anything is read.
+ *
+ * `flush` marks the end of the input: rows that do not fill a batch then come out as a final short chunk instead of
+ * being held back for the next array. Pass NULL for `array` with `flush` set to release the held rows without supplying
+ * more input.
+ *
+ * `consume` decides what happens to the caller's array.
+ *
+ * When true, the importer takes over the array and sets its `release` to NULL; the caller must not release it
+ * afterwards. The produced chunks reference the Arrow buffers directly, without copying, and keep them alive, so the
+ * chunks stay valid after the importer is destroyed. Prefer this path.
+ *
+ * When false, the caller keeps the array and must keep it valid until the drain finishes. The produced chunks are
+ * copies, so they do not depend on the array, at the cost of one copy per chunk.
+ *
+ * Either way, a chunk that joins rows held back from the previous array is a copy, since it cannot reference two
+ * arrays.
+ *
+ * Only the default, dictionary-encoded and run-end-encoded Arrow layouts are supported. Any other layout reports
+ * `ERROR_QUERY_NOT_IMPLEMENTED` when the column is converted.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param converter The converter to destroy.
+ * @param importer The importer to feed.
+ * @param array The array to convert. Its `release` is set to NULL when `consume` is true.
+ * @param consume True to hand the array over for a zero-copy import; false to keep it, in which case every produced
+ * chunk is a copy.
+ * @param flush True to mark the end of the input, releasing held rows as a final short chunk. Pass NULL for `array`
+ * with this set to flush without supplying more input.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_converter_destroy(duckdb_v2_arrow_converter_handle *converter);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_importer_append(duckdb_v2_arrow_importer_handle importer,
+                                                             struct ArrowArray *array, bool consume, bool flush,
+                                                             duckdb_v2_error_info_handle *err);
+
+/*!
+ * Produces the next chunk of the appended array, or NULL once the array is drained.
+ *
+ * Call it in a loop until `*out_chunk` is NULL. An importer with no array appended also returns NULL. Each chunk holds
+ * at most the importer's `batch_size` rows, or the whole array when that is 0. A chunk may start with rows held back
+ * from the previous array, and rows that do not fill a batch are held back in turn unless the append asked to flush. So
+ * NULL means the array has been read, not that all of its rows have come out.
+ *
+ * The conversion runs under the context the importer was created with, which must still be alive. `*out_chunk` is set
+ * to NULL on failure.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param importer The importer to drain.
+ * @param out_chunk On success, receives the next chunk, or NULL once the array is drained. Destroy via
+ * `duckdb_v2_data_chunk_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_importer_next_chunk(duckdb_v2_arrow_importer_handle importer,
+                                                                 duckdb_v2_data_chunk_handle *out_chunk,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys an importer.
+ *
+ * Null-safe: passing NULL, or a slot already set to NULL, is a no-op. Chunks already produced stay valid, including the
+ * zero-copy ones, which keep the Arrow buffers alive themselves. An array appended with `consume` true and not fully
+ * drained is released here. Rows held back for a next array are dropped. On success the slot is set to NULL.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param importer The importer to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_importer_destroy(duckdb_v2_arrow_importer_handle *importer);
+
+/*!
+ * Creates an exporter for one fixed list of columns.
+ *
+ * Resolves the extension types and captures the session's Arrow settings, so every array this exporter produces matches
+ * the schema `duckdb_v2_arrow_exporter_get_schema()` reports, even if a setting changes afterwards.
+ *
+ * `batch_size` caps the rows per produced array. A long chunk is split across several arrays. Rows left over that do
+ * not fill a batch are held back and joined with the next chunk, unless the append asked to flush. Pass 0 for no
+ * maximum: each chunk becomes one array, however long it is.
+ *
+ * `types` and `names` are parallel arrays of `count` entries, borrowed and copied; they may be NULL only when `count`
+ * is 0. Resolving reads the catalog, so `context` must have an active transaction. `*out_exporter` is set to NULL on
+ * failure.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param context The context whose Arrow settings are captured and whose transaction resolves the types.
+ * @param types An array of `count` column types. May be NULL only when `count` is 0.
+ * @param names An array of `count` column names, parallel to `types`. May be NULL only when `count` is 0.
+ * @param count The number of columns, being the length of both `types` and `names`.
+ * @param batch_size Maximum rows per produced array, or 0 for no maximum.
+ * @param out_exporter On success, receives the new exporter. Owned by the caller; destroy via
+ * `duckdb_v2_arrow_exporter_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_create(duckdb_v2_context_handle context,
+                                                             const duckdb_v2_logical_type_handle *types,
+                                                             const duckdb_v2_str *names, idx_t count, idx_t batch_size,
+                                                             duckdb_v2_arrow_exporter_handle *out_exporter,
+                                                             duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the Arrow schema of the arrays this exporter produces.
+ *
+ * Fills the caller-allocated `out_schema`. The caller owns the result and releases it with
+ * `out_schema->release(out_schema)`. Callable at any point, and always returns the same schema, since it is built from
+ * the settings captured at creation.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param exporter The exporter to read.
+ * @param out_schema Caller-allocated schema the library fills. Release it with `out_schema->release(out_schema)`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_get_schema(duckdb_v2_arrow_exporter_handle exporter,
+                                                                 struct ArrowSchema *out_schema,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Gives the exporter one chunk to convert.
+ *
+ * The chunk is converted in full before this returns. The conversion copies into freshly allocated Arrow buffers, so
+ * nothing of the caller's is retained. Every array completed by this chunk becomes available from
+ * `duckdb_v2_arrow_exporter_next_array()`; rows that do not complete a batch are held back and finished by the next
+ * chunk. Completed arrays queue up, so appending again before they are taken is allowed.
+ *
+ * `flush` marks the end of the input: the held rows are then finished as a final short array. Pass NULL for `chunk`
+ * with `flush` set to release the held rows without supplying more input.
+ *
+ * The chunk's types must match the ones the exporter was created with, or the call is rejected with
+ * `ERROR_INPUT_INVALID` before anything is read.
+ *
+ * `consume` decides only what happens to the caller's handle, since the data is copied either way. When true the chunk
+ * is destroyed and the slot set to NULL, saving a `duckdb_v2_data_chunk_destroy()` for a chunk the caller owns. When
+ * false the chunk is left untouched, which is what a chunk borrowed from a callback needs, such as the output chunk of
+ * a table function's exec callback, which the caller does not own and must not destroy.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param exporter The exporter to feed.
+ * @param chunk The chunk to convert. Destroyed and set to NULL only when `consume` is true.
+ * @param consume True to hand the chunk over, destroying it; false to leave the caller's handle untouched.
+ * @param flush True to mark the end of the input, releasing the held rows as a final short array. Pass NULL for `chunk`
+ * with this set to flush without supplying more input.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_append(duckdb_v2_arrow_exporter_handle exporter,
+                                                             duckdb_v2_data_chunk_handle *chunk, bool consume,
+                                                             bool flush, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Takes the next completed array, or reports that none is ready.
+ *
+ * Call it in a loop after every `duckdb_v2_arrow_exporter_append()` until `out_array->release` is NULL, which is how
+ * the Arrow C Data Interface signals "no array" and what a stream's `get_next` does at end of input. Rows held back
+ * towards an unfinished batch are not an array yet; they come out after a further append or a flush.
+ *
+ * Each array is owned by the caller and released with `out_array->release(out_array)`, independently of the exporter
+ * and of every other array.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param exporter The exporter to drain.
+ * @param out_array Caller-allocated array the library fills. Left released -- `release` NULL -- when none is ready.
+ * Release a filled one with `out_array->release(out_array)`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_next_array(duckdb_v2_arrow_exporter_handle exporter,
+                                                                 struct ArrowArray *out_array,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys an exporter.
+ *
+ * Null-safe: passing NULL, or a slot already set to NULL, is a no-op. Arrays already taken stay valid. Arrays still
+ * queued inside are released here, and rows held back towards an unfinished batch are dropped. On success the slot is
+ * set to NULL.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param exporter The exporter to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_destroy(duckdb_v2_arrow_exporter_handle *exporter);
 
 /* --- Struct definitions for arrow --- */
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -4687,6 +4687,226 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_aggregate_function_destroy(duckdb_v2_aggr
 /* --- Struct definitions for aggregate --- */
 
 /* ============================================================================
+ * MODULE: arrow
+ * ============================================================================ */
+
+/* --- Enums for arrow --- */
+
+/* --- Struct forward declarations for arrow --- */
+
+/* --- Types for arrow --- */
+
+/*!
+ * An owned, resolved interpretation of an ArrowSchema: the DuckDB logical type of every column plus the per-column
+ * Arrow type information needed to import an array. Built once from an ArrowSchema with
+ * `duckdb_v2_arrow_converter_create()` and reused across many arrays by `duckdb_v2_arrow_converter_array_to_chunk()`,
+ * so a table function can resolve the schema at bind time and pay nothing per chunk. Read the resolved names and types
+ * back with `duckdb_v2_arrow_converter_get_schema()`, and destroy with `duckdb_v2_arrow_converter_destroy()`.
+ */
+typedef struct _duckdb_v2_arrow_converter {
+	void *internal_ptr;
+} * duckdb_v2_arrow_converter_handle;
+
+/* --- Constants for arrow --- */
+
+/* --- Function pointer typedefs for arrow --- */
+
+/* --- Functions for arrow --- */
+
+/*!
+ * Exports a result as a lazy ArrowArrayStream. Consuming.
+ *
+ * Takes the result by transfer, setting the slot to NULL, and fills the caller-allocated `out_stream`. The stream owns
+ * the result from then on: releasing it does not drain anything, but it does close the query and free the connection's
+ * live-result slot exactly as `duckdb_v2_result_destroy()` would, so the connection can run its next query. Release it
+ * by calling `out_stream->release(out_stream)`.
+ *
+ * The stream is lazy. Its `get_next` drives the result, stepping past waiting states internally until a batch is ready,
+ * and coalesces DuckDB chunks into one Arrow array of up to `batch_size` rows. Its `get_schema` returns the Arrow
+ * schema and never touches the catalog, because both the schema and the extension type map are built and cached while
+ * this call still holds the query's transaction. That caching is a correctness requirement rather than an optimization:
+ * building the schema can run extension populate-schema callbacks and read ENUM dictionaries, neither of which is
+ * available once the transaction is gone.
+ *
+ * Passing a result that has already yielded some chunks is allowed and produces a stream over what remains.
+ *
+ * A statement that expanded into a group whose row-producing fragment has not started yet is stepped far enough here
+ * for its schema to be cached, which can block briefly; no rows are lost, since none can be produced before that
+ * fragment is prepared. For an ordinary statement nothing executes here.
+ *
+ * The result is consumed on every path that reaches the engine, including failures. Only a null-argument rejection
+ * leaves it intact, and `out_stream` is untouched unless the call succeeds.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param result The result to export. Consumed and set to NULL, except when the call rejects a null argument.
+ * @param batch_size Target rows per Arrow array. Pass 0 for the default of 131072, which is 64 vectors in a default
+ * build and matches pyarrow's dataset scanner.
+ * @param out_stream Caller-allocated stream the library fills. Release it with `out_stream->release(out_stream)`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_result_to_arrow_stream(duckdb_v2_result_handle *result, idx_t batch_size,
+                                                              struct ArrowArrayStream *out_stream,
+                                                              duckdb_v2_error_info_handle *err);
+
+/*!
+ * Converts a list of column types and names into an Arrow schema.
+ *
+ * Fills the caller-allocated `out_schema` using the Arrow options carried by `context`. The caller owns the result and
+ * releases it with `out_schema->release(out_schema)`.
+ *
+ * `types` and `names` are parallel arrays of `count` entries, and may be NULL only when `count` is 0. Building the
+ * schema can read the catalog -- extension populate-schema callbacks, ENUM dictionaries -- so `context` must have an
+ * active transaction, which a callback context does.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param context The context whose Arrow options and transaction drive the conversion.
+ * @param types An array of `count` column types. May be NULL only when `count` is 0.
+ * @param names An array of `count` column names, parallel to `types`. May be NULL only when `count` is 0.
+ * @param count The number of columns, being the length of both `types` and `names`.
+ * @param out_schema Caller-allocated schema the library fills. Release it with `out_schema->release(out_schema)`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_types_to_arrow_schema(duckdb_v2_context_handle context,
+                                                                     const duckdb_v2_logical_type_handle *types,
+                                                                     const duckdb_v2_str *names, idx_t count,
+                                                                     struct ArrowSchema *out_schema,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Converts a data chunk into an Arrow array.
+ *
+ * Fills the caller-allocated `out_array`, using the Arrow options and extension type casts resolved from `context`. The
+ * caller owns the result and releases it with `out_array->release(out_array)`. The chunk is borrowed, not consumed, and
+ * stays valid afterwards.
+ *
+ * The Arrow schema for the array comes from `duckdb_v2_logical_types_to_arrow_schema()`, given the chunk's column
+ * types; this call produces data only.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param context The context whose Arrow options and transaction drive the conversion.
+ * @param chunk The chunk to convert. Borrowed; not consumed.
+ * @param out_array Caller-allocated array the library fills. Release it with `out_array->release(out_array)`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_data_chunk_to_arrow_array(duckdb_v2_context_handle context,
+                                                                 duckdb_v2_data_chunk_handle chunk,
+                                                                 struct ArrowArray *out_array,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Resolves an Arrow schema into a reusable converter.
+ *
+ * Interprets `schema` against `context`, working out each column's DuckDB logical type and the Arrow type information
+ * an import needs, and returns a converter that `duckdb_v2_arrow_converter_array_to_chunk()` reuses across every array
+ * of that shape. `schema` is read, not consumed: the caller keeps ownership and still releases it.
+ *
+ * Resolving reads the catalog for extension types, so `context` must have an active transaction. The converter itself
+ * captures no context: build it under a bind-time context and use it at execution time under another.
+ *
+ * `*out_converter` is set to NULL on failure.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param context The context used to resolve the Arrow types, extension types included.
+ * @param schema The schema to resolve. Read, not consumed; the caller keeps ownership.
+ * @param out_converter On success, receives the new converter. Owned by the caller; destroy via
+ * `duckdb_v2_arrow_converter_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_converter_create(duckdb_v2_context_handle context,
+                                                              struct ArrowSchema *schema,
+                                                              duckdb_v2_arrow_converter_handle *out_converter,
+                                                              duckdb_v2_error_info_handle *err);
+
+/*!
+ * Converts an Arrow array into a data chunk, interpreting it through a converter. Consuming.
+ *
+ * The chunk adopts the array's buffers zero-copy and `array->release` is set to NULL, so the caller must not release
+ * `array` afterwards; destroying the chunk releases the Arrow data. Ownership transfers even on the failure paths that
+ * have already taken it, so a caller must never release an array it has passed here.
+ *
+ * The chunk is sized to the array's length, which may exceed the engine's vector size: that is the size of a chunk
+ * flowing through a pipeline, not a cap on a chunk that stands alone.
+ *
+ * An array whose shape disagrees with the converter -- a different child count, a child length that does not match the
+ * array's, a null or already-released child -- is rejected with `ERROR_INPUT_INVALID` rather than read. Only the
+ * default, dictionary-encoded and run-end-encoded layouts are supported; any other reports
+ * `ERROR_QUERY_NOT_IMPLEMENTED`. `*out_chunk` is set to NULL on failure.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param context The context used during the conversion.
+ * @param array The array to convert. Its data is adopted by the chunk and its `release` is set to NULL.
+ * @param converter The converter describing the array, from `duckdb_v2_arrow_converter_create()`.
+ * @param out_chunk On success, receives the new chunk. Owned by the caller; destroy via
+ * `duckdb_v2_data_chunk_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_converter_array_to_chunk(duckdb_v2_context_handle context,
+                                                                      struct ArrowArray *array,
+                                                                      duckdb_v2_arrow_converter_handle converter,
+                                                                      duckdb_v2_data_chunk_handle *out_chunk,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the converter's resolved columns as a schema.
+ *
+ * Writes an owned schema handle carrying the DuckDB name and logical type of every column the converter resolved. This
+ * is how a caller learns the DuckDB shape of an arbitrary ArrowSchema, to declare a table function's result columns for
+ * instance: mapping Arrow format strings onto logical types is engine knowledge, not something a binding should
+ * reimplement.
+ *
+ * The fields are copied from what was resolved at creation, so this reads no catalog and needs no transaction.
+ * `*out_schema` is set to NULL on failure.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param converter The converter to read.
+ * @param out_schema On success, receives an owned schema. Destroy via `duckdb_v2_schema_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_converter_get_schema(duckdb_v2_arrow_converter_handle converter,
+                                                                  duckdb_v2_schema_handle *out_schema,
+                                                                  duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys an Arrow converter.
+ *
+ * Null-safe: passing NULL, or a slot already set to NULL, is a no-op. Chunks already produced through it are
+ * independent of the converter and stay valid. On success the slot is set to NULL.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param converter The converter to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_arrow_converter_destroy(duckdb_v2_arrow_converter_handle *converter);
+
+/* --- Struct definitions for arrow --- */
+
+/* ============================================================================
  * MODULE: connection
  * ============================================================================ */
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -2356,6 +2356,442 @@ struct duckdb_v2_extension_input {
 };
 
 /* ============================================================================
+ * MODULE: file system
+ * ============================================================================ */
+
+/* --- Enums for file system --- */
+
+/*!
+ * How `duckdb_v2_file_system_open()` opens a file. These are not a bitmask -- apply them one at a time with
+ * `duckdb_v2_file_open_options_set_flag()`, calling it once per behaviour you want, e.g. `FILE_FLAG_WRITE` then
+ * `FILE_FLAG_CREATE` to write to a file and create it when it does not exist.
+ */
+typedef enum DUCKDB_V2_FILE_FLAG {
+	//! Not a flag. The zero value, so that an uninitialized variable does not name a behaviour; applying it is an
+	//! error.
+	DUCKDB_V2_FILE_FLAG_INVALID = 0,
+
+	//! Open the file with "read" capabilities.
+	DUCKDB_V2_FILE_FLAG_READ = 1,
+
+	//! Open the file with "write" capabilities.
+	DUCKDB_V2_FILE_FLAG_WRITE = 2,
+
+	//! Create the file if it does not exist, and open it as it is if it does.
+	DUCKDB_V2_FILE_FLAG_CREATE = 3,
+
+	/*!
+	 * Create the file if it does not exist, and truncate it to empty if it does. To fail instead of truncating, combine
+	 * `FILE_FLAG_CREATE` with `FILE_FLAG_EXCLUSIVE_CREATE`.
+	 */
+	DUCKDB_V2_FILE_FLAG_CREATE_NEW = 4,
+
+	//! Open the file in "append" mode.
+	DUCKDB_V2_FILE_FLAG_APPEND = 5,
+
+	//! Fail if the file already exists. A modifier on `FILE_FLAG_CREATE`, and meaningless without it.
+	DUCKDB_V2_FILE_FLAG_EXCLUSIVE_CREATE = 6,
+
+	/*!
+	 * The file will be read and written at explicit offsets from several threads at once. Pass it whenever
+	 * `duckdb_v2_file_read_at()` or `duckdb_v2_file_write_at()` are used concurrently -- a file system that would
+	 * otherwise assume sequential access, by caching, buffering, or keeping a single cursor, needs to know not to.
+	 */
+	DUCKDB_V2_FILE_FLAG_PARALLEL_ACCESS = 7,
+	DUCKDB_V2_FILE_FLAG_MAX_ENUM = 0x7FFFFFFF,
+} DUCKDB_V2_FILE_FLAG;
+
+/* --- Struct forward declarations for file system --- */
+
+/* --- Types for file system --- */
+
+/*!
+ * A borrowed opaque handle to a file system. Obtained from `duckdb_v2_file_system_get_from_context()` or
+ * `duckdb_v2_file_system_get_from_connection()`, and used to open files with `duckdb_v2_file_system_open()`. Borrowed:
+ * the handle belongs to the context or connection it came from, is valid only for as long as that is, and must not be
+ * destroyed.
+ */
+typedef struct _duckdb_v2_file_system {
+	void *internal_ptr;
+} * duckdb_v2_file_system_handle;
+
+/*!
+ * An owned opaque handle to the options a file is opened with. Created with `duckdb_v2_file_open_options_create()`,
+ * configured with `duckdb_v2_file_open_options_set_flag()` and `duckdb_v2_file_open_options_set_value()`, passed to
+ * `duckdb_v2_file_system_open()`, and destroyed with `duckdb_v2_file_open_options_destroy()`. One options object can
+ * open any number of files, and destroying it does not affect files already opened with it.
+ */
+typedef struct _duckdb_v2_file_open_options {
+	void *internal_ptr;
+} * duckdb_v2_file_open_options_handle;
+
+/*!
+ * An owned opaque handle to an open file, produced by `duckdb_v2_file_system_open()` and destroyed with
+ * `duckdb_v2_file_destroy()`. Read, write, seek and sync through the `file_*` functions. Only usable while the file
+ * system it was opened through is still valid.
+ */
+typedef struct _duckdb_v2_file {
+	void *internal_ptr;
+} * duckdb_v2_file_handle;
+
+/* --- Constants for file system --- */
+
+/* --- Function pointer typedefs for file system --- */
+
+/* --- Functions for file system --- */
+
+/*!
+ * Borrows the file system of a context.
+ *
+ * Use this from inside a callback, where a context is in hand. The returned handle is borrowed: it is valid only for as
+ * long as the context is, and must not be destroyed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param context The context to take the file system from.
+ * @param file_system Receives the borrowed file system.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_system_get_from_context(duckdb_v2_context_handle context,
+                                                                    duckdb_v2_file_system_handle *file_system,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Borrows the file system of a connection.
+ *
+ * The connection form of `duckdb_v2_file_system_get_from_context()`, for callers outside a callback. The returned
+ * handle is borrowed: it is valid only for as long as the connection is, and must not be destroyed.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param connection The connection to take the file system from.
+ * @param file_system Receives the borrowed file system.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_system_get_from_connection(duckdb_v2_connection_handle connection,
+                                                                       duckdb_v2_file_system_handle *file_system,
+                                                                       duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a set of open options for a file system.
+ *
+ * The options start out empty: give them flags with `duckdb_v2_file_open_options_set_flag()`, which is required, and
+ * optionally attach values with `duckdb_v2_file_open_options_set_value()`. They are then passed to
+ * `duckdb_v2_file_system_open()`, and can be reused for as many opens as you like. The caller owns the returned handle
+ * and must destroy it with `duckdb_v2_file_open_options_destroy()`.
+ *
+ * The options belong to the file system they were created from, since which values mean anything depends on which file
+ * system ends up handling the path.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file_system The file system the options are for.
+ * @param options On success, receives the new options. Owned by the caller; destroy via
+ * `duckdb_v2_file_open_options_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_open_options_create(duckdb_v2_file_system_handle file_system,
+                                                                duckdb_v2_file_open_options_handle *options,
+                                                                duckdb_v2_error_info_handle *err);
+
+/*!
+ * Applies one flag to the options.
+ *
+ * Additive: call it once per behaviour you want, and applying the same flag twice is harmless. At least one flag must
+ * be applied before the options can open anything, since the flags are what say whether the file is being read or
+ * written. There is no way to take a flag back -- build a fresh set of options instead.
+ *
+ * `FILE_FLAG_INVALID` names no behaviour and is rejected, as is any value that is not a `DUCKDB_V2_FILE_FLAG`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param options The options to apply the flag to.
+ * @param flag The flag to apply.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_open_options_set_flag(duckdb_v2_file_open_options_handle options,
+                                                                  DUCKDB_V2_FILE_FLAG flag,
+                                                                  duckdb_v2_error_info_handle *err);
+
+/*!
+ * Attaches a named value to the options.
+ *
+ * These are hints for whichever file system ends up handling the path, and what they mean is that file system's
+ * business: a value it does not recognise is ignored rather than rejected, and the same name can mean different things
+ * to different file systems. They are the same values a file system reports when listing files, so a known file size or
+ * modification time learned from a listing can be handed straight back to avoid re-reading it.
+ *
+ * The name and the value are borrowed and copied, so the caller may destroy the value immediately after. Setting the
+ * same name again replaces the previous value. Names are case-sensitive.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param options The options to set the value on.
+ * @param name The name of the value. Borrowed and copied.
+ * @param value The value. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_open_options_set_value(duckdb_v2_file_open_options_handle options,
+                                                                   duckdb_v2_str name, duckdb_v2_value_handle value,
+                                                                   duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the options, releasing their resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Files already opened with these options are unaffected.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param options The options to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_open_options_destroy(duckdb_v2_file_open_options_handle *options);
+
+/*!
+ * Opens a file.
+ *
+ * Opens the file at the given path through the file system, which routes it the way the engine would -- a path handled
+ * by a registered virtual or remote file system goes there rather than to local disk. The returned handle is owned by
+ * the caller and must be destroyed with `duckdb_v2_file_destroy()`.
+ *
+ * The options carry the flags and any file-system-specific values; see `duckdb_v2_file_open_options_create()`. Opening
+ * without having set flags fails, since the flags are what say whether the file is being read or written.
+ *
+ * Failure to open -- a missing file without `FILE_FLAG_CREATE`, insufficient permissions, an existing file under
+ * `FILE_FLAG_EXCLUSIVE_CREATE` -- is reported as an error.
+ *
+ * Flag combinations that contradict each other, such as naming neither read nor write or combining `FILE_FLAG_CREATE`
+ * with `FILE_FLAG_CREATE_NEW`, are a programming error rather than a supported input. An assertion build catches them;
+ * elsewhere the behaviour is whatever the underlying file system does with them.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file_system The file system to open the file through.
+ * @param file_path The path of the file to open. Borrowed for the call only.
+ * @param options How to open the file. Borrowed for the call only, and reusable across opens.
+ * @param file On success, receives the open file. Owned by the caller; destroy via `duckdb_v2_file_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_system_open(duckdb_v2_file_system_handle file_system,
+                                                        duckdb_v2_str file_path,
+                                                        duckdb_v2_file_open_options_handle options,
+                                                        duckdb_v2_file_handle *file, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reads from the file into a caller-supplied buffer.
+ *
+ * Reads up to `buffer_size` bytes from the file's current position, advancing it by however many were read. Fewer bytes
+ * than asked for is normal at the end of the file, and zero means there is nothing left; neither is an error. The file
+ * must have been opened with `FILE_FLAG_READ`.
+ *
+ * Use `duckdb_v2_file_read_at()` to read at an explicit offset instead, which leaves the position alone and so can run
+ * on several threads at once.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to read from.
+ * @param buffer A caller-owned buffer of at least `buffer_size` bytes, receiving what was read.
+ * @param buffer_size The maximum number of bytes to read.
+ * @param bytes_read Receives how many bytes were actually read, which may be fewer than `buffer_size` at the end of the
+ * file.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_read(duckdb_v2_file_handle file, void *buffer, idx_t buffer_size,
+                                                 idx_t *bytes_read, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Writes a caller-supplied buffer to the file.
+ *
+ * Writes up to `buffer_size` bytes at the file's current position, advancing it by however many were written. The file
+ * must have been opened with `FILE_FLAG_WRITE` or `FILE_FLAG_APPEND`. Writes may be buffered; use
+ * `duckdb_v2_file_sync()` to force them out.
+ *
+ * Use `duckdb_v2_file_write_at()` to write at an explicit offset instead, which leaves the position alone and so can
+ * run on several threads at once.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to write to.
+ * @param buffer A caller-owned buffer of at least `buffer_size` bytes, holding what to write.
+ * @param buffer_size The number of bytes to write.
+ * @param bytes_written Receives how many bytes were actually written.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_write(duckdb_v2_file_handle file, const void *buffer, idx_t buffer_size,
+                                                  idx_t *bytes_written, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reads from a fixed offset, without moving the file's position.
+ *
+ * Reads exactly `buffer_size` bytes starting at `location`. Unlike `duckdb_v2_file_read()`, a short read is an error
+ * rather than a result: reaching the end of the file before `buffer_size` bytes fails, so there is no count to report
+ * back. The file's read/write position is untouched, which is what makes this safe to call from several threads at once
+ * -- provided the file was opened with `FILE_FLAG_PARALLEL_ACCESS`.
+ *
+ * The file must have been opened with `FILE_FLAG_READ`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to read from.
+ * @param buffer A caller-owned buffer of at least `buffer_size` bytes, receiving what was read.
+ * @param buffer_size The number of bytes to read. All of them are read, or the call fails.
+ * @param location The absolute byte offset to read from, measured from the start of the file.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_read_at(duckdb_v2_file_handle file, void *buffer, idx_t buffer_size,
+                                                    idx_t location, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Writes at a fixed offset, without moving the file's position.
+ *
+ * Writes exactly `buffer_size` bytes starting at `location`, extending the file when the offset is past its end. Unlike
+ * `duckdb_v2_file_write()` there is no count to report back: all of the bytes are written, or the call fails. The
+ * file's read/write position is untouched, which is what makes this safe to call from several threads at once --
+ * provided the file was opened with `FILE_FLAG_PARALLEL_ACCESS`, and that the threads write disjoint ranges.
+ *
+ * The file must have been opened with `FILE_FLAG_WRITE`. Writes may be buffered; use `duckdb_v2_file_sync()` to force
+ * them out.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to write to.
+ * @param buffer A caller-owned buffer of at least `buffer_size` bytes, holding what to write.
+ * @param buffer_size The number of bytes to write. All of them are written, or the call fails.
+ * @param location The absolute byte offset to write at, measured from the start of the file.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_write_at(duckdb_v2_file_handle file, const void *buffer, idx_t buffer_size,
+                                                     idx_t location, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the file's current read/write position, as a byte offset from the start of the file.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to query.
+ * @param position Receives the current position, as a byte offset from the start of the file.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_tell(duckdb_v2_file_handle file, idx_t *position,
+                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the total size of the file in bytes.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to query.
+ * @param size Receives the total size of the file in bytes.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_size(duckdb_v2_file_handle file, idx_t *size,
+                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Moves the file's read/write position.
+ *
+ * Sets the position to an absolute byte offset from the start of the file; subsequent reads and writes start there.
+ * Seeking past the end is allowed, and reading from there yields nothing.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to seek within.
+ * @param position The absolute byte offset to seek to, measured from the start of the file.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_seek(duckdb_v2_file_handle file, idx_t position,
+                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Flushes buffered writes to persistent storage.
+ *
+ * Forces anything still buffered out to storage, which is what makes writes durable across a crash or a process exit.
+ * Closing or destroying the handle flushes as well.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to synchronize.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_sync(duckdb_v2_file_handle file, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Closes the file without destroying the handle.
+ *
+ * Releases the operating-system resources behind the file, such as its descriptor. The handle itself stays valid and
+ * must still be destroyed with `duckdb_v2_file_destroy()`, but it can no longer read, write or seek.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to close.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_close(duckdb_v2_file_handle file, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the file, closing it if it is still open.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param file The file to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_file_destroy(duckdb_v2_file_handle *file);
+
+/* --- Struct definitions for file system --- */
+
+/* ============================================================================
  * MODULE: function signature
  * ============================================================================ */
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -2871,6 +2871,56 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_function_signature_set_return_type(duckdb
 /* --- Struct definitions for function signature --- */
 
 /* ============================================================================
+ * MODULE: identifier
+ * ============================================================================ */
+
+/* --- Enums for identifier --- */
+
+/* --- Struct forward declarations for identifier --- */
+
+/* --- Types for identifier --- */
+
+/* --- Constants for identifier --- */
+
+/* --- Function pointer typedefs for identifier --- */
+
+/* --- Functions for identifier --- */
+
+/*!
+ * Renders a name as a SQL identifier, quoting and escaping only when required.
+ *
+ * Produces the SQL text for the name: the name itself when it is already a legal bare identifier, or the name
+ * double-quoted with interior double quotes doubled when it is a keyword or contains characters that require quoting.
+ * This is the engine's own identifier rendering, so the result parses back to a name equal to the input.
+ *
+ * Writes into a caller-supplied buffer, so nothing is allocated on the caller's behalf and nothing has to be freed.
+ * Pass out_text = NULL to size the buffer without rendering into it: out_length then receives the length, and
+ * out_capacity is ignored. With out_text != NULL, out_capacity must be at least out_length + 1, or the call returns
+ * ERROR_INPUT_OBJECT_SIZE with out_length set to the required length and out_text left untouched.
+ *
+ * out_length never counts the terminator, but a successful write always appends one, so the buffer is usable as a C
+ * string.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param name The name to render. Borrowed for the call only.
+ * @param out_text Caller-owned buffer receiving the text plus a null terminator, or NULL to only report the required
+ * length in out_length.
+ * @param out_capacity Bytes available in out_text, terminator included. Ignored when out_text is NULL.
+ * @param out_length Receives the text length excluding the null terminator — written on success and on
+ * ERROR_INPUT_OBJECT_SIZE.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_identifier_render_quoted(duckdb_v2_identifier_t name, char *out_text,
+                                                                idx_t out_capacity, idx_t *out_length,
+                                                                duckdb_v2_error_info_handle *err);
+
+/* --- Struct definitions for identifier --- */
+
+/* ============================================================================
  * MODULE: logging
  * ============================================================================ */
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -2500,414 +2500,116 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_log(duckdb_v2_context_handle ctx,
 /* --- Struct definitions for logging --- */
 
 /* ============================================================================
- * MODULE: logical_type
+ * MODULE: qname
  * ============================================================================ */
 
-/* --- Enums for logical_type --- */
+/* --- Enums for qname --- */
+
+/* --- Struct forward declarations for qname --- */
+
+/* --- Types for qname --- */
 
 /*!
- * Logical type identifier. The values are the same integers DuckDB uses internally, so round-tripping is lossless. The
- * bind- and UDF-only ids (UNKNOWN, ANY, TEMPLATE) appear here for completeness; they do not show up in result column
- * types in practice.
+ * An owned qualified name: an ordered path of one to three non-empty identifier parts whose last element is the object
+ * name. Construct with `duckdb_v2_qname_parse()` or `duckdb_v2_qname_create()`, read with
+ * `duckdb_v2_qname_get_part_count()` and `duckdb_v2_qname_get_part()`, render back to SQL with
+ * `duckdb_v2_qname_render()`, compare with `duckdb_v2_qname_equals()`, and destroy with `duckdb_v2_qname_destroy()`.
+ * Two handles are compared with `duckdb_v2_qname_equals()`, never by pointer.
  */
-typedef enum DUCKDB_V2_LOGICAL_TYPE_ID {
-	//! Invalid / unset.
-	DUCKDB_V2_LOGICAL_TYPE_ID_INVALID = 0,
+typedef struct _duckdb_v2_qname {
+	void *internal_ptr;
+} * duckdb_v2_qname_handle;
 
-	//! NULL constant type.
-	DUCKDB_V2_LOGICAL_TYPE_ID_SQLNULL = 1,
+/* --- Constants for qname --- */
 
-	//! Unknown — used for unresolved parameter expressions.
-	DUCKDB_V2_LOGICAL_TYPE_ID_UNKNOWN = 2,
+/* --- Function pointer typedefs for qname --- */
 
-	//! ANY — used for functions that accept any type.
-	DUCKDB_V2_LOGICAL_TYPE_ID_ANY = 3,
-
-	/*!
-	 * A type carried as a value (type parameters). Values of this type are built via value_create_type_with_context /
-	 * _with_connection.
-	 */
-	DUCKDB_V2_LOGICAL_TYPE_ID_TYPE = 6,
-	DUCKDB_V2_LOGICAL_TYPE_ID_BOOLEAN = 10,
-	DUCKDB_V2_LOGICAL_TYPE_ID_TINYINT = 11,
-	DUCKDB_V2_LOGICAL_TYPE_ID_SMALLINT = 12,
-	DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER = 13,
-	DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT = 14,
-
-	//! 32-bit days since epoch.
-	DUCKDB_V2_LOGICAL_TYPE_ID_DATE = 15,
-
-	//! 64-bit microseconds since midnight.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIME = 16,
-
-	//! 64-bit seconds since epoch.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_SEC = 17,
-
-	//! 64-bit milliseconds since epoch.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_MS = 18,
-
-	//! 64-bit microseconds since epoch.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP = 19,
-
-	//! 64-bit nanoseconds since epoch.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_NS = 20,
-
-	//! Decimal with width and scale parameters.
-	DUCKDB_V2_LOGICAL_TYPE_ID_DECIMAL = 21,
-	DUCKDB_V2_LOGICAL_TYPE_ID_FLOAT = 22,
-	DUCKDB_V2_LOGICAL_TYPE_ID_DOUBLE = 23,
-	DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR = 25,
-	DUCKDB_V2_LOGICAL_TYPE_ID_BLOB = 26,
-	DUCKDB_V2_LOGICAL_TYPE_ID_INTERVAL = 27,
-	DUCKDB_V2_LOGICAL_TYPE_ID_UTINYINT = 28,
-	DUCKDB_V2_LOGICAL_TYPE_ID_USMALLINT = 29,
-	DUCKDB_V2_LOGICAL_TYPE_ID_UINTEGER = 30,
-	DUCKDB_V2_LOGICAL_TYPE_ID_UBIGINT = 31,
-
-	//! 64-bit microseconds since epoch, timezone-aware.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_TZ = 32,
-
-	//! 64-bit nanoseconds since epoch, timezone-aware.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_TZ_NS = 33,
-
-	//! 64-bit microseconds since midnight + 32-bit offset.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIME_TZ = 34,
-
-	//! 64-bit nanoseconds since midnight.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TIME_NS = 35,
-	DUCKDB_V2_LOGICAL_TYPE_ID_BIT = 36,
-
-	//! Arbitrary-precision integer (VARINT-encoded).
-	DUCKDB_V2_LOGICAL_TYPE_ID_BIGNUM = 39,
-	DUCKDB_V2_LOGICAL_TYPE_ID_UHUGEINT = 49,
-	DUCKDB_V2_LOGICAL_TYPE_ID_HUGEINT = 50,
-	DUCKDB_V2_LOGICAL_TYPE_ID_UUID = 54,
-
-	//! Geometry (spatial extension).
-	DUCKDB_V2_LOGICAL_TYPE_ID_GEOMETRY = 60,
-	DUCKDB_V2_LOGICAL_TYPE_ID_STRUCT = 100,
-	DUCKDB_V2_LOGICAL_TYPE_ID_LIST = 101,
-	DUCKDB_V2_LOGICAL_TYPE_ID_MAP = 102,
-	DUCKDB_V2_LOGICAL_TYPE_ID_ENUM = 104,
-	DUCKDB_V2_LOGICAL_TYPE_ID_UNION = 107,
-	DUCKDB_V2_LOGICAL_TYPE_ID_ARRAY = 108,
-	DUCKDB_V2_LOGICAL_TYPE_ID_VARIANT = 109,
-
-	//! Unnamed struct; shares the physical representation of STRUCT.
-	DUCKDB_V2_LOGICAL_TYPE_ID_TUPLE = 110,
-	DUCKDB_V2_LOGICAL_TYPE_ID_MAX_ENUM = 0x7FFFFFFF,
-} DUCKDB_V2_LOGICAL_TYPE_ID;
-
-/* --- Struct forward declarations for logical_type --- */
-
-/* --- Types for logical_type --- */
-
-/* --- Constants for logical_type --- */
-
-/* --- Function pointer typedefs for logical_type --- */
-
-/* --- Functions for logical_type --- */
+/* --- Functions for qname --- */
 
 /*!
- * Creates a logical type from a type id plus value parameters.
+ * Parses SQL text into a qualified name.
  *
- * The id-keyed twin of context_create_type_from_name: the type id names the kind, and the parameters bind it. With
- * param_count 0 it instantiates a primitive directly, without touching the catalog: BOOLEAN, TINYINT..BIGINT,
- * UTINYINT..UBIGINT, HUGEINT, UHUGEINT, FLOAT, DOUBLE, DATE, every TIME and TIMESTAMP variant, INTERVAL, VARCHAR, BLOB,
- * BIT, BIGNUM, and UUID. ANY is accepted as well.
- *
- * ANY is a function-signature wildcard, constructible here so it can be passed to the function parameter and varargs
- * setters, as a fixed-arity ANY parameter or an ANY varargs type. Data-creating surfaces reject it: value and data
- * chunk creation, scalar and aggregate return types, table function result columns, cast source and target types, and
- * custom type registration.
- *
- * With parameters, the id resolves to its canonical type name and binds through the same path as
- * context_create_type_from_name, so the parameterized kinds construct here too: decimal(width, scale); list(T);
- * array(T, size); map(K, V); struct(fields); union(members); enum(entries); and varchar with a named "collation"
- * parameter. Parameters are (name, value) pairs in two parallel arrays, exactly as for context_create_type_from_name.
- *
- * Returns ERROR_INPUT_INVALID when param_count is 0 and the id needs parameters (DECIMAL, LIST, STRUCT, TUPLE, MAP,
- * ARRAY, UNION, ENUM, VARIANT, GEOMETRY), for the bind-time-only ids (SQLNULL, UNKNOWN), for TYPE — construct that via
- * context_create_type_from_text — and for INVALID.
+ * Applies the engine's qualified-name rules: dots separate parts, and a double-quoted part may contain dots and doubled
+ * interior quotes. More than three parts and an unterminated quote are rejected with the parser's own error; text
+ * without at least one non-empty part is rejected with `ERROR_INPUT_INVALID`. When the parts are already separate,
+ * build the name with `duckdb_v2_qname_create()` rather than joining them and parsing the result.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param ctx The context supplying the catalog and active transaction.
- * @param type_id The type id to instantiate.
- * @param param_names Optional. An array of param_count parameter names; a {NULL, 0} entry is positional. Pass NULL for
- * all-positional parameters.
- * @param param_values An array of param_count parameter values. Borrowed (copied in). Pass NULL when param_count is 0.
- * @param param_count The number of parameters. 0 instantiates a parameterless primitive.
- * @param out_type Receives the new logical type handle.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @param text The name text to parse. Borrowed for the call only.
+ * @param name On success, receives the qualified name. Owned by the caller; destroy via `duckdb_v2_qname_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_id(
-    duckdb_v2_context_handle ctx, DUCKDB_V2_LOGICAL_TYPE_ID type_id, const duckdb_v2_identifier_t *param_names,
-    const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
-    duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_qname_parse(duckdb_v2_str text, duckdb_v2_qname_handle *name,
+                                                   duckdb_v2_error_info_handle *err);
 
 /*!
- * Creates a logical type from a type name plus value parameters.
+ * Creates a qualified name from its parts.
  *
- * The generic constructor: resolves the name in the context's catalog — search path first, then the system catalog —
- * and binds it with the given parameters, exactly as SQL binds a type expression. Built-in parameterized kinds and
- * registered extension types construct through this same call.
- *
- * Parameters are (name, value) pairs in two parallel arrays. param_names may be NULL to make every parameter
- * positional, and a {NULL, 0} entry makes that one parameter positional. Child types cross as TYPE values, built with
- * value_create_type_with_context / _with_connection. The built-in shapes are: decimal(width, scale); list(T); array(T,
- * size); map(K, V); struct(fields, as named or all-positional TYPE values); union(members, as named TYPE values);
- * enum(entries, as VARCHAR values); and varchar with a named "collation" VARCHAR parameter.
- *
- * A name that resolves to a type with no bind function takes no parameters, and passing any fails. Bind errors —
- * unknown name, wrong parameter count or types — surface from the call.
- *
- * Runs in the caller's context scope, as create_type_from_text does: reach it from a bind-phase callback or another
- * context-holding scope, not from an exec-phase worker callback. External callers holding only a connection use
- * connection_create_type_from_name instead.
- *
- * The returned logical type is caller-owned and must be destroyed via logical_type_destroy. A type resolved from the
- * catalog shares database-owned storage, such as an ENUM dictionary, so destroy it before closing the database. This is
- * the inverse of logical_type_get_param_count / logical_type_get_param.
+ * The parts are ordered outermost first, so the last one is the object name. Between one and three parts are accepted
+ * -- the engine qualifies at most catalog.schema.name today -- and every part must be non-empty: partial qualification
+ * is expressed by passing fewer parts, never by empty placeholders. Zero parts, more than three, and an empty part are
+ * all rejected with `ERROR_INPUT_INVALID`. The parts are borrowed and copied.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param ctx The context supplying the catalog and active transaction.
- * @param name View of the type name to resolve. Unqualified; case-insensitive.
- * @param param_names Optional. An array of param_count parameter names; a {NULL, 0} entry is positional. Pass NULL for
- * all-positional parameters.
- * @param param_values An array of param_count parameter values. Borrowed (copied in). Pass NULL when param_count is 0.
- * @param param_count The number of parameters.
- * @param out_type Receives the new logical type handle.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @param parts An array of `part_count` non-empty identifier views, outermost first.
+ * @param part_count The number of parts, between one and three.
+ * @param name On success, receives the qualified name. Owned by the caller; destroy via `duckdb_v2_qname_destroy()`.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_name(
-    duckdb_v2_context_handle ctx, duckdb_v2_identifier_t name, const duckdb_v2_identifier_t *param_names,
-    const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
-    duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_qname_create(const duckdb_v2_identifier_t *parts, idx_t part_count,
+                                                    duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err);
 
 /*!
- * Creates a logical type by parsing SQL text.
+ * Returns how many parts the qualified name has.
  *
- * Parses a SQL type expression in the given context and returns the bound logical type. It accepts primitives
- * ("INTEGER"), parameterized kinds ("DECIMAL(18,3)", "INTEGER[]", "STRUCT(a INTEGER, b VARCHAR)", "MAP(VARCHAR,
- * INTEGER)", "INTEGER[3]", "UNION(i INTEGER, s VARCHAR)", "ENUM('a', 'b')"), and catalog-registered type names, both
- * user-defined and from extensions. A catalog type name binds to its structural type, and the name is not preserved as
- * an alias. Names are case-insensitive. Parse and bind errors surface from the call.
- *
- * Runs in the caller's context scope: a context handle arrives with the context lock held and a transaction active, as
- * in a function bind callback or custom type registration. Catalog-touching context calls belong in bind-phase
- * callbacks and other context-holding scopes, not in exec-phase worker callbacks. External callers holding only a
- * connection use connection_create_type_from_text instead.
- *
- * The returned logical type is caller-owned and must be destroyed via logical_type_destroy. A type resolved from the
- * catalog shares database-owned storage, such as an ENUM dictionary, so destroy it before closing the database. This is
- * the inverse of logical_type_to_text for every constructible kind.
+ * Always at least one. Valid indices for `duckdb_v2_qname_get_part()` are [0, count), and the object name is the part
+ * at count - 1.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param ctx The context supplying the catalog and active transaction.
- * @param text View of the SQL type expression to parse.
- * @param out_type Receives the new logical type handle.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @param name The qualified name.
+ * @param count Receives the number of parts.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_text(duckdb_v2_context_handle ctx, duckdb_v2_str text,
-                                                                     duckdb_v2_logical_type_handle *out_type,
-                                                                     duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_qname_get_part_count(duckdb_v2_qname_handle name, idx_t *count,
+                                                            duckdb_v2_error_info_handle *err);
 
 /*!
- * Creates a logical type from a type id plus value parameters.
+ * Borrows one part of the qualified name.
  *
- * The id-keyed twin of connection_create_type_from_name: the type id names the kind, and the parameters bind it. With
- * param_count 0 it instantiates a primitive directly, without touching the catalog: BOOLEAN, TINYINT..BIGINT,
- * UTINYINT..UBIGINT, HUGEINT, UHUGEINT, FLOAT, DOUBLE, DATE, every TIME and TIMESTAMP variant, INTERVAL, VARCHAR, BLOB,
- * BIT, BIGNUM, and UUID. ANY is accepted as well.
- *
- * ANY is a function-signature wildcard, constructible here so it can be passed to the function parameter and varargs
- * setters, as a fixed-arity ANY parameter or an ANY varargs type. Data-creating surfaces reject it: value and data
- * chunk creation, scalar and aggregate return types, table function result columns, cast source and target types, and
- * custom type registration.
- *
- * With parameters, the id resolves to its canonical type name and binds through the same path as
- * connection_create_type_from_name, so the parameterized kinds construct here too: decimal(width, scale); list(T);
- * array(T, size); map(K, V); struct(fields); union(members); enum(entries); and varchar with a named "collation"
- * parameter. Parameters are (name, value) pairs in two parallel arrays, exactly as for
- * connection_create_type_from_name.
- *
- * Returns ERROR_INPUT_INVALID when param_count is 0 and the id needs parameters (DECIMAL, LIST, STRUCT, TUPLE, MAP,
- * ARRAY, UNION, ENUM, VARIANT, GEOMETRY), for the bind-time-only ids (SQLNULL, UNKNOWN), for TYPE — construct that via
- * connection_create_type_from_text — and for INVALID.
+ * Parts are ordered outermost first, so the object name is the part at `duckdb_v2_qname_get_part_count()` - 1. The view
+ * is valid until the qualified name is destroyed. An index outside [0, count) is rejected with
+ * `ERROR_INPUT_OUT_OF_RANGE`.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param conn The connection supplying the catalog and active transaction.
- * @param type_id The type id to instantiate.
- * @param param_names Optional. An array of param_count parameter names; a {NULL, 0} entry is positional. Pass NULL for
- * all-positional parameters.
- * @param param_values An array of param_count parameter values. Borrowed (copied in). Pass NULL when param_count is 0.
- * @param param_count The number of parameters. 0 instantiates a parameterless primitive.
- * @param out_type Receives the new logical type handle.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @param name The qualified name.
+ * @param index Zero-based part index.
+ * @param part Receives a borrowed view of the part, valid until the qualified name is destroyed.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_create_type_from_id(
-    duckdb_v2_connection_handle conn, DUCKDB_V2_LOGICAL_TYPE_ID type_id, const duckdb_v2_identifier_t *param_names,
-    const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
-    duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_qname_get_part(duckdb_v2_qname_handle name, idx_t index,
+                                                      duckdb_v2_identifier_t *part, duckdb_v2_error_info_handle *err);
 
 /*!
- * Creates a logical type from a type name plus value parameters, using a connection.
+ * Renders the qualified name as SQL text.
  *
- * The same as context_create_type_from_name, except that the catalog and transaction come from a connection: the bind
- * runs in its own transaction on that connection's context. Use it from outside DuckDB, where a connection — but no
- * context — is in hand.
- *
- * Parameters are (name, value) pairs in two parallel arrays, exactly as for context_create_type_from_name.
- *
- * The returned logical type is caller-owned and must be destroyed via logical_type_destroy. A type resolved from the
- * catalog shares database-owned storage, such as an ENUM dictionary, so destroy it before closing the database.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param conn The connection supplying the catalog and active transaction.
- * @param name View of the type name to resolve. Unqualified; case-insensitive.
- * @param param_names Optional. An array of param_count parameter names; a {NULL, 0} entry is positional. Pass NULL for
- * all-positional parameters.
- * @param param_values An array of param_count parameter values. Borrowed (copied in). Pass NULL when param_count is 0.
- * @param param_count The number of parameters.
- * @param out_type Receives the new logical type handle.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_create_type_from_name(
-    duckdb_v2_connection_handle conn, duckdb_v2_identifier_t name, const duckdb_v2_identifier_t *param_names,
-    const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
-    duckdb_v2_error_info_handle *err);
-
-/*!
- * Creates a logical type by parsing SQL text, using a connection.
- *
- * The same as context_create_type_from_text, except that the catalog and transaction come from a connection: the parse
- * and bind run in their own transaction on that connection's context. Use it from outside DuckDB, where a connection —
- * but no context — is in hand.
- *
- * The returned logical type is caller-owned and must be destroyed via logical_type_destroy. A type resolved from the
- * catalog shares database-owned storage, such as an ENUM dictionary, so destroy it before closing the database.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param conn The connection supplying the catalog and active transaction.
- * @param text View of the SQL type expression to parse.
- * @param out_type Receives the new logical type handle.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_create_type_from_text(duckdb_v2_connection_handle conn,
-                                                                        duckdb_v2_str text,
-                                                                        duckdb_v2_logical_type_handle *out_type,
-                                                                        duckdb_v2_error_info_handle *err);
-
-/*!
- * Creates a copy of a logical type.
- *
- * On success, writes the new caller-owned handle into *out_type; destroy it via logical_type_destroy.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param type The logical type to copy.
- * @param out_type Receives the new logical type handle.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_copy(duckdb_v2_logical_type_handle type,
-                                                         duckdb_v2_logical_type_handle *out_type,
-                                                         duckdb_v2_error_info_handle *err);
-
-/*!
- * Destroys a logical type handle.
- *
- * Null-safe: passing nullptr or a slot already set to nullptr is a no-op. On success the slot is set to nullptr.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param type The logical type to destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_destroy(duckdb_v2_logical_type_handle *type);
-
-/*!
- * Compares two logical types for deep equality.
- *
- * Two types are equal when they agree in kind and in every parameter, recursively. DECIMAL(10, 2) equals DECIMAL(10,
- * 2), but not DECIMAL(10, 3) and not FLOAT; two STRUCTs are equal when they have the same field names in the same order
- * and equal field types.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param left The first logical type.
- * @param right The second logical type.
- * @param result Receives the result of the comparison.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_is_equal(duckdb_v2_logical_type_handle left,
-                                                             duckdb_v2_logical_type_handle right, bool *result,
-                                                             duckdb_v2_error_info_handle *err);
-
-/*!
- * Returns the logical type id.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param type The logical type.
- * @param out_id Receives the type id.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_id(duckdb_v2_logical_type_handle type,
-                                                           DUCKDB_V2_LOGICAL_TYPE_ID *out_id,
-                                                           duckdb_v2_error_info_handle *err);
-
-/*!
- * Borrows the logical type's name.
- *
- * The alias when one is set — an extension or user-defined name such as "POINT_2D" — otherwise the canonical name of
- * the type id, such as "INTEGER", "DECIMAL", or "TIMESTAMP WITH TIME ZONE". Never the empty view. This is exactly the
- * name vocabulary create_type_from_name accepts. The view is valid until the logical type is destroyed; a canonical
- * name points at static storage.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param type The logical type.
- * @param out_name Receives a borrowed view of the name (alias when set, else the id's canonical name).
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_name(duckdb_v2_logical_type_handle type,
-                                                             duckdb_v2_identifier_t *out_name,
-                                                             duckdb_v2_error_info_handle *err);
-
-/*!
- * Renders a logical type as SQL text.
- *
- * An aliased type renders as its alias, and create_type_from_text resolves that spelling only when the name is
- * registered in the connection's catalog. The text round-trips through create_type_from_text for every constructible
- * kind, with one exception: ANY renders as "ANY", but create_type_from_text cannot parse it back, since ANY is a
- * signature wildcard rather than a parseable SQL type.
+ * Joins the parts with dots, quoting and escaping each one only where the identifier requires it, so the result parses
+ * back through `duckdb_v2_qname_parse()` to an equal name.
  *
  * Writes into a caller-supplied buffer, so nothing is allocated on the caller's behalf and nothing has to be freed.
  * Pass out_text = NULL to size the buffer without rendering into it: out_length then receives the length, and
@@ -2920,119 +2622,73 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_name(duckdb_v2_logical_t
  * history:
  * - stable: v2.0.0
  *
- * @param type The logical type.
+ * @param name The qualified name to render.
  * @param out_text Caller-owned buffer receiving the text plus a null terminator, or NULL to only report the required
  * length in out_length.
  * @param out_capacity Bytes available in out_text, terminator included. Ignored when out_text is NULL.
  * @param out_length Receives the text length excluding the null terminator — written on success and on
  * ERROR_INPUT_OBJECT_SIZE.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_to_text(duckdb_v2_logical_type_handle type, char *out_text,
-                                                            idx_t out_capacity, idx_t *out_length,
-                                                            duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_qname_render(duckdb_v2_qname_handle name, char *out_text, idx_t out_capacity,
+                                                    idx_t *out_length, duckdb_v2_error_info_handle *err);
 
 /*!
- * Returns the number of value parameters of a logical type.
+ * Compares two qualified names.
  *
- * The inspection dual of create_type_from_name: these are the parameters that reconstruct the type through it. Per
- * kind: DECIMAL 2 (width, scale); LIST 1 (element type); ARRAY 2 (element type, size); MAP 2 (key type, value type);
- * STRUCT and TUPLE one per field; UNION one per member; ENUM one per dictionary entry; VARCHAR 1 when a collation is
- * set, else 0; GEOMETRY 1 when a coordinate system is set, else 0; everything else 0. A bound type reports only what it
- * actually carries, so a bind-time modifier that is not retained — an ignored VARCHAR length, say — does not reappear.
+ * True when both have the same number of parts and every part matches case-insensitively, which is the engine's own
+ * identifier equality: casing never distinguishes two names. This is the only way to compare names; two handles holding
+ * equal names are still distinct pointers.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param type The logical type.
- * @param out_count Receives the number of parameters.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @param left The first qualified name.
+ * @param right The second qualified name.
+ * @param result Receives whether the two names are equal.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_param_count(duckdb_v2_logical_type_handle type,
-                                                                    idx_t *out_count, duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_qname_equals(duckdb_v2_qname_handle left, duckdb_v2_qname_handle right,
+                                                    bool *result, duckdb_v2_error_info_handle *err);
 
 /*!
- * Returns one value parameter of a logical type.
+ * Hashes a qualified name.
  *
- * out_name receives a borrowed view of the parameter name — a STRUCT field name, a UNION member name, "collation" — or
- * the empty view {NULL, 0} for a positional parameter. A non-empty view is valid until the logical type is destroyed.
- * out_value receives an owned value, destroyed via value_destroy: child types come back as TYPE values (unwrap them
- * with value_get_type), DECIMAL width and scale as UTINYINT, ARRAY size as BIGINT, and ENUM dictionary entries and
- * collations as VARCHAR. An out-of-range index returns ERROR_INPUT_INVALID. Each call allocates one owned value.
+ * Consistent with `duckdb_v2_qname_equals()`: names that compare equal hash equal, casing differences included. The
+ * value is not stable across processes or library versions, so use it for in-process lookup tables only and never
+ * persist it.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param type The logical type.
- * @param index The parameter index, in [0, param_count).
- * @param out_name Receives a borrowed view of the parameter name, or the empty view {NULL, 0} for a positional
- * parameter.
- * @param out_value Receives the owned parameter value.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @param name The qualified name to hash.
+ * @param hash Receives the hash value.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_param(duckdb_v2_logical_type_handle type, idx_t index,
-                                                              duckdb_v2_identifier_t *out_name,
-                                                              duckdb_v2_value_handle *out_value,
-                                                              duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_qname_hash(duckdb_v2_qname_handle name, uint64_t *hash,
+                                                  duckdb_v2_error_info_handle *err);
 
 /*!
- * Creates a logical type that is an alias of another logical type.
+ * Destroys the qualified name, releasing its resources.
  *
- * The alias keeps the base type's internal representation, so executing against it needs no special handling, while
- * remaining logically distinct from the base type. Intended for custom type bind callbacks, where both the base type
- * and the name come from the bind info.
- *
- * Scoped like the rest of the create_type family: the alias is resolved against the catalog reachable from the context.
- * An empty alias name returns ERROR_INPUT_INVALID.
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Any part views borrowed from it become dangling.
  *
  * history:
  * - stable: v2.0.0
  *
- * @param ctx The context to resolve the alias against.
- * @param base_type The logical type to alias. Typically the base type supplied in the custom type bind info.
- * @param alias_name The name for the resulting type. Typically the name of the custom type being constructed, also
- * available from the bind info.
- * @param out_type Receives the new type: the base type's internal representation under the given alias name.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @param name The qualified name to destroy.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_create_type_with_alias(duckdb_v2_context_handle ctx,
-                                                                      duckdb_v2_logical_type_handle base_type,
-                                                                      duckdb_v2_identifier_t alias_name,
-                                                                      duckdb_v2_logical_type_handle *out_type,
-                                                                      duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_qname_destroy(duckdb_v2_qname_handle *name);
 
-/*!
- * Creates a logical type that is an alias of another logical type.
- *
- * The alias keeps the base type's internal representation, so executing against it needs no special handling, while
- * remaining logically distinct from the base type. Intended for custom type bind callbacks, where both the base type
- * and the name come from the bind info.
- *
- * Scoped like the rest of the create_type family: the alias is resolved against the catalog reachable from the
- * connection. An empty alias name returns ERROR_INPUT_INVALID.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param conn The connection to resolve the alias against.
- * @param base_type The logical type to alias. Typically the base type supplied in the custom type bind info.
- * @param alias_name The name for the resulting type. Typically the name of the custom type being constructed, also
- * available from the bind info.
- * @param out_type Receives the new type: the base type's internal representation under the given alias name.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_create_type_with_alias(duckdb_v2_connection_handle conn,
-                                                                         duckdb_v2_logical_type_handle base_type,
-                                                                         duckdb_v2_identifier_t alias_name,
-                                                                         duckdb_v2_logical_type_handle *out_type,
-                                                                         duckdb_v2_error_info_handle *err);
-
-/* --- Struct definitions for logical_type --- */
+/* --- Struct definitions for qname --- */
 
 /* ============================================================================
  * MODULE: schema
@@ -4835,6 +4491,547 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_query_progress_destroy(duckdb_v2_query_pr
 /* --- Struct definitions for connection --- */
 
 /* ============================================================================
+ * MODULE: logical_type
+ * ============================================================================ */
+
+/* --- Enums for logical_type --- */
+
+/*!
+ * Logical type identifier. The values are the same integers DuckDB uses internally, so round-tripping is lossless. The
+ * bind- and UDF-only ids (UNKNOWN, ANY, TEMPLATE) appear here for completeness; they do not show up in result column
+ * types in practice.
+ */
+typedef enum DUCKDB_V2_LOGICAL_TYPE_ID {
+	//! Invalid / unset.
+	DUCKDB_V2_LOGICAL_TYPE_ID_INVALID = 0,
+
+	//! NULL constant type.
+	DUCKDB_V2_LOGICAL_TYPE_ID_SQLNULL = 1,
+
+	//! Unknown — used for unresolved parameter expressions.
+	DUCKDB_V2_LOGICAL_TYPE_ID_UNKNOWN = 2,
+
+	//! ANY — used for functions that accept any type.
+	DUCKDB_V2_LOGICAL_TYPE_ID_ANY = 3,
+
+	/*!
+	 * A type carried as a value (type parameters). Values of this type are built via value_create_type_with_context /
+	 * _with_connection.
+	 */
+	DUCKDB_V2_LOGICAL_TYPE_ID_TYPE = 6,
+	DUCKDB_V2_LOGICAL_TYPE_ID_BOOLEAN = 10,
+	DUCKDB_V2_LOGICAL_TYPE_ID_TINYINT = 11,
+	DUCKDB_V2_LOGICAL_TYPE_ID_SMALLINT = 12,
+	DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER = 13,
+	DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT = 14,
+
+	//! 32-bit days since epoch.
+	DUCKDB_V2_LOGICAL_TYPE_ID_DATE = 15,
+
+	//! 64-bit microseconds since midnight.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIME = 16,
+
+	//! 64-bit seconds since epoch.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_SEC = 17,
+
+	//! 64-bit milliseconds since epoch.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_MS = 18,
+
+	//! 64-bit microseconds since epoch.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP = 19,
+
+	//! 64-bit nanoseconds since epoch.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_NS = 20,
+
+	//! Decimal with width and scale parameters.
+	DUCKDB_V2_LOGICAL_TYPE_ID_DECIMAL = 21,
+	DUCKDB_V2_LOGICAL_TYPE_ID_FLOAT = 22,
+	DUCKDB_V2_LOGICAL_TYPE_ID_DOUBLE = 23,
+	DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR = 25,
+	DUCKDB_V2_LOGICAL_TYPE_ID_BLOB = 26,
+	DUCKDB_V2_LOGICAL_TYPE_ID_INTERVAL = 27,
+	DUCKDB_V2_LOGICAL_TYPE_ID_UTINYINT = 28,
+	DUCKDB_V2_LOGICAL_TYPE_ID_USMALLINT = 29,
+	DUCKDB_V2_LOGICAL_TYPE_ID_UINTEGER = 30,
+	DUCKDB_V2_LOGICAL_TYPE_ID_UBIGINT = 31,
+
+	//! 64-bit microseconds since epoch, timezone-aware.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_TZ = 32,
+
+	//! 64-bit nanoseconds since epoch, timezone-aware.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIMESTAMP_TZ_NS = 33,
+
+	//! 64-bit microseconds since midnight + 32-bit offset.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIME_TZ = 34,
+
+	//! 64-bit nanoseconds since midnight.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TIME_NS = 35,
+	DUCKDB_V2_LOGICAL_TYPE_ID_BIT = 36,
+
+	//! Arbitrary-precision integer (VARINT-encoded).
+	DUCKDB_V2_LOGICAL_TYPE_ID_BIGNUM = 39,
+	DUCKDB_V2_LOGICAL_TYPE_ID_UHUGEINT = 49,
+	DUCKDB_V2_LOGICAL_TYPE_ID_HUGEINT = 50,
+	DUCKDB_V2_LOGICAL_TYPE_ID_UUID = 54,
+
+	//! Geometry (spatial extension).
+	DUCKDB_V2_LOGICAL_TYPE_ID_GEOMETRY = 60,
+	DUCKDB_V2_LOGICAL_TYPE_ID_STRUCT = 100,
+	DUCKDB_V2_LOGICAL_TYPE_ID_LIST = 101,
+	DUCKDB_V2_LOGICAL_TYPE_ID_MAP = 102,
+	DUCKDB_V2_LOGICAL_TYPE_ID_ENUM = 104,
+	DUCKDB_V2_LOGICAL_TYPE_ID_UNION = 107,
+	DUCKDB_V2_LOGICAL_TYPE_ID_ARRAY = 108,
+	DUCKDB_V2_LOGICAL_TYPE_ID_VARIANT = 109,
+
+	//! Unnamed struct; shares the physical representation of STRUCT.
+	DUCKDB_V2_LOGICAL_TYPE_ID_TUPLE = 110,
+	DUCKDB_V2_LOGICAL_TYPE_ID_MAX_ENUM = 0x7FFFFFFF,
+} DUCKDB_V2_LOGICAL_TYPE_ID;
+
+/* --- Struct forward declarations for logical_type --- */
+
+/* --- Types for logical_type --- */
+
+/* --- Constants for logical_type --- */
+
+/* --- Function pointer typedefs for logical_type --- */
+
+/* --- Functions for logical_type --- */
+
+/*!
+ * Creates a logical type from a type id plus value parameters.
+ *
+ * The id-keyed twin of context_create_type_from_name: the type id names the kind, and the parameters bind it. With
+ * param_count 0 it instantiates a primitive directly, without touching the catalog: BOOLEAN, TINYINT..BIGINT,
+ * UTINYINT..UBIGINT, HUGEINT, UHUGEINT, FLOAT, DOUBLE, DATE, every TIME and TIMESTAMP variant, INTERVAL, VARCHAR, BLOB,
+ * BIT, BIGNUM, and UUID. ANY is accepted as well.
+ *
+ * ANY is a function-signature wildcard, constructible here so it can be passed to the function parameter and varargs
+ * setters, as a fixed-arity ANY parameter or an ANY varargs type. Data-creating surfaces reject it: value and data
+ * chunk creation, scalar and aggregate return types, table function result columns, cast source and target types, and
+ * custom type registration.
+ *
+ * With parameters, the id resolves to its canonical type name and binds through the same path as
+ * context_create_type_from_name, so the parameterized kinds construct here too: decimal(width, scale); list(T);
+ * array(T, size); map(K, V); struct(fields); union(members); enum(entries); and varchar with a named "collation"
+ * parameter. Parameters are (name, value) pairs in two parallel arrays, exactly as for context_create_type_from_name.
+ *
+ * Returns ERROR_INPUT_INVALID when param_count is 0 and the id needs parameters (DECIMAL, LIST, STRUCT, TUPLE, MAP,
+ * ARRAY, UNION, ENUM, VARIANT, GEOMETRY), for the bind-time-only ids (SQLNULL, UNKNOWN), for TYPE — construct that via
+ * context_create_type_from_text — and for INVALID.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param ctx The context supplying the catalog and active transaction.
+ * @param type_id The type id to instantiate.
+ * @param param_names Optional. An array of param_count parameter names; a {NULL, 0} entry is positional. Pass NULL for
+ * all-positional parameters.
+ * @param param_values An array of param_count parameter values. Borrowed (copied in). Pass NULL when param_count is 0.
+ * @param param_count The number of parameters. 0 instantiates a parameterless primitive.
+ * @param out_type Receives the new logical type handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_id(
+    duckdb_v2_context_handle ctx, DUCKDB_V2_LOGICAL_TYPE_ID type_id, const duckdb_v2_identifier_t *param_names,
+    const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a logical type from a type name plus value parameters.
+ *
+ * The generic constructor: resolves the name in the context's catalog and binds it with the given parameters, exactly
+ * as SQL binds a type expression. Built-in parameterized kinds and registered extension types construct through this
+ * same call.
+ *
+ * An unqualified name is resolved along the search path first and then in the system catalog, which is where the
+ * built-in kinds live. A qualified name is resolved exactly as written, with no system-catalog fallback, so it names
+ * the type in that catalog or schema or fails.
+ *
+ * Parameters are (name, value) pairs in two parallel arrays. param_names may be NULL to make every parameter
+ * positional, and a {NULL, 0} entry makes that one parameter positional. Child types cross as TYPE values, built with
+ * value_create_type_with_context / _with_connection. The built-in shapes are: decimal(width, scale); list(T); array(T,
+ * size); map(K, V); struct(fields, as named or all-positional TYPE values); union(members, as named TYPE values);
+ * enum(entries, as VARCHAR values); and varchar with a named "collation" VARCHAR parameter.
+ *
+ * A name that resolves to a type with no bind function takes no parameters, and passing any fails. Bind errors —
+ * unknown name, wrong parameter count or types — surface from the call.
+ *
+ * Runs in the caller's context scope, as create_type_from_text does: reach it from a bind-phase callback or another
+ * context-holding scope, not from an exec-phase worker callback. External callers holding only a connection use
+ * connection_create_type_from_name instead.
+ *
+ * The returned logical type is caller-owned and must be destroyed via logical_type_destroy. A type resolved from the
+ * catalog shares database-owned storage, such as an ENUM dictionary, so destroy it before closing the database. This is
+ * the inverse of logical_type_get_param_count / logical_type_get_param.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param ctx The context supplying the catalog and active transaction.
+ * @param name The type name to resolve. Parts are matched case-insensitively; qualify it to name a type in a particular
+ * catalog or schema.
+ * @param param_names Optional. An array of param_count parameter names; a {NULL, 0} entry is positional. Pass NULL for
+ * all-positional parameters.
+ * @param param_values An array of param_count parameter values. Borrowed (copied in). Pass NULL when param_count is 0.
+ * @param param_count The number of parameters.
+ * @param out_type Receives the new logical type handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_name(
+    duckdb_v2_context_handle ctx, duckdb_v2_qname_handle name, const duckdb_v2_identifier_t *param_names,
+    const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a logical type by parsing SQL text.
+ *
+ * Parses a SQL type expression in the given context and returns the bound logical type. It accepts primitives
+ * ("INTEGER"), parameterized kinds ("DECIMAL(18,3)", "INTEGER[]", "STRUCT(a INTEGER, b VARCHAR)", "MAP(VARCHAR,
+ * INTEGER)", "INTEGER[3]", "UNION(i INTEGER, s VARCHAR)", "ENUM('a', 'b')"), and catalog-registered type names, both
+ * user-defined and from extensions. A catalog type name binds to its structural type, and the name is not preserved as
+ * an alias. Names are case-insensitive. Parse and bind errors surface from the call.
+ *
+ * Runs in the caller's context scope: a context handle arrives with the context lock held and a transaction active, as
+ * in a function bind callback or custom type registration. Catalog-touching context calls belong in bind-phase
+ * callbacks and other context-holding scopes, not in exec-phase worker callbacks. External callers holding only a
+ * connection use connection_create_type_from_text instead.
+ *
+ * The returned logical type is caller-owned and must be destroyed via logical_type_destroy. A type resolved from the
+ * catalog shares database-owned storage, such as an ENUM dictionary, so destroy it before closing the database. This is
+ * the inverse of logical_type_to_text for every constructible kind.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param ctx The context supplying the catalog and active transaction.
+ * @param text View of the SQL type expression to parse.
+ * @param out_type Receives the new logical type handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_text(duckdb_v2_context_handle ctx, duckdb_v2_str text,
+                                                                     duckdb_v2_logical_type_handle *out_type,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a logical type from a type id plus value parameters.
+ *
+ * The id-keyed twin of connection_create_type_from_name: the type id names the kind, and the parameters bind it. With
+ * param_count 0 it instantiates a primitive directly, without touching the catalog: BOOLEAN, TINYINT..BIGINT,
+ * UTINYINT..UBIGINT, HUGEINT, UHUGEINT, FLOAT, DOUBLE, DATE, every TIME and TIMESTAMP variant, INTERVAL, VARCHAR, BLOB,
+ * BIT, BIGNUM, and UUID. ANY is accepted as well.
+ *
+ * ANY is a function-signature wildcard, constructible here so it can be passed to the function parameter and varargs
+ * setters, as a fixed-arity ANY parameter or an ANY varargs type. Data-creating surfaces reject it: value and data
+ * chunk creation, scalar and aggregate return types, table function result columns, cast source and target types, and
+ * custom type registration.
+ *
+ * With parameters, the id resolves to its canonical type name and binds through the same path as
+ * connection_create_type_from_name, so the parameterized kinds construct here too: decimal(width, scale); list(T);
+ * array(T, size); map(K, V); struct(fields); union(members); enum(entries); and varchar with a named "collation"
+ * parameter. Parameters are (name, value) pairs in two parallel arrays, exactly as for
+ * connection_create_type_from_name.
+ *
+ * Returns ERROR_INPUT_INVALID when param_count is 0 and the id needs parameters (DECIMAL, LIST, STRUCT, TUPLE, MAP,
+ * ARRAY, UNION, ENUM, VARIANT, GEOMETRY), for the bind-time-only ids (SQLNULL, UNKNOWN), for TYPE — construct that via
+ * connection_create_type_from_text — and for INVALID.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param conn The connection supplying the catalog and active transaction.
+ * @param type_id The type id to instantiate.
+ * @param param_names Optional. An array of param_count parameter names; a {NULL, 0} entry is positional. Pass NULL for
+ * all-positional parameters.
+ * @param param_values An array of param_count parameter values. Borrowed (copied in). Pass NULL when param_count is 0.
+ * @param param_count The number of parameters. 0 instantiates a parameterless primitive.
+ * @param out_type Receives the new logical type handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_create_type_from_id(
+    duckdb_v2_connection_handle conn, DUCKDB_V2_LOGICAL_TYPE_ID type_id, const duckdb_v2_identifier_t *param_names,
+    const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a logical type from a type name plus value parameters, using a connection.
+ *
+ * The same as context_create_type_from_name, except that the catalog and transaction come from a connection: the bind
+ * runs in its own transaction on that connection's context. Use it from outside DuckDB, where a connection — but no
+ * context — is in hand.
+ *
+ * Parameters are (name, value) pairs in two parallel arrays, exactly as for context_create_type_from_name.
+ *
+ * The returned logical type is caller-owned and must be destroyed via logical_type_destroy. A type resolved from the
+ * catalog shares database-owned storage, such as an ENUM dictionary, so destroy it before closing the database.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param conn The connection supplying the catalog and active transaction.
+ * @param name The type name to resolve. Parts are matched case-insensitively; qualify it to name a type in a particular
+ * catalog or schema.
+ * @param param_names Optional. An array of param_count parameter names; a {NULL, 0} entry is positional. Pass NULL for
+ * all-positional parameters.
+ * @param param_values An array of param_count parameter values. Borrowed (copied in). Pass NULL when param_count is 0.
+ * @param param_count The number of parameters.
+ * @param out_type Receives the new logical type handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_create_type_from_name(
+    duckdb_v2_connection_handle conn, duckdb_v2_qname_handle name, const duckdb_v2_identifier_t *param_names,
+    const duckdb_v2_value_handle *param_values, idx_t param_count, duckdb_v2_logical_type_handle *out_type,
+    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a logical type by parsing SQL text, using a connection.
+ *
+ * The same as context_create_type_from_text, except that the catalog and transaction come from a connection: the parse
+ * and bind run in their own transaction on that connection's context. Use it from outside DuckDB, where a connection —
+ * but no context — is in hand.
+ *
+ * The returned logical type is caller-owned and must be destroyed via logical_type_destroy. A type resolved from the
+ * catalog shares database-owned storage, such as an ENUM dictionary, so destroy it before closing the database.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param conn The connection supplying the catalog and active transaction.
+ * @param text View of the SQL type expression to parse.
+ * @param out_type Receives the new logical type handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_create_type_from_text(duckdb_v2_connection_handle conn,
+                                                                        duckdb_v2_str text,
+                                                                        duckdb_v2_logical_type_handle *out_type,
+                                                                        duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a copy of a logical type.
+ *
+ * On success, writes the new caller-owned handle into *out_type; destroy it via logical_type_destroy.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The logical type to copy.
+ * @param out_type Receives the new logical type handle.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_copy(duckdb_v2_logical_type_handle type,
+                                                         duckdb_v2_logical_type_handle *out_type,
+                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys a logical type handle.
+ *
+ * Null-safe: passing nullptr or a slot already set to nullptr is a no-op. On success the slot is set to nullptr.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The logical type to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_destroy(duckdb_v2_logical_type_handle *type);
+
+/*!
+ * Compares two logical types for deep equality.
+ *
+ * Two types are equal when they agree in kind and in every parameter, recursively. DECIMAL(10, 2) equals DECIMAL(10,
+ * 2), but not DECIMAL(10, 3) and not FLOAT; two STRUCTs are equal when they have the same field names in the same order
+ * and equal field types.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param left The first logical type.
+ * @param right The second logical type.
+ * @param result Receives the result of the comparison.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_is_equal(duckdb_v2_logical_type_handle left,
+                                                             duckdb_v2_logical_type_handle right, bool *result,
+                                                             duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the logical type id.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The logical type.
+ * @param out_id Receives the type id.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_id(duckdb_v2_logical_type_handle type,
+                                                           DUCKDB_V2_LOGICAL_TYPE_ID *out_id,
+                                                           duckdb_v2_error_info_handle *err);
+
+/*!
+ * Borrows the logical type's name.
+ *
+ * The alias when one is set — an extension or user-defined name such as "POINT_2D" — otherwise the canonical name of
+ * the type id, such as "INTEGER", "DECIMAL", or "TIMESTAMP WITH TIME ZONE". Never the empty view. This is exactly the
+ * name vocabulary create_type_from_name accepts. The view is valid until the logical type is destroyed; a canonical
+ * name points at static storage.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The logical type.
+ * @param out_name Receives a borrowed view of the name (alias when set, else the id's canonical name).
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_name(duckdb_v2_logical_type_handle type,
+                                                             duckdb_v2_identifier_t *out_name,
+                                                             duckdb_v2_error_info_handle *err);
+
+/*!
+ * Renders a logical type as SQL text.
+ *
+ * An aliased type renders as its alias, and create_type_from_text resolves that spelling only when the name is
+ * registered in the connection's catalog. The text round-trips through create_type_from_text for every constructible
+ * kind, with one exception: ANY renders as "ANY", but create_type_from_text cannot parse it back, since ANY is a
+ * signature wildcard rather than a parseable SQL type.
+ *
+ * Writes into a caller-supplied buffer, so nothing is allocated on the caller's behalf and nothing has to be freed.
+ * Pass out_text = NULL to size the buffer without rendering into it: out_length then receives the length, and
+ * out_capacity is ignored. With out_text != NULL, out_capacity must be at least out_length + 1, or the call returns
+ * ERROR_INPUT_OBJECT_SIZE with out_length set to the required length and out_text left untouched.
+ *
+ * out_length never counts the terminator, but a successful write always appends one, so the buffer is usable as a C
+ * string.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The logical type.
+ * @param out_text Caller-owned buffer receiving the text plus a null terminator, or NULL to only report the required
+ * length in out_length.
+ * @param out_capacity Bytes available in out_text, terminator included. Ignored when out_text is NULL.
+ * @param out_length Receives the text length excluding the null terminator — written on success and on
+ * ERROR_INPUT_OBJECT_SIZE.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_to_text(duckdb_v2_logical_type_handle type, char *out_text,
+                                                            idx_t out_capacity, idx_t *out_length,
+                                                            duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns the number of value parameters of a logical type.
+ *
+ * The inspection dual of create_type_from_name: these are the parameters that reconstruct the type through it. Per
+ * kind: DECIMAL 2 (width, scale); LIST 1 (element type); ARRAY 2 (element type, size); MAP 2 (key type, value type);
+ * STRUCT and TUPLE one per field; UNION one per member; ENUM one per dictionary entry; VARCHAR 1 when a collation is
+ * set, else 0; GEOMETRY 1 when a coordinate system is set, else 0; everything else 0. A bound type reports only what it
+ * actually carries, so a bind-time modifier that is not retained — an ignored VARCHAR length, say — does not reappear.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The logical type.
+ * @param out_count Receives the number of parameters.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_param_count(duckdb_v2_logical_type_handle type,
+                                                                    idx_t *out_count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Returns one value parameter of a logical type.
+ *
+ * out_name receives a borrowed view of the parameter name — a STRUCT field name, a UNION member name, "collation" — or
+ * the empty view {NULL, 0} for a positional parameter. A non-empty view is valid until the logical type is destroyed.
+ * out_value receives an owned value, destroyed via value_destroy: child types come back as TYPE values (unwrap them
+ * with value_get_type), DECIMAL width and scale as UTINYINT, ARRAY size as BIGINT, and ENUM dictionary entries and
+ * collations as VARCHAR. An out-of-range index returns ERROR_INPUT_INVALID. Each call allocates one owned value.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param type The logical type.
+ * @param index The parameter index, in [0, param_count).
+ * @param out_name Receives a borrowed view of the parameter name, or the empty view {NULL, 0} for a positional
+ * parameter.
+ * @param out_value Receives the owned parameter value.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_logical_type_get_param(duckdb_v2_logical_type_handle type, idx_t index,
+                                                              duckdb_v2_identifier_t *out_name,
+                                                              duckdb_v2_value_handle *out_value,
+                                                              duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a logical type that is an alias of another logical type.
+ *
+ * The alias keeps the base type's internal representation, so executing against it needs no special handling, while
+ * remaining logically distinct from the base type. Intended for custom type bind callbacks, where both the base type
+ * and the name come from the bind info.
+ *
+ * Scoped like the rest of the create_type family: the alias is resolved against the catalog reachable from the context.
+ * An empty alias name returns ERROR_INPUT_INVALID.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param ctx The context to resolve the alias against.
+ * @param base_type The logical type to alias. Typically the base type supplied in the custom type bind info.
+ * @param alias_name The name for the resulting type. Typically the name of the custom type being constructed, also
+ * available from the bind info.
+ * @param out_type Receives the new type: the base type's internal representation under the given alias name.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_context_create_type_with_alias(duckdb_v2_context_handle ctx,
+                                                                      duckdb_v2_logical_type_handle base_type,
+                                                                      duckdb_v2_identifier_t alias_name,
+                                                                      duckdb_v2_logical_type_handle *out_type,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a logical type that is an alias of another logical type.
+ *
+ * The alias keeps the base type's internal representation, so executing against it needs no special handling, while
+ * remaining logically distinct from the base type. Intended for custom type bind callbacks, where both the base type
+ * and the name come from the bind info.
+ *
+ * Scoped like the rest of the create_type family: the alias is resolved against the catalog reachable from the
+ * connection. An empty alias name returns ERROR_INPUT_INVALID.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param conn The connection to resolve the alias against.
+ * @param base_type The logical type to alias. Typically the base type supplied in the custom type bind info.
+ * @param alias_name The name for the resulting type. Typically the name of the custom type being constructed, also
+ * available from the bind info.
+ * @param out_type Receives the new type: the base type's internal representation under the given alias name.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_connection_create_type_with_alias(duckdb_v2_connection_handle conn,
+                                                                         duckdb_v2_logical_type_handle base_type,
+                                                                         duckdb_v2_identifier_t alias_name,
+                                                                         duckdb_v2_logical_type_handle *out_type,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/* --- Struct definitions for logical_type --- */
+
+/* ============================================================================
  * MODULE: replacement scan
  * ============================================================================ */
 
@@ -4858,7 +5055,7 @@ typedef struct _duckdb_v2_replacement_scan {
 /*!
  * A borrowed opaque handle to the arguments supplied to a replacement scan when the binder consults it. The callback
  * receives this handle and can use it to inspect the unresolved name and to claim it by naming what to read instead.
- * Valid only for the duration of the callback, as are the name views obtained through it.
+ * Valid only for the duration of the callback; the name it hands out is owned separately and outlives it.
  */
 typedef struct _duckdb_v2_replacement_scan_info {
 	void *internal_ptr;
@@ -4945,7 +5142,7 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_create_with_extension(du
  * Sets the callback of the replacement scan.
  *
  * The callback is invoked during query planning for each table reference the catalog could not resolve. It can inspect
- * the unresolved name via `duckdb_v2_replacement_scan_get_table_name()` and its qualifiers, and claim the reference via
+ * the unresolved name via `duckdb_v2_replacement_scan_get_name()`, and claim the reference via
  * `duckdb_v2_replacement_scan_set_function_name()`, `duckdb_v2_replacement_scan_set_collection()` or
  * `duckdb_v2_replacement_scan_set_subquery()`; returning without claiming declines it. The context passed to the
  * callback may be used to read settings, but not to run queries. A callback must be set before registration.
@@ -5000,70 +5197,34 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_user_data(duckdb_v2_
                                                                       void **data, duckdb_v2_error_info_handle *err);
 
 /*!
- * Retrieves the catalog name of the unresolved reference.
+ * Retrieves the name the catalog could not resolve.
  *
- * Returns the empty view `{NULL, 0}` when the reference carries no catalog qualifier. The name is borrowed and valid
- * only for the duration of the callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The info handle.
- * @param name Receives the borrowed catalog name, or the empty view when the reference carries no catalog qualifier.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_catalog_name(duckdb_v2_replacement_scan_info_handle info,
-                                                                         duckdb_v2_identifier_t *name,
-                                                                         duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the schema name of the unresolved reference.
- *
- * Returns the empty view `{NULL, 0}` when the reference carries no schema qualifier. The name is borrowed and valid
- * only for the duration of the callback.
+ * The name as written in the query, as a path: an unqualified reference has a single part, and a qualified one carries
+ * its catalog and schema before it -- see `duckdb_v2_qname_get_part()`. For a file-backed reference the single part is
+ * the path with the quotes stripped. The returned name is owned by the caller and must be destroyed via
+ * `duckdb_v2_qname_destroy()`; being owned, it may outlive the callback.
  *
  * history:
  * - stable: v2.0.0
  *
  * @param info The info handle.
- * @param name Receives the borrowed schema name, or the empty view when the reference carries no schema qualifier.
+ * @param name Receives the unresolved name. Owned by the caller; destroy via `duckdb_v2_qname_destroy()`.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_schema_name(duckdb_v2_replacement_scan_info_handle info,
-                                                                        duckdb_v2_identifier_t *name,
-                                                                        duckdb_v2_error_info_handle *err);
-
-/*!
- * Retrieves the table name of the unresolved reference.
- *
- * This is the name as written in the query, which for a file-backed reference is the path with the quotes stripped.
- * Never the empty view. The name is borrowed and valid only for the duration of the callback.
- *
- * history:
- * - stable: v2.0.0
- *
- * @param info The info handle.
- * @param name Receives the borrowed table name.
- * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
- * `duckdb_v2_error_info_destroy()`.
- * @return DUCKDB_V2_ERROR
- */
-DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_table_name(duckdb_v2_replacement_scan_info_handle info,
-                                                                       duckdb_v2_identifier_t *name,
-                                                                       duckdb_v2_error_info_handle *err);
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_name(duckdb_v2_replacement_scan_info_handle info,
+                                                                 duckdb_v2_qname_handle *name,
+                                                                 duckdb_v2_error_info_handle *err);
 
 /*!
  * Claims the reference by naming a table function to read instead.
  *
  * Arguments to the function are added with `duckdb_v2_replacement_scan_add_argument()` and
- * `duckdb_v2_replacement_scan_add_named_argument()`. The name is borrowed and copied. It is matched case-insensitively
- * and is never split on ".", so it always names an unqualified function; an empty name results in an error. The name is
- * not resolved here: an unknown function fails later, when the replacement is bound. Calling this again replaces the
- * previous name and keeps the arguments added so far.
+ * `duckdb_v2_replacement_scan_add_named_argument()`. The name is borrowed and copied, and its parts are matched
+ * case-insensitively. A qualified name targets a function in a particular schema or catalog, exactly as writing it out
+ * in SQL would. The name is not resolved here: an unknown function fails later, when the replacement is bound. Calling
+ * this again replaces the previous name and keeps the arguments added so far.
  *
  * The three claim forms, `duckdb_v2_replacement_scan_set_function_name()`,
  * `duckdb_v2_replacement_scan_set_collection()` and `duckdb_v2_replacement_scan_set_subquery()`, are mutually
@@ -5073,13 +5234,13 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_table_name(duckdb_v2
  * - stable: v2.0.0
  *
  * @param info The info handle.
- * @param name The name of the table function to read instead. Borrowed and copied.
+ * @param name The table function to read instead. Borrowed and copied.
  * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
  * `duckdb_v2_error_info_destroy()`.
  * @return DUCKDB_V2_ERROR
  */
 DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_function_name(duckdb_v2_replacement_scan_info_handle info,
-                                                                          duckdb_v2_identifier_t name,
+                                                                          duckdb_v2_qname_handle name,
                                                                           duckdb_v2_error_info_handle *err);
 
 /*!

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -1188,8 +1188,8 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_data_collection_create_with_contex
  * Drops all buffered rows, keeping the column types.
  *
  * Drops all buffered rows and releases their memory. The column types are unchanged and the collection is immediately
- * appendable again. Outstanding append and scan states are invalidated; create new ones. Must not be called while a
- * live result executes over the collection, because that result's scan borrows the collection's buffers.
+ * appendable again. Existing append and scan states are invalidated. Use `duckdb_v2_column_data_collection_clear()`
+ * instead to keep the memory for the next appends.
  *
  * history:
  * - stable: v2.0.0
@@ -1199,6 +1199,24 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_data_collection_create_with_contex
  * @return DUCKDB_V2_ERROR
  */
 DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_data_collection_reset(duckdb_v2_column_data_collection_handle collection,
+                                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Drops all buffered rows, keeping the column types and the memory.
+ *
+ * Like `duckdb_v2_column_data_collection_reset()`, but the buffers are retained rather than released, so the next
+ * appends write into memory that is already allocated. Use this when the collection is refilled repeatedly. The column
+ * types are unchanged and the collection is immediately appendable again. Existing append and scan states are
+ * invalidated.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param collection The collection to clear.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_column_data_collection_clear(duckdb_v2_column_data_collection_handle collection,
                                                                     duckdb_v2_error_info_handle *err);
 
 /*!
@@ -4815,6 +4833,412 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_query_progress_get_total_rows_to_process(
 DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_query_progress_destroy(duckdb_v2_query_progress_handle *progress);
 
 /* --- Struct definitions for connection --- */
+
+/* ============================================================================
+ * MODULE: replacement scan
+ * ============================================================================ */
+
+/* --- Enums for replacement scan --- */
+
+/* --- Struct forward declarations for replacement scan --- */
+
+/* --- Types for replacement scan --- */
+
+/*!
+ * An owned opaque handle to a replacement scan being built. Created with
+ * `duckdb_v2_replacement_scan_create_with_connection()`, `duckdb_v2_replacement_scan_create_with_database()` or
+ * `duckdb_v2_replacement_scan_create_with_extension()`, configured with `duckdb_v2_replacement_scan_set_callback()` and
+ * `duckdb_v2_replacement_scan_set_user_data()`, made available with `duckdb_v2_replacement_scan_register()`, and
+ * destroyed with `duckdb_v2_replacement_scan_destroy()`.
+ */
+typedef struct _duckdb_v2_replacement_scan {
+	void *internal_ptr;
+} * duckdb_v2_replacement_scan_handle;
+
+/*!
+ * A borrowed opaque handle to the arguments supplied to a replacement scan when the binder consults it. The callback
+ * receives this handle and can use it to inspect the unresolved name and to claim it by naming what to read instead.
+ * Valid only for the duration of the callback, as are the name views obtained through it.
+ */
+typedef struct _duckdb_v2_replacement_scan_info {
+	void *internal_ptr;
+} * duckdb_v2_replacement_scan_info_handle;
+
+/* --- Constants for replacement scan --- */
+
+/* --- Function pointer typedefs for replacement scan --- */
+
+typedef void (*duckdb_v2_replacement_scan_callback_fn)(duckdb_v2_replacement_scan_info_handle info,
+                                                       duckdb_v2_context_handle context,
+                                                       duckdb_v2_error_info_handle *err);
+
+/* --- Functions for replacement scan --- */
+
+/*!
+ * Creates a new replacement scan that will be registered on the connection.
+ *
+ * The scan is visible only to queries on this connection and is released when the connection closes. It is consulted
+ * before every database-wide scan, so it can claim a name that a built-in scan would otherwise take. The scan starts
+ * out empty: configure it with `duckdb_v2_replacement_scan_set_callback()` and optionally
+ * `duckdb_v2_replacement_scan_set_user_data()`, then make it available with `duckdb_v2_replacement_scan_register()`.
+ * The caller owns the returned handle and must destroy it with `duckdb_v2_replacement_scan_destroy()`, also after
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param connection The connection to create the scan on.
+ * @param scan On success, receives the newly created replacement scan. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_create_with_connection(duckdb_v2_connection_handle connection,
+                                                                               duckdb_v2_replacement_scan_handle *scan,
+                                                                               duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a new replacement scan that will be registered on the database.
+ *
+ * The scan is visible to every connection to the database and lives until the database closes. The scan starts out
+ * empty: configure it with `duckdb_v2_replacement_scan_set_callback()` and optionally
+ * `duckdb_v2_replacement_scan_set_user_data()`, then make it available with `duckdb_v2_replacement_scan_register()`.
+ * The caller owns the returned handle and must destroy it with `duckdb_v2_replacement_scan_destroy()`, also after
+ * registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param database The database to create the scan on.
+ * @param scan On success, receives the newly created replacement scan. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_create_with_database(duckdb_v2_database_handle database,
+                                                                             duckdb_v2_replacement_scan_handle *scan,
+                                                                             duckdb_v2_error_info_handle *err);
+
+/*!
+ * Creates a new replacement scan that will be registered on the loading extension's database.
+ *
+ * Use this from an extension load callback, where an extension handle is available. The scan is visible to every
+ * connection to that database and lives until the database closes. The scan starts out empty: configure it with
+ * `duckdb_v2_replacement_scan_set_callback()` and optionally `duckdb_v2_replacement_scan_set_user_data()`, then make it
+ * available with `duckdb_v2_replacement_scan_register()`. The caller owns the returned handle and must destroy it with
+ * `duckdb_v2_replacement_scan_destroy()`, also after registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param extension The extension to create the scan on.
+ * @param scan On success, receives the newly created replacement scan. Owned by the caller.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_create_with_extension(duckdb_v2_extension_handle extension,
+                                                                              duckdb_v2_replacement_scan_handle *scan,
+                                                                              duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the callback of the replacement scan.
+ *
+ * The callback is invoked during query planning for each table reference the catalog could not resolve. It can inspect
+ * the unresolved name via `duckdb_v2_replacement_scan_get_table_name()` and its qualifiers, and claim the reference via
+ * `duckdb_v2_replacement_scan_set_function_name()`, `duckdb_v2_replacement_scan_set_collection()` or
+ * `duckdb_v2_replacement_scan_set_subquery()`; returning without claiming declines it. The context passed to the
+ * callback may be used to read settings, but not to run queries. A callback must be set before registration.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param scan The scan to set the callback of.
+ * @param callback The callback to set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_callback(duckdb_v2_replacement_scan_handle scan,
+                                                                     duckdb_v2_replacement_scan_callback_fn callback,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets arbitrary user data on the replacement scan.
+ *
+ * Associates an opaque pointer with the scan, retrievable from the callback via
+ * `duckdb_v2_replacement_scan_get_user_data()`. The opaque handle bundles the pointer with an optional destructor,
+ * invoked when the data is no longer needed, at the latest when the scan's scope ends. The callback may be invoked from
+ * several connections at once, so the data must be safe to read concurrently.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param scan The scan to set the user data of.
+ * @param data Opaque handle bundling the user data pointer plus an optional destructor.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_user_data(duckdb_v2_replacement_scan_handle scan,
+                                                                      duckdb_v2_opaque *data,
+                                                                      duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the user data set via `duckdb_v2_replacement_scan_set_user_data()`.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param data Receives the user data pointer, or null if none was set.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_user_data(duckdb_v2_replacement_scan_info_handle info,
+                                                                      void **data, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the catalog name of the unresolved reference.
+ *
+ * Returns the empty view `{NULL, 0}` when the reference carries no catalog qualifier. The name is borrowed and valid
+ * only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param name Receives the borrowed catalog name, or the empty view when the reference carries no catalog qualifier.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_catalog_name(duckdb_v2_replacement_scan_info_handle info,
+                                                                         duckdb_v2_identifier_t *name,
+                                                                         duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the schema name of the unresolved reference.
+ *
+ * Returns the empty view `{NULL, 0}` when the reference carries no schema qualifier. The name is borrowed and valid
+ * only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param name Receives the borrowed schema name, or the empty view when the reference carries no schema qualifier.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_schema_name(duckdb_v2_replacement_scan_info_handle info,
+                                                                        duckdb_v2_identifier_t *name,
+                                                                        duckdb_v2_error_info_handle *err);
+
+/*!
+ * Retrieves the table name of the unresolved reference.
+ *
+ * This is the name as written in the query, which for a file-backed reference is the path with the quotes stripped.
+ * Never the empty view. The name is borrowed and valid only for the duration of the callback.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param name Receives the borrowed table name.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_table_name(duckdb_v2_replacement_scan_info_handle info,
+                                                                       duckdb_v2_identifier_t *name,
+                                                                       duckdb_v2_error_info_handle *err);
+
+/*!
+ * Claims the reference by naming a table function to read instead.
+ *
+ * Arguments to the function are added with `duckdb_v2_replacement_scan_add_argument()` and
+ * `duckdb_v2_replacement_scan_add_named_argument()`. The name is borrowed and copied. It is matched case-insensitively
+ * and is never split on ".", so it always names an unqualified function; an empty name results in an error. The name is
+ * not resolved here: an unknown function fails later, when the replacement is bound. Calling this again replaces the
+ * previous name and keeps the arguments added so far.
+ *
+ * The three claim forms, `duckdb_v2_replacement_scan_set_function_name()`,
+ * `duckdb_v2_replacement_scan_set_collection()` and `duckdb_v2_replacement_scan_set_subquery()`, are mutually
+ * exclusive: claiming the reference through a second, different form results in an error.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param name The name of the table function to read instead. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_function_name(duckdb_v2_replacement_scan_info_handle info,
+                                                                          duckdb_v2_identifier_t name,
+                                                                          duckdb_v2_error_info_handle *err);
+
+/*!
+ * Appends a positional argument to the claimed table function.
+ *
+ * Positional arguments are passed in the order they are added, before any named ones. The value is borrowed and copied,
+ * so the caller may destroy it after the call. Requires `duckdb_v2_replacement_scan_set_function_name()` to have been
+ * called first; otherwise the call results in an error.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param value The argument value. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_add_argument(duckdb_v2_replacement_scan_info_handle info,
+                                                                     duckdb_v2_value_handle value,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Appends a named argument to the claimed table function.
+ *
+ * Equivalent to writing `name := value` at the call site. The name and the value are borrowed and copied, so the caller
+ * may destroy the value after the call. Requires `duckdb_v2_replacement_scan_set_function_name()` to have been called
+ * first; otherwise the call results in an error.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param name The name of the parameter to bind the value to. Borrowed and copied.
+ * @param value The argument value. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_add_named_argument(duckdb_v2_replacement_scan_info_handle info,
+                                                                           duckdb_v2_identifier_t name,
+                                                                           duckdb_v2_value_handle value,
+                                                                           duckdb_v2_error_info_handle *err);
+
+/*!
+ * Claims the reference by naming a column data collection to read instead.
+ *
+ * The collection is borrowed, not copied: the caller keeps ownership and must keep it alive, and must not clear, reset
+ * or destroy it, for as long as any result reading it is live, since the result scans its buffers directly. A prepared
+ * statement holds on to the collection it was bound against, so destroy such statements before releasing the
+ * collection.
+ *
+ * By default the collection's columns are named col1..colN. Pass `column_names` to name them instead. When supplied,
+ * `column_count` must equal the collection's column count and no name may be empty; pass NULL and 0 for the default
+ * names.
+ *
+ * The three claim forms, `duckdb_v2_replacement_scan_set_function_name()`,
+ * `duckdb_v2_replacement_scan_set_collection()` and `duckdb_v2_replacement_scan_set_subquery()`, are mutually
+ * exclusive: claiming the reference through a second, different form results in an error.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param collection The collection to read instead. Borrowed; the caller keeps ownership and must keep it alive.
+ * @param column_names Optional. An array of `column_count` column names, in order. Pass NULL for the default names
+ * col1..colN.
+ * @param column_count The number of names in `column_names`. Must equal the collection's column count, or 0 for the
+ * default names.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_collection(
+    duckdb_v2_replacement_scan_info_handle info, duckdb_v2_column_data_collection_handle collection,
+    const duckdb_v2_identifier_t *column_names, idx_t column_count, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Claims the reference by naming a query to read instead.
+ *
+ * The text is parsed at the call and must contain exactly one SELECT statement: a syntax error, several statements or a
+ * statement of another kind results in an error. The text is borrowed for the call only. Prefer
+ * `duckdb_v2_replacement_scan_set_function_name()` when a single table function call suffices, as it avoids the parse
+ * and keeps the plan flatter.
+ *
+ * The three claim forms, `duckdb_v2_replacement_scan_set_function_name()`,
+ * `duckdb_v2_replacement_scan_set_collection()` and `duckdb_v2_replacement_scan_set_subquery()`, are mutually
+ * exclusive: claiming the reference through a second, different form results in an error.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param sql The SELECT statement to read instead. Borrowed for the call only.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_subquery(duckdb_v2_replacement_scan_info_handle info,
+                                                                     duckdb_v2_str sql,
+                                                                     duckdb_v2_error_info_handle *err);
+
+/*!
+ * Sets the alias the claimed replacement is bound under.
+ *
+ * Optional, and independent of the claim form. An alias written in the query takes precedence over this one; without
+ * either, the table name of the reference is used, which for a file-backed reference is the path. The alias is borrowed
+ * and copied.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param info The info handle.
+ * @param alias The alias to bind the replacement under. Borrowed and copied.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_alias(duckdb_v2_replacement_scan_info_handle info,
+                                                                  duckdb_v2_identifier_t alias,
+                                                                  duckdb_v2_error_info_handle *err);
+
+/*!
+ * Registers the replacement scan, making it consulted for names the catalog cannot resolve.
+ *
+ * The scan is registered on the target given at creation: the connection, the database or the loading extension's
+ * database. Registration requires a callback. Scans are consulted in registration order within their scope,
+ * connection-scoped ones before database-wide ones, and the first to claim a name wins. A scan cannot be registered
+ * twice, and a registered scan cannot be unregistered: it lives until its scope ends. Registering a database-wide scan
+ * while queries are binding on other connections is not thread-safe; register from an extension load callback or before
+ * issuing queries. The caller still owns the handle after registration and must destroy it with
+ * `duckdb_v2_replacement_scan_destroy()`, which does not affect the registered scan.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param scan The scan to register.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via
+ * `duckdb_v2_error_info_destroy()`.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_register(duckdb_v2_replacement_scan_handle scan,
+                                                                 duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys the replacement scan, releasing its resources.
+ *
+ * Null-safe: passing a null pointer or null handle is a no-op. The handle is set to null on return to prevent
+ * double-destruction. Destroying the handle after registration does not affect the registered scan.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param scan The scan to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_replacement_scan_destroy(duckdb_v2_replacement_scan_handle *scan);
+
+/* --- Struct definitions for replacement scan --- */
 
 /* ============================================================================
  * MODULE: scalar

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library_unity(
   capi_v2_logging.cpp
   capi_v2_logical_type.cpp
   capi_v2_option.cpp
+  capi_v2_prepared_statement.cpp
   capi_v2_qname.cpp
   capi_v2_replacement_scan.cpp
   capi_v2_result.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -6,12 +6,14 @@ add_library_unity(
   capi_v2_arena.cpp
   capi_v2_column_data_collection.cpp
   capi_v2_connection.cpp
+  capi_v2_custom_type.cpp
   capi_v2_data_chunk.cpp
   capi_v2_database.cpp
   capi_v2_environment.cpp
   capi_v2_error.cpp
   capi_v2_extension.cpp
   capi_v2_func_aggregate.cpp
+  capi_v2_func_cast.cpp
   capi_v2_func_properties.cpp
   capi_v2_func_scalar.cpp
   capi_v2_func_signature.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library_unity(
   capi_v2_stubs.cpp
   capi_v2_arena.cpp
   capi_v2_arrow.cpp
+  capi_v2_expression.cpp
   capi_v2_catalog.cpp
   capi_v2_column_data_collection.cpp
   capi_v2_connection.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library_unity(
   capi_v2_logging.cpp
   capi_v2_logical_type.cpp
   capi_v2_option.cpp
+  capi_v2_qname.cpp
   capi_v2_replacement_scan.cpp
   capi_v2_result.cpp
   capi_v2_schema.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library_unity(
   capi_v2_func_properties.cpp
   capi_v2_func_scalar.cpp
   capi_v2_func_signature.cpp
+  capi_v2_func_table.cpp
   capi_v2_logging.cpp
   capi_v2_logical_type.cpp
   capi_v2_option.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library_unity(
   capi_v2_file_system.cpp
   capi_v2_func_aggregate.cpp
   capi_v2_func_cast.cpp
+  capi_v2_func_copy.cpp
   capi_v2_func_properties.cpp
   capi_v2_func_scalar.cpp
   capi_v2_func_signature.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library_unity(
   capi_v2_stubs.cpp
   capi_v2_arena.cpp
   capi_v2_arrow.cpp
+  capi_v2_catalog.cpp
   capi_v2_column_data_collection.cpp
   capi_v2_connection.cpp
   capi_v2_custom_type.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library_unity(
   capi_v2_func_scalar.cpp
   capi_v2_func_signature.cpp
   capi_v2_func_table.cpp
+  capi_v2_identifier.cpp
   capi_v2_logging.cpp
   capi_v2_logical_type.cpp
   capi_v2_option.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library_unity(
   capi_v2_logging.cpp
   capi_v2_logical_type.cpp
   capi_v2_option.cpp
+  capi_v2_replacement_scan.cpp
   capi_v2_result.cpp
   capi_v2_schema.cpp
   capi_v2_statement.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_unity(
   capi_v2.cpp
   capi_v2_stubs.cpp
   capi_v2_arena.cpp
+  capi_v2_arrow.cpp
   capi_v2_column_data_collection.cpp
   capi_v2_connection.cpp
   capi_v2_custom_type.cpp

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library_unity(
   capi_v2_environment.cpp
   capi_v2_error.cpp
   capi_v2_extension.cpp
+  capi_v2_file_system.cpp
   capi_v2_func_aggregate.cpp
   capi_v2_func_cast.cpp
   capi_v2_func_properties.cpp

--- a/src/main/capi/v2/capi_v2_arrow.cpp
+++ b/src/main/capi/v2/capi_v2_arrow.cpp
@@ -1,0 +1,441 @@
+#include "duckdb/main/capi_v2/capi_v2_result_internal.hpp"
+
+#include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/common/arrow/arrow_util.hpp"
+#include "duckdb/common/arrow/arrow_wrapper.hpp"
+#include "duckdb/common/arrow/nanoarrow/nanoarrow.hpp"
+#include "duckdb/function/table/arrow.hpp"
+#include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
+#include "duckdb/main/chunk_scan_state.hpp"
+
+#include <cerrno>
+
+namespace duckdb::capiv2 {
+
+//! The converter is the engine's resolved Arrow table schema, handed out directly.
+using CV2ArrowConverter = duckdb::ArrowTableSchema;
+
+auto Convert(duckdb_v2_arrow_converter_handle converter) -> CV2ArrowConverter * {
+	return reinterpret_cast<CV2ArrowConverter *>(converter);
+}
+auto Convert(CV2ArrowConverter *converter) -> duckdb_v2_arrow_converter_handle {
+	return reinterpret_cast<duckdb_v2_arrow_converter_handle>(converter);
+}
+
+namespace {
+
+//! What batch_size 0 selects: pyarrow's dataset-scanner default, and 64 vectors in a default
+//! build, so one Arrow array coalesces a clean 64 engine chunks.
+constexpr idx_t CV2_DEFAULT_ARROW_BATCH_SIZE = 131072;
+
+//----------------------------------------------------------------------------------------------------------------------
+// result_to_arrow_stream
+//----------------------------------------------------------------------------------------------------------------------
+
+//! Drives a V2 result through the engine's chunk-cursor interface, so ArrowUtil::TryFetchChunk
+//! (offset tracking plus appender coalescing) can pull from it. End of stream is signalled the
+//! way QueryResultChunkScanState signals it: a null current chunk.
+class CV2ArrowScanState : public ChunkScanState {
+public:
+	explicit CV2ArrowScanState(ResultWrapperV2 &wrapper) : wrapper(wrapper) {
+	}
+
+	bool LoadNextChunk(ErrorData &error) override {
+		if (finished) {
+			current_chunk = nullptr;
+			return true;
+		}
+		try {
+			current_chunk = wrapper.FetchChunkBlocking();
+		} catch (std::exception &ex) {
+			scan_error = ErrorData(ex);
+			has_scan_error = true;
+			finished = true;
+			current_chunk = nullptr;
+			error = scan_error;
+			return false;
+		}
+		offset = 0;
+		if (!current_chunk) {
+			finished = true;
+		}
+		return true;
+	}
+	bool HasError() const override {
+		return has_scan_error;
+	}
+	ErrorData &GetError() override {
+		return scan_error;
+	}
+	const vector<LogicalType> &Types() const override {
+		return wrapper.types;
+	}
+	const vector<Identifier> &Names() const override {
+		return wrapper.names;
+	}
+
+private:
+	ResultWrapperV2 &wrapper;
+	ErrorData scan_error;
+	bool has_scan_error = false;
+};
+
+//! The stream's private_data. Owns the result state machine -- and through it the query's
+//! transaction and the connection's live-result slot -- the cursor driving it, and the schema
+//! cached while the producing transaction was still live.
+struct CV2ArrowStream {
+	unique_ptr<ResultWrapperV2> wrapper;
+	unique_ptr<ChunkScanState> scan_state;
+	ArrowSchema cached_schema {};
+	unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_types;
+	ClientProperties client_properties;
+	idx_t batch_size = CV2_DEFAULT_ARROW_BATCH_SIZE;
+	ErrorData last_error;
+
+	~CV2ArrowStream() {
+		if (cached_schema.release) {
+			cached_schema.release(&cached_schema);
+		}
+		// The scan state holds a reference into *wrapper, so drop it first.
+		scan_state.reset();
+	}
+};
+
+//! An Arrow callback must not let an exception cross the C ABI, so each one is wrapped whole and
+//! reports through the errno-style return code the interface specifies.
+int CV2ArrowStreamGetSchema(ArrowArrayStream *stream, ArrowSchema *out) {
+	if (!stream->release || !stream->private_data) {
+		return EINVAL;
+	}
+	auto &self = *static_cast<CV2ArrowStream *>(stream->private_data);
+	try {
+		if (!self.cached_schema.release) {
+			self.last_error = ErrorData("arrow stream: the schema is unavailable");
+			return EINVAL;
+		}
+		// The consumer owns what get_schema returns and releases it independently of the
+		// stream, so hand out a deep copy. Copying the cached schema is pure: it never
+		// re-reads the catalog, which is the point of having cached it.
+		if (duckdb_nanoarrow::ArrowSchemaDeepCopy(&self.cached_schema, out) != NANOARROW_OK) {
+			self.last_error = ErrorData("arrow stream: failed to copy the schema");
+			return ENOMEM;
+		}
+		return 0;
+	} catch (std::exception &ex) {
+		// Recording the message is itself best-effort under memory pressure; the return code
+		// is what the consumer must rely on.
+		try {
+			self.last_error = ErrorData(ex);
+		} catch (...) { // NOLINT: best-effort
+		}
+		return EIO;
+	} catch (...) {
+		return EIO;
+	}
+}
+
+int CV2ArrowStreamGetNext(ArrowArrayStream *stream, ArrowArray *out) {
+	if (!stream->release || !stream->private_data) {
+		return EINVAL;
+	}
+	auto &self = *static_cast<CV2ArrowStream *>(stream->private_data);
+	out->release = nullptr;
+	try {
+		idx_t result_count = 0;
+		ErrorData error;
+		if (!ArrowUtil::TryFetchChunk(*self.scan_state, self.client_properties, self.batch_size, out, result_count,
+		                              error, self.extension_types)) {
+			self.last_error = error;
+			return EIO;
+		}
+		if (result_count == 0) {
+			// End of stream, which the interface spells as a released array.
+			out->release = nullptr;
+		}
+	} catch (std::exception &ex) {
+		self.last_error = ErrorData(ex);
+		return EIO;
+	} catch (...) {
+		return EIO;
+	}
+	return 0;
+}
+
+const char *CV2ArrowStreamGetLastError(ArrowArrayStream *stream) {
+	if (!stream->release || !stream->private_data) {
+		return "arrow stream was released";
+	}
+	auto &self = *static_cast<CV2ArrowStream *>(stream->private_data);
+	return self.last_error.Message().c_str();
+}
+
+void CV2ArrowStreamRelease(ArrowArrayStream *stream) {
+	if (!stream || !stream->release) {
+		return;
+	}
+	stream->release = nullptr;
+	auto self = static_cast<CV2ArrowStream *>(stream->private_data);
+	stream->private_data = nullptr;
+	if (!self) {
+		return;
+	}
+	// Mirror result_destroy: close the engine result and roll back any transaction the bridge
+	// injected, before freeing. A release callback must not throw across the C ABI.
+	self->scan_state.reset();
+	try {
+		if (self->wrapper) {
+			self->wrapper->Finalize();
+		}
+	} catch (...) { // NOLINT: best-effort cleanup
+	}
+	// Frees the cached schema, and the wrapper, whose destructor releases the busy slot.
+	delete self;
+}
+
+} // namespace
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public API
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_result_to_arrow_stream(duckdb_v2_result_handle *result, idx_t batch_size,
+                                                 struct ArrowArrayStream *out_stream,
+                                                 duckdb_v2_error_info_handle *err) {
+	// Validate before taking ownership, so a rejection leaves the caller's result intact.
+	DUCKDB_CHECK_ARG(result);
+	DUCKDB_CHECK_ARG(*result);
+	DUCKDB_CHECK_ARG(out_stream);
+	return WithErrorHandler(err, [&]() {
+		// Adopt by transfer; consumed on success and failure alike.
+		auto wrapper = duckdb::unique_ptr<ResultWrapperV2>(Convert(*result));
+		*result = nullptr;
+		try {
+			// The schema must be built while the query's transaction is live, so advance to the
+			// principal fragment if its metadata is not available yet. No rows can be produced
+			// before that fragment is prepared, so stepping here never drops data.
+			while (!wrapper->metadata_available) {
+				duckdb::unique_ptr<duckdb::DataChunk> discard;
+				auto status = wrapper->Step(discard);
+				if (status == DUCKDB_V2_RESULT_STEP_STATUS_WAITING) {
+					wrapper->Wait();
+					continue;
+				}
+				if (status == DUCKDB_V2_RESULT_STEP_STATUS_CHUNK) {
+					throw duckdb::InternalException(
+					    "arrow stream: a row was produced before result metadata was available");
+				}
+				break; // FINISHED / CANCELLED: no row-producing fragment.
+			}
+			if (!wrapper->context) {
+				throw duckdb::InvalidInputException("result is not associated with an active context");
+			}
+			auto &context = *wrapper->context;
+
+			auto self = duckdb::make_uniq<CV2ArrowStream>();
+			self->batch_size = batch_size == 0 ? CV2_DEFAULT_ARROW_BATCH_SIZE : batch_size;
+			self->client_properties = context.GetClientProperties();
+			// Cache the schema and the extension type map now, under the live transaction:
+			// populate-schema callbacks and ENUM dictionaries read the catalog, which get_schema
+			// cannot do once the transaction is gone.
+			self->extension_types = duckdb::ArrowTypeExtensionData::GetExtensionTypes(context, wrapper->types);
+			duckdb::ArrowConverter::ToArrowSchema(&self->cached_schema, wrapper->types,
+			                                      duckdb::IdentifiersToStrings(wrapper->names),
+			                                      self->client_properties);
+			self->scan_state = duckdb::make_uniq<CV2ArrowScanState>(*wrapper);
+			self->wrapper = std::move(wrapper);
+
+			out_stream->get_schema = CV2ArrowStreamGetSchema;
+			out_stream->get_next = CV2ArrowStreamGetNext;
+			out_stream->get_last_error = CV2ArrowStreamGetLastError;
+			out_stream->release = CV2ArrowStreamRelease;
+			out_stream->private_data = self.release();
+		} catch (...) {
+			// A throw before ownership moved into the stream leaves the result with us. Finalize
+			// it so a failed export cleans up exactly as result_destroy would, rather than
+			// leaving the query open until the local pointer goes out of scope.
+			if (wrapper) {
+				try {
+					wrapper->Finalize();
+				} catch (...) { // NOLINT: never mask the original error
+				}
+			}
+			throw;
+		}
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_logical_types_to_arrow_schema(duckdb_v2_context_handle context,
+                                                        const duckdb_v2_logical_type_handle *types,
+                                                        const duckdb_v2_str *names, idx_t count,
+                                                        struct ArrowSchema *out_schema,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(context);
+	DUCKDB_CHECK_ARG(out_schema);
+	if (count > 0 && !types) {
+		return NullArgumentError(err, __func__, "types");
+	}
+	if (count > 0 && !names) {
+		return NullArgumentError(err, __func__, "names");
+	}
+	return WithErrorHandler(err, [&]() {
+		duckdb::vector<duckdb::LogicalType> schema_types;
+		duckdb::vector<duckdb::string> schema_names;
+		schema_types.reserve(count);
+		schema_names.reserve(count);
+		for (idx_t i = 0; i < count; i++) {
+			if (!types[i]) {
+				throw duckdb::InvalidInputException("null logical type at index %llu", i);
+			}
+			if (IsNullArgument(names[i])) {
+				throw duckdb::InvalidInputException("malformed column name at index %llu", i);
+			}
+			schema_types.push_back(*Convert(types[i]));
+			schema_names.emplace_back(Convert(names[i]));
+		}
+		auto properties = Convert(context)->GetClientProperties();
+		duckdb::ArrowConverter::ToArrowSchema(out_schema, schema_types, schema_names, properties);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_data_chunk_to_arrow_array(duckdb_v2_context_handle context, duckdb_v2_data_chunk_handle chunk,
+                                                    struct ArrowArray *out_array, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(context);
+	DUCKDB_CHECK_ARG(chunk);
+	DUCKDB_CHECK_ARG(out_array);
+	return WithErrorHandler(err, [&]() {
+		auto &ctx = *Convert(context);
+		auto &data_chunk = *Convert(chunk);
+		auto properties = ctx.GetClientProperties();
+		auto extension_types = duckdb::ArrowTypeExtensionData::GetExtensionTypes(ctx, data_chunk.GetTypes());
+		duckdb::ArrowConverter::ToArrowArray(data_chunk, out_array, properties, extension_types);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_converter_create(duckdb_v2_context_handle context, struct ArrowSchema *schema,
+                                                 duckdb_v2_arrow_converter_handle *out_converter,
+                                                 duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(context);
+	DUCKDB_CHECK_ARG(schema);
+	DUCKDB_CHECK_ARG(out_converter);
+	*out_converter = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto converter = duckdb::make_uniq<CV2ArrowConverter>();
+		duckdb::ArrowTableFunction::PopulateArrowTableSchema(*Convert(context), *converter, *schema);
+		*out_converter = Convert(converter.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_converter_array_to_chunk(duckdb_v2_context_handle context, struct ArrowArray *array,
+                                                         duckdb_v2_arrow_converter_handle converter,
+                                                         duckdb_v2_data_chunk_handle *out_chunk,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(context);
+	DUCKDB_CHECK_ARG(array);
+	DUCKDB_CHECK_ARG(converter);
+	DUCKDB_CHECK_ARG(out_chunk);
+	*out_chunk = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &ctx = *Convert(context);
+		auto &resolved = *Convert(converter);
+		auto &types = resolved.GetTypes();
+		auto &arrow_types = resolved.GetColumns();
+
+		auto chunk = duckdb::make_uniq<duckdb::DataChunk>();
+		chunk->Initialize(duckdb::Allocator::DefaultAllocator(), types, duckdb::NumericCast<idx_t>(array->length));
+		// Check the array against the converter before indexing into its children, which would
+		// otherwise run off the end.
+		if (duckdb::NumericCast<idx_t>(array->n_children) != chunk->ColumnCount()) {
+			throw duckdb::InvalidInputException("Arrow array child count does not match the converter column count");
+		}
+		chunk->SetChildCardinality(duckdb::NumericCast<idx_t>(array->length));
+
+		// One shared owner for the whole foreign array, transferred once. The chunk's zero-copy
+		// vectors keep it alive, and a column that copies instead still leaves it owned here.
+		// This mirrors the engine's scan path: a per-column wrapper would free the shared parent
+		// after the first copying column and dangle the rest.
+		auto owned_array = duckdb::make_shared_ptr<duckdb::ArrowArrayWrapper>();
+		owned_array->arrow_array = *array;
+		array->release = nullptr;
+		auto &parent_array = owned_array->arrow_array;
+		if (chunk->ColumnCount() > 0 && !parent_array.children) {
+			throw duckdb::InvalidInputException("Arrow array has null children");
+		}
+		for (duckdb::idx_t i = 0; i < chunk->ColumnCount(); i++) {
+			auto *child_array = parent_array.children[i];
+			// Validate each foreign child before handing it to the engine, so a malformed array
+			// is an input error rather than a crash inside the conversion.
+			if (!child_array || !child_array->release) {
+				throw duckdb::InvalidInputException("Arrow array child is null or already released");
+			}
+			if (child_array->length != parent_array.length) {
+				throw duckdb::InvalidInputException("Arrow array child length does not match the array length");
+			}
+			auto arrow_type = arrow_types.at(i);
+			auto array_state = duckdb::make_uniq<duckdb::ArrowArrayScanState>(ctx);
+			array_state->owned_data = owned_array;
+			switch (arrow_type->GetPhysicalType()) {
+			case duckdb::ArrowArrayPhysicalType::DICTIONARY_ENCODED:
+				if (!child_array->dictionary) {
+					throw duckdb::InvalidInputException("Dictionary-encoded Arrow array has no dictionary");
+				}
+				duckdb::ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(
+				    chunk->data[i], *child_array, 0, *array_state, chunk->size(), *arrow_type);
+				break;
+			case duckdb::ArrowArrayPhysicalType::RUN_END_ENCODED:
+				duckdb::ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(
+				    chunk->data[i], *child_array, 0, *array_state, chunk->size(), *arrow_type);
+				break;
+			case duckdb::ArrowArrayPhysicalType::DEFAULT:
+				duckdb::ArrowToDuckDBConversion::SetValidityMask(chunk->data[i], *child_array, 0, chunk->size(),
+				                                                 parent_array.offset, -1);
+				duckdb::ArrowToDuckDBConversion::ColumnArrowToDuckDB(chunk->data[i], *child_array, 0, *array_state,
+				                                                     chunk->size(), *arrow_type);
+				break;
+			default:
+				throw duckdb::NotImplementedException("Only default Arrow physical types are currently supported");
+			}
+			// Parity with the engine's own scan loop, which re-asserts the size after each
+			// column: a dictionary or run-end conversion replaces the vector rather than filling
+			// it. It is inert here, because the chunk is freshly allocated per call and every
+			// vector is sized before the conversion, but it becomes load-bearing the moment a
+			// chunk is reused across conversions.
+			duckdb::FlatVector::SetSize(chunk->data[i], duckdb::count_t(chunk->size()));
+		}
+		*out_chunk = Convert(chunk.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_converter_get_schema(duckdb_v2_arrow_converter_handle converter,
+                                                     duckdb_v2_schema_handle *out_schema,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(converter);
+	DUCKDB_CHECK_ARG(out_schema);
+	*out_schema = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &resolved = *Convert(converter);
+		auto &types = resolved.GetTypes();
+		auto &names = resolved.GetNames();
+		D_ASSERT(names.size() == types.size());
+		// The same owned schema shape statement_bind produces; the caller destroys it.
+		auto schema = duckdb::make_uniq<CV2Schema>();
+		for (duckdb::idx_t i = 0; i < types.size(); i++) {
+			schema->fields.push_back({names[i], types[i]});
+		}
+		*out_schema = Convert(schema.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_converter_destroy(duckdb_v2_arrow_converter_handle *converter) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!converter) {
+			return;
+		}
+		if (*converter) {
+			delete Convert(*converter);
+			*converter = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_arrow.cpp
+++ b/src/main/capi/v2/capi_v2_arrow.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/capi_v2/capi_v2_result_internal.hpp"
 
+#include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/common/arrow/arrow_converter.hpp"
 #include "duckdb/common/arrow/arrow_util.hpp"
 #include "duckdb/common/arrow/arrow_wrapper.hpp"
@@ -9,32 +10,140 @@
 #include "duckdb/main/chunk_scan_state.hpp"
 
 #include <cerrno>
+#include <deque>
 
 namespace duckdb::capiv2 {
+namespace {
 
-//! The converter is the engine's resolved Arrow table schema, handed out directly.
-using CV2ArrowConverter = duckdb::ArrowTableSchema;
+//! What batch_size 0 selects for a result stream: 64 vectors in a default build, so one Arrow array gathers a clean 64
+//! engine chunks.
+constexpr idx_t CV2_DEFAULT_ARROW_BATCH_SIZE = 131072;
 
-auto Convert(duckdb_v2_arrow_converter_handle converter) -> CV2ArrowConverter * {
-	return reinterpret_cast<CV2ArrowConverter *>(converter);
+} // namespace
+
+//----------------------------------------------------------------------------------------------------------------------
+// arrow_importer
+//----------------------------------------------------------------------------------------------------------------------
+
+//! Reads Arrow arrays into data chunks against one resolved schema. Holds at most one array in flight and slices it
+//! lazily, so a long array does not have to be materialized all at once.
+class CV2ArrowImporter {
+public:
+	//! The resolved correspondence: DuckDB types plus the per-column Arrow type information.
+	ArrowTableSchema table;
+	//! Borrowed from creation: every conversion runs under it, so the importer must not outlive it. Within a connection
+	//! this is one context throughout, so a bind-time importer works from the matching exec callback.
+	optional_ptr<ClientContext> context;
+	//! The most rows a produced chunk may hold; 0 means no maximum.
+	idx_t batch_size = 0;
+
+	//! Set when the array was handed over: the chunks reference its buffers zero-copy and keep this alive themselves,
+	//! so they may outlive the importer.
+	shared_ptr<ArrowArrayWrapper> owned_array;
+	//! Set when the caller kept the array: borrowed for the drain, and every produced chunk is materialized so it does
+	//! not reference it.
+	optional_ptr<ArrowArray> borrowed_array;
+	//! Rows of the in-flight array already handed out.
+	idx_t offset = 0;
+	idx_t length = 0;
+	//! Set by an append asking to flush: the rows left over when the array runs out come out as a short chunk rather
+	//! than waiting for a batch that will never fill.
+	bool flush_on_drain = false;
+
+	//! Rows held back from a previous array because they did not fill a batch. Materialized, since a chunk that spans
+	//! two arrays cannot reference either of them. Always fewer than batch_size rows.
+	unique_ptr<DataChunk> pending;
+
+	auto HasInputRows() const -> bool {
+		return offset < length;
+	}
+	auto PendingRows() const -> idx_t {
+		return pending ? pending->size() : 0;
+	}
+	//! The in-flight array, whichever way it arrived.
+	auto Array() -> ArrowArray & {
+		return owned_array ? owned_array->arrow_array : *borrowed_array;
+	}
+	void ReleaseInput() {
+		owned_array.reset();
+		borrowed_array = nullptr;
+		offset = 0;
+		length = 0;
+	}
+};
+
+auto Convert(duckdb_v2_arrow_importer_handle importer) -> CV2ArrowImporter * {
+	return reinterpret_cast<CV2ArrowImporter *>(importer);
 }
-auto Convert(CV2ArrowConverter *converter) -> duckdb_v2_arrow_converter_handle {
-	return reinterpret_cast<duckdb_v2_arrow_converter_handle>(converter);
+auto Convert(CV2ArrowImporter *importer) -> duckdb_v2_arrow_importer_handle {
+	return reinterpret_cast<duckdb_v2_arrow_importer_handle>(importer);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// arrow_exporter
+//----------------------------------------------------------------------------------------------------------------------
+
+//! Writes data chunks out as Arrow arrays for one fixed column list. The mirror of the importer: chunks go in, and
+//! arrays of at most batch_size rows come out, gathering across chunks when one is too short to fill a batch. The Arrow
+//! settings are pinned at construction so the schema and the arrays cannot disagree.
+class CV2ArrowExporter {
+public:
+	vector<LogicalType> types;
+	vector<string> names;
+	//! Pinned at construction: the schema this exporter reports is built from these, and so is every array, which is
+	//! what keeps the two consistent.
+	ClientProperties properties;
+	unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> extension_types;
+	//! The most rows an array may hold; 0 means no maximum.
+	idx_t batch_size = 0;
+
+	//! Live while rows have been gathered but not yet finalized into an array.
+	unique_ptr<ArrowAppender> appender;
+	idx_t gathered = 0;
+	//! Completed arrays waiting to be taken.
+	std::deque<ArrowArray> ready;
+
+	~CV2ArrowExporter() {
+		for (auto &array : ready) {
+			if (array.release) {
+				array.release(&array);
+			}
+		}
+	}
+
+	void EnsureAppender(idx_t capacity) {
+		if (!appender) {
+			appender = make_uniq<ArrowAppender>(types, capacity, properties, extension_types);
+			gathered = 0;
+		}
+	}
+
+	//! Finalizes the gathered rows into a queued array. A no-op with nothing gathered.
+	void Emit() {
+		if (appender && gathered > 0) {
+			ready.push_back(appender->Finalize());
+		}
+		appender.reset();
+		gathered = 0;
+	}
+};
+
+auto Convert(duckdb_v2_arrow_exporter_handle exporter) -> CV2ArrowExporter * {
+	return reinterpret_cast<CV2ArrowExporter *>(exporter);
+}
+auto Convert(CV2ArrowExporter *exporter) -> duckdb_v2_arrow_exporter_handle {
+	return reinterpret_cast<duckdb_v2_arrow_exporter_handle>(exporter);
 }
 
 namespace {
-
-//! What batch_size 0 selects: pyarrow's dataset-scanner default, and 64 vectors in a default
-//! build, so one Arrow array coalesces a clean 64 engine chunks.
-constexpr idx_t CV2_DEFAULT_ARROW_BATCH_SIZE = 131072;
 
 //----------------------------------------------------------------------------------------------------------------------
 // result_to_arrow_stream
 //----------------------------------------------------------------------------------------------------------------------
 
-//! Drives a V2 result through the engine's chunk-cursor interface, so ArrowUtil::TryFetchChunk
-//! (offset tracking plus appender coalescing) can pull from it. End of stream is signalled the
-//! way QueryResultChunkScanState signals it: a null current chunk.
+//! Drives a V2 result through the engine's chunk-cursor interface, so ArrowUtil::TryFetchChunk (offset tracking plus
+//! appender coalescing) can pull from it. End of stream is signalled the way QueryResultChunkScanState signals it: a
+//! null current chunk.
 class CV2ArrowScanState : public ChunkScanState {
 public:
 	explicit CV2ArrowScanState(ResultWrapperV2 &wrapper) : wrapper(wrapper) {
@@ -80,9 +189,9 @@ private:
 	bool has_scan_error = false;
 };
 
-//! The stream's private_data. Owns the result state machine -- and through it the query's
-//! transaction and the connection's live-result slot -- the cursor driving it, and the schema
-//! cached while the producing transaction was still live.
+//! The stream's private_data. Owns the result state machine -- and through it the query's transaction and the
+//! connection's live-result slot -- the cursor driving it, and the schema cached while the producing transaction was
+//! still live.
 struct CV2ArrowStream {
 	unique_ptr<ResultWrapperV2> wrapper;
 	unique_ptr<ChunkScanState> scan_state;
@@ -101,8 +210,8 @@ struct CV2ArrowStream {
 	}
 };
 
-//! An Arrow callback must not let an exception cross the C ABI, so each one is wrapped whole and
-//! reports through the errno-style return code the interface specifies.
+//! An Arrow callback must not let an exception cross the C ABI, so each one is wrapped whole and reports through the
+//! errno-style return code the interface specifies.
 int CV2ArrowStreamGetSchema(ArrowArrayStream *stream, ArrowSchema *out) {
 	if (!stream->release || !stream->private_data) {
 		return EINVAL;
@@ -113,17 +222,17 @@ int CV2ArrowStreamGetSchema(ArrowArrayStream *stream, ArrowSchema *out) {
 			self.last_error = ErrorData("arrow stream: the schema is unavailable");
 			return EINVAL;
 		}
-		// The consumer owns what get_schema returns and releases it independently of the
-		// stream, so hand out a deep copy. Copying the cached schema is pure: it never
-		// re-reads the catalog, which is the point of having cached it.
+		// The consumer owns what get_schema returns and releases it independently of the stream, so hand out a deep
+		// copy. Copying the cached schema is pure: it never re-reads the catalog, which is the point of having cached
+		// it.
 		if (duckdb_nanoarrow::ArrowSchemaDeepCopy(&self.cached_schema, out) != NANOARROW_OK) {
 			self.last_error = ErrorData("arrow stream: failed to copy the schema");
 			return ENOMEM;
 		}
 		return 0;
 	} catch (std::exception &ex) {
-		// Recording the message is itself best-effort under memory pressure; the return code
-		// is what the consumer must rely on.
+		// Recording the message is itself best-effort under memory pressure; the return code is what the consumer must
+		// rely on.
 		try {
 			self.last_error = ErrorData(ex);
 		} catch (...) { // NOLINT: best-effort
@@ -179,8 +288,8 @@ void CV2ArrowStreamRelease(ArrowArrayStream *stream) {
 	if (!self) {
 		return;
 	}
-	// Mirror result_destroy: close the engine result and roll back any transaction the bridge
-	// injected, before freeing. A release callback must not throw across the C ABI.
+	// Mirror result_destroy: close the engine result and roll back any transaction the bridge injected, before freeing.
+	// A release callback must not throw across the C ABI.
 	self->scan_state.reset();
 	try {
 		if (self->wrapper) {
@@ -190,6 +299,85 @@ void CV2ArrowStreamRelease(ArrowArrayStream *stream) {
 	}
 	// Frees the cached schema, and the wrapper, whose destructor releases the busy slot.
 	delete self;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Import conversion
+//----------------------------------------------------------------------------------------------------------------------
+
+//! Converts `rows` rows starting at `from` of `array` into a fresh chunk, through the resolved per-column Arrow types.
+//! `owner` is the shared owner the chunk's zero-copy vectors keep alive; it is null when the caller kept the array, in
+//! which case the result is materialized instead.
+auto CV2ConvertArrowSlice(ClientContext &context, CV2ArrowImporter &importer, ArrowArray &array,
+                          const shared_ptr<ArrowArrayWrapper> &owner, idx_t from, idx_t rows) -> unique_ptr<DataChunk> {
+	auto &types = importer.table.GetTypes();
+	auto &arrow_types = importer.table.GetColumns();
+
+	auto chunk = make_uniq<DataChunk>();
+	chunk->Initialize(Allocator::DefaultAllocator(), types, MaxValue<idx_t>(rows, 1));
+	chunk->SetChildCardinality(rows);
+	for (idx_t i = 0; i < chunk->ColumnCount(); i++) {
+		auto *child_array = array.children[i];
+		auto arrow_type = arrow_types.at(i);
+		// A fresh scan state per slice, so nothing cached for one array leaks into the next. The cost is re-decoding a
+		// dictionary per chunk.
+		auto array_state = make_uniq<ArrowArrayScanState>(context);
+		array_state->owned_data = owner;
+		switch (arrow_type->GetPhysicalType()) {
+		case ArrowArrayPhysicalType::DICTIONARY_ENCODED:
+			if (!child_array->dictionary) {
+				throw InvalidInputException("Dictionary-encoded Arrow array has no dictionary");
+			}
+			ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(chunk->data[i], *child_array, from, *array_state,
+			                                                       rows, *arrow_type);
+			break;
+		case ArrowArrayPhysicalType::RUN_END_ENCODED:
+			ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(chunk->data[i], *child_array, from, *array_state,
+			                                                          rows, *arrow_type);
+			break;
+		case ArrowArrayPhysicalType::DEFAULT:
+			ArrowToDuckDBConversion::SetValidityMask(chunk->data[i], *child_array, from, rows, array.offset, -1);
+			ArrowToDuckDBConversion::ColumnArrowToDuckDB(chunk->data[i], *child_array, from, *array_state, rows,
+			                                             *arrow_type);
+			break;
+		default:
+			throw NotImplementedException("Only default Arrow physical types are currently supported");
+		}
+		// Re-assert the size after the conversion, mirroring the engine's own scan loop: a dictionary or run-end
+		// conversion replaces the vector rather than filling it.
+		FlatVector::SetSize(chunk->data[i], count_t(rows));
+	}
+	chunk->CheckCardinality(rows);
+	if (owner) {
+		return chunk;
+	}
+	// The caller kept the array, so the chunk must not reference it: copy the rows out into flat vectors that own their
+	// memory.
+	auto materialized = make_uniq<DataChunk>();
+	materialized->Initialize(Allocator::DefaultAllocator(), types, MaxValue<idx_t>(rows, 1));
+	chunk->Copy(*materialized, 0);
+	return materialized;
+}
+
+//! Rejects an array whose shape disagrees with the resolved schema before anything reads it, so a malformed array is an
+//! input error rather than a crash inside the conversion.
+void CV2ValidateArrowArray(CV2ArrowImporter &importer, ArrowArray &array) {
+	auto column_count = importer.table.GetTypes().size();
+	if (NumericCast<idx_t>(array.n_children) != column_count) {
+		throw InvalidInputException("Arrow array child count does not match the importer column count");
+	}
+	if (column_count > 0 && !array.children) {
+		throw InvalidInputException("Arrow array has null children");
+	}
+	for (idx_t i = 0; i < column_count; i++) {
+		auto *child_array = array.children[i];
+		if (!child_array || !child_array->release) {
+			throw InvalidInputException("Arrow array child is null or already released");
+		}
+		if (child_array->length != array.length) {
+			throw InvalidInputException("Arrow array child length does not match the array length");
+		}
+	}
 }
 
 } // namespace
@@ -213,9 +401,9 @@ DUCKDB_V2_ERROR duckdb_v2_result_to_arrow_stream(duckdb_v2_result_handle *result
 		auto wrapper = duckdb::unique_ptr<ResultWrapperV2>(Convert(*result));
 		*result = nullptr;
 		try {
-			// The schema must be built while the query's transaction is live, so advance to the
-			// principal fragment if its metadata is not available yet. No rows can be produced
-			// before that fragment is prepared, so stepping here never drops data.
+			// The schema must be built while the query's transaction is live, so advance to the principal fragment if
+			// its metadata is not available yet. No rows can be produced before that fragment is prepared, so stepping
+			// here never drops data.
 			while (!wrapper->metadata_available) {
 				duckdb::unique_ptr<duckdb::DataChunk> discard;
 				auto status = wrapper->Step(discard);
@@ -237,9 +425,8 @@ DUCKDB_V2_ERROR duckdb_v2_result_to_arrow_stream(duckdb_v2_result_handle *result
 			auto self = duckdb::make_uniq<CV2ArrowStream>();
 			self->batch_size = batch_size == 0 ? CV2_DEFAULT_ARROW_BATCH_SIZE : batch_size;
 			self->client_properties = context.GetClientProperties();
-			// Cache the schema and the extension type map now, under the live transaction:
-			// populate-schema callbacks and ENUM dictionaries read the catalog, which get_schema
-			// cannot do once the transaction is gone.
+			// Cache the schema and the extension type map now, under the live transaction: populate-schema callbacks
+			// and ENUM dictionaries read the catalog, which get_schema cannot do once the transaction is gone.
 			self->extension_types = duckdb::ArrowTypeExtensionData::GetExtensionTypes(context, wrapper->types);
 			duckdb::ArrowConverter::ToArrowSchema(&self->cached_schema, wrapper->types,
 			                                      duckdb::IdentifiersToStrings(wrapper->names),
@@ -253,9 +440,9 @@ DUCKDB_V2_ERROR duckdb_v2_result_to_arrow_stream(duckdb_v2_result_handle *result
 			out_stream->release = CV2ArrowStreamRelease;
 			out_stream->private_data = self.release();
 		} catch (...) {
-			// A throw before ownership moved into the stream leaves the result with us. Finalize
-			// it so a failed export cleans up exactly as result_destroy would, rather than
-			// leaving the query open until the local pointer goes out of scope.
+			// A throw before ownership moved into the stream leaves the result with us. Finalize it so a failed export
+			// cleans up exactly as result_destroy would, rather than leaving the query open until the local pointer
+			// goes out of scope.
 			if (wrapper) {
 				try {
 					wrapper->Finalize();
@@ -267,157 +454,36 @@ DUCKDB_V2_ERROR duckdb_v2_result_to_arrow_stream(duckdb_v2_result_handle *result
 	});
 }
 
-DUCKDB_V2_ERROR duckdb_v2_logical_types_to_arrow_schema(duckdb_v2_context_handle context,
-                                                        const duckdb_v2_logical_type_handle *types,
-                                                        const duckdb_v2_str *names, idx_t count,
-                                                        struct ArrowSchema *out_schema,
-                                                        duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(context);
-	DUCKDB_CHECK_ARG(out_schema);
-	if (count > 0 && !types) {
-		return NullArgumentError(err, __func__, "types");
-	}
-	if (count > 0 && !names) {
-		return NullArgumentError(err, __func__, "names");
-	}
-	return WithErrorHandler(err, [&]() {
-		duckdb::vector<duckdb::LogicalType> schema_types;
-		duckdb::vector<duckdb::string> schema_names;
-		schema_types.reserve(count);
-		schema_names.reserve(count);
-		for (idx_t i = 0; i < count; i++) {
-			if (!types[i]) {
-				throw duckdb::InvalidInputException("null logical type at index %llu", i);
-			}
-			if (IsNullArgument(names[i])) {
-				throw duckdb::InvalidInputException("malformed column name at index %llu", i);
-			}
-			schema_types.push_back(*Convert(types[i]));
-			schema_names.emplace_back(Convert(names[i]));
-		}
-		auto properties = Convert(context)->GetClientProperties();
-		duckdb::ArrowConverter::ToArrowSchema(out_schema, schema_types, schema_names, properties);
-	});
-}
+//----------------------------------------------------------------------------------------------------------------------
+// arrow_importer
+//----------------------------------------------------------------------------------------------------------------------
 
-DUCKDB_V2_ERROR duckdb_v2_data_chunk_to_arrow_array(duckdb_v2_context_handle context, duckdb_v2_data_chunk_handle chunk,
-                                                    struct ArrowArray *out_array, duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(context);
-	DUCKDB_CHECK_ARG(chunk);
-	DUCKDB_CHECK_ARG(out_array);
-	return WithErrorHandler(err, [&]() {
-		auto &ctx = *Convert(context);
-		auto &data_chunk = *Convert(chunk);
-		auto properties = ctx.GetClientProperties();
-		auto extension_types = duckdb::ArrowTypeExtensionData::GetExtensionTypes(ctx, data_chunk.GetTypes());
-		duckdb::ArrowConverter::ToArrowArray(data_chunk, out_array, properties, extension_types);
-	});
-}
-
-DUCKDB_V2_ERROR duckdb_v2_arrow_converter_create(duckdb_v2_context_handle context, struct ArrowSchema *schema,
-                                                 duckdb_v2_arrow_converter_handle *out_converter,
-                                                 duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_arrow_importer_create(duckdb_v2_context_handle context, struct ArrowSchema *schema,
+                                                idx_t batch_size, duckdb_v2_arrow_importer_handle *out_importer,
+                                                duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(context);
 	DUCKDB_CHECK_ARG(schema);
-	DUCKDB_CHECK_ARG(out_converter);
-	*out_converter = nullptr;
+	DUCKDB_CHECK_ARG(out_importer);
+	*out_importer = nullptr;
 	return WithErrorHandler(err, [&]() {
-		auto converter = duckdb::make_uniq<CV2ArrowConverter>();
-		duckdb::ArrowTableFunction::PopulateArrowTableSchema(*Convert(context), *converter, *schema);
-		*out_converter = Convert(converter.release());
+		auto importer = duckdb::make_uniq<CV2ArrowImporter>();
+		importer->context = Convert(context);
+		importer->batch_size = batch_size;
+		duckdb::ArrowTableFunction::PopulateArrowTableSchema(*Convert(context), importer->table, *schema);
+		*out_importer = Convert(importer.release());
 	});
 }
 
-DUCKDB_V2_ERROR duckdb_v2_arrow_converter_array_to_chunk(duckdb_v2_context_handle context, struct ArrowArray *array,
-                                                         duckdb_v2_arrow_converter_handle converter,
-                                                         duckdb_v2_data_chunk_handle *out_chunk,
-                                                         duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(context);
-	DUCKDB_CHECK_ARG(array);
-	DUCKDB_CHECK_ARG(converter);
-	DUCKDB_CHECK_ARG(out_chunk);
-	*out_chunk = nullptr;
-	return WithErrorHandler(err, [&]() {
-		auto &ctx = *Convert(context);
-		auto &resolved = *Convert(converter);
-		auto &types = resolved.GetTypes();
-		auto &arrow_types = resolved.GetColumns();
-
-		auto chunk = duckdb::make_uniq<duckdb::DataChunk>();
-		chunk->Initialize(duckdb::Allocator::DefaultAllocator(), types, duckdb::NumericCast<idx_t>(array->length));
-		// Check the array against the converter before indexing into its children, which would
-		// otherwise run off the end.
-		if (duckdb::NumericCast<idx_t>(array->n_children) != chunk->ColumnCount()) {
-			throw duckdb::InvalidInputException("Arrow array child count does not match the converter column count");
-		}
-		chunk->SetChildCardinality(duckdb::NumericCast<idx_t>(array->length));
-
-		// One shared owner for the whole foreign array, transferred once. The chunk's zero-copy
-		// vectors keep it alive, and a column that copies instead still leaves it owned here.
-		// This mirrors the engine's scan path: a per-column wrapper would free the shared parent
-		// after the first copying column and dangle the rest.
-		auto owned_array = duckdb::make_shared_ptr<duckdb::ArrowArrayWrapper>();
-		owned_array->arrow_array = *array;
-		array->release = nullptr;
-		auto &parent_array = owned_array->arrow_array;
-		if (chunk->ColumnCount() > 0 && !parent_array.children) {
-			throw duckdb::InvalidInputException("Arrow array has null children");
-		}
-		for (duckdb::idx_t i = 0; i < chunk->ColumnCount(); i++) {
-			auto *child_array = parent_array.children[i];
-			// Validate each foreign child before handing it to the engine, so a malformed array
-			// is an input error rather than a crash inside the conversion.
-			if (!child_array || !child_array->release) {
-				throw duckdb::InvalidInputException("Arrow array child is null or already released");
-			}
-			if (child_array->length != parent_array.length) {
-				throw duckdb::InvalidInputException("Arrow array child length does not match the array length");
-			}
-			auto arrow_type = arrow_types.at(i);
-			auto array_state = duckdb::make_uniq<duckdb::ArrowArrayScanState>(ctx);
-			array_state->owned_data = owned_array;
-			switch (arrow_type->GetPhysicalType()) {
-			case duckdb::ArrowArrayPhysicalType::DICTIONARY_ENCODED:
-				if (!child_array->dictionary) {
-					throw duckdb::InvalidInputException("Dictionary-encoded Arrow array has no dictionary");
-				}
-				duckdb::ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(
-				    chunk->data[i], *child_array, 0, *array_state, chunk->size(), *arrow_type);
-				break;
-			case duckdb::ArrowArrayPhysicalType::RUN_END_ENCODED:
-				duckdb::ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(
-				    chunk->data[i], *child_array, 0, *array_state, chunk->size(), *arrow_type);
-				break;
-			case duckdb::ArrowArrayPhysicalType::DEFAULT:
-				duckdb::ArrowToDuckDBConversion::SetValidityMask(chunk->data[i], *child_array, 0, chunk->size(),
-				                                                 parent_array.offset, -1);
-				duckdb::ArrowToDuckDBConversion::ColumnArrowToDuckDB(chunk->data[i], *child_array, 0, *array_state,
-				                                                     chunk->size(), *arrow_type);
-				break;
-			default:
-				throw duckdb::NotImplementedException("Only default Arrow physical types are currently supported");
-			}
-			// Parity with the engine's own scan loop, which re-asserts the size after each
-			// column: a dictionary or run-end conversion replaces the vector rather than filling
-			// it. It is inert here, because the chunk is freshly allocated per call and every
-			// vector is sized before the conversion, but it becomes load-bearing the moment a
-			// chunk is reused across conversions.
-			duckdb::FlatVector::SetSize(chunk->data[i], duckdb::count_t(chunk->size()));
-		}
-		*out_chunk = Convert(chunk.release());
-	});
-}
-
-DUCKDB_V2_ERROR duckdb_v2_arrow_converter_get_schema(duckdb_v2_arrow_converter_handle converter,
-                                                     duckdb_v2_schema_handle *out_schema,
-                                                     duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(converter);
+DUCKDB_V2_ERROR duckdb_v2_arrow_importer_get_schema(duckdb_v2_arrow_importer_handle importer,
+                                                    duckdb_v2_schema_handle *out_schema,
+                                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(importer);
 	DUCKDB_CHECK_ARG(out_schema);
 	*out_schema = nullptr;
 	return WithErrorHandler(err, [&]() {
-		auto &resolved = *Convert(converter);
-		auto &types = resolved.GetTypes();
-		auto &names = resolved.GetNames();
+		auto &table = Convert(importer)->table;
+		auto &types = table.GetTypes();
+		auto &names = table.GetNames();
 		D_ASSERT(names.size() == types.size());
 		// The same owned schema shape statement_bind produces; the caller destroys it.
 		auto schema = duckdb::make_uniq<CV2Schema>();
@@ -428,14 +494,217 @@ DUCKDB_V2_ERROR duckdb_v2_arrow_converter_get_schema(duckdb_v2_arrow_converter_h
 	});
 }
 
-DUCKDB_V2_ERROR duckdb_v2_arrow_converter_destroy(duckdb_v2_arrow_converter_handle *converter) {
-	return WithErrorHandler(nullptr, [&]() {
-		if (!converter) {
+DUCKDB_V2_ERROR duckdb_v2_arrow_importer_append(duckdb_v2_arrow_importer_handle importer, struct ArrowArray *array,
+                                                bool consume, bool flush, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(importer);
+	return WithErrorHandler(err, [&]() {
+		auto &self = *Convert(importer);
+		if (self.HasInputRows()) {
+			throw duckdb::InvalidInputException(
+			    "the previous Arrow array still has rows; drain it with arrow_importer_next_chunk first");
+		}
+		if (!array) {
+			// A missing array is allowed only to ask for a flush, which releases the held rows as a short chunk.
+			if (!flush) {
+				throw duckdb::InvalidInputException("null argument 'array' to duckdb_v2_arrow_importer_append");
+			}
+			self.flush_on_drain = true;
 			return;
 		}
-		if (*converter) {
-			delete Convert(*converter);
-			*converter = nullptr;
+		// Validate before taking anything, so a rejected array is left untouched.
+		CV2ValidateArrowArray(self, *array);
+		self.ReleaseInput();
+		if (consume) {
+			// Adopt the array; the chunks reference its buffers and keep this wrapper alive.
+			auto owned = duckdb::make_shared_ptr<duckdb::ArrowArrayWrapper>();
+			owned->arrow_array = *array;
+			array->release = nullptr;
+			self.owned_array = std::move(owned);
+		} else {
+			self.borrowed_array = array;
+		}
+		self.length = duckdb::NumericCast<duckdb::idx_t>(self.Array().length);
+		self.offset = 0;
+		self.flush_on_drain = flush;
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_importer_next_chunk(duckdb_v2_arrow_importer_handle importer,
+                                                    duckdb_v2_data_chunk_handle *out_chunk,
+                                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(importer);
+	DUCKDB_CHECK_ARG(out_chunk);
+	*out_chunk = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &self = *Convert(importer);
+		auto remaining = self.HasInputRows() ? self.length - self.offset : 0;
+		auto pending_rows = self.PendingRows();
+		if (remaining == 0 && pending_rows == 0) {
+			self.ReleaseInput();
+			return; // drained, or nothing appended
+		}
+		// Rows carried over from a previous array have to be joined with the head of this one, which is the one case an
+		// imported chunk cannot reference its array.
+		if (pending_rows > 0) {
+			auto need = self.batch_size == 0 ? remaining : self.batch_size - pending_rows;
+			auto take = duckdb::MinValue<duckdb::idx_t>(need, remaining);
+			if (take > 0) {
+				auto slice = CV2ConvertArrowSlice(*self.context, self, self.Array(), nullptr, self.offset, take);
+				self.pending->Append(*slice, duckdb::VectorAppendMode::ALLOW_RESIZE);
+				self.offset += take;
+				pending_rows += take;
+			}
+			auto batch_full = self.batch_size != 0 && pending_rows >= self.batch_size;
+			if (!batch_full && !self.flush_on_drain) {
+				return; // hold the partial batch until more input arrives
+			}
+			*out_chunk = Convert(self.pending.release());
+			return;
+		}
+		auto take = self.batch_size == 0 ? remaining : duckdb::MinValue<duckdb::idx_t>(self.batch_size, remaining);
+		// A tail too short to fill a batch is carried over, unless the caller asked to flush. Everything else converts
+		// straight out of the array, zero-copy when it was handed over.
+		auto is_short = self.batch_size != 0 && take < self.batch_size;
+		auto owner = self.owned_array;
+		if (is_short && !self.flush_on_drain) {
+			self.pending = CV2ConvertArrowSlice(*self.context, self, self.Array(), nullptr, self.offset, take);
+			self.offset += take;
+			return;
+		}
+		auto chunk = CV2ConvertArrowSlice(*self.context, self, self.Array(), owner, self.offset, take);
+		self.offset += take;
+		*out_chunk = Convert(chunk.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_importer_destroy(duckdb_v2_arrow_importer_handle *importer) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!importer) {
+			return;
+		}
+		if (*importer) {
+			delete Convert(*importer);
+			*importer = nullptr;
+		}
+	});
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// arrow_exporter
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_create(duckdb_v2_context_handle context,
+                                                const duckdb_v2_logical_type_handle *types, const duckdb_v2_str *names,
+                                                idx_t count, idx_t batch_size,
+                                                duckdb_v2_arrow_exporter_handle *out_exporter,
+                                                duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(context);
+	DUCKDB_CHECK_ARG(out_exporter);
+	*out_exporter = nullptr;
+	if (count > 0 && !types) {
+		return NullArgumentError(err, __func__, "types");
+	}
+	if (count > 0 && !names) {
+		return NullArgumentError(err, __func__, "names");
+	}
+	return WithErrorHandler(err, [&]() {
+		auto &ctx = *Convert(context);
+		auto exporter = duckdb::make_uniq<CV2ArrowExporter>();
+		exporter->batch_size = batch_size;
+		exporter->types.reserve(count);
+		exporter->names.reserve(count);
+		for (idx_t i = 0; i < count; i++) {
+			if (!types[i]) {
+				throw duckdb::InvalidInputException("null logical type at index %llu", i);
+			}
+			if (IsNullArgument(names[i])) {
+				throw duckdb::InvalidInputException("malformed column name at index %llu", i);
+			}
+			exporter->types.push_back(*Convert(types[i]));
+			exporter->names.emplace_back(Convert(names[i]));
+		}
+		// Pin the settings and the extension map now: the schema below and every array this exporter produces are built
+		// from them, which is what keeps the two consistent.
+		exporter->properties = ctx.GetClientProperties();
+		exporter->extension_types = duckdb::ArrowTypeExtensionData::GetExtensionTypes(ctx, exporter->types);
+		*out_exporter = Convert(exporter.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_get_schema(duckdb_v2_arrow_exporter_handle exporter,
+                                                    struct ArrowSchema *out_schema, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(exporter);
+	DUCKDB_CHECK_ARG(out_schema);
+	return WithErrorHandler(err, [&]() {
+		auto &self = *Convert(exporter);
+		duckdb::ArrowConverter::ToArrowSchema(out_schema, self.types, self.names, self.properties);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_append(duckdb_v2_arrow_exporter_handle exporter,
+                                                duckdb_v2_data_chunk_handle *chunk, bool consume, bool flush,
+                                                duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(exporter);
+	return WithErrorHandler(err, [&]() {
+		auto &self = *Convert(exporter);
+		if (chunk && *chunk) {
+			auto &input = *Convert(*chunk);
+			if (input.GetTypes() != self.types) {
+				throw duckdb::InvalidInputException("chunk types do not match the types the exporter was created with");
+			}
+			// The chunk is read in full before this returns -- the conversion copies into freshly allocated Arrow
+			// buffers -- filling batches of at most batch_size rows and carrying whatever is left over into the next
+			// append.
+			auto rows = input.size();
+			for (duckdb::idx_t consumed = 0; consumed < rows;) {
+				self.EnsureAppender(self.batch_size == 0 ? rows : self.batch_size);
+				auto room = self.batch_size == 0 ? rows - consumed : self.batch_size - self.gathered;
+				auto take = duckdb::MinValue<duckdb::idx_t>(room, rows - consumed);
+				self.appender->Append(input, consumed, consumed + take, rows);
+				self.gathered += take;
+				consumed += take;
+				if (self.batch_size == 0 || self.gathered >= self.batch_size) {
+					self.Emit();
+				}
+			}
+			if (consume) {
+				duckdb_v2_data_chunk_destroy(chunk);
+			}
+		} else if (!flush) {
+			// A missing chunk is allowed only to ask for a flush.
+			throw duckdb::InvalidInputException("null argument 'chunk' to duckdb_v2_arrow_exporter_append");
+		}
+		if (flush) {
+			// No further input, so whatever was gathered comes out as a short array.
+			self.Emit();
+		}
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_next_array(duckdb_v2_arrow_exporter_handle exporter,
+                                                    struct ArrowArray *out_array, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(exporter);
+	DUCKDB_CHECK_ARG(out_array);
+	out_array->release = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &self = *Convert(exporter);
+		if (self.ready.empty()) {
+			// Nothing ready, which the Arrow interface spells as a released array.
+			return;
+		}
+		*out_array = self.ready.front();
+		self.ready.pop_front();
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_arrow_exporter_destroy(duckdb_v2_arrow_exporter_handle *exporter) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!exporter) {
+			return;
+		}
+		if (*exporter) {
+			delete Convert(*exporter);
+			*exporter = nullptr;
 		}
 	});
 }

--- a/src/main/capi/v2/capi_v2_catalog.cpp
+++ b/src/main/capi/v2/capi_v2_catalog.cpp
@@ -1,0 +1,146 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+
+#include "duckdb/main/table_description.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/planner/binder.hpp"
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_connection_describe_table(duckdb_v2_connection_handle conn, duckdb_v2_qname_handle name,
+                                                    duckdb_v2_table_description_handle *desc,
+                                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(conn);
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(desc);
+	*desc = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &context = *Convert(conn)->context;
+		auto &qname = *Convert(name);
+		auto &path = qname.Path();
+		// The qname invariant guarantees one to three non-empty parts. A two-part name is read as SQL reads it: the
+		// first part tries as a schema and as an attached database, and BindSchemaOrCatalog rejects the ambiguous case.
+		auto catalog = duckdb::Identifier::InvalidCatalog();
+		auto schema = duckdb::Identifier::InvalidSchema();
+		if (path.size() == 3) {
+			catalog = path[0];
+			schema = path[1];
+		} else if (path.size() == 2) {
+			schema = path[0];
+			// The attached-database lookup reads catalog state and needs a transaction.
+			context.RunFunctionInTransaction([&]() { duckdb::Binder::BindSchemaOrCatalog(context, catalog, schema); });
+		}
+		auto description = context.TableInfo(catalog, schema, path.back());
+		if (!description) {
+			throw duckdb::CatalogException("Table with name %s does not exist!", qname.ToString());
+		}
+		*desc = Convert(description.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_description_get_qname(duckdb_v2_table_description_handle desc,
+                                                      duckdb_v2_qname_handle *name, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(desc);
+	DUCKDB_CHECK_ARG(name);
+	*name = nullptr;
+	return WithErrorHandler(err, [&]() { *name = Convert(new duckdb::QualifiedName(Convert(desc)->qualified_name)); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_description_get_column_count(duckdb_v2_table_description_handle desc, idx_t *count,
+                                                             duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(desc);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(desc)->columns.size(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_description_get_column(duckdb_v2_table_description_handle desc, idx_t index,
+                                                       duckdb_v2_column_description_handle *column,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(desc);
+	DUCKDB_CHECK_ARG(column);
+	*column = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &columns = Convert(desc)->columns;
+		if (index >= columns.size()) {
+			throw duckdb::Exception(
+			    duckdb::ExceptionType::OUT_OF_RANGE,
+			    duckdb::StringUtil::Format("Column index %llu is out of range for a table with %llu "
+			                               "columns in duckdb_v2_table_description_get_column.",
+			                               static_cast<uint64_t>(index), static_cast<uint64_t>(columns.size())));
+		}
+		*column = Convert(new duckdb::ColumnDefinition(columns[index].Copy()));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_description_is_readonly(duckdb_v2_table_description_handle desc, bool *readonly,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(desc);
+	DUCKDB_CHECK_ARG(readonly);
+	return WithErrorHandler(err, [&]() { *readonly = Convert(desc)->readonly; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_description_destroy(duckdb_v2_table_description_handle *desc) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!desc) {
+			return;
+		}
+		if (*desc) {
+			delete Convert(*desc);
+			*desc = nullptr;
+		}
+	});
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Column Description
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_column_description_get_name(duckdb_v2_column_description_handle column,
+                                                      duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(column);
+	DUCKDB_CHECK_ARG(name);
+	*name = duckdb_v2_identifier_t {nullptr, 0};
+	return WithErrorHandler(err, [&]() { *name = Convert(Convert(column)->Name()); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_column_description_get_type(duckdb_v2_column_description_handle column,
+                                                      duckdb_v2_logical_type_handle *type,
+                                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(column);
+	DUCKDB_CHECK_ARG(type);
+	*type = nullptr;
+	// Borrowed: the column definition owns the type for as long as the description lives.
+	return WithErrorHandler(err, [&]() { *type = Convert(&Convert(column)->TypeMutable()); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_column_description_has_default(duckdb_v2_column_description_handle column, bool *has_default,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(column);
+	DUCKDB_CHECK_ARG(has_default);
+	return WithErrorHandler(err, [&]() {
+		auto &definition = *Convert(column);
+		*has_default = !definition.Generated() && definition.HasDefaultValue();
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_column_description_has_generated(duckdb_v2_column_description_handle column,
+                                                           bool *has_generated, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(column);
+	DUCKDB_CHECK_ARG(has_generated);
+	return WithErrorHandler(err, [&]() { *has_generated = Convert(column)->Generated(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_column_description_destroy(duckdb_v2_column_description_handle *column) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!column) {
+			return;
+		}
+		if (*column) {
+			delete Convert(*column);
+			*column = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_column_data_collection.cpp
+++ b/src/main/capi/v2/capi_v2_column_data_collection.cpp
@@ -115,6 +115,12 @@ DUCKDB_V2_ERROR duckdb_v2_column_data_collection_reset(duckdb_v2_column_data_col
 	return WithErrorHandler(err, [&]() { Convert(collection)->Reset(); });
 }
 
+DUCKDB_V2_ERROR duckdb_v2_column_data_collection_clear(duckdb_v2_column_data_collection_handle collection,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(collection);
+	return WithErrorHandler(err, [&]() { Convert(collection)->ResetForReuse(); });
+}
+
 DUCKDB_V2_ERROR duckdb_v2_column_data_collection_destroy(duckdb_v2_column_data_collection_handle *collection) {
 	return WithErrorHandler(nullptr, [&]() {
 		if (collection && *collection) {

--- a/src/main/capi/v2/capi_v2_custom_type.cpp
+++ b/src/main/capi/v2/capi_v2_custom_type.cpp
@@ -42,7 +42,9 @@ public:
 
 		context.RunFunctionInTransaction([&]() {
 			auto &catalog = Catalog::GetSystemCatalog(context);
-			CreateTypeInfo type_info(type.GetAlias(), std::move(type));
+			// Read the name before the type is moved out: sibling arguments have no evaluation order.
+			auto name = type.GetAlias();
+			CreateTypeInfo type_info(std::move(name), std::move(type));
 			type_info.temporary = true;
 			type_info.internal = true;
 			type_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
@@ -60,7 +62,8 @@ public:
 	}
 
 	void RegisterToCatalog(LogicalType type) override {
-		loader.RegisterType(type.GetAlias(), std::move(type));
+		auto name = type.GetAlias();
+		loader.RegisterType(std::move(name), std::move(type));
 	}
 
 private:

--- a/src/main/capi/v2/capi_v2_custom_type.cpp
+++ b/src/main/capi/v2/capi_v2_custom_type.cpp
@@ -1,0 +1,141 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/parser/parsed_data/create_type_info.hpp"
+
+namespace duckdb::capiv2 {
+
+class CV2CustomType {
+public:
+	// Validates the configuration and returns the type to install: the base type carrying the custom type's name as
+	// its alias, which is what makes it logically distinct from the base type.
+	LogicalType Build() {
+		if (name.empty()) {
+			throw InvalidInputException("Type name cannot be empty.");
+		}
+		if (base_type.id() == LogicalTypeId::INVALID) {
+			throw InvalidInputException("Base type must be set for the type.");
+		}
+		if (!base_type.IsComplete()) {
+			throw InvalidInputException("Base type must be a fully defined concrete type");
+		}
+		return base_type.WithAlias(name.GetIdentifierName());
+	}
+
+	void Register() {
+		RegisterToCatalog(Build());
+	}
+
+	virtual ~CV2CustomType() = default;
+	virtual void RegisterToCatalog(LogicalType type) = 0;
+
+public:
+	Identifier name;
+	LogicalType base_type;
+};
+
+class CV2ConnectionCustomType : public CV2CustomType {
+public:
+	explicit CV2ConnectionCustomType(Connection &connection) : connection(connection) {
+	}
+
+	void RegisterToCatalog(LogicalType type) override {
+		auto &context = *connection.context;
+
+		context.RunFunctionInTransaction([&]() {
+			auto &catalog = Catalog::GetSystemCatalog(context);
+			CreateTypeInfo type_info(type.GetAlias(), std::move(type));
+			type_info.temporary = true;
+			type_info.internal = true;
+			type_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+			catalog.CreateType(context, type_info);
+		});
+	}
+
+private:
+	Connection &connection;
+};
+
+class CV2ExtensionCustomType : public CV2CustomType {
+public:
+	explicit CV2ExtensionCustomType(ExtensionLoader &loader) : loader(loader) {
+	}
+
+	void RegisterToCatalog(LogicalType type) override {
+		loader.RegisterType(type.GetAlias(), std::move(type));
+	}
+
+private:
+	ExtensionLoader &loader;
+};
+
+static auto Convert(duckdb_v2_custom_type_handle type) -> CV2CustomType * {
+	return reinterpret_cast<CV2CustomType *>(type);
+}
+static auto Convert(CV2CustomType *type) -> duckdb_v2_custom_type_handle {
+	return reinterpret_cast<duckdb_v2_custom_type_handle>(type);
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_custom_type_create_with_connection(duckdb_v2_connection_handle connection,
+                                                             duckdb_v2_custom_type_handle *out_type,
+                                                             duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(connection);
+	DUCKDB_CHECK_ARG(out_type);
+	*out_type = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &conn = *Convert(connection);
+		auto type = duckdb::make_uniq<CV2ConnectionCustomType>(conn);
+		*out_type = Convert(type.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_custom_type_create_with_extension(duckdb_v2_extension_handle extension,
+                                                            duckdb_v2_custom_type_handle *out_type,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(extension);
+	DUCKDB_CHECK_ARG(out_type);
+	*out_type = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &loader = GetExtensionLoader(extension);
+		auto type = duckdb::make_uniq<CV2ExtensionCustomType>(loader);
+		*out_type = Convert(type.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_custom_type_set_name(duckdb_v2_custom_type_handle type, duckdb_v2_identifier_t name,
+                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(type);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(err, [&]() { Convert(type)->name = duckdb::Identifier(Convert(name)); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_custom_type_set_base_type(duckdb_v2_custom_type_handle type,
+                                                    duckdb_v2_logical_type_handle base_type,
+                                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(type);
+	DUCKDB_CHECK_ARG(base_type);
+	return WithErrorHandler(err, [&]() { Convert(type)->base_type = *Convert(base_type); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_custom_type_register(duckdb_v2_custom_type_handle type, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(type);
+	return WithErrorHandler(err, [&]() { Convert(type)->Register(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_custom_type_destroy(duckdb_v2_custom_type_handle *type) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!type) {
+			return;
+		}
+		if (*type) {
+			delete Convert(*type);
+			*type = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_expression.cpp
+++ b/src/main/capi/v2/capi_v2_expression.cpp
@@ -1,0 +1,222 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+
+namespace duckdb::capiv2 {
+
+// The public enum mirrors the engine's ExpressionType numerically for the values it exposes, so that the mapping
+// below is a plain cast. Any renumbering of an exposed value is caught here instead of surfacing as a wrong type.
+#define CV2_ASSERT_EXPRESSION_TYPE(NAME)                                                                               \
+	static_assert(static_cast<int>(ExpressionType::NAME) == DUCKDB_V2_EXPRESSION_TYPE_##NAME,                          \
+	              "EXPRESSION_TYPE numeric drift: " #NAME)
+
+CV2_ASSERT_EXPRESSION_TYPE(INVALID);
+CV2_ASSERT_EXPRESSION_TYPE(OPERATOR_CAST);
+CV2_ASSERT_EXPRESSION_TYPE(OPERATOR_NOT);
+CV2_ASSERT_EXPRESSION_TYPE(OPERATOR_IS_NULL);
+CV2_ASSERT_EXPRESSION_TYPE(OPERATOR_IS_NOT_NULL);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_EQUAL);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_NOTEQUAL);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_LESSTHAN);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_GREATERTHAN);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_LESSTHANOREQUALTO);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_GREATERTHANOREQUALTO);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_IN);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_NOT_IN);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_DISTINCT_FROM);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_BETWEEN);
+CV2_ASSERT_EXPRESSION_TYPE(COMPARE_NOT_DISTINCT_FROM);
+CV2_ASSERT_EXPRESSION_TYPE(CONJUNCTION_AND);
+CV2_ASSERT_EXPRESSION_TYPE(CONJUNCTION_OR);
+CV2_ASSERT_EXPRESSION_TYPE(VALUE_CONSTANT);
+CV2_ASSERT_EXPRESSION_TYPE(VALUE_PARAMETER);
+CV2_ASSERT_EXPRESSION_TYPE(BOUND_FUNCTION);
+CV2_ASSERT_EXPRESSION_TYPE(CASE_EXPR);
+CV2_ASSERT_EXPRESSION_TYPE(OPERATOR_COALESCE);
+CV2_ASSERT_EXPRESSION_TYPE(BOUND_COLUMN_REF);
+
+#undef CV2_ASSERT_EXPRESSION_TYPE
+
+//! Maps an expression type onto the public enum: the exposed subset passes through, everything else is INVALID.
+static auto CV2ExpressionGetType(const Expression &expression) -> DUCKDB_V2_EXPRESSION_TYPE {
+	switch (expression.GetExpressionType()) {
+	case ExpressionType::OPERATOR_CAST:
+	case ExpressionType::OPERATOR_NOT:
+	case ExpressionType::OPERATOR_IS_NULL:
+	case ExpressionType::OPERATOR_IS_NOT_NULL:
+	case ExpressionType::COMPARE_EQUAL:
+	case ExpressionType::COMPARE_NOTEQUAL:
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_GREATERTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+	case ExpressionType::COMPARE_IN:
+	case ExpressionType::COMPARE_NOT_IN:
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+	case ExpressionType::COMPARE_BETWEEN:
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+	case ExpressionType::CONJUNCTION_AND:
+	case ExpressionType::CONJUNCTION_OR:
+	case ExpressionType::VALUE_CONSTANT:
+	case ExpressionType::VALUE_PARAMETER:
+	case ExpressionType::BOUND_FUNCTION:
+	case ExpressionType::CASE_EXPR:
+	case ExpressionType::OPERATOR_COALESCE:
+	case ExpressionType::BOUND_COLUMN_REF:
+		return static_cast<DUCKDB_V2_EXPRESSION_TYPE>(expression.GetExpressionType());
+	default:
+		return DUCKDB_V2_EXPRESSION_TYPE_INVALID;
+	}
+}
+
+// Children are walked with the engine's own iterator, which covers every expression class, so the walk is total
+// even over nodes the public enum does not model. Fan-outs are small, so counting on every call is fine.
+static auto CV2ExpressionChildCount(Expression &expression) -> idx_t {
+	idx_t count = 0;
+	ExpressionIterator::EnumerateChildren(expression, [&](Expression &) { count++; });
+	return count;
+}
+
+static auto CV2ExpressionChild(Expression &expression, idx_t index) -> Expression & {
+	optional_ptr<Expression> result;
+	idx_t current = 0;
+	ExpressionIterator::EnumerateChildren(expression, [&](Expression &child) {
+		if (current++ == index) {
+			result = &child;
+		}
+	});
+	if (!result) {
+		throw InvalidInputException("Index out of bounds in duckdb_v2_expression_get_child");
+	}
+	return *result;
+}
+
+static auto CV2ExpressionRequireType(const Expression &expression, ExpressionType type, const char *function) -> void {
+	if (expression.GetExpressionType() != type) {
+		throw InvalidInputException("%s: expression is not of type %s", function, ExpressionTypeToString(type));
+	}
+}
+
+//! The bound scalar function behind a function node, for the accessors that only apply to function calls.
+static auto CV2ExpressionRequireFunction(const Expression &expression, const char *function)
+    -> const BoundScalarFunction & {
+	if (expression.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		throw InvalidInputException("%s: expression is not a function call", function);
+	}
+	return expression.Cast<BoundFunctionExpression>().Function();
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_expression_get_type(duckdb_v2_expression_handle expression, DUCKDB_V2_EXPRESSION_TYPE *type,
+                                              duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(type);
+	return WithErrorHandler(err, [&]() { *type = CV2ExpressionGetType(*Convert(expression)); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_expression_get_return_type(duckdb_v2_expression_handle expression,
+                                                     duckdb_v2_logical_type_handle *type,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(type);
+	*type = nullptr;
+	return WithErrorHandler(err,
+	                        [&]() { *type = Convert(new duckdb::LogicalType(Convert(expression)->GetReturnType())); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_expression_get_child_count(duckdb_v2_expression_handle expression, idx_t *count,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = CV2ExpressionChildCount(*Convert(expression)); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_expression_get_child(duckdb_v2_expression_handle expression, idx_t index,
+                                               duckdb_v2_expression_handle *child, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(child);
+	*child = nullptr;
+	return WithErrorHandler(err, [&]() { *child = Convert(&CV2ExpressionChild(*Convert(expression), index)); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_expression_constant_get_value(duckdb_v2_expression_handle expression,
+                                                        duckdb_v2_value_handle *value,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(value);
+	*value = nullptr;
+	return WithErrorHandler(err, [&]() {
+		const auto &node = *Convert(expression);
+		CV2ExpressionRequireType(node, duckdb::ExpressionType::VALUE_CONSTANT,
+		                         "duckdb_v2_expression_constant_get_value");
+		*value = Convert(new duckdb::Value(node.Cast<duckdb::BoundConstantExpression>().GetValue()));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_expression_column_ref_get_index(duckdb_v2_expression_handle expression, idx_t *index,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(index);
+	return WithErrorHandler(err, [&]() {
+		const auto &node = *Convert(expression);
+		CV2ExpressionRequireType(node, duckdb::ExpressionType::BOUND_COLUMN_REF,
+		                         "duckdb_v2_expression_column_ref_get_index");
+		*index = node.Cast<duckdb::BoundColumnRefExpression>().Binding().column_index.GetIndex();
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_expression_function_get_name(duckdb_v2_expression_handle expression,
+                                                       duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(name);
+	*name = duckdb_v2_identifier_t {nullptr, 0};
+	return WithErrorHandler(err, [&]() {
+		const auto &function =
+		    CV2ExpressionRequireFunction(*Convert(expression), "duckdb_v2_expression_function_get_name");
+		// Borrowed from the bound function's own name, which lives as long as the node.
+		*name = Convert(function.GetName());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_expression_function_get_qname(duckdb_v2_expression_handle expression,
+                                                        duckdb_v2_qname_handle *name,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(name);
+	*name = nullptr;
+	return WithErrorHandler(err, [&]() {
+		const auto &function =
+		    CV2ExpressionRequireFunction(*Convert(expression), "duckdb_v2_expression_function_get_qname");
+		// Only the qualifiers the binder actually resolved: a function bound outside the catalog has none.
+		duckdb::vector<duckdb::Identifier> path;
+		if (!function.GetCatalogName().empty()) {
+			path.push_back(function.GetCatalogName());
+		}
+		if (!function.GetSchemaName().empty()) {
+			path.push_back(function.GetSchemaName());
+		}
+		*name = Convert(new duckdb::QualifiedName(std::move(path), function.GetName()));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_expression_cast_get_mode(duckdb_v2_expression_handle expression, DUCKDB_V2_CAST_MODE *mode,
+                                                   duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(expression);
+	DUCKDB_CHECK_ARG(mode);
+	return WithErrorHandler(err, [&]() {
+		const auto &node = *Convert(expression);
+		CV2ExpressionRequireType(node, duckdb::ExpressionType::OPERATOR_CAST, "duckdb_v2_expression_cast_get_mode");
+		const auto &cast = node.Cast<duckdb::BoundFunctionExpression>();
+		*mode = duckdb::BoundCastExpression::IsTryCast(cast) ? DUCKDB_V2_CAST_MODE_TRY : DUCKDB_V2_CAST_MODE_NORMAL;
+	});
+}

--- a/src/main/capi/v2/capi_v2_file_system.cpp
+++ b/src/main/capi/v2/capi_v2_file_system.cpp
@@ -1,0 +1,296 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+
+#include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/open_file_info.hpp"
+#include "duckdb/common/query_context.hpp"
+
+namespace duckdb::capiv2 {
+
+// The file system handle, borrowed. It carries the context it was taken from alongside the file system itself, so
+// that reads and writes can hand the engine a QueryContext and have their bytes attributed to the query. Kept on the
+// context's own state, so the handle stays borrowed -- one per context, alive exactly as long as the context is.
+class CV2FileSystem : public ClientContextState {
+public:
+	optional_ptr<FileSystem> fs;
+	//! The context the file system was taken from, so reads and writes can be attributed to the query.
+	QueryContext query;
+};
+
+inline auto GetFileSystemSlot(ClientContext &context) -> shared_ptr<CV2FileSystem> {
+	constexpr auto FILE_SYSTEM_SLOT_KEY = "c_api_v2_file_system";
+	auto slot = context.registered_state->GetOrCreate<CV2FileSystem>(FILE_SYSTEM_SLOT_KEY);
+	slot->fs = &FileSystem::GetFileSystem(context);
+	slot->query = context;
+	return slot;
+}
+
+// How a file is opened, owned. Holds the flag word as given rather than the engine's FileOpenFlags, so that
+// "no flags set yet" stays distinguishable and is reported when the options are actually used.
+class CV2FileOpenOptions {
+public:
+	FileOpenFlags flags;
+	//! Flags are applied one at a time, so this is what distinguishes "none applied yet" from any particular set.
+	bool has_flags = false;
+	//! Built on first use: an absent extended info is meaningfully different from an empty one.
+	shared_ptr<ExtendedOpenFileInfo> extended_info;
+
+	auto Options() -> unordered_map<string, Value> & {
+		if (!extended_info) {
+			extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		}
+		return extended_info->options;
+	}
+};
+
+// An open file, owned. Carries the context for the same reason the file system handle does.
+class CV2File {
+public:
+	unique_ptr<FileHandle> handle;
+	QueryContext query;
+
+	auto Handle() const -> FileHandle & {
+		return *handle;
+	}
+};
+
+static auto Convert(duckdb_v2_file_system_handle fs) -> CV2FileSystem * {
+	return reinterpret_cast<CV2FileSystem *>(fs);
+}
+static auto Convert(CV2FileSystem *fs) -> duckdb_v2_file_system_handle {
+	return reinterpret_cast<duckdb_v2_file_system_handle>(fs);
+}
+
+static auto Convert(duckdb_v2_file_open_options_handle options) -> CV2FileOpenOptions * {
+	return reinterpret_cast<CV2FileOpenOptions *>(options);
+}
+static auto Convert(CV2FileOpenOptions *options) -> duckdb_v2_file_open_options_handle {
+	return reinterpret_cast<duckdb_v2_file_open_options_handle>(options);
+}
+
+static auto Convert(duckdb_v2_file_handle handle) -> CV2File * {
+	return reinterpret_cast<CV2File *>(handle);
+}
+static auto Convert(CV2File *handle) -> duckdb_v2_file_handle {
+	return reinterpret_cast<duckdb_v2_file_handle>(handle);
+}
+
+// Applies one C flag to the engine's flag set. The C enum is a list of names rather than a bitmask, so each value
+// maps to exactly one engine flag and anything else is a caller error.
+static void ApplyFileFlag(CV2FileOpenOptions &options, DUCKDB_V2_FILE_FLAG flag) {
+	switch (flag) {
+	case DUCKDB_V2_FILE_FLAG_READ:
+		options.flags |= FileOpenFlags::FILE_FLAGS_READ;
+		break;
+	case DUCKDB_V2_FILE_FLAG_WRITE:
+		options.flags |= FileOpenFlags::FILE_FLAGS_WRITE;
+		break;
+	case DUCKDB_V2_FILE_FLAG_CREATE:
+		options.flags |= FileOpenFlags::FILE_FLAGS_FILE_CREATE;
+		break;
+	case DUCKDB_V2_FILE_FLAG_CREATE_NEW:
+		options.flags |= FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW;
+		break;
+	case DUCKDB_V2_FILE_FLAG_APPEND:
+		options.flags |= FileOpenFlags::FILE_FLAGS_APPEND;
+		break;
+	case DUCKDB_V2_FILE_FLAG_EXCLUSIVE_CREATE:
+		options.flags |= FileOpenFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
+		break;
+	case DUCKDB_V2_FILE_FLAG_PARALLEL_ACCESS:
+		options.flags |= FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS;
+		break;
+	default:
+		// Includes FILE_FLAG_INVALID, which names no behaviour.
+		throw InvalidInputException("'%d' is not a file flag.", static_cast<int>(flag));
+	}
+	options.has_flags = true;
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_file_system_get_from_context(duckdb_v2_context_handle context,
+                                                       duckdb_v2_file_system_handle *out_file_system,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(context);
+	DUCKDB_CHECK_ARG(out_file_system);
+	*out_file_system = nullptr;
+	return WithErrorHandler(err, [&]() { *out_file_system = Convert(GetFileSystemSlot(*Convert(context)).get()); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_system_get_from_connection(duckdb_v2_connection_handle connection,
+                                                          duckdb_v2_file_system_handle *out_file_system,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(connection);
+	DUCKDB_CHECK_ARG(out_file_system);
+	*out_file_system = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &context = *Convert(connection)->context;
+		*out_file_system = Convert(GetFileSystemSlot(context).get());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_open_options_create(duckdb_v2_file_system_handle file_system,
+                                                   duckdb_v2_file_open_options_handle *out_options,
+                                                   duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file_system);
+	DUCKDB_CHECK_ARG(out_options);
+	*out_options = nullptr;
+	return WithErrorHandler(err, [&]() { *out_options = Convert(duckdb::make_uniq<CV2FileOpenOptions>().release()); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_open_options_set_flag(duckdb_v2_file_open_options_handle options,
+                                                     DUCKDB_V2_FILE_FLAG flag, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(options);
+	return WithErrorHandler(err, [&]() { ApplyFileFlag(*Convert(options), flag); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_open_options_set_value(duckdb_v2_file_open_options_handle options, duckdb_v2_str name,
+                                                      duckdb_v2_value_handle value, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(options);
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(value);
+	return WithErrorHandler(err, [&]() {
+		auto key = duckdb::string(Convert(name));
+		if (key.empty()) {
+			throw duckdb::InvalidInputException("A file option name cannot be empty.");
+		}
+		Convert(options)->Options()[key] = *Convert(value);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_open_options_destroy(duckdb_v2_file_open_options_handle *options) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!options) {
+			return;
+		}
+		if (*options) {
+			delete Convert(*options);
+			*options = nullptr;
+		}
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_system_open(duckdb_v2_file_system_handle file_system, duckdb_v2_str file_path,
+                                           duckdb_v2_file_open_options_handle options,
+                                           duckdb_v2_file_handle *out_file_handle, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file_system);
+	DUCKDB_CHECK_ARG(file_path);
+	DUCKDB_CHECK_ARG(options);
+	DUCKDB_CHECK_ARG(out_file_handle);
+	*out_file_handle = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &slot = *Convert(file_system);
+		auto &opts = *Convert(options);
+		if (!opts.has_flags) {
+			throw duckdb::InvalidInputException(
+			    "The open options carry no flags, so they cannot say whether the file is being read or written.");
+		}
+
+		duckdb::OpenFileInfo info(duckdb::string(Convert(file_path)));
+		info.extended_info = opts.extended_info;
+
+		// No opener is passed: FileSystem::GetFileSystem hands back the context's own OpenerFileSystem, which
+		// pushes the opener itself -- which is how a remote file system reaches settings and secrets. Supplying one
+		// here is rejected outright ("the opener is pushed automatically").
+		auto handle = slot.fs->OpenFile(info, opts.flags);
+		if (!handle) {
+			throw duckdb::IOException("Failed to open file: %s", info.path);
+		}
+		auto file = duckdb::make_uniq<CV2File>();
+		file->handle = std::move(handle);
+		file->query = slot.query;
+		*out_file_handle = Convert(file.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_read(duckdb_v2_file_handle file, void *buffer, idx_t buffer_size, idx_t *bytes_read,
+                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	DUCKDB_CHECK_ARG(buffer);
+	DUCKDB_CHECK_ARG(bytes_read);
+	return WithErrorHandler(err, [&]() {
+		auto &f = *Convert(file);
+		*bytes_read = duckdb::NumericCast<idx_t>(f.Handle().Read(f.query, buffer, buffer_size));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_write(duckdb_v2_file_handle file, const void *buffer, idx_t buffer_size,
+                                     idx_t *bytes_written, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	DUCKDB_CHECK_ARG(buffer);
+	DUCKDB_CHECK_ARG(bytes_written);
+	return WithErrorHandler(err, [&]() {
+		// The engine's Write takes a mutable pointer but does not write through it.
+		auto *data = const_cast<void *>(buffer); // NOLINT: the engine's signature is not const-correct
+		auto &f = *Convert(file);
+		*bytes_written = duckdb::NumericCast<idx_t>(f.Handle().Write(f.query, data, buffer_size));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_read_at(duckdb_v2_file_handle file, void *buffer, idx_t buffer_size, idx_t location,
+                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	DUCKDB_CHECK_ARG(buffer);
+	return WithErrorHandler(err, [&]() {
+		// Reads all of buffer_size or throws, and leaves the file's position alone.
+		auto &f = *Convert(file);
+		f.Handle().Read(f.query, buffer, buffer_size, location);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_write_at(duckdb_v2_file_handle file, const void *buffer, idx_t buffer_size,
+                                        idx_t location, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	DUCKDB_CHECK_ARG(buffer);
+	return WithErrorHandler(err, [&]() {
+		auto *data = const_cast<void *>(buffer); // NOLINT: the engine's signature is not const-correct
+		auto &f = *Convert(file);
+		f.Handle().Write(f.query, data, buffer_size, location);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_tell(duckdb_v2_file_handle file, idx_t *position, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	DUCKDB_CHECK_ARG(position);
+	return WithErrorHandler(err, [&]() { *position = Convert(file)->Handle().SeekPosition(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_size(duckdb_v2_file_handle file, idx_t *size, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	DUCKDB_CHECK_ARG(size);
+	return WithErrorHandler(err, [&]() { *size = Convert(file)->Handle().GetFileSize(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_seek(duckdb_v2_file_handle file, idx_t position, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	return WithErrorHandler(err, [&]() { Convert(file)->Handle().Seek(position); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_sync(duckdb_v2_file_handle file, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	return WithErrorHandler(err, [&]() { Convert(file)->Handle().Sync(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_close(duckdb_v2_file_handle file, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(file);
+	return WithErrorHandler(err, [&]() { Convert(file)->Handle().Close(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_file_destroy(duckdb_v2_file_handle *file_handle) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!file_handle) {
+			return;
+		}
+		if (*file_handle) {
+			delete Convert(*file_handle);
+			*file_handle = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_func_cast.cpp
+++ b/src/main/capi/v2/capi_v2_func_cast.cpp
@@ -1,0 +1,282 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/function/cast/cast_function_set.hpp"
+
+namespace duckdb::capiv2 {
+
+class CV2CastBoundData final : public BoundCastData {
+public:
+	CV2CastBoundData(duckdb_v2_cast_function_exec_callback_fn exec_cb, shared_ptr<CV2UserData> user_data)
+	    : exec_cb(exec_cb), user_data(std::move(user_data)) {
+	}
+
+	auto Copy() const -> unique_ptr<BoundCastData> override {
+		return make_uniq<CV2CastBoundData>(exec_cb, user_data);
+	}
+
+public:
+	duckdb_v2_cast_function_exec_callback_fn exec_cb;
+	shared_ptr<CV2UserData> user_data;
+};
+
+// CastParameters carries no context, so the only place to pick one up is the local state init, which does receive
+// one. The state exists purely to forward it to the exec callback.
+class CV2CastLocalState final : public FunctionLocalState {
+public:
+	optional_ptr<ClientContext> context;
+};
+
+class CV2CastExecInfo {
+public:
+	void *in_user_data = nullptr;
+
+	Vector *input = nullptr;
+	Vector *output = nullptr;
+	idx_t count = 0;
+	DUCKDB_V2_CAST_MODE mode = DUCKDB_V2_CAST_MODE_NORMAL;
+};
+
+static auto Convert(duckdb_v2_cast_function_exec_info_handle info) -> CV2CastExecInfo * {
+	return reinterpret_cast<CV2CastExecInfo *>(info);
+}
+static auto Convert(CV2CastExecInfo *info) -> duckdb_v2_cast_function_exec_info_handle {
+	return reinterpret_cast<duckdb_v2_cast_function_exec_info_handle>(info);
+}
+
+static auto CV2CastInitLocalState(CastLocalStateParameters &parameters) -> unique_ptr<FunctionLocalState> {
+	auto state = make_uniq<CV2CastLocalState>();
+
+	if (!parameters.context) {
+		throw InvalidInputException("Cannot initialize local state for extension cast function without a context");
+	}
+
+	state->context = parameters.context;
+	return std::move(state);
+}
+
+static auto CV2CastExec(Vector &input, Vector &output, idx_t count, CastParameters &parameters) -> bool {
+	const auto &bound_data = parameters.cast_data->Cast<CV2CastBoundData>();
+
+	// A try cast is exactly the case where the engine handed us a slot to write a message into instead of aborting.
+	const auto is_try_cast = parameters.error_message != nullptr;
+
+	CV2CastExecInfo args = {};
+	args.in_user_data = bound_data.user_data ? bound_data.user_data->GetData() : nullptr;
+	args.input = &input;
+	args.output = &output;
+	args.count = count;
+	args.mode = is_try_cast ? DUCKDB_V2_CAST_MODE_TRY : DUCKDB_V2_CAST_MODE_NORMAL;
+
+	optional_ptr<ClientContext> context = nullptr;
+	if (parameters.local_state) {
+		context = parameters.local_state->Cast<CV2CastLocalState>().context;
+	}
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	bound_data.exec_cb(Convert(&args), Convert(context.get()), &err_ptr);
+
+	if (!err.HasError()) {
+		return true;
+	}
+	if (is_try_cast) {
+		// The engine discards the message and keeps whatever the callback left in the output vector.
+		HandleCastError::AssignError(err.message, parameters);
+		return false;
+	}
+	err.ThrowAsException();
+}
+
+class CV2CastFunction {
+public:
+	void Register() {
+		if (!source_type.IsComplete()) {
+			throw InvalidInputException("Source type must be set to a fully defined concrete type");
+		}
+		if (!target_type.IsComplete()) {
+			throw InvalidInputException("Target type must be set to a fully defined concrete type");
+		}
+		if (!exec_cb) {
+			throw InvalidInputException("Exec callback must be set for the function.");
+		}
+
+		BoundCastInfo cast_info(CV2CastExec, make_uniq<CV2CastBoundData>(exec_cb, user_data), CV2CastInitLocalState);
+		RegisterToCatalog(std::move(cast_info));
+	}
+
+	virtual ~CV2CastFunction() = default;
+	virtual void RegisterToCatalog(BoundCastInfo cast_info) = 0;
+
+public:
+	LogicalType source_type;
+	LogicalType target_type;
+	int64_t implicit_cast_cost = -1;
+	duckdb_v2_cast_function_exec_callback_fn exec_cb = nullptr;
+	shared_ptr<CV2UserData> user_data = nullptr;
+};
+
+class CV2ConnectionCastFunction : public CV2CastFunction {
+public:
+	explicit CV2ConnectionCastFunction(Connection &connection) : connection(connection) {
+	}
+
+	void RegisterToCatalog(BoundCastInfo cast_info) override {
+		auto &context = *connection.context;
+
+		context.RunFunctionInTransaction([&]() {
+			auto &casts = CastFunctionSet::Get(context);
+			casts.RegisterCastFunction(source_type, target_type, std::move(cast_info), implicit_cast_cost);
+		});
+	}
+
+private:
+	Connection &connection;
+};
+
+class CV2ExtensionCastFunction : public CV2CastFunction {
+public:
+	explicit CV2ExtensionCastFunction(ExtensionLoader &loader) : loader(loader) {
+	}
+
+	void RegisterToCatalog(BoundCastInfo cast_info) override {
+		loader.RegisterCastFunction(source_type, target_type, std::move(cast_info), implicit_cast_cost);
+	}
+
+private:
+	ExtensionLoader &loader;
+};
+
+static auto Convert(duckdb_v2_cast_function_handle func) -> CV2CastFunction * {
+	return reinterpret_cast<CV2CastFunction *>(func);
+}
+static auto Convert(CV2CastFunction *func) -> duckdb_v2_cast_function_handle {
+	return reinterpret_cast<duckdb_v2_cast_function_handle>(func);
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_create_with_connection(duckdb_v2_connection_handle connection,
+                                                               duckdb_v2_cast_function_handle *out_function,
+                                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(connection);
+	DUCKDB_CHECK_ARG(out_function);
+	*out_function = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &conn = *Convert(connection);
+		auto function = duckdb::make_uniq<CV2ConnectionCastFunction>(conn);
+		*out_function = Convert(function.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_create_with_extension(duckdb_v2_extension_handle extension,
+                                                              duckdb_v2_cast_function_handle *out_function,
+                                                              duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(extension);
+	DUCKDB_CHECK_ARG(out_function);
+	*out_function = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &loader = GetExtensionLoader(extension);
+		auto function = duckdb::make_uniq<CV2ExtensionCastFunction>(loader);
+		*out_function = Convert(function.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_set_source_type(duckdb_v2_cast_function_handle function,
+                                                        duckdb_v2_logical_type_handle source_type,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	DUCKDB_CHECK_ARG(source_type);
+	return WithErrorHandler(err, [&]() { Convert(function)->source_type = *Convert(source_type); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_set_target_type(duckdb_v2_cast_function_handle function,
+                                                        duckdb_v2_logical_type_handle target_type,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	DUCKDB_CHECK_ARG(target_type);
+	return WithErrorHandler(err, [&]() { Convert(function)->target_type = *Convert(target_type); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_set_implicit_cast_cost(duckdb_v2_cast_function_handle function, int64_t cost,
+                                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->implicit_cast_cost = cost; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_set_user_data(duckdb_v2_cast_function_handle function,
+                                                      duckdb_v2_opaque *user_data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	DUCKDB_CHECK_ARG(user_data);
+	return WithErrorHandler(err, [&]() {
+		Convert(function)->user_data =
+		    duckdb::make_shared_ptr<CV2UserData>(user_data->ptr, user_data->destroy, user_data->equals);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_set_exec_callback(duckdb_v2_cast_function_handle function,
+                                                          duckdb_v2_cast_function_exec_callback_fn callback,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->exec_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_user_data(duckdb_v2_cast_function_exec_info_handle info, void **data,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_row_count(duckdb_v2_cast_function_exec_info_handle info, idx_t *count,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->count; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_input(duckdb_v2_cast_function_exec_info_handle info,
+                                                       duckdb_v2_vector_handle *vector,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(vector);
+	return WithErrorHandler(err, [&]() { *vector = Convert(Convert(info)->input); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_output(duckdb_v2_cast_function_exec_info_handle info,
+                                                        duckdb_v2_vector_handle *vector,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(vector);
+	return WithErrorHandler(err, [&]() { *vector = Convert(Convert(info)->output); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_exec_get_mode(duckdb_v2_cast_function_exec_info_handle info,
+                                                      DUCKDB_V2_CAST_MODE *mode, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(mode);
+	return WithErrorHandler(err, [&]() { *mode = Convert(info)->mode; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_register(duckdb_v2_cast_function_handle function,
+                                                 duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->Register(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_cast_function_destroy(duckdb_v2_cast_function_handle *function) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!function) {
+			return;
+		}
+		if (*function) {
+			delete Convert(*function);
+			*function = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_func_copy.cpp
+++ b/src/main/capi/v2/capi_v2_func_copy.cpp
@@ -1,32 +1,69 @@
 #include "duckdb/main/capi_v2/capi_v2_internal.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/execution/execution_context.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/parser/parsed_data/create_copy_function_info.hpp"
+#include "duckdb/storage/statistics/node_statistics.hpp"
+
+#include <algorithm>
 
 namespace duckdb::capiv2 {
 
 class CV2CopyFunctionInfo final : public CopyFunctionInfo {
 public:
-	duckdb_v2_copy_function_bind_callback_fn bind_cb = nullptr;
-	duckdb_v2_copy_function_init_callback_fn init_cb = nullptr;
-	duckdb_v2_copy_function_batch_callback_fn batch_cb = nullptr;
-	duckdb_v2_copy_function_flush_callback_fn flush_cb = nullptr;
-	duckdb_v2_copy_function_finalize_callback_fn finalize_cb = nullptr;
-	duckdb_v2_copy_function_batch_size_callback_fn batch_size_cb = nullptr;
+	// COPY ... TO
+	duckdb_v2_copy_to_bind_callback_fn to_bind_cb = nullptr;
+	duckdb_v2_copy_to_batch_size_callback_fn to_batch_size_cb = nullptr;
+	duckdb_v2_copy_to_init_callback_fn to_init_cb = nullptr;
+	duckdb_v2_copy_to_batch_callback_fn to_batch_cb = nullptr;
+	duckdb_v2_copy_to_flush_callback_fn to_flush_cb = nullptr;
+	duckdb_v2_copy_to_finalize_callback_fn to_finalize_cb = nullptr;
+	// COPY ... FROM
+	duckdb_v2_copy_from_bind_callback_fn from_bind_cb = nullptr;
+	duckdb_v2_copy_from_init_global_callback_fn from_init_global_cb = nullptr;
+	duckdb_v2_copy_from_init_local_callback_fn from_init_local_cb = nullptr;
+	duckdb_v2_copy_from_exec_callback_fn from_exec_cb = nullptr;
+	duckdb_v2_copy_from_progress_callback_fn from_progress_cb = nullptr;
+
 	shared_ptr<CV2UserData> user_data = nullptr;
+
+	bool HasCopyTo() const {
+		return to_bind_cb || to_batch_size_cb || to_init_cb || to_batch_cb || to_flush_cb || to_finalize_cb;
+	}
+	bool HasCopyFrom() const {
+		return from_bind_cb || from_init_global_cb || from_init_local_cb || from_exec_cb || from_progress_cb;
+	}
 };
 
-//! The bind data of a bound COPY statement. Besides the user's own bind data it shares ownership of the function info:
-//! the init, batch, flush and finalize hooks only receive the bind data, so it is their only route to the callbacks.
+//! The reader table function behind the COPY FROM side only receives itself in its bind input, so it carries the
+//! function info along to reach the callbacks.
+class CV2CopyFromTableInfo final : public TableFunctionInfo {
+public:
+	explicit CV2CopyFromTableInfo(shared_ptr<CopyFunctionInfo> info) : info(std::move(info)) {
+	}
+	shared_ptr<CopyFunctionInfo> info;
+};
+
+//! The bind data of a bound COPY statement, in either direction. Besides the user's own bind data it shares
+//! ownership of the function info: the later hooks only receive the bind data, so it is their only route to the
+//! callbacks.
 class CV2CopyFunctionData final : public FunctionData {
 public:
 	shared_ptr<CV2UserData> handle;
 	shared_ptr<CopyFunctionInfo> info;
 
+	// The static estimate a COPY FROM bind callback may set via copy_from_bind_set_cardinality.
+	idx_t cardinality = 0;
+	bool cardinality_is_exact = false;
+	bool cardinality_set = false;
+
 	auto Copy() const -> unique_ptr<FunctionData> override {
 		auto copy = make_uniq<CV2CopyFunctionData>();
 		copy->handle = handle;
 		copy->info = info;
+		copy->cardinality = cardinality;
+		copy->cardinality_is_exact = cardinality_is_exact;
+		copy->cardinality_set = cardinality_set;
 		return std::move(copy);
 	}
 
@@ -36,33 +73,86 @@ public:
 	}
 };
 
-class CV2CopyGlobalState final : public GlobalFunctionData {
+class CV2CopyToGlobalState final : public GlobalFunctionData {
 public:
 	CV2UserData handle;
 };
 
-class CV2CopyBatchData final : public PreparedBatchData {
+class CV2CopyToBatchData final : public PreparedBatchData {
 public:
 	CV2UserData handle;
 };
 
-class CV2CopyBindInfo {
+class CV2CopyFromGlobalState final : public GlobalTableFunctionState {
+public:
+	auto MaxThreads() const -> idx_t override {
+		return max_threads;
+	}
+
+	CV2UserData handle;
+	idx_t max_threads = 1;
+};
+
+class CV2CopyFromLocalState final : public LocalTableFunctionState {
+public:
+	CV2UserData handle;
+};
+
+//! The statement's options, snapshotted for the duration of a bind callback and ordered by name so that indices
+//! are predictable.
+using CV2CopyOptionList = vector<std::pair<const Identifier *, const vector<Value> *>>;
+
+static auto CV2CopyCollectOptions(const identifier_map_t<vector<Value>> &options) -> CV2CopyOptionList {
+	CV2CopyOptionList result;
+	for (auto &entry : options) {
+		result.emplace_back(&entry.first, &entry.second);
+	}
+	std::sort(result.begin(), result.end(),
+	          [](const CV2CopyOptionList::value_type &a, const CV2CopyOptionList::value_type &b) {
+		          return StringUtil::Lower(a.first->GetIdentifierName()) <
+		                 StringUtil::Lower(b.first->GetIdentifierName());
+	          });
+	return result;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO callback info
+//----------------------------------------------------------------------------------------------------------------------
+
+class CV2CopyToBindInfo {
 public:
 	void *in_user_data = nullptr;
+	const string *in_file_path = nullptr;
 	const vector<Identifier> *in_names = nullptr;
 	const vector<LogicalType> *in_types = nullptr;
+	CV2CopyOptionList in_options;
 
 	duckdb_v2_opaque out_bind_data = {};
 };
 
-static auto Convert(duckdb_v2_copy_function_bind_info_handle info) -> CV2CopyBindInfo * {
-	return reinterpret_cast<CV2CopyBindInfo *>(info);
+static auto Convert(duckdb_v2_copy_to_bind_info_handle info) -> CV2CopyToBindInfo * {
+	return reinterpret_cast<CV2CopyToBindInfo *>(info);
 }
-static auto Convert(CV2CopyBindInfo *info) -> duckdb_v2_copy_function_bind_info_handle {
-	return reinterpret_cast<duckdb_v2_copy_function_bind_info_handle>(info);
+static auto Convert(CV2CopyToBindInfo *info) -> duckdb_v2_copy_to_bind_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_to_bind_info_handle>(info);
 }
 
-class CV2CopyInitInfo {
+class CV2CopyToBatchSizeInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+
+	idx_t out_target = 0;
+};
+
+static auto Convert(duckdb_v2_copy_to_batch_size_info_handle info) -> CV2CopyToBatchSizeInfo * {
+	return reinterpret_cast<CV2CopyToBatchSizeInfo *>(info);
+}
+static auto Convert(CV2CopyToBatchSizeInfo *info) -> duckdb_v2_copy_to_batch_size_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_to_batch_size_info_handle>(info);
+}
+
+class CV2CopyToInitInfo {
 public:
 	void *in_user_data = nullptr;
 	void *in_bind_data = nullptr;
@@ -71,14 +161,14 @@ public:
 	duckdb_v2_opaque out_init_data = {};
 };
 
-static auto Convert(duckdb_v2_copy_function_init_info_handle info) -> CV2CopyInitInfo * {
-	return reinterpret_cast<CV2CopyInitInfo *>(info);
+static auto Convert(duckdb_v2_copy_to_init_info_handle info) -> CV2CopyToInitInfo * {
+	return reinterpret_cast<CV2CopyToInitInfo *>(info);
 }
-static auto Convert(CV2CopyInitInfo *info) -> duckdb_v2_copy_function_init_info_handle {
-	return reinterpret_cast<duckdb_v2_copy_function_init_info_handle>(info);
+static auto Convert(CV2CopyToInitInfo *info) -> duckdb_v2_copy_to_init_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_to_init_info_handle>(info);
 }
 
-class CV2CopyBatchInfo {
+class CV2CopyToBatchInfo {
 public:
 	void *in_user_data = nullptr;
 	void *in_bind_data = nullptr;
@@ -89,14 +179,14 @@ public:
 	duckdb_v2_opaque out_batch_data = {};
 };
 
-static auto Convert(duckdb_v2_copy_function_batch_info_handle info) -> CV2CopyBatchInfo * {
-	return reinterpret_cast<CV2CopyBatchInfo *>(info);
+static auto Convert(duckdb_v2_copy_to_batch_info_handle info) -> CV2CopyToBatchInfo * {
+	return reinterpret_cast<CV2CopyToBatchInfo *>(info);
 }
-static auto Convert(CV2CopyBatchInfo *info) -> duckdb_v2_copy_function_batch_info_handle {
-	return reinterpret_cast<duckdb_v2_copy_function_batch_info_handle>(info);
+static auto Convert(CV2CopyToBatchInfo *info) -> duckdb_v2_copy_to_batch_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_to_batch_info_handle>(info);
 }
 
-class CV2CopyFlushInfo {
+class CV2CopyToFlushInfo {
 public:
 	void *in_user_data = nullptr;
 	void *in_bind_data = nullptr;
@@ -104,41 +194,120 @@ public:
 	void *in_batch_data = nullptr;
 };
 
-static auto Convert(duckdb_v2_copy_function_flush_info_handle info) -> CV2CopyFlushInfo * {
-	return reinterpret_cast<CV2CopyFlushInfo *>(info);
+static auto Convert(duckdb_v2_copy_to_flush_info_handle info) -> CV2CopyToFlushInfo * {
+	return reinterpret_cast<CV2CopyToFlushInfo *>(info);
 }
-static auto Convert(CV2CopyFlushInfo *info) -> duckdb_v2_copy_function_flush_info_handle {
-	return reinterpret_cast<duckdb_v2_copy_function_flush_info_handle>(info);
-}
-
-class CV2CopyBatchSizeInfo {
-public:
-	void *in_user_data = nullptr;
-	void *in_bind_data = nullptr;
-
-	idx_t out_target = 0;
-};
-
-static auto Convert(duckdb_v2_copy_function_batch_size_info_handle info) -> CV2CopyBatchSizeInfo * {
-	return reinterpret_cast<CV2CopyBatchSizeInfo *>(info);
-}
-static auto Convert(CV2CopyBatchSizeInfo *info) -> duckdb_v2_copy_function_batch_size_info_handle {
-	return reinterpret_cast<duckdb_v2_copy_function_batch_size_info_handle>(info);
+static auto Convert(CV2CopyToFlushInfo *info) -> duckdb_v2_copy_to_flush_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_to_flush_info_handle>(info);
 }
 
-class CV2CopyFinalizeInfo {
+class CV2CopyToFinalizeInfo {
 public:
 	void *in_user_data = nullptr;
 	void *in_bind_data = nullptr;
 	void *in_init_data = nullptr;
 };
 
-static auto Convert(duckdb_v2_copy_function_finalize_info_handle info) -> CV2CopyFinalizeInfo * {
-	return reinterpret_cast<CV2CopyFinalizeInfo *>(info);
+static auto Convert(duckdb_v2_copy_to_finalize_info_handle info) -> CV2CopyToFinalizeInfo * {
+	return reinterpret_cast<CV2CopyToFinalizeInfo *>(info);
 }
-static auto Convert(CV2CopyFinalizeInfo *info) -> duckdb_v2_copy_function_finalize_info_handle {
-	return reinterpret_cast<duckdb_v2_copy_function_finalize_info_handle>(info);
+static auto Convert(CV2CopyToFinalizeInfo *info) -> duckdb_v2_copy_to_finalize_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_to_finalize_info_handle>(info);
 }
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY FROM callback info
+//----------------------------------------------------------------------------------------------------------------------
+
+class CV2CopyFromBindInfo {
+public:
+	void *in_user_data = nullptr;
+	const string *in_file_path = nullptr;
+	const vector<Identifier> *in_names = nullptr;
+	const vector<LogicalType> *in_types = nullptr;
+	CV2CopyOptionList in_options;
+
+	duckdb_v2_opaque out_bind_data = {};
+	idx_t out_cardinality = 0;
+	bool out_cardinality_is_exact = false;
+	bool out_cardinality_set = false;
+};
+
+static auto Convert(duckdb_v2_copy_from_bind_info_handle info) -> CV2CopyFromBindInfo * {
+	return reinterpret_cast<CV2CopyFromBindInfo *>(info);
+}
+static auto Convert(CV2CopyFromBindInfo *info) -> duckdb_v2_copy_from_bind_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_from_bind_info_handle>(info);
+}
+
+class CV2CopyFromInitGlobalInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+
+	duckdb_v2_opaque out_global_state = {};
+	idx_t out_max_threads = 1;
+};
+
+static auto Convert(duckdb_v2_copy_from_init_global_info_handle info) -> CV2CopyFromInitGlobalInfo * {
+	return reinterpret_cast<CV2CopyFromInitGlobalInfo *>(info);
+}
+static auto Convert(CV2CopyFromInitGlobalInfo *info) -> duckdb_v2_copy_from_init_global_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_from_init_global_info_handle>(info);
+}
+
+class CV2CopyFromInitLocalInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_global_state = nullptr;
+
+	duckdb_v2_opaque out_local_state = {};
+};
+
+static auto Convert(duckdb_v2_copy_from_init_local_info_handle info) -> CV2CopyFromInitLocalInfo * {
+	return reinterpret_cast<CV2CopyFromInitLocalInfo *>(info);
+}
+static auto Convert(CV2CopyFromInitLocalInfo *info) -> duckdb_v2_copy_from_init_local_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_from_init_local_info_handle>(info);
+}
+
+class CV2CopyFromExecInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_global_state = nullptr;
+	void *in_local_state = nullptr;
+
+	DataChunk *output = nullptr;
+};
+
+static auto Convert(duckdb_v2_copy_from_exec_info_handle info) -> CV2CopyFromExecInfo * {
+	return reinterpret_cast<CV2CopyFromExecInfo *>(info);
+}
+static auto Convert(CV2CopyFromExecInfo *info) -> duckdb_v2_copy_from_exec_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_from_exec_info_handle>(info);
+}
+
+class CV2CopyFromProgressInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_global_state = nullptr;
+
+	double out_progress = 0.0;
+};
+
+static auto Convert(duckdb_v2_copy_from_progress_info_handle info) -> CV2CopyFromProgressInfo * {
+	return reinterpret_cast<CV2CopyFromProgressInfo *>(info);
+}
+static auto Convert(CV2CopyFromProgressInfo *info) -> duckdb_v2_copy_from_progress_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_from_progress_info_handle>(info);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Shared helpers
+//----------------------------------------------------------------------------------------------------------------------
 
 static auto GetFunctionInfo(const FunctionData &bind_data) -> const CV2CopyFunctionInfo & {
 	return bind_data.Cast<CV2CopyFunctionData>().info->Cast<CV2CopyFunctionInfo>();
@@ -153,58 +322,83 @@ static auto GetUserBindData(const FunctionData &bind_data) -> void * {
 	return handle ? handle->GetData() : nullptr;
 }
 
-static auto GetUserInitData(const GlobalFunctionData &gstate) -> void * {
-	return gstate.Cast<CV2CopyGlobalState>().handle.GetData();
+//! Takes ownership of whatever bind data the callback set, so it is destroyed even when the callback failed.
+static auto MakeBindData(const shared_ptr<CopyFunctionInfo> &info, const duckdb_v2_opaque &out_bind_data)
+    -> unique_ptr<CV2CopyFunctionData> {
+	auto result = make_uniq<CV2CopyFunctionData>();
+	result->info = info;
+	if (out_bind_data.ptr) {
+		result->handle = make_shared_ptr<CV2UserData>(out_bind_data.ptr, out_bind_data.destroy, out_bind_data.equals);
+	}
+	return result;
 }
 
-static auto CV2CopyBind(ClientContext &context, CopyFunctionBindInput &input, const vector<Identifier> &names,
-                        const vector<LogicalType> &sql_types) -> unique_ptr<FunctionData> {
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO hooks
+//----------------------------------------------------------------------------------------------------------------------
+
+static auto CV2CopyToBind(ClientContext &context, CopyFunctionBindInput &input, const vector<Identifier> &names,
+                          const vector<LogicalType> &sql_types) -> unique_ptr<FunctionData> {
 	const auto &info = input.function_info->Cast<CV2CopyFunctionInfo>();
 
-	CV2CopyBindInfo args = {};
+	CV2CopyToBindInfo args = {};
 	args.in_user_data = GetUserData(info);
+	args.in_file_path = &input.info.file_path;
 	args.in_names = &names;
 	args.in_types = &sql_types;
+	args.in_options = CV2CopyCollectOptions(input.info.options);
 
 	// The bind callback is optional: without one, the statement carries no bind data.
 	CV2ErrorInfo err = {};
-	if (info.bind_cb) {
+	if (info.to_bind_cb) {
 		auto err_ptr = Convert(&err);
-		info.bind_cb(Convert(&args), Convert(&context), &err_ptr);
+		info.to_bind_cb(Convert(&args), Convert(&context), &err_ptr);
 	}
 
-	// Take ownership of whatever the callback set before reporting an error, so it is destroyed either way.
-	auto result = make_uniq<CV2CopyFunctionData>();
-	result->info = input.function_info;
-	if (args.out_bind_data.ptr) {
-		result->handle =
-		    make_shared_ptr<CV2UserData>(args.out_bind_data.ptr, args.out_bind_data.destroy, args.out_bind_data.equals);
+	auto result = MakeBindData(input.function_info, args.out_bind_data);
+	if (err.HasError()) {
+		err.ThrowAsException();
 	}
+	return std::move(result);
+}
+
+static auto CV2CopyToBatchSize(ClientContext &context, FunctionData &bind_data) -> idx_t {
+	const auto &info = GetFunctionInfo(bind_data);
+
+	CV2CopyToBatchSizeInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(bind_data);
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.to_batch_size_cb(Convert(&args), Convert(&context), &err_ptr);
 
 	if (err.HasError()) {
 		err.ThrowAsException();
 	}
-
-	return std::move(result);
+	if (args.out_target == 0) {
+		throw InvalidInputException("The batch size callback must set a target greater than 0.");
+	}
+	return args.out_target;
 }
 
-static auto CV2CopyInitGlobal(ClientContext &context, FunctionData &bind_data, const string &file_path)
+static auto CV2CopyToInitGlobal(ClientContext &context, FunctionData &bind_data, const string &file_path)
     -> unique_ptr<GlobalFunctionData> {
 	const auto &info = GetFunctionInfo(bind_data);
 
-	CV2CopyInitInfo args = {};
+	CV2CopyToInitInfo args = {};
 	args.in_user_data = GetUserData(info);
 	args.in_bind_data = GetUserBindData(bind_data);
 	args.in_file_path = &file_path;
 
 	// The init callback is optional: without one, the file carries no init data.
 	CV2ErrorInfo err = {};
-	if (info.init_cb) {
+	if (info.to_init_cb) {
 		auto err_ptr = Convert(&err);
-		info.init_cb(Convert(&args), Convert(&context), &err_ptr);
+		info.to_init_cb(Convert(&args), Convert(&context), &err_ptr);
 	}
 
-	auto result = make_uniq<CV2CopyGlobalState>();
+	auto result = make_uniq<CV2CopyToGlobalState>();
 	if (args.out_init_data.ptr) {
 		result->handle = CV2UserData(args.out_init_data.ptr, args.out_init_data.destroy, args.out_init_data.equals);
 	}
@@ -216,21 +410,21 @@ static auto CV2CopyInitGlobal(ClientContext &context, FunctionData &bind_data, c
 	return std::move(result);
 }
 
-static auto CV2CopyPrepareBatch(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
-                                unique_ptr<ColumnDataCollection> collection) -> unique_ptr<PreparedBatchData> {
+static auto CV2CopyToPrepareBatch(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                                  unique_ptr<ColumnDataCollection> collection) -> unique_ptr<PreparedBatchData> {
 	const auto &info = GetFunctionInfo(bind_data);
 
-	CV2CopyBatchInfo args = {};
+	CV2CopyToBatchInfo args = {};
 	args.in_user_data = GetUserData(info);
 	args.in_bind_data = GetUserBindData(bind_data);
-	args.in_init_data = GetUserInitData(gstate);
+	args.in_init_data = gstate.Cast<CV2CopyToGlobalState>().handle.GetData();
 	args.in_collection = std::move(collection);
 
 	CV2ErrorInfo err = {};
 	auto err_ptr = Convert(&err);
-	info.batch_cb(Convert(&args), Convert(&context), &err_ptr);
+	info.to_batch_cb(Convert(&args), Convert(&context), &err_ptr);
 
-	auto result = make_uniq<CV2CopyBatchData>();
+	auto result = make_uniq<CV2CopyToBatchData>();
 	if (args.out_batch_data.ptr) {
 		result->handle = CV2UserData(args.out_batch_data.ptr, args.out_batch_data.destroy, args.out_batch_data.equals);
 	}
@@ -242,66 +436,217 @@ static auto CV2CopyPrepareBatch(ClientContext &context, FunctionData &bind_data,
 	return std::move(result);
 }
 
-static auto CV2CopyFlushBatch(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
-                              PreparedBatchData &batch) -> void {
+static auto CV2CopyToFlushBatch(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                                PreparedBatchData &batch) -> void {
 	const auto &info = GetFunctionInfo(bind_data);
 
-	CV2CopyFlushInfo args = {};
+	CV2CopyToFlushInfo args = {};
 	args.in_user_data = GetUserData(info);
 	args.in_bind_data = GetUserBindData(bind_data);
-	args.in_init_data = GetUserInitData(gstate);
-	args.in_batch_data = batch.Cast<CV2CopyBatchData>().handle.GetData();
+	args.in_init_data = gstate.Cast<CV2CopyToGlobalState>().handle.GetData();
+	args.in_batch_data = batch.Cast<CV2CopyToBatchData>().handle.GetData();
 
 	CV2ErrorInfo err = {};
 	auto err_ptr = Convert(&err);
-	info.flush_cb(Convert(&args), Convert(&context), &err_ptr);
+	info.to_flush_cb(Convert(&args), Convert(&context), &err_ptr);
 
 	if (err.HasError()) {
 		err.ThrowAsException();
 	}
 }
 
-static auto CV2CopyFinalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) -> void {
+static auto CV2CopyToFinalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) -> void {
 	const auto &info = GetFunctionInfo(bind_data);
 
 	// Always wired, as the engine requires a finalize hook; the user's callback is optional.
-	if (!info.finalize_cb) {
+	if (!info.to_finalize_cb) {
 		return;
 	}
 
-	CV2CopyFinalizeInfo args = {};
+	CV2CopyToFinalizeInfo args = {};
 	args.in_user_data = GetUserData(info);
 	args.in_bind_data = GetUserBindData(bind_data);
-	args.in_init_data = GetUserInitData(gstate);
+	args.in_init_data = gstate.Cast<CV2CopyToGlobalState>().handle.GetData();
 
 	CV2ErrorInfo err = {};
 	auto err_ptr = Convert(&err);
-	info.finalize_cb(Convert(&args), Convert(&context), &err_ptr);
+	info.to_finalize_cb(Convert(&args), Convert(&context), &err_ptr);
 
 	if (err.HasError()) {
 		err.ThrowAsException();
 	}
 }
 
-static auto CV2CopyBatchSize(ClientContext &context, FunctionData &bind_data) -> idx_t {
+//----------------------------------------------------------------------------------------------------------------------
+// COPY FROM hooks
+//----------------------------------------------------------------------------------------------------------------------
+
+static auto CV2CopyFromBind(ClientContext &context, CopyFromFunctionBindInput &input,
+                            vector<Identifier> &expected_names, vector<LogicalType> &expected_types)
+    -> unique_ptr<FunctionData> {
+	const auto &function_info = input.tf.function_info->Cast<CV2CopyFromTableInfo>().info;
+	const auto &info = function_info->Cast<CV2CopyFunctionInfo>();
+
+	CV2CopyFromBindInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_file_path = &input.info.file_path;
+	args.in_names = &expected_names;
+	args.in_types = &expected_types;
+	args.in_options = CV2CopyCollectOptions(input.info.options);
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.from_bind_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	auto result = MakeBindData(function_info, args.out_bind_data);
+	result->cardinality = args.out_cardinality;
+	result->cardinality_is_exact = args.out_cardinality_is_exact;
+	result->cardinality_set = args.out_cardinality_set;
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+	return std::move(result);
+}
+
+static auto CV2CopyFromInitGlobal(ClientContext &context, TableFunctionInitInput &input)
+    -> unique_ptr<GlobalTableFunctionState> {
+	const auto &bind_data = *input.bind_data;
 	const auto &info = GetFunctionInfo(bind_data);
 
-	CV2CopyBatchSizeInfo args = {};
+	// Always produced, even without a callback: it carries the thread count the read runs with.
+	auto result = make_uniq<CV2CopyFromGlobalState>();
+	if (!info.from_init_global_cb) {
+		return std::move(result);
+	}
+
+	CV2CopyFromInitGlobalInfo args = {};
 	args.in_user_data = GetUserData(info);
 	args.in_bind_data = GetUserBindData(bind_data);
 
 	CV2ErrorInfo err = {};
 	auto err_ptr = Convert(&err);
-	info.batch_size_cb(Convert(&args), Convert(&context), &err_ptr);
+	info.from_init_global_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (args.out_global_state.ptr) {
+		result->handle =
+		    CV2UserData(args.out_global_state.ptr, args.out_global_state.destroy, args.out_global_state.equals);
+	}
+	result->max_threads = args.out_max_threads;
+
+	// Throw after taking ownership of the state, so that it is destroyed even if we error.
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	return std::move(result);
+}
+
+static auto CV2CopyFromInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                 GlobalTableFunctionState *global_state) -> unique_ptr<LocalTableFunctionState> {
+	const auto &bind_data = *input.bind_data;
+	const auto &info = GetFunctionInfo(bind_data);
+
+	if (!info.from_init_local_cb) {
+		return nullptr;
+	}
+
+	CV2CopyFromInitLocalInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(bind_data);
+	if (global_state) {
+		args.in_global_state = global_state->Cast<CV2CopyFromGlobalState>().handle.GetData();
+	}
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.from_init_local_cb(Convert(&args), Convert(&context.client), &err_ptr);
+
+	unique_ptr<LocalTableFunctionState> result = nullptr;
+	if (args.out_local_state.ptr) {
+		auto set_result = make_uniq<CV2CopyFromLocalState>();
+		set_result->handle =
+		    CV2UserData(args.out_local_state.ptr, args.out_local_state.destroy, args.out_local_state.equals);
+		result = std::move(set_result);
+	}
+
+	// Throw after taking ownership of the state, so that it is destroyed even if we error.
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	return result;
+}
+
+static auto CV2CopyFromExec(ClientContext &context, TableFunctionInput &input, DataChunk &output) -> void {
+	const auto &bind_data = *input.bind_data;
+	const auto &info = GetFunctionInfo(bind_data);
+
+	CV2CopyFromExecInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(bind_data);
+	if (input.global_state) {
+		args.in_global_state = input.global_state->Cast<CV2CopyFromGlobalState>().handle.GetData();
+	}
+	if (input.local_state) {
+		args.in_local_state = input.local_state->Cast<CV2CopyFromLocalState>().handle.GetData();
+	}
+	args.output = &output;
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.from_exec_cb(Convert(&args), Convert(&context), &err_ptr);
 
 	if (err.HasError()) {
 		err.ThrowAsException();
 	}
-	if (args.out_target == 0) {
-		throw InvalidInputException("The batch size callback must set a target greater than 0.");
-	}
-	return args.out_target;
+
+	// The vector write API sizes per vector, while the engine reads the chunk's cardinality. Callers typically size
+	// only the first vector and write the rest through direct buffer writes, so take the first vector's size as the
+	// batch's row count and propagate it to the others. The target table always has at least one column.
+	output.SetChildCardinality(output.data[0].size());
 }
+
+static auto CV2CopyFromCardinality(ClientContext &context, const FunctionData *bind_data)
+    -> unique_ptr<NodeStatistics> {
+	const auto &data = bind_data->Cast<CV2CopyFunctionData>();
+	if (!data.cardinality_set) {
+		// No estimate at all: the optimizer falls back on its own defaults.
+		return nullptr;
+	}
+	// An exact estimate also pins the maximum; otherwise only the estimate is known.
+	if (data.cardinality_is_exact) {
+		return make_uniq<NodeStatistics>(data.cardinality, data.cardinality);
+	}
+	return make_uniq<NodeStatistics>(data.cardinality);
+}
+
+static auto CV2CopyFromProgress(ClientContext &context, const FunctionData *bind_data,
+                                const GlobalTableFunctionState *global_state) -> double {
+	const auto &info = GetFunctionInfo(*bind_data);
+
+	CV2CopyFromProgressInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(*bind_data);
+	if (global_state) {
+		// The callback runs concurrently with the read, so the state it reads is the shared one, unsynchronized.
+		args.in_global_state = global_state->Cast<CV2CopyFromGlobalState>().handle.GetData();
+	}
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.from_progress_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	// The API contract is a 0.0-1.0 fraction, the engine reads a 0-100 percentage.
+	return MinValue<double>(MaxValue<double>(args.out_progress, 0.0), 1.0) * 100.0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Function handle
+//----------------------------------------------------------------------------------------------------------------------
 
 class CV2CopyFunction {
 public:
@@ -309,23 +654,55 @@ public:
 		if (name.empty()) {
 			throw InvalidInputException("Function name cannot be empty.");
 		}
-		if (!info.batch_cb) {
-			throw InvalidInputException("Batch callback must be set for the function.");
+		const bool has_copy_to = info.HasCopyTo();
+		const bool has_copy_from = info.HasCopyFrom();
+		if (!has_copy_to && !has_copy_from) {
+			throw InvalidInputException(
+			    "At least one of the COPY TO and COPY FROM sides must be set for the function.");
 		}
-		if (!info.flush_cb) {
-			throw InvalidInputException("Flush callback must be set for the function.");
+		if (has_copy_to) {
+			if (!info.to_batch_cb) {
+				throw InvalidInputException("Batch callback must be set for the COPY TO side of the function.");
+			}
+			if (!info.to_flush_cb) {
+				throw InvalidInputException("Flush callback must be set for the COPY TO side of the function.");
+			}
+		}
+		if (has_copy_from) {
+			if (!info.from_bind_cb) {
+				throw InvalidInputException("Bind callback must be set for the COPY FROM side of the function.");
+			}
+			if (!info.from_exec_cb) {
+				throw InvalidInputException("Exec callback must be set for the COPY FROM side of the function.");
+			}
 		}
 
+		auto function_info = make_shared_ptr<CV2CopyFunctionInfo>(std::move(info));
+
 		CopyFunction function(name);
-		function.copy_to_bind = CV2CopyBind;
-		function.copy_to_initialize_global = CV2CopyInitGlobal;
-		function.prepare_batch = CV2CopyPrepareBatch;
-		function.flush_batch = CV2CopyFlushBatch;
-		function.copy_to_finalize = CV2CopyFinalize;
-		if (info.batch_size_cb) {
-			function.desired_batch_size = CV2CopyBatchSize;
+		if (has_copy_to) {
+			function.copy_to_bind = CV2CopyToBind;
+			function.copy_to_initialize_global = CV2CopyToInitGlobal;
+			function.prepare_batch = CV2CopyToPrepareBatch;
+			function.flush_batch = CV2CopyToFlushBatch;
+			function.copy_to_finalize = CV2CopyToFinalize;
+			if (function_info->to_batch_size_cb) {
+				function.desired_batch_size = CV2CopyToBatchSize;
+			}
 		}
-		function.function_info = make_shared_ptr<CV2CopyFunctionInfo>(std::move(info));
+		if (has_copy_from) {
+			// The engine reads through a table function whose own bind is skipped in favour of copy_from_bind.
+			TableFunction reader(name, {}, CV2CopyFromExec, nullptr, CV2CopyFromInitGlobal, CV2CopyFromInitLocal);
+			// Always wired: it serves the static estimate a bind callback may set, which is not known at registration.
+			reader.cardinality = CV2CopyFromCardinality;
+			if (function_info->from_progress_cb) {
+				reader.table_scan_progress = CV2CopyFromProgress;
+			}
+			reader.function_info = make_shared_ptr<CV2CopyFromTableInfo>(function_info);
+			function.copy_from_bind = CV2CopyFromBind;
+			function.copy_from_function = std::move(reader);
+		}
+		function.function_info = std::move(function_info);
 
 		// Call the implementation to register
 		RegisterToCatalog(std::move(function));
@@ -377,6 +754,51 @@ static auto Convert(duckdb_v2_copy_function_handle func) -> CV2CopyFunction * {
 }
 static auto Convert(CV2CopyFunction *func) -> duckdb_v2_copy_function_handle {
 	return reinterpret_cast<duckdb_v2_copy_function_handle>(func);
+}
+
+//! The column and option accessors of the two bind infos share their bodies.
+template <class INFO>
+static auto GetColumnType(INFO &args, idx_t index, const char *function) -> duckdb_v2_logical_type_handle {
+	const auto &types = *args.in_types;
+	if (index >= types.size()) {
+		throw InvalidInputException("Index out of bounds in %s", function);
+	}
+	return Convert(new LogicalType(types[index]));
+}
+
+template <class INFO>
+static auto GetColumnName(INFO &args, idx_t index, const char *function) -> duckdb_v2_identifier_t {
+	const auto &names = *args.in_names;
+	if (index >= names.size()) {
+		throw InvalidInputException("Index out of bounds in %s", function);
+	}
+	return Convert(names[index]);
+}
+
+template <class INFO>
+static auto GetOption(INFO &args, idx_t index, const char *function) -> const CV2CopyOptionList::value_type & {
+	if (index >= args.in_options.size()) {
+		throw InvalidInputException("Index out of bounds in %s", function);
+	}
+	return args.in_options[index];
+}
+
+//! One value per option: a bare option reads as true, a single value as itself, and a list as a tuple of its
+//! elements, i.e. an unnamed struct.
+template <class INFO>
+static auto GetOptionValue(INFO &args, idx_t index, const char *function) -> duckdb_v2_value_handle {
+	const auto &values = *GetOption(args, index, function).second;
+	if (values.empty()) {
+		return Convert(new Value(Value::BOOLEAN(true)));
+	}
+	if (values.size() == 1) {
+		return Convert(new Value(values[0]));
+	}
+	child_list_t<Value> elements;
+	for (auto &value : values) {
+		elements.emplace_back(string(), value);
+	}
+	return Convert(new Value(Value::STRUCT(std::move(elements))));
 }
 
 } // namespace duckdb::capiv2
@@ -431,170 +853,212 @@ DUCKDB_V2_ERROR duckdb_v2_copy_function_set_user_data(duckdb_v2_copy_function_ha
 	});
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_set_bind_callback(duckdb_v2_copy_function_handle function,
-                                                          duckdb_v2_copy_function_bind_callback_fn callback,
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO callbacks
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_set_bind_callback(duckdb_v2_copy_function_handle function,
+                                                    duckdb_v2_copy_to_bind_callback_fn callback,
+                                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.to_bind_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_set_batch_size_callback(duckdb_v2_copy_function_handle function,
+                                                          duckdb_v2_copy_to_batch_size_callback_fn callback,
                                                           duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(function);
-	return WithErrorHandler(err, [&]() { Convert(function)->info.bind_cb = callback; });
+	return WithErrorHandler(err, [&]() { Convert(function)->info.to_batch_size_cb = callback; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_set_init_callback(duckdb_v2_copy_function_handle function,
-                                                          duckdb_v2_copy_function_init_callback_fn callback,
-                                                          duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_set_init_callback(duckdb_v2_copy_function_handle function,
+                                                    duckdb_v2_copy_to_init_callback_fn callback,
+                                                    duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(function);
-	return WithErrorHandler(err, [&]() { Convert(function)->info.init_cb = callback; });
+	return WithErrorHandler(err, [&]() { Convert(function)->info.to_init_cb = callback; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_set_batch_callback(duckdb_v2_copy_function_handle function,
-                                                           duckdb_v2_copy_function_batch_callback_fn callback,
-                                                           duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_set_batch_callback(duckdb_v2_copy_function_handle function,
+                                                     duckdb_v2_copy_to_batch_callback_fn callback,
+                                                     duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(function);
-	return WithErrorHandler(err, [&]() { Convert(function)->info.batch_cb = callback; });
+	return WithErrorHandler(err, [&]() { Convert(function)->info.to_batch_cb = callback; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_set_flush_callback(duckdb_v2_copy_function_handle function,
-                                                           duckdb_v2_copy_function_flush_callback_fn callback,
-                                                           duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_set_flush_callback(duckdb_v2_copy_function_handle function,
+                                                     duckdb_v2_copy_to_flush_callback_fn callback,
+                                                     duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(function);
-	return WithErrorHandler(err, [&]() { Convert(function)->info.flush_cb = callback; });
+	return WithErrorHandler(err, [&]() { Convert(function)->info.to_flush_cb = callback; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_set_batch_size_callback(duckdb_v2_copy_function_handle function,
-                                                                duckdb_v2_copy_function_batch_size_callback_fn callback,
-                                                                duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_set_finalize_callback(duckdb_v2_copy_function_handle function,
+                                                        duckdb_v2_copy_to_finalize_callback_fn callback,
+                                                        duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(function);
-	return WithErrorHandler(err, [&]() { Convert(function)->info.batch_size_cb = callback; });
+	return WithErrorHandler(err, [&]() { Convert(function)->info.to_finalize_cb = callback; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_set_finalize_callback(duckdb_v2_copy_function_handle function,
-                                                              duckdb_v2_copy_function_finalize_callback_fn callback,
-                                                              duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(function);
-	return WithErrorHandler(err, [&]() { Convert(function)->info.finalize_cb = callback; });
-}
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO bind
+//----------------------------------------------------------------------------------------------------------------------
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_user_data(duckdb_v2_copy_function_bind_info_handle info, void **data,
-                                                           duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_user_data(duckdb_v2_copy_to_bind_info_handle info, void **data,
+                                                     duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_set_bind_data(duckdb_v2_copy_function_bind_info_handle info,
-                                                           duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_set_bind_data(duckdb_v2_copy_to_bind_info_handle info, duckdb_v2_opaque *data,
+                                                     duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { Convert(info)->out_bind_data = *data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_count(duckdb_v2_copy_function_bind_info_handle info,
-                                                              idx_t *count, duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(count);
-	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_types->size(); });
-}
-
-DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_type(duckdb_v2_copy_function_bind_info_handle info, idx_t index,
-                                                             duckdb_v2_logical_type_handle *type,
-                                                             duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(type);
-	*type = nullptr;
-	return WithErrorHandler(err, [&]() {
-		const auto &types = *Convert(info)->in_types;
-		if (index >= types.size()) {
-			throw duckdb::InvalidInputException("Index out of bounds in duckdb_v2_copy_function_bind_get_column_type");
-		}
-		*type = Convert(new duckdb::LogicalType(types[index]));
-	});
-}
-
-DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_name(duckdb_v2_copy_function_bind_info_handle info, idx_t index,
-                                                             duckdb_v2_identifier_t *name,
-                                                             duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(name);
-	return WithErrorHandler(err, [&]() {
-		const auto &names = *Convert(info)->in_names;
-		if (index >= names.size()) {
-			throw duckdb::InvalidInputException("Index out of bounds in duckdb_v2_copy_function_bind_get_column_name");
-		}
-		*name = Convert(names[index]);
-	});
-}
-
-DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_user_data(duckdb_v2_copy_function_batch_size_info_handle info,
-                                                                 void **data, duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(data);
-	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
-}
-
-DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_bind_data(duckdb_v2_copy_function_batch_size_info_handle info,
-                                                                 void **data, duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(data);
-	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
-}
-
-DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_set_target(duckdb_v2_copy_function_batch_size_info_handle info,
-                                                              idx_t rows, duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	return WithErrorHandler(err, [&]() { Convert(info)->out_target = rows; });
-}
-
-DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_user_data(duckdb_v2_copy_function_init_info_handle info, void **data,
-                                                           duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(data);
-	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
-}
-
-DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_bind_data(duckdb_v2_copy_function_init_info_handle info, void **data,
-                                                           duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(data);
-	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
-}
-
-DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_file_path(duckdb_v2_copy_function_init_info_handle info,
-                                                           duckdb_v2_str *path, duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_file_path(duckdb_v2_copy_to_bind_info_handle info, duckdb_v2_str *path,
+                                                     duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(path);
 	return WithErrorHandler(err, [&]() { *path = Convert(*Convert(info)->in_file_path); });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_init_set_init_data(duckdb_v2_copy_function_init_info_handle info,
-                                                           duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_column_count(duckdb_v2_copy_to_bind_info_handle info, idx_t *count,
+                                                        duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(data);
-	return WithErrorHandler(err, [&]() { Convert(info)->out_init_data = *data; });
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_types->size(); });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_user_data(duckdb_v2_copy_function_batch_info_handle info, void **data,
-                                                            duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_column_type(duckdb_v2_copy_to_bind_info_handle info, idx_t index,
+                                                       duckdb_v2_logical_type_handle *type,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(type);
+	*type = nullptr;
+	return WithErrorHandler(
+	    err, [&]() { *type = GetColumnType(*Convert(info), index, "duckdb_v2_copy_to_bind_get_column_type"); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_column_name(duckdb_v2_copy_to_bind_info_handle info, idx_t index,
+                                                       duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(
+	    err, [&]() { *name = GetColumnName(*Convert(info), index, "duckdb_v2_copy_to_bind_get_column_name"); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_option_count(duckdb_v2_copy_to_bind_info_handle info, idx_t *count,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_options.size(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_option_name(duckdb_v2_copy_to_bind_info_handle info, idx_t index,
+                                                       duckdb_v2_identifier_t *name, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(err, [&]() {
+		*name = Convert(*GetOption(*Convert(info), index, "duckdb_v2_copy_to_bind_get_option_name").first);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_bind_get_option_value(duckdb_v2_copy_to_bind_info_handle info, idx_t index,
+                                                        duckdb_v2_value_handle *value,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(value);
+	*value = nullptr;
+	return WithErrorHandler(
+	    err, [&]() { *value = GetOptionValue(*Convert(info), index, "duckdb_v2_copy_to_bind_get_option_value"); });
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO batch size
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_size_get_user_data(duckdb_v2_copy_to_batch_size_info_handle info, void **data,
+                                                           duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_bind_data(duckdb_v2_copy_function_batch_info_handle info, void **data,
-                                                            duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_size_get_bind_data(duckdb_v2_copy_to_batch_size_info_handle info, void **data,
+                                                           duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_init_data(duckdb_v2_copy_function_batch_info_handle info, void **data,
-                                                            duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_size_set_target(duckdb_v2_copy_to_batch_size_info_handle info, idx_t rows,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_target = rows; });
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO init
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_init_get_user_data(duckdb_v2_copy_to_init_info_handle info, void **data,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_init_get_bind_data(duckdb_v2_copy_to_init_info_handle info, void **data,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_init_get_file_path(duckdb_v2_copy_to_init_info_handle info, duckdb_v2_str *path,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(path);
+	return WithErrorHandler(err, [&]() { *path = Convert(*Convert(info)->in_file_path); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_init_set_init_data(duckdb_v2_copy_to_init_info_handle info, duckdb_v2_opaque *data,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_init_data = *data; });
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO batch
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_get_user_data(duckdb_v2_copy_to_batch_info_handle info, void **data,
+                                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_get_bind_data(duckdb_v2_copy_to_batch_info_handle info, void **data,
+                                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_get_init_data(duckdb_v2_copy_to_batch_info_handle info, void **data,
+                                                      duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_init_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_take_input(duckdb_v2_copy_function_batch_info_handle info,
-                                                         duckdb_v2_column_data_collection_handle *collection,
-                                                         duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_take_input(duckdb_v2_copy_to_batch_info_handle info,
+                                                   duckdb_v2_column_data_collection_handle *collection,
+                                                   duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(collection);
 	*collection = nullptr;
@@ -607,61 +1071,342 @@ DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_take_input(duckdb_v2_copy_function
 	});
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_set_batch_data(duckdb_v2_copy_function_batch_info_handle info,
-                                                             duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_batch_set_batch_data(duckdb_v2_copy_to_batch_info_handle info, duckdb_v2_opaque *data,
+                                                       duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { Convert(info)->out_batch_data = *data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_user_data(duckdb_v2_copy_function_flush_info_handle info, void **data,
-                                                            duckdb_v2_error_info_handle *err) {
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO flush
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_flush_get_user_data(duckdb_v2_copy_to_flush_info_handle info, void **data,
+                                                      duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_bind_data(duckdb_v2_copy_function_flush_info_handle info, void **data,
-                                                            duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_flush_get_bind_data(duckdb_v2_copy_to_flush_info_handle info, void **data,
+                                                      duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_init_data(duckdb_v2_copy_function_flush_info_handle info, void **data,
-                                                            duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_flush_get_init_data(duckdb_v2_copy_to_flush_info_handle info, void **data,
+                                                      duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_init_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_batch_data(duckdb_v2_copy_function_flush_info_handle info,
-                                                             void **data, duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_flush_get_batch_data(duckdb_v2_copy_to_flush_info_handle info, void **data,
+                                                       duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_batch_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_user_data(duckdb_v2_copy_function_finalize_info_handle info,
-                                                               void **data, duckdb_v2_error_info_handle *err) {
+//----------------------------------------------------------------------------------------------------------------------
+// COPY TO finalize
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_to_finalize_get_user_data(duckdb_v2_copy_to_finalize_info_handle info, void **data,
+                                                         duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_bind_data(duckdb_v2_copy_function_finalize_info_handle info,
-                                                               void **data, duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_finalize_get_bind_data(duckdb_v2_copy_to_finalize_info_handle info, void **data,
+                                                         duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_init_data(duckdb_v2_copy_function_finalize_info_handle info,
-                                                               void **data, duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_copy_to_finalize_get_init_data(duckdb_v2_copy_to_finalize_info_handle info, void **data,
+                                                         duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_init_data; });
 }
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY FROM callbacks
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_set_bind_callback(duckdb_v2_copy_function_handle function,
+                                                      duckdb_v2_copy_from_bind_callback_fn callback,
+                                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.from_bind_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_set_init_global_callback(duckdb_v2_copy_function_handle function,
+                                                             duckdb_v2_copy_from_init_global_callback_fn callback,
+                                                             duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.from_init_global_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_set_init_local_callback(duckdb_v2_copy_function_handle function,
+                                                            duckdb_v2_copy_from_init_local_callback_fn callback,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.from_init_local_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_set_exec_callback(duckdb_v2_copy_function_handle function,
+                                                      duckdb_v2_copy_from_exec_callback_fn callback,
+                                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.from_exec_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_set_progress_callback(duckdb_v2_copy_function_handle function,
+                                                          duckdb_v2_copy_from_progress_callback_fn callback,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.from_progress_cb = callback; });
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY FROM bind
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_user_data(duckdb_v2_copy_from_bind_info_handle info, void **data,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_set_bind_data(duckdb_v2_copy_from_bind_info_handle info,
+                                                       duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_bind_data = *data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_file_path(duckdb_v2_copy_from_bind_info_handle info, duckdb_v2_str *path,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(path);
+	return WithErrorHandler(err, [&]() { *path = Convert(*Convert(info)->in_file_path); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_column_count(duckdb_v2_copy_from_bind_info_handle info, idx_t *count,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_types->size(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_column_type(duckdb_v2_copy_from_bind_info_handle info, idx_t index,
+                                                         duckdb_v2_logical_type_handle *type,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(type);
+	*type = nullptr;
+	return WithErrorHandler(
+	    err, [&]() { *type = GetColumnType(*Convert(info), index, "duckdb_v2_copy_from_bind_get_column_type"); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_column_name(duckdb_v2_copy_from_bind_info_handle info, idx_t index,
+                                                         duckdb_v2_identifier_t *name,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(
+	    err, [&]() { *name = GetColumnName(*Convert(info), index, "duckdb_v2_copy_from_bind_get_column_name"); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_option_count(duckdb_v2_copy_from_bind_info_handle info, idx_t *count,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_options.size(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_option_name(duckdb_v2_copy_from_bind_info_handle info, idx_t index,
+                                                         duckdb_v2_identifier_t *name,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(err, [&]() {
+		*name = Convert(*GetOption(*Convert(info), index, "duckdb_v2_copy_from_bind_get_option_name").first);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_get_option_value(duckdb_v2_copy_from_bind_info_handle info, idx_t index,
+                                                          duckdb_v2_value_handle *value,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(value);
+	*value = nullptr;
+	return WithErrorHandler(
+	    err, [&]() { *value = GetOptionValue(*Convert(info), index, "duckdb_v2_copy_from_bind_get_option_value"); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_bind_set_cardinality(duckdb_v2_copy_from_bind_info_handle info, idx_t cardinality,
+                                                         bool is_exact, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() {
+		auto &bind_info = *Convert(info);
+		bind_info.out_cardinality = cardinality;
+		bind_info.out_cardinality_is_exact = is_exact;
+		bind_info.out_cardinality_set = true;
+	});
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY FROM init global
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_init_global_get_user_data(duckdb_v2_copy_from_init_global_info_handle info,
+                                                              void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_init_global_get_bind_data(duckdb_v2_copy_from_init_global_info_handle info,
+                                                              void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_init_global_set_global_state(duckdb_v2_copy_from_init_global_info_handle info,
+                                                                 duckdb_v2_opaque *data,
+                                                                 duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_global_state = *data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_init_global_set_max_threads(duckdb_v2_copy_from_init_global_info_handle info,
+                                                                idx_t max_threads, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() {
+		if (max_threads == 0) {
+			throw duckdb::InvalidInputException("The maximum number of threads must be at least 1");
+		}
+		Convert(info)->out_max_threads = max_threads;
+	});
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY FROM init local
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_init_local_get_user_data(duckdb_v2_copy_from_init_local_info_handle info,
+                                                             void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_init_local_get_bind_data(duckdb_v2_copy_from_init_local_info_handle info,
+                                                             void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_init_local_get_global_state(duckdb_v2_copy_from_init_local_info_handle info,
+                                                                void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_global_state; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_init_local_set_local_state(duckdb_v2_copy_from_init_local_info_handle info,
+                                                               duckdb_v2_opaque *data,
+                                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_local_state = *data; });
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY FROM exec
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_user_data(duckdb_v2_copy_from_exec_info_handle info, void **data,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_bind_data(duckdb_v2_copy_from_exec_info_handle info, void **data,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_global_state(duckdb_v2_copy_from_exec_info_handle info, void **data,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_global_state; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_local_state(duckdb_v2_copy_from_exec_info_handle info, void **data,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_local_state; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_exec_get_output_chunk(duckdb_v2_copy_from_exec_info_handle info,
+                                                          duckdb_v2_data_chunk_handle *chunk,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(chunk);
+	return WithErrorHandler(err, [&]() { *chunk = Convert(Convert(info)->output); });
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// COPY FROM progress
+//----------------------------------------------------------------------------------------------------------------------
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_progress_get_user_data(duckdb_v2_copy_from_progress_info_handle info, void **data,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_progress_get_bind_data(duckdb_v2_copy_from_progress_info_handle info, void **data,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_progress_get_global_state(duckdb_v2_copy_from_progress_info_handle info,
+                                                              void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_global_state; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_from_progress_set_progress(duckdb_v2_copy_from_progress_info_handle info,
+                                                          double progress, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_progress = progress; });
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Register / destroy
+//----------------------------------------------------------------------------------------------------------------------
 
 DUCKDB_V2_ERROR duckdb_v2_copy_function_register(duckdb_v2_copy_function_handle function,
                                                  duckdb_v2_error_info_handle *err) {

--- a/src/main/capi/v2/capi_v2_func_copy.cpp
+++ b/src/main/capi/v2/capi_v2_func_copy.cpp
@@ -1,0 +1,682 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/function/copy_function.hpp"
+#include "duckdb/parser/parsed_data/create_copy_function_info.hpp"
+
+namespace duckdb::capiv2 {
+
+class CV2CopyFunctionInfo final : public CopyFunctionInfo {
+public:
+	duckdb_v2_copy_function_bind_callback_fn bind_cb = nullptr;
+	duckdb_v2_copy_function_init_callback_fn init_cb = nullptr;
+	duckdb_v2_copy_function_batch_callback_fn batch_cb = nullptr;
+	duckdb_v2_copy_function_flush_callback_fn flush_cb = nullptr;
+	duckdb_v2_copy_function_finalize_callback_fn finalize_cb = nullptr;
+	duckdb_v2_copy_function_batch_size_callback_fn batch_size_cb = nullptr;
+	shared_ptr<CV2UserData> user_data = nullptr;
+};
+
+//! The bind data of a bound COPY statement. Besides the user's own bind data it shares ownership of the function info:
+//! the init, batch, flush and finalize hooks only receive the bind data, so it is their only route to the callbacks.
+class CV2CopyFunctionData final : public FunctionData {
+public:
+	shared_ptr<CV2UserData> handle;
+	shared_ptr<CopyFunctionInfo> info;
+
+	auto Copy() const -> unique_ptr<FunctionData> override {
+		auto copy = make_uniq<CV2CopyFunctionData>();
+		copy->handle = handle;
+		copy->info = info;
+		return std::move(copy);
+	}
+
+	auto Equals(const FunctionData &other) const -> bool override {
+		const auto &other_data = other.Cast<CV2CopyFunctionData>();
+		return handle && other_data.handle && handle->Equals(*other_data.handle);
+	}
+};
+
+class CV2CopyGlobalState final : public GlobalFunctionData {
+public:
+	CV2UserData handle;
+};
+
+class CV2CopyBatchData final : public PreparedBatchData {
+public:
+	CV2UserData handle;
+};
+
+class CV2CopyBindInfo {
+public:
+	void *in_user_data = nullptr;
+	const vector<Identifier> *in_names = nullptr;
+	const vector<LogicalType> *in_types = nullptr;
+
+	duckdb_v2_opaque out_bind_data = {};
+};
+
+static auto Convert(duckdb_v2_copy_function_bind_info_handle info) -> CV2CopyBindInfo * {
+	return reinterpret_cast<CV2CopyBindInfo *>(info);
+}
+static auto Convert(CV2CopyBindInfo *info) -> duckdb_v2_copy_function_bind_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_function_bind_info_handle>(info);
+}
+
+class CV2CopyInitInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	const string *in_file_path = nullptr;
+
+	duckdb_v2_opaque out_init_data = {};
+};
+
+static auto Convert(duckdb_v2_copy_function_init_info_handle info) -> CV2CopyInitInfo * {
+	return reinterpret_cast<CV2CopyInitInfo *>(info);
+}
+static auto Convert(CV2CopyInitInfo *info) -> duckdb_v2_copy_function_init_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_function_init_info_handle>(info);
+}
+
+class CV2CopyBatchInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_init_data = nullptr;
+	// The batch, until the callback takes it; whatever is left is destroyed with the args.
+	unique_ptr<ColumnDataCollection> in_collection;
+
+	duckdb_v2_opaque out_batch_data = {};
+};
+
+static auto Convert(duckdb_v2_copy_function_batch_info_handle info) -> CV2CopyBatchInfo * {
+	return reinterpret_cast<CV2CopyBatchInfo *>(info);
+}
+static auto Convert(CV2CopyBatchInfo *info) -> duckdb_v2_copy_function_batch_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_function_batch_info_handle>(info);
+}
+
+class CV2CopyFlushInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_init_data = nullptr;
+	void *in_batch_data = nullptr;
+};
+
+static auto Convert(duckdb_v2_copy_function_flush_info_handle info) -> CV2CopyFlushInfo * {
+	return reinterpret_cast<CV2CopyFlushInfo *>(info);
+}
+static auto Convert(CV2CopyFlushInfo *info) -> duckdb_v2_copy_function_flush_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_function_flush_info_handle>(info);
+}
+
+class CV2CopyBatchSizeInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+
+	idx_t out_target = 0;
+};
+
+static auto Convert(duckdb_v2_copy_function_batch_size_info_handle info) -> CV2CopyBatchSizeInfo * {
+	return reinterpret_cast<CV2CopyBatchSizeInfo *>(info);
+}
+static auto Convert(CV2CopyBatchSizeInfo *info) -> duckdb_v2_copy_function_batch_size_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_function_batch_size_info_handle>(info);
+}
+
+class CV2CopyFinalizeInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_init_data = nullptr;
+};
+
+static auto Convert(duckdb_v2_copy_function_finalize_info_handle info) -> CV2CopyFinalizeInfo * {
+	return reinterpret_cast<CV2CopyFinalizeInfo *>(info);
+}
+static auto Convert(CV2CopyFinalizeInfo *info) -> duckdb_v2_copy_function_finalize_info_handle {
+	return reinterpret_cast<duckdb_v2_copy_function_finalize_info_handle>(info);
+}
+
+static auto GetFunctionInfo(const FunctionData &bind_data) -> const CV2CopyFunctionInfo & {
+	return bind_data.Cast<CV2CopyFunctionData>().info->Cast<CV2CopyFunctionInfo>();
+}
+
+static auto GetUserData(const CV2CopyFunctionInfo &info) -> void * {
+	return info.user_data ? info.user_data->GetData() : nullptr;
+}
+
+static auto GetUserBindData(const FunctionData &bind_data) -> void * {
+	const auto &handle = bind_data.Cast<CV2CopyFunctionData>().handle;
+	return handle ? handle->GetData() : nullptr;
+}
+
+static auto GetUserInitData(const GlobalFunctionData &gstate) -> void * {
+	return gstate.Cast<CV2CopyGlobalState>().handle.GetData();
+}
+
+static auto CV2CopyBind(ClientContext &context, CopyFunctionBindInput &input, const vector<Identifier> &names,
+                        const vector<LogicalType> &sql_types) -> unique_ptr<FunctionData> {
+	const auto &info = input.function_info->Cast<CV2CopyFunctionInfo>();
+
+	CV2CopyBindInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_names = &names;
+	args.in_types = &sql_types;
+
+	// The bind callback is optional: without one, the statement carries no bind data.
+	CV2ErrorInfo err = {};
+	if (info.bind_cb) {
+		auto err_ptr = Convert(&err);
+		info.bind_cb(Convert(&args), Convert(&context), &err_ptr);
+	}
+
+	// Take ownership of whatever the callback set before reporting an error, so it is destroyed either way.
+	auto result = make_uniq<CV2CopyFunctionData>();
+	result->info = input.function_info;
+	if (args.out_bind_data.ptr) {
+		result->handle =
+		    make_shared_ptr<CV2UserData>(args.out_bind_data.ptr, args.out_bind_data.destroy, args.out_bind_data.equals);
+	}
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	return std::move(result);
+}
+
+static auto CV2CopyInitGlobal(ClientContext &context, FunctionData &bind_data, const string &file_path)
+    -> unique_ptr<GlobalFunctionData> {
+	const auto &info = GetFunctionInfo(bind_data);
+
+	CV2CopyInitInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(bind_data);
+	args.in_file_path = &file_path;
+
+	// The init callback is optional: without one, the file carries no init data.
+	CV2ErrorInfo err = {};
+	if (info.init_cb) {
+		auto err_ptr = Convert(&err);
+		info.init_cb(Convert(&args), Convert(&context), &err_ptr);
+	}
+
+	auto result = make_uniq<CV2CopyGlobalState>();
+	if (args.out_init_data.ptr) {
+		result->handle = CV2UserData(args.out_init_data.ptr, args.out_init_data.destroy, args.out_init_data.equals);
+	}
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	return std::move(result);
+}
+
+static auto CV2CopyPrepareBatch(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                                unique_ptr<ColumnDataCollection> collection) -> unique_ptr<PreparedBatchData> {
+	const auto &info = GetFunctionInfo(bind_data);
+
+	CV2CopyBatchInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(bind_data);
+	args.in_init_data = GetUserInitData(gstate);
+	args.in_collection = std::move(collection);
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.batch_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	auto result = make_uniq<CV2CopyBatchData>();
+	if (args.out_batch_data.ptr) {
+		result->handle = CV2UserData(args.out_batch_data.ptr, args.out_batch_data.destroy, args.out_batch_data.equals);
+	}
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	return std::move(result);
+}
+
+static auto CV2CopyFlushBatch(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                              PreparedBatchData &batch) -> void {
+	const auto &info = GetFunctionInfo(bind_data);
+
+	CV2CopyFlushInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(bind_data);
+	args.in_init_data = GetUserInitData(gstate);
+	args.in_batch_data = batch.Cast<CV2CopyBatchData>().handle.GetData();
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.flush_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+}
+
+static auto CV2CopyFinalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) -> void {
+	const auto &info = GetFunctionInfo(bind_data);
+
+	// Always wired, as the engine requires a finalize hook; the user's callback is optional.
+	if (!info.finalize_cb) {
+		return;
+	}
+
+	CV2CopyFinalizeInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(bind_data);
+	args.in_init_data = GetUserInitData(gstate);
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.finalize_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+}
+
+static auto CV2CopyBatchSize(ClientContext &context, FunctionData &bind_data) -> idx_t {
+	const auto &info = GetFunctionInfo(bind_data);
+
+	CV2CopyBatchSizeInfo args = {};
+	args.in_user_data = GetUserData(info);
+	args.in_bind_data = GetUserBindData(bind_data);
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.batch_size_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+	if (args.out_target == 0) {
+		throw InvalidInputException("The batch size callback must set a target greater than 0.");
+	}
+	return args.out_target;
+}
+
+class CV2CopyFunction {
+public:
+	void Register() {
+		if (name.empty()) {
+			throw InvalidInputException("Function name cannot be empty.");
+		}
+		if (!info.batch_cb) {
+			throw InvalidInputException("Batch callback must be set for the function.");
+		}
+		if (!info.flush_cb) {
+			throw InvalidInputException("Flush callback must be set for the function.");
+		}
+
+		CopyFunction function(name);
+		function.copy_to_bind = CV2CopyBind;
+		function.copy_to_initialize_global = CV2CopyInitGlobal;
+		function.prepare_batch = CV2CopyPrepareBatch;
+		function.flush_batch = CV2CopyFlushBatch;
+		function.copy_to_finalize = CV2CopyFinalize;
+		if (info.batch_size_cb) {
+			function.desired_batch_size = CV2CopyBatchSize;
+		}
+		function.function_info = make_shared_ptr<CV2CopyFunctionInfo>(std::move(info));
+
+		// Call the implementation to register
+		RegisterToCatalog(std::move(function));
+	}
+
+	virtual ~CV2CopyFunction() = default;
+	virtual void RegisterToCatalog(CopyFunction function) = 0;
+
+public:
+	CV2CopyFunctionInfo info;
+	Identifier name;
+};
+
+class CV2ConnectionCopyFunction : public CV2CopyFunction {
+public:
+	explicit CV2ConnectionCopyFunction(Connection &connection) : connection(connection) {
+	}
+
+	void RegisterToCatalog(CopyFunction function) override {
+		auto &context = *connection.context;
+
+		context.RunFunctionInTransaction([&]() {
+			auto &catalog = Catalog::GetSystemCatalog(context);
+			CreateCopyFunctionInfo cf_info(std::move(function));
+			cf_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+			catalog.CreateCopyFunction(context, cf_info);
+		});
+	}
+
+private:
+	Connection &connection;
+};
+
+class CV2ExtensionCopyFunction : public CV2CopyFunction {
+public:
+	explicit CV2ExtensionCopyFunction(ExtensionLoader &loader) : loader(loader) {
+	}
+
+	void RegisterToCatalog(CopyFunction function) override {
+		loader.RegisterFunction(std::move(function));
+	}
+
+private:
+	ExtensionLoader &loader;
+};
+
+static auto Convert(duckdb_v2_copy_function_handle func) -> CV2CopyFunction * {
+	return reinterpret_cast<CV2CopyFunction *>(func);
+}
+static auto Convert(CV2CopyFunction *func) -> duckdb_v2_copy_function_handle {
+	return reinterpret_cast<duckdb_v2_copy_function_handle>(func);
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_create_with_connection(duckdb_v2_connection_handle connection,
+                                                               duckdb_v2_copy_function_handle *function,
+                                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(connection);
+	DUCKDB_CHECK_ARG(function);
+	*function = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &conn = *Convert(connection);
+		auto result = duckdb::make_uniq<CV2ConnectionCopyFunction>(conn);
+		*function = Convert(result.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_create_with_extension(duckdb_v2_extension_handle extension,
+                                                              duckdb_v2_copy_function_handle *function,
+                                                              duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(extension);
+	DUCKDB_CHECK_ARG(function);
+	*function = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &loader = GetExtensionLoader(extension);
+		auto result = duckdb::make_uniq<CV2ExtensionCopyFunction>(loader);
+		*function = Convert(result.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_set_name(duckdb_v2_copy_function_handle function, duckdb_v2_str *name,
+                                                 duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(*name);
+	return WithErrorHandler(err, [&]() { Convert(function)->name = duckdb::Identifier(Convert(*name)); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_set_user_data(duckdb_v2_copy_function_handle function, duckdb_v2_opaque *data,
+                                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() {
+		Convert(function)->info.user_data =
+		    duckdb::make_shared_ptr<CV2UserData>(data->ptr, data->destroy, data->equals);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_set_bind_callback(duckdb_v2_copy_function_handle function,
+                                                          duckdb_v2_copy_function_bind_callback_fn callback,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.bind_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_set_init_callback(duckdb_v2_copy_function_handle function,
+                                                          duckdb_v2_copy_function_init_callback_fn callback,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.init_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_set_batch_callback(duckdb_v2_copy_function_handle function,
+                                                           duckdb_v2_copy_function_batch_callback_fn callback,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.batch_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_set_flush_callback(duckdb_v2_copy_function_handle function,
+                                                           duckdb_v2_copy_function_flush_callback_fn callback,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.flush_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_set_batch_size_callback(duckdb_v2_copy_function_handle function,
+                                                                duckdb_v2_copy_function_batch_size_callback_fn callback,
+                                                                duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.batch_size_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_set_finalize_callback(duckdb_v2_copy_function_handle function,
+                                                              duckdb_v2_copy_function_finalize_callback_fn callback,
+                                                              duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.finalize_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_user_data(duckdb_v2_copy_function_bind_info_handle info, void **data,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_set_bind_data(duckdb_v2_copy_function_bind_info_handle info,
+                                                           duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_bind_data = *data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_count(duckdb_v2_copy_function_bind_info_handle info,
+                                                              idx_t *count, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_types->size(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_type(duckdb_v2_copy_function_bind_info_handle info, idx_t index,
+                                                             duckdb_v2_logical_type_handle *type,
+                                                             duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(type);
+	*type = nullptr;
+	return WithErrorHandler(err, [&]() {
+		const auto &types = *Convert(info)->in_types;
+		if (index >= types.size()) {
+			throw duckdb::InvalidInputException("Index out of bounds in duckdb_v2_copy_function_bind_get_column_type");
+		}
+		*type = Convert(new duckdb::LogicalType(types[index]));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_bind_get_column_name(duckdb_v2_copy_function_bind_info_handle info, idx_t index,
+                                                             duckdb_v2_identifier_t *name,
+                                                             duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(err, [&]() {
+		const auto &names = *Convert(info)->in_names;
+		if (index >= names.size()) {
+			throw duckdb::InvalidInputException("Index out of bounds in duckdb_v2_copy_function_bind_get_column_name");
+		}
+		*name = Convert(names[index]);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_user_data(duckdb_v2_copy_function_batch_size_info_handle info,
+                                                                 void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_get_bind_data(duckdb_v2_copy_function_batch_size_info_handle info,
+                                                                 void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_size_set_target(duckdb_v2_copy_function_batch_size_info_handle info,
+                                                              idx_t rows, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_target = rows; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_user_data(duckdb_v2_copy_function_init_info_handle info, void **data,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_bind_data(duckdb_v2_copy_function_init_info_handle info, void **data,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_init_get_file_path(duckdb_v2_copy_function_init_info_handle info,
+                                                           duckdb_v2_str *path, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(path);
+	return WithErrorHandler(err, [&]() { *path = Convert(*Convert(info)->in_file_path); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_init_set_init_data(duckdb_v2_copy_function_init_info_handle info,
+                                                           duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_init_data = *data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_user_data(duckdb_v2_copy_function_batch_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_bind_data(duckdb_v2_copy_function_batch_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_get_init_data(duckdb_v2_copy_function_batch_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_init_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_take_input(duckdb_v2_copy_function_batch_info_handle info,
+                                                         duckdb_v2_column_data_collection_handle *collection,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(collection);
+	*collection = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &batch_info = *Convert(info);
+		if (!batch_info.in_collection) {
+			throw duckdb::InvalidInputException("The batch input was already taken.");
+		}
+		*collection = Convert(batch_info.in_collection.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_batch_set_batch_data(duckdb_v2_copy_function_batch_info_handle info,
+                                                             duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_batch_data = *data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_user_data(duckdb_v2_copy_function_flush_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_bind_data(duckdb_v2_copy_function_flush_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_init_data(duckdb_v2_copy_function_flush_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_init_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_flush_get_batch_data(duckdb_v2_copy_function_flush_info_handle info,
+                                                             void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_batch_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_user_data(duckdb_v2_copy_function_finalize_info_handle info,
+                                                               void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_bind_data(duckdb_v2_copy_function_finalize_info_handle info,
+                                                               void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_finalize_get_init_data(duckdb_v2_copy_function_finalize_info_handle info,
+                                                               void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_init_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_register(duckdb_v2_copy_function_handle function,
+                                                 duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->Register(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_copy_function_destroy(duckdb_v2_copy_function_handle *function) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!function) {
+			return;
+		}
+		if (*function) {
+			delete Convert(*function);
+			*function = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_func_table.cpp
+++ b/src/main/capi/v2/capi_v2_func_table.cpp
@@ -7,8 +7,8 @@ namespace duckdb::capiv2 {
 class CV2TableFunctionInfo;
 
 //! The bind data of a bound call site. Besides the user's own bind data it carries a borrowed pointer back to the
-//! function info: the cardinality and progress hooks only receive the bind data, so it is their only route to the
-//! callbacks. The registered function owns the info and outlives every call site bound against it.
+//! function info: the progress hook only receives the bind data, so it is its only route to the callbacks. The
+//! registered function owns the info and outlives every call site bound against it.
 class CV2TableFunctionData final : public FunctionData {
 public:
 	shared_ptr<CV2UserData> handle;
@@ -119,23 +119,6 @@ static auto Convert(CV2TableExecInfo *info) -> duckdb_v2_table_function_exec_inf
 	return reinterpret_cast<duckdb_v2_table_function_exec_info_handle>(info);
 }
 
-class CV2TableCardinalityInfo {
-public:
-	void *in_user_data = nullptr;
-	void *in_bind_data = nullptr;
-
-	idx_t out_cardinality = 0;
-	bool out_is_exact = false;
-	bool out_set = false;
-};
-
-static auto Convert(duckdb_v2_table_function_cardinality_info_handle info) -> CV2TableCardinalityInfo * {
-	return reinterpret_cast<CV2TableCardinalityInfo *>(info);
-}
-static auto Convert(CV2TableCardinalityInfo *info) -> duckdb_v2_table_function_cardinality_info_handle {
-	return reinterpret_cast<duckdb_v2_table_function_cardinality_info_handle>(info);
-}
-
 class CV2TableProgressInfo {
 public:
 	void *in_user_data = nullptr;
@@ -158,7 +141,6 @@ public:
 	duckdb_v2_table_function_init_global_callback_fn init_global_cb = nullptr;
 	duckdb_v2_table_function_init_local_callback_fn init_local_cb = nullptr;
 	duckdb_v2_table_function_exec_callback_fn exec_cb = nullptr;
-	duckdb_v2_table_function_cardinality_callback_fn cardinality_cb = nullptr;
 	duckdb_v2_table_function_progress_callback_fn progress_cb = nullptr;
 	shared_ptr<CV2UserData> user_data = nullptr;
 
@@ -343,32 +325,11 @@ static auto CV2TableMakeStatistics(idx_t cardinality, bool is_exact) -> unique_p
 
 static auto CV2TableCardinality(ClientContext &context, const FunctionData *bind_data) -> unique_ptr<NodeStatistics> {
 	const auto &data = bind_data->Cast<CV2TableFunctionData>();
-	const auto &info = *data.info;
-
-	if (info.cardinality_cb) {
-		CV2TableCardinalityInfo args = {};
-		args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
-		args.in_bind_data = data.handle ? data.handle->GetData() : nullptr;
-
-		CV2ErrorInfo err = {};
-		auto err_ptr = Convert(&err);
-		info.cardinality_cb(Convert(&args), Convert(&context), &err_ptr);
-
-		if (err.HasError()) {
-			err.ThrowAsException();
-		}
-		if (args.out_set) {
-			return CV2TableMakeStatistics(args.out_cardinality, args.out_is_exact);
-		}
+	if (!data.cardinality_set) {
+		// No estimate at all: the optimizer falls back on its own defaults.
 		return nullptr;
 	}
-
-	if (data.cardinality_set) {
-		return CV2TableMakeStatistics(data.cardinality, data.cardinality_is_exact);
-	}
-
-	// No estimate at all: the optimizer falls back on its own defaults.
-	return nullptr;
+	return CV2TableMakeStatistics(data.cardinality, data.cardinality_is_exact);
 }
 
 static auto CV2TableProgress(ClientContext &context, const FunctionData *bind_data,
@@ -430,8 +391,8 @@ public:
 			function.SetVarArgs(signature.GetVarArgs());
 		}
 
-		// Always wired: it serves both the cardinality callback and the static estimate a bind callback may set,
-		// which is not known at registration. It reports no estimate when the function provides neither.
+		// Always wired: it serves the estimate a bind callback may set, which is not known at registration. It
+		// reports no estimate when the bind callback sets none.
 		function.cardinality = CV2TableCardinality;
 		if (info.progress_cb) {
 			function.table_scan_progress = CV2TableProgress;
@@ -590,14 +551,6 @@ DUCKDB_V2_ERROR duckdb_v2_table_function_set_exec_callback(duckdb_v2_table_funct
                                                            duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(function);
 	return WithErrorHandler(err, [&]() { Convert(function)->info.exec_cb = callback; });
-}
-
-DUCKDB_V2_ERROR
-duckdb_v2_table_function_set_cardinality_callback(duckdb_v2_table_function_handle function,
-                                                  duckdb_v2_table_function_cardinality_callback_fn callback,
-                                                  duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(function);
-	return WithErrorHandler(err, [&]() { Convert(function)->info.cardinality_cb = callback; });
 }
 
 DUCKDB_V2_ERROR duckdb_v2_table_function_set_progress_callback(duckdb_v2_table_function_handle function,
@@ -789,35 +742,6 @@ DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_output_chunk(duckdb_v2_table_f
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(chunk);
 	return WithErrorHandler(err, [&]() { *chunk = Convert(Convert(info)->output); });
-}
-
-DUCKDB_V2_ERROR
-duckdb_v2_table_function_cardinality_get_user_data(duckdb_v2_table_function_cardinality_info_handle info, void **data,
-                                                   duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(data);
-	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
-}
-
-DUCKDB_V2_ERROR
-duckdb_v2_table_function_cardinality_get_bind_data(duckdb_v2_table_function_cardinality_info_handle info, void **data,
-                                                   duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(data);
-	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
-}
-
-DUCKDB_V2_ERROR
-duckdb_v2_table_function_cardinality_set_cardinality(duckdb_v2_table_function_cardinality_info_handle info,
-                                                     idx_t cardinality, bool is_exact,
-                                                     duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	return WithErrorHandler(err, [&]() {
-		auto &cardinality_info = *Convert(info);
-		cardinality_info.out_cardinality = cardinality;
-		cardinality_info.out_is_exact = is_exact;
-		cardinality_info.out_set = true;
-	});
 }
 
 DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_user_data(duckdb_v2_table_function_progress_info_handle info,

--- a/src/main/capi/v2/capi_v2_func_table.cpp
+++ b/src/main/capi/v2/capi_v2_func_table.cpp
@@ -1,0 +1,866 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/storage/statistics/node_statistics.hpp"
+
+namespace duckdb::capiv2 {
+
+class CV2TableFunctionInfo;
+
+//! The bind data of a bound call site. Besides the user's own bind data it carries a borrowed pointer back to the
+//! function info: the cardinality and progress hooks only receive the bind data, so it is their only route to the
+//! callbacks. The registered function owns the info and outlives every call site bound against it.
+class CV2TableFunctionData final : public FunctionData {
+public:
+	shared_ptr<CV2UserData> handle;
+	optional_ptr<const CV2TableFunctionInfo> info;
+
+	// The static estimate a bind callback may set via table_function_bind_set_cardinality.
+	idx_t cardinality = 0;
+	bool cardinality_is_exact = false;
+	bool cardinality_set = false;
+
+	auto Copy() const -> unique_ptr<FunctionData> override {
+		auto copy = make_uniq<CV2TableFunctionData>();
+		copy->handle = handle;
+		copy->info = info;
+		copy->cardinality = cardinality;
+		copy->cardinality_is_exact = cardinality_is_exact;
+		copy->cardinality_set = cardinality_set;
+		return std::move(copy);
+	}
+
+	auto Equals(const FunctionData &other) const -> bool override {
+		const auto &other_data = other.Cast<CV2TableFunctionData>();
+		return handle && other_data.handle && handle->Equals(*other_data.handle);
+	}
+};
+
+class CV2TableGlobalState final : public GlobalTableFunctionState {
+public:
+	auto MaxThreads() const -> idx_t override {
+		return max_threads;
+	}
+
+	CV2UserData handle;
+	idx_t max_threads = 1;
+};
+
+class CV2TableLocalState final : public LocalTableFunctionState {
+public:
+	CV2UserData handle;
+};
+
+class CV2TableBindInfo {
+public:
+	void *in_user_data = nullptr;
+	const vector<Value> *in_args = nullptr;
+
+	vector<LogicalType> out_column_types;
+	vector<Identifier> out_column_names;
+	duckdb_v2_opaque out_bind_data = {};
+	idx_t out_cardinality = 0;
+	bool out_cardinality_is_exact = false;
+	bool out_cardinality_set = false;
+};
+
+static auto Convert(duckdb_v2_table_function_bind_info_handle info) -> CV2TableBindInfo * {
+	return reinterpret_cast<CV2TableBindInfo *>(info);
+}
+static auto Convert(CV2TableBindInfo *info) -> duckdb_v2_table_function_bind_info_handle {
+	return reinterpret_cast<duckdb_v2_table_function_bind_info_handle>(info);
+}
+
+class CV2TableInitGlobalInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+
+	duckdb_v2_opaque out_global_state = {};
+	idx_t out_max_threads = 1;
+};
+
+static auto Convert(duckdb_v2_table_function_init_global_info_handle info) -> CV2TableInitGlobalInfo * {
+	return reinterpret_cast<CV2TableInitGlobalInfo *>(info);
+}
+static auto Convert(CV2TableInitGlobalInfo *info) -> duckdb_v2_table_function_init_global_info_handle {
+	return reinterpret_cast<duckdb_v2_table_function_init_global_info_handle>(info);
+}
+
+class CV2TableInitLocalInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_global_state = nullptr;
+
+	duckdb_v2_opaque out_local_state = {};
+};
+
+static auto Convert(duckdb_v2_table_function_init_local_info_handle info) -> CV2TableInitLocalInfo * {
+	return reinterpret_cast<CV2TableInitLocalInfo *>(info);
+}
+static auto Convert(CV2TableInitLocalInfo *info) -> duckdb_v2_table_function_init_local_info_handle {
+	return reinterpret_cast<duckdb_v2_table_function_init_local_info_handle>(info);
+}
+
+class CV2TableExecInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_global_state = nullptr;
+	void *in_local_state = nullptr;
+
+	DataChunk *output = nullptr;
+};
+
+static auto Convert(duckdb_v2_table_function_exec_info_handle info) -> CV2TableExecInfo * {
+	return reinterpret_cast<CV2TableExecInfo *>(info);
+}
+static auto Convert(CV2TableExecInfo *info) -> duckdb_v2_table_function_exec_info_handle {
+	return reinterpret_cast<duckdb_v2_table_function_exec_info_handle>(info);
+}
+
+class CV2TableCardinalityInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+
+	idx_t out_cardinality = 0;
+	bool out_is_exact = false;
+	bool out_set = false;
+};
+
+static auto Convert(duckdb_v2_table_function_cardinality_info_handle info) -> CV2TableCardinalityInfo * {
+	return reinterpret_cast<CV2TableCardinalityInfo *>(info);
+}
+static auto Convert(CV2TableCardinalityInfo *info) -> duckdb_v2_table_function_cardinality_info_handle {
+	return reinterpret_cast<duckdb_v2_table_function_cardinality_info_handle>(info);
+}
+
+class CV2TableProgressInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	void *in_global_state = nullptr;
+
+	double out_progress = 0.0;
+};
+
+static auto Convert(duckdb_v2_table_function_progress_info_handle info) -> CV2TableProgressInfo * {
+	return reinterpret_cast<CV2TableProgressInfo *>(info);
+}
+static auto Convert(CV2TableProgressInfo *info) -> duckdb_v2_table_function_progress_info_handle {
+	return reinterpret_cast<duckdb_v2_table_function_progress_info_handle>(info);
+}
+
+class CV2TableFunctionInfo : public TableFunctionInfo {
+public:
+	duckdb_v2_table_function_bind_callback_fn bind_cb = nullptr;
+	duckdb_v2_table_function_init_global_callback_fn init_global_cb = nullptr;
+	duckdb_v2_table_function_init_local_callback_fn init_local_cb = nullptr;
+	duckdb_v2_table_function_exec_callback_fn exec_cb = nullptr;
+	duckdb_v2_table_function_cardinality_callback_fn cardinality_cb = nullptr;
+	duckdb_v2_table_function_progress_callback_fn progress_cb = nullptr;
+	shared_ptr<CV2UserData> user_data = nullptr;
+
+	// The signature's slot plan, captured at registration: every parameter name in signature order, how many of them
+	// lead the positional prefix (the ones without a default), and the default of each remaining parameter. The bind
+	// wrapper assembles the argument list from it, injecting the default for a parameter the call site omitted, so
+	// the bind callback observes a value for every parameter.
+	vector<Identifier> parameter_names;
+	idx_t positional_count = 0;
+	identifier_map_t<Value> named_parameter_defaults;
+};
+
+//! Assembles the call's arguments in signature-slot order: first the parameters without a default, taken from the
+//! positional arguments, then the parameters with one, taken from the named arguments or the declared default when
+//! the call site omitted them, then the variadic tail.
+static auto CV2TableCollectArguments(const CV2TableFunctionInfo &info, TableFunctionBindInput &input) -> vector<Value> {
+	vector<Value> arguments;
+	const auto positional_count = MinValue<idx_t>(info.positional_count, input.inputs.size());
+
+	for (idx_t i = 0; i < positional_count; i++) {
+		arguments.push_back(input.inputs[i]);
+	}
+	for (idx_t i = info.positional_count; i < info.parameter_names.size(); i++) {
+		const auto &name = info.parameter_names[i];
+		auto provided = input.named_parameters.find(name);
+		if (provided != input.named_parameters.end()) {
+			arguments.push_back(provided->second);
+		} else {
+			arguments.push_back(info.named_parameter_defaults.at(name));
+		}
+	}
+	for (idx_t i = positional_count; i < input.inputs.size(); i++) {
+		arguments.push_back(input.inputs[i]);
+	}
+	return arguments;
+}
+
+static auto CV2TableBind(ClientContext &context, TableFunctionBindInput &input, vector<LogicalType> &return_types,
+                         vector<Identifier> &names) -> unique_ptr<FunctionData> {
+	const auto &info = input.info->Cast<CV2TableFunctionInfo>();
+
+	auto arguments = CV2TableCollectArguments(info, input);
+
+	CV2TableBindInfo args = {};
+	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
+	args.in_args = &arguments;
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.bind_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	// Take ownership of whatever the callback set before reporting an error, so it is destroyed either way.
+	auto result = make_uniq<CV2TableFunctionData>();
+	result->info = &info;
+	if (args.out_bind_data.ptr) {
+		result->handle =
+		    make_shared_ptr<CV2UserData>(args.out_bind_data.ptr, args.out_bind_data.destroy, args.out_bind_data.equals);
+	}
+	result->cardinality = args.out_cardinality;
+	result->cardinality_is_exact = args.out_cardinality_is_exact;
+	result->cardinality_set = args.out_cardinality_set;
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	if (args.out_column_types.empty()) {
+		throw InvalidInputException("The bind callback of table function \"%s\" did not declare any result columns.",
+		                            input.table_function.name);
+	}
+
+	return_types = std::move(args.out_column_types);
+	names = std::move(args.out_column_names);
+	return std::move(result);
+}
+
+static auto CV2TableInitGlobal(ClientContext &context, TableFunctionInitInput &input)
+    -> unique_ptr<GlobalTableFunctionState> {
+	const auto &bind_data = input.bind_data->Cast<CV2TableFunctionData>();
+	const auto &info = *bind_data.info;
+
+	// Always produced, even without a callback: it carries the thread count the scan runs with.
+	auto result = make_uniq<CV2TableGlobalState>();
+	if (!info.init_global_cb) {
+		return std::move(result);
+	}
+
+	CV2TableInitGlobalInfo args = {};
+	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
+	args.in_bind_data = bind_data.handle ? bind_data.handle->GetData() : nullptr;
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.init_global_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (args.out_global_state.ptr) {
+		result->handle =
+		    CV2UserData(args.out_global_state.ptr, args.out_global_state.destroy, args.out_global_state.equals);
+	}
+	result->max_threads = args.out_max_threads;
+
+	// Throw after taking ownership of the state, so that it is destroyed even if we error.
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	return std::move(result);
+}
+
+static auto CV2TableInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                              GlobalTableFunctionState *global_state) -> unique_ptr<LocalTableFunctionState> {
+	const auto &bind_data = input.bind_data->Cast<CV2TableFunctionData>();
+	const auto &info = *bind_data.info;
+
+	if (!info.init_local_cb) {
+		return nullptr;
+	}
+
+	CV2TableInitLocalInfo args = {};
+	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
+	args.in_bind_data = bind_data.handle ? bind_data.handle->GetData() : nullptr;
+	if (global_state) {
+		args.in_global_state = global_state->Cast<CV2TableGlobalState>().handle.GetData();
+	}
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.init_local_cb(Convert(&args), Convert(&context.client), &err_ptr);
+
+	unique_ptr<LocalTableFunctionState> result = nullptr;
+	if (args.out_local_state.ptr) {
+		auto set_result = make_uniq<CV2TableLocalState>();
+		set_result->handle =
+		    CV2UserData(args.out_local_state.ptr, args.out_local_state.destroy, args.out_local_state.equals);
+		result = std::move(set_result);
+	}
+
+	// Throw after taking ownership of the state, so that it is destroyed even if we error.
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	return result;
+}
+
+static auto CV2TableExec(ClientContext &context, TableFunctionInput &input, DataChunk &output) -> void {
+	const auto &bind_data = input.bind_data->Cast<CV2TableFunctionData>();
+	const auto &info = *bind_data.info;
+
+	CV2TableExecInfo args = {};
+	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
+	args.in_bind_data = bind_data.handle ? bind_data.handle->GetData() : nullptr;
+	if (input.global_state) {
+		args.in_global_state = input.global_state->Cast<CV2TableGlobalState>().handle.GetData();
+	}
+	if (input.local_state) {
+		args.in_local_state = input.local_state->Cast<CV2TableLocalState>().handle.GetData();
+	}
+	args.output = &output;
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.exec_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	// The vector write API sizes per vector, while the engine reads the chunk's cardinality. Callers typically size
+	// only the first vector and write the rest through direct buffer writes, so take the first vector's size as the
+	// batch's row count and propagate it to the others. A table function always has at least one result column.
+	output.SetChildCardinality(output.data[0].size());
+}
+
+//! An exact estimate also pins the maximum; otherwise only the estimate is known.
+static auto CV2TableMakeStatistics(idx_t cardinality, bool is_exact) -> unique_ptr<NodeStatistics> {
+	if (is_exact) {
+		return make_uniq<NodeStatistics>(cardinality, cardinality);
+	}
+	return make_uniq<NodeStatistics>(cardinality);
+}
+
+static auto CV2TableCardinality(ClientContext &context, const FunctionData *bind_data) -> unique_ptr<NodeStatistics> {
+	const auto &data = bind_data->Cast<CV2TableFunctionData>();
+	const auto &info = *data.info;
+
+	if (info.cardinality_cb) {
+		CV2TableCardinalityInfo args = {};
+		args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
+		args.in_bind_data = data.handle ? data.handle->GetData() : nullptr;
+
+		CV2ErrorInfo err = {};
+		auto err_ptr = Convert(&err);
+		info.cardinality_cb(Convert(&args), Convert(&context), &err_ptr);
+
+		if (err.HasError()) {
+			err.ThrowAsException();
+		}
+		if (args.out_set) {
+			return CV2TableMakeStatistics(args.out_cardinality, args.out_is_exact);
+		}
+		return nullptr;
+	}
+
+	if (data.cardinality_set) {
+		return CV2TableMakeStatistics(data.cardinality, data.cardinality_is_exact);
+	}
+
+	// No estimate at all: the optimizer falls back on its own defaults.
+	return nullptr;
+}
+
+static auto CV2TableProgress(ClientContext &context, const FunctionData *bind_data,
+                             const GlobalTableFunctionState *global_state) -> double {
+	const auto &data = bind_data->Cast<CV2TableFunctionData>();
+	const auto &info = *data.info;
+
+	CV2TableProgressInfo args = {};
+	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
+	args.in_bind_data = data.handle ? data.handle->GetData() : nullptr;
+	if (global_state) {
+		// The callback runs concurrently with the scan, so the state it reads is the shared one, unsynchronized.
+		args.in_global_state = global_state->Cast<CV2TableGlobalState>().handle.GetData();
+	}
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.progress_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	// The API contract is a 0.0-1.0 fraction, the engine reads a 0-100 percentage.
+	return MinValue<double>(MaxValue<double>(args.out_progress, 0.0), 1.0) * 100.0;
+}
+
+class CV2TableFunction {
+public:
+	void Register() {
+		if (name.empty()) {
+			throw InvalidInputException("Function name cannot be empty.");
+		}
+		if (!info.bind_cb) {
+			throw InvalidInputException("Bind callback must be set for the function.");
+		}
+		if (!info.exec_cb) {
+			throw InvalidInputException("Exec callback must be set for the function.");
+		}
+		// A table function declares the columns it returns from its bind callback, not through a return type.
+		if (signature.GetReturnType().id() != LogicalTypeId::INVALID) {
+			throw InvalidInputException("A table function signature cannot set a return type.");
+		}
+
+		signature.Verify();
+
+		// Route the signature onto the two ways SQL passes arguments to a table function: a parameter without a
+		// default value is a required positional argument, a parameter with one is an optional named argument.
+		vector<LogicalType> positional;
+		for (idx_t i = 0; i < signature.GetParameterCount(); i++) {
+			const auto &param = signature.GetParameter(i);
+			if (!param.HasDefaultValue()) {
+				positional.push_back(param.GetType());
+			}
+		}
+
+		TableFunction function(name, positional, CV2TableExec, CV2TableBind, CV2TableInitGlobal, CV2TableInitLocal);
+		if (signature.HasVarArgs()) {
+			function.SetVarArgs(signature.GetVarArgs());
+		}
+
+		// Always wired: it serves both the cardinality callback and the static estimate a bind callback may set,
+		// which is not known at registration. It reports no estimate when the function provides neither.
+		function.cardinality = CV2TableCardinality;
+		if (info.progress_cb) {
+			function.table_scan_progress = CV2TableProgress;
+		}
+
+		auto function_info = make_shared_ptr<CV2TableFunctionInfo>(std::move(info));
+		for (idx_t i = 0; i < signature.GetParameterCount(); i++) {
+			const auto &param = signature.GetParameter(i);
+			if (param.HasDefaultValue()) {
+				function.named_parameters[param.GetName()] = param.GetType();
+				function_info->named_parameter_defaults[param.GetName()] = *param.GetDefaultValue();
+			}
+			function_info->parameter_names.push_back(param.GetName());
+		}
+		function_info->positional_count = positional.size();
+		function.function_info = std::move(function_info);
+
+		// Call the implementation to register
+		RegisterToCatalog(std::move(function));
+	}
+
+	virtual ~CV2TableFunction() = default;
+	virtual void RegisterToCatalog(TableFunction function) = 0;
+
+public:
+	FunctionSignature signature;
+	CV2TableFunctionInfo info;
+	Identifier name;
+};
+
+class CV2ConnectionTableFunction : public CV2TableFunction {
+public:
+	explicit CV2ConnectionTableFunction(Connection &connection) : connection(connection) {
+	}
+
+	void RegisterToCatalog(TableFunction function) override {
+		auto &context = *connection.context;
+
+		context.RunFunctionInTransaction([&]() {
+			auto &catalog = Catalog::GetSystemCatalog(context);
+			CreateTableFunctionInfo tf_info(std::move(function));
+			tf_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+			catalog.CreateTableFunction(context, tf_info);
+		});
+	}
+
+private:
+	Connection &connection;
+};
+
+class CV2ExtensionTableFunction : public CV2TableFunction {
+public:
+	explicit CV2ExtensionTableFunction(ExtensionLoader &loader) : loader(loader) {
+	}
+
+	void RegisterToCatalog(TableFunction function) override {
+		loader.RegisterFunction(std::move(function));
+	}
+
+private:
+	ExtensionLoader &loader;
+};
+
+static auto Convert(duckdb_v2_table_function_handle func) -> CV2TableFunction * {
+	return reinterpret_cast<CV2TableFunction *>(func);
+}
+static auto Convert(CV2TableFunction *func) -> duckdb_v2_table_function_handle {
+	return reinterpret_cast<duckdb_v2_table_function_handle>(func);
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_create_with_connection(duckdb_v2_connection_handle connection,
+                                                                duckdb_v2_table_function_handle *function,
+                                                                duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(connection);
+	DUCKDB_CHECK_ARG(function);
+	*function = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &conn = *Convert(connection);
+		auto result = duckdb::make_uniq<CV2ConnectionTableFunction>(conn);
+		*function = Convert(result.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_create_with_extension(duckdb_v2_extension_handle extension,
+                                                               duckdb_v2_table_function_handle *function,
+                                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(extension);
+	DUCKDB_CHECK_ARG(function);
+	*function = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &loader = GetExtensionLoader(extension);
+		auto result = duckdb::make_uniq<CV2ExtensionTableFunction>(loader);
+		*function = Convert(result.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_set_name(duckdb_v2_table_function_handle function, duckdb_v2_str *name,
+                                                  duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(*name);
+	return WithErrorHandler(err, [&]() { Convert(function)->name = duckdb::Identifier(Convert(*name)); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_get_signature(duckdb_v2_table_function_handle function,
+                                                       duckdb_v2_function_signature_handle *sig,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	DUCKDB_CHECK_ARG(sig);
+	return WithErrorHandler(err, [&]() { *sig = Convert(&Convert(function)->signature); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_set_user_data(duckdb_v2_table_function_handle function, duckdb_v2_opaque *data,
+                                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() {
+		Convert(function)->info.user_data =
+		    duckdb::make_shared_ptr<CV2UserData>(data->ptr, data->destroy, data->equals);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_set_bind_callback(duckdb_v2_table_function_handle function,
+                                                           duckdb_v2_table_function_bind_callback_fn callback,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.bind_cb = callback; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_set_init_global_callback(duckdb_v2_table_function_handle function,
+                                                  duckdb_v2_table_function_init_global_callback_fn callback,
+                                                  duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.init_global_cb = callback; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_set_init_local_callback(duckdb_v2_table_function_handle function,
+                                                 duckdb_v2_table_function_init_local_callback_fn callback,
+                                                 duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.init_local_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_set_exec_callback(duckdb_v2_table_function_handle function,
+                                                           duckdb_v2_table_function_exec_callback_fn callback,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.exec_cb = callback; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_set_cardinality_callback(duckdb_v2_table_function_handle function,
+                                                  duckdb_v2_table_function_cardinality_callback_fn callback,
+                                                  duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.cardinality_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_set_progress_callback(duckdb_v2_table_function_handle function,
+                                                               duckdb_v2_table_function_progress_callback_fn callback,
+                                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.progress_cb = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_user_data(duckdb_v2_table_function_bind_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_bind_set_bind_data(duckdb_v2_table_function_bind_info_handle info,
+                                                            duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_bind_data = *data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_count(duckdb_v2_table_function_bind_info_handle info,
+                                                            idx_t *count, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_args->size(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_type(duckdb_v2_table_function_bind_info_handle info, idx_t index,
+                                                           duckdb_v2_logical_type_handle *type,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(type);
+	*type = nullptr;
+	return WithErrorHandler(err, [&]() {
+		const auto &arguments = *Convert(info)->in_args;
+		if (index >= arguments.size()) {
+			throw duckdb::InvalidInputException("Index out of bounds in duckdb_v2_table_function_bind_get_arg_type");
+		}
+		*type = Convert(new duckdb::LogicalType(arguments[index].type()));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_arg_value(duckdb_v2_table_function_bind_info_handle info, idx_t index,
+                                                            duckdb_v2_value_handle *value,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(value);
+	*value = nullptr;
+	return WithErrorHandler(err, [&]() {
+		const auto &arguments = *Convert(info)->in_args;
+		if (index >= arguments.size()) {
+			throw duckdb::InvalidInputException("Index out of bounds in duckdb_v2_table_function_bind_get_arg_value");
+		}
+		*value = Convert(new duckdb::Value(arguments[index]));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_bind_add_result_column(duckdb_v2_table_function_bind_info_handle info,
+                                                                duckdb_v2_identifier_t name,
+                                                                duckdb_v2_logical_type_handle type,
+                                                                duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(type);
+	return WithErrorHandler(err, [&]() {
+		const auto &column_type = *Convert(type);
+		// A result column carries data, so a wildcard or otherwise incomplete type has no meaning here.
+		if (!column_type.IsComplete()) {
+			throw duckdb::InvalidInputException("Result column type must be a fully defined concrete type");
+		}
+		auto &bind_info = *Convert(info);
+		bind_info.out_column_names.emplace_back(Convert(name));
+		bind_info.out_column_types.push_back(column_type);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_bind_set_cardinality(duckdb_v2_table_function_bind_info_handle info,
+                                                              idx_t cardinality, bool is_exact,
+                                                              duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() {
+		auto &bind_info = *Convert(info);
+		bind_info.out_cardinality = cardinality;
+		bind_info.out_cardinality_is_exact = is_exact;
+		bind_info.out_cardinality_set = true;
+	});
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_global_get_user_data(duckdb_v2_table_function_init_global_info_handle info, void **data,
+                                                   duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_global_get_bind_data(duckdb_v2_table_function_init_global_info_handle info, void **data,
+                                                   duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_global_set_global_state(duckdb_v2_table_function_init_global_info_handle info,
+                                                      duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_global_state = *data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_global_set_max_threads(duckdb_v2_table_function_init_global_info_handle info,
+                                                     idx_t max_threads, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() {
+		if (max_threads == 0) {
+			throw duckdb::InvalidInputException("The maximum number of threads must be at least 1");
+		}
+		Convert(info)->out_max_threads = max_threads;
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_user_data(duckdb_v2_table_function_init_local_info_handle info,
+                                                                  void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_bind_data(duckdb_v2_table_function_init_local_info_handle info,
+                                                                  void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_local_get_global_state(duckdb_v2_table_function_init_local_info_handle info, void **data,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_global_state; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_local_set_local_state(duckdb_v2_table_function_init_local_info_handle info,
+                                                    duckdb_v2_opaque *data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_local_state = *data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_user_data(duckdb_v2_table_function_exec_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_bind_data(duckdb_v2_table_function_exec_info_handle info, void **data,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_global_state(duckdb_v2_table_function_exec_info_handle info,
+                                                               void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_global_state; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_local_state(duckdb_v2_table_function_exec_info_handle info,
+                                                              void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_local_state; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_output_chunk(duckdb_v2_table_function_exec_info_handle info,
+                                                               duckdb_v2_data_chunk_handle *chunk,
+                                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(chunk);
+	return WithErrorHandler(err, [&]() { *chunk = Convert(Convert(info)->output); });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_cardinality_get_user_data(duckdb_v2_table_function_cardinality_info_handle info, void **data,
+                                                   duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_cardinality_get_bind_data(duckdb_v2_table_function_cardinality_info_handle info, void **data,
+                                                   duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_cardinality_set_cardinality(duckdb_v2_table_function_cardinality_info_handle info,
+                                                     idx_t cardinality, bool is_exact,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() {
+		auto &cardinality_info = *Convert(info);
+		cardinality_info.out_cardinality = cardinality;
+		cardinality_info.out_is_exact = is_exact;
+		cardinality_info.out_set = true;
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_user_data(duckdb_v2_table_function_progress_info_handle info,
+                                                                void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_bind_data(duckdb_v2_table_function_progress_info_handle info,
+                                                                void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_global_state(duckdb_v2_table_function_progress_info_handle info,
+                                                                   void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_global_state; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_progress_set_progress(duckdb_v2_table_function_progress_info_handle info,
+                                                               double progress, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_progress = progress; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_register(duckdb_v2_table_function_handle function,
+                                                  duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->Register(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_destroy(duckdb_v2_table_function_handle *function) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!function) {
+			return;
+		}
+		if (*function) {
+			delete Convert(*function);
+			*function = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_func_table.cpp
+++ b/src/main/capi/v2/capi_v2_func_table.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/capi_v2/capi_v2_internal.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/storage/statistics/node_statistics.hpp"
 
 namespace duckdb::capiv2 {
@@ -19,6 +20,9 @@ public:
 	bool cardinality_is_exact = false;
 	bool cardinality_set = false;
 
+	// How many result columns the bind callback declared.
+	idx_t column_count = 0;
+
 	auto Copy() const -> unique_ptr<FunctionData> override {
 		auto copy = make_uniq<CV2TableFunctionData>();
 		copy->handle = handle;
@@ -26,6 +30,7 @@ public:
 		copy->cardinality = cardinality;
 		copy->cardinality_is_exact = cardinality_is_exact;
 		copy->cardinality_set = cardinality_set;
+		copy->column_count = column_count;
 		return std::move(copy);
 	}
 
@@ -43,6 +48,9 @@ public:
 
 	CV2UserData handle;
 	idx_t max_threads = 1;
+
+	// The declared column each vector of the output chunk stands for, kept here so the exec callback can ask.
+	vector<column_t> scan_columns;
 };
 
 class CV2TableLocalState final : public LocalTableFunctionState {
@@ -74,6 +82,7 @@ class CV2TableInitGlobalInfo {
 public:
 	void *in_user_data = nullptr;
 	void *in_bind_data = nullptr;
+	const vector<column_t> *in_scan_columns = nullptr;
 
 	duckdb_v2_opaque out_global_state = {};
 	idx_t out_max_threads = 1;
@@ -91,6 +100,7 @@ public:
 	void *in_user_data = nullptr;
 	void *in_bind_data = nullptr;
 	void *in_global_state = nullptr;
+	const vector<column_t> *in_scan_columns = nullptr;
 
 	duckdb_v2_opaque out_local_state = {};
 };
@@ -108,6 +118,7 @@ public:
 	void *in_bind_data = nullptr;
 	void *in_global_state = nullptr;
 	void *in_local_state = nullptr;
+	const vector<column_t> *in_scan_columns = nullptr;
 
 	DataChunk *output = nullptr;
 };
@@ -135,6 +146,25 @@ static auto Convert(CV2TableProgressInfo *info) -> duckdb_v2_table_function_prog
 	return reinterpret_cast<duckdb_v2_table_function_progress_info_handle>(info);
 }
 
+class CV2TableFilterPushdownInfo {
+public:
+	void *in_user_data = nullptr;
+	void *in_bind_data = nullptr;
+	// The predicates the optimizer offers, borrowed from the engine for the duration of the callback.
+	const vector<unique_ptr<Expression>> *in_filters = nullptr;
+	// What the column references inside the predicates index: the scan's column list at optimization time.
+	const vector<ColumnIndex> *in_column_ids = nullptr;
+
+	vector<bool> out_handled;
+};
+
+static auto Convert(duckdb_v2_table_function_filter_pushdown_info_handle info) -> CV2TableFilterPushdownInfo * {
+	return reinterpret_cast<CV2TableFilterPushdownInfo *>(info);
+}
+static auto Convert(CV2TableFilterPushdownInfo *info) -> duckdb_v2_table_function_filter_pushdown_info_handle {
+	return reinterpret_cast<duckdb_v2_table_function_filter_pushdown_info_handle>(info);
+}
+
 class CV2TableFunctionInfo : public TableFunctionInfo {
 public:
 	duckdb_v2_table_function_bind_callback_fn bind_cb = nullptr;
@@ -142,7 +172,9 @@ public:
 	duckdb_v2_table_function_init_local_callback_fn init_local_cb = nullptr;
 	duckdb_v2_table_function_exec_callback_fn exec_cb = nullptr;
 	duckdb_v2_table_function_progress_callback_fn progress_cb = nullptr;
+	duckdb_v2_table_function_filter_pushdown_callback_fn filter_pushdown_cb = nullptr;
 	shared_ptr<CV2UserData> user_data = nullptr;
+	bool projection_pushdown = false;
 
 	// The signature's slot plan, captured at registration: every parameter name in signature order, how many of them
 	// lead the positional prefix (the ones without a default), and the default of each remaining parameter. The bind
@@ -212,9 +244,24 @@ static auto CV2TableBind(ClientContext &context, TableFunctionBindInput &input, 
 		                            input.table_function.name);
 	}
 
+	result->column_count = args.out_column_types.size();
 	return_types = std::move(args.out_column_types);
 	names = std::move(args.out_column_names);
 	return std::move(result);
+}
+
+//! The declared column behind each vector of the output chunk. With projection pushdown the engine sizes the chunk
+//! to the columns it asked for; without it the chunk always holds every declared column, whatever the engine asked.
+static auto CV2TableScanColumns(const CV2TableFunctionData &bind_data, const TableFunctionInitInput &input)
+    -> vector<column_t> {
+	if (bind_data.info->projection_pushdown) {
+		return input.column_ids;
+	}
+	vector<column_t> columns;
+	for (idx_t i = 0; i < bind_data.column_count; i++) {
+		columns.push_back(i);
+	}
+	return columns;
 }
 
 static auto CV2TableInitGlobal(ClientContext &context, TableFunctionInitInput &input)
@@ -222,8 +269,9 @@ static auto CV2TableInitGlobal(ClientContext &context, TableFunctionInitInput &i
 	const auto &bind_data = input.bind_data->Cast<CV2TableFunctionData>();
 	const auto &info = *bind_data.info;
 
-	// Always produced, even without a callback: it carries the thread count the scan runs with.
+	// Always produced, even without a callback: it carries the thread count and column list the scan runs with.
 	auto result = make_uniq<CV2TableGlobalState>();
+	result->scan_columns = CV2TableScanColumns(bind_data, input);
 	if (!info.init_global_cb) {
 		return std::move(result);
 	}
@@ -231,6 +279,7 @@ static auto CV2TableInitGlobal(ClientContext &context, TableFunctionInitInput &i
 	CV2TableInitGlobalInfo args = {};
 	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
 	args.in_bind_data = bind_data.handle ? bind_data.handle->GetData() : nullptr;
+	args.in_scan_columns = &result->scan_columns;
 
 	CV2ErrorInfo err = {};
 	auto err_ptr = Convert(&err);
@@ -259,9 +308,12 @@ static auto CV2TableInitLocal(ExecutionContext &context, TableFunctionInitInput 
 		return nullptr;
 	}
 
+	auto scan_columns = CV2TableScanColumns(bind_data, input);
+
 	CV2TableInitLocalInfo args = {};
 	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
 	args.in_bind_data = bind_data.handle ? bind_data.handle->GetData() : nullptr;
+	args.in_scan_columns = &scan_columns;
 	if (global_state) {
 		args.in_global_state = global_state->Cast<CV2TableGlobalState>().handle.GetData();
 	}
@@ -294,7 +346,9 @@ static auto CV2TableExec(ClientContext &context, TableFunctionInput &input, Data
 	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
 	args.in_bind_data = bind_data.handle ? bind_data.handle->GetData() : nullptr;
 	if (input.global_state) {
-		args.in_global_state = input.global_state->Cast<CV2TableGlobalState>().handle.GetData();
+		auto &global_state = input.global_state->Cast<CV2TableGlobalState>();
+		args.in_global_state = global_state.handle.GetData();
+		args.in_scan_columns = &global_state.scan_columns;
 	}
 	if (input.local_state) {
 		args.in_local_state = input.local_state->Cast<CV2TableLocalState>().handle.GetData();
@@ -357,6 +411,40 @@ static auto CV2TableProgress(ClientContext &context, const FunctionData *bind_da
 	return MinValue<double>(MaxValue<double>(args.out_progress, 0.0), 1.0) * 100.0;
 }
 
+//! The optimizer hands over the predicates it would otherwise evaluate above the scan; whatever the callback accepts
+//! is removed from the list, and the engine keeps applying the rest itself.
+static auto CV2TableFilterPushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data_p,
+                                   vector<unique_ptr<Expression>> &filters) -> void {
+	if (filters.empty()) {
+		return;
+	}
+	const auto &bind_data = bind_data_p->Cast<CV2TableFunctionData>();
+	const auto &info = *bind_data.info;
+
+	CV2TableFilterPushdownInfo args = {};
+	args.in_user_data = info.user_data ? info.user_data->GetData() : nullptr;
+	args.in_bind_data = bind_data.handle ? bind_data.handle->GetData() : nullptr;
+	args.in_filters = &filters;
+	args.in_column_ids = &get.GetColumnIds();
+	args.out_handled.resize(filters.size(), false);
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	info.filter_pushdown_cb(Convert(&args), Convert(&context), &err_ptr);
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+
+	vector<unique_ptr<Expression>> remaining;
+	for (idx_t i = 0; i < filters.size(); i++) {
+		if (!args.out_handled[i]) {
+			remaining.push_back(std::move(filters[i]));
+		}
+	}
+	filters = std::move(remaining);
+}
+
 class CV2TableFunction {
 public:
 	void Register() {
@@ -397,6 +485,10 @@ public:
 		if (info.progress_cb) {
 			function.table_scan_progress = CV2TableProgress;
 		}
+		if (info.filter_pushdown_cb) {
+			function.pushdown_complex_filter = CV2TableFilterPushdown;
+		}
+		function.projection_pushdown = info.projection_pushdown;
 
 		auto function_info = make_shared_ptr<CV2TableFunctionInfo>(std::move(info));
 		for (idx_t i = 0; i < signature.GetParameterCount(); i++) {
@@ -560,6 +652,20 @@ DUCKDB_V2_ERROR duckdb_v2_table_function_set_progress_callback(duckdb_v2_table_f
 	return WithErrorHandler(err, [&]() { Convert(function)->info.progress_cb = callback; });
 }
 
+DUCKDB_V2_ERROR duckdb_v2_table_function_set_projection_pushdown(duckdb_v2_table_function_handle function, bool enable,
+                                                                 duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.projection_pushdown = enable; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_set_filter_pushdown_callback(duckdb_v2_table_function_handle function,
+                                                      duckdb_v2_table_function_filter_pushdown_callback_fn callback,
+                                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(function);
+	return WithErrorHandler(err, [&]() { Convert(function)->info.filter_pushdown_cb = callback; });
+}
+
 DUCKDB_V2_ERROR duckdb_v2_table_function_bind_get_user_data(duckdb_v2_table_function_bind_info_handle info, void **data,
                                                             duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
@@ -678,6 +784,30 @@ duckdb_v2_table_function_init_global_set_max_threads(duckdb_v2_table_function_in
 	});
 }
 
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_global_get_column_count(duckdb_v2_table_function_init_global_info_handle info,
+                                                      idx_t *count, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_scan_columns->size(); });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_global_get_column_index(duckdb_v2_table_function_init_global_info_handle info,
+                                                      idx_t index, idx_t *column_index,
+                                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(column_index);
+	return WithErrorHandler(err, [&]() {
+		const auto &columns = *Convert(info)->in_scan_columns;
+		if (index >= columns.size()) {
+			throw duckdb::InvalidInputException(
+			    "Index out of bounds in duckdb_v2_table_function_init_global_get_column_index");
+		}
+		*column_index = columns[index];
+	});
+}
+
 DUCKDB_V2_ERROR duckdb_v2_table_function_init_local_get_user_data(duckdb_v2_table_function_init_local_info_handle info,
                                                                   void **data, duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
@@ -706,6 +836,29 @@ duckdb_v2_table_function_init_local_set_local_state(duckdb_v2_table_function_ini
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(data);
 	return WithErrorHandler(err, [&]() { Convert(info)->out_local_state = *data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_local_get_column_count(duckdb_v2_table_function_init_local_info_handle info, idx_t *count,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_scan_columns->size(); });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_init_local_get_column_index(duckdb_v2_table_function_init_local_info_handle info, idx_t index,
+                                                     idx_t *column_index, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(column_index);
+	return WithErrorHandler(err, [&]() {
+		const auto &columns = *Convert(info)->in_scan_columns;
+		if (index >= columns.size()) {
+			throw duckdb::InvalidInputException(
+			    "Index out of bounds in duckdb_v2_table_function_init_local_get_column_index");
+		}
+		*column_index = columns[index];
+	});
 }
 
 DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_user_data(duckdb_v2_table_function_exec_info_handle info, void **data,
@@ -744,6 +897,28 @@ DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_output_chunk(duckdb_v2_table_f
 	return WithErrorHandler(err, [&]() { *chunk = Convert(Convert(info)->output); });
 }
 
+DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_column_count(duckdb_v2_table_function_exec_info_handle info,
+                                                               idx_t *count, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_scan_columns->size(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_table_function_exec_get_column_index(duckdb_v2_table_function_exec_info_handle info,
+                                                               idx_t index, idx_t *column_index,
+                                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(column_index);
+	return WithErrorHandler(err, [&]() {
+		const auto &columns = *Convert(info)->in_scan_columns;
+		if (index >= columns.size()) {
+			throw duckdb::InvalidInputException(
+			    "Index out of bounds in duckdb_v2_table_function_exec_get_column_index");
+		}
+		*column_index = columns[index];
+	});
+}
+
 DUCKDB_V2_ERROR duckdb_v2_table_function_progress_get_user_data(duckdb_v2_table_function_progress_info_handle info,
                                                                 void **data, duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
@@ -769,6 +944,86 @@ DUCKDB_V2_ERROR duckdb_v2_table_function_progress_set_progress(duckdb_v2_table_f
                                                                double progress, duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	return WithErrorHandler(err, [&]() { Convert(info)->out_progress = progress; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_filter_pushdown_get_user_data(duckdb_v2_table_function_filter_pushdown_info_handle info,
+                                                       void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_filter_pushdown_get_bind_data(duckdb_v2_table_function_filter_pushdown_info_handle info,
+                                                       void **data, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_bind_data; });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_filter_pushdown_get_filter_count(duckdb_v2_table_function_filter_pushdown_info_handle info,
+                                                          idx_t *count, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_filters->size(); });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_filter_pushdown_get_filter(duckdb_v2_table_function_filter_pushdown_info_handle info,
+                                                    idx_t index, duckdb_v2_expression_handle *filter,
+                                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(filter);
+	*filter = nullptr;
+	return WithErrorHandler(err, [&]() {
+		const auto &filters = *Convert(info)->in_filters;
+		if (index >= filters.size()) {
+			throw duckdb::InvalidInputException(
+			    "Index out of bounds in duckdb_v2_table_function_filter_pushdown_get_filter");
+		}
+		*filter = Convert(filters[index].get());
+	});
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_filter_pushdown_accept(duckdb_v2_table_function_filter_pushdown_info_handle info, idx_t index,
+                                                duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	return WithErrorHandler(err, [&]() {
+		auto &handled = Convert(info)->out_handled;
+		if (index >= handled.size()) {
+			throw duckdb::InvalidInputException(
+			    "Index out of bounds in duckdb_v2_table_function_filter_pushdown_accept");
+		}
+		handled[index] = true;
+	});
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_filter_pushdown_get_column_count(duckdb_v2_table_function_filter_pushdown_info_handle info,
+                                                          idx_t *count, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(count);
+	return WithErrorHandler(err, [&]() { *count = Convert(info)->in_column_ids->size(); });
+}
+
+DUCKDB_V2_ERROR
+duckdb_v2_table_function_filter_pushdown_get_column_index(duckdb_v2_table_function_filter_pushdown_info_handle info,
+                                                          idx_t index, idx_t *column_index,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(column_index);
+	return WithErrorHandler(err, [&]() {
+		const auto &columns = *Convert(info)->in_column_ids;
+		if (index >= columns.size()) {
+			throw duckdb::InvalidInputException(
+			    "Index out of bounds in duckdb_v2_table_function_filter_pushdown_get_column_index");
+		}
+		// A function registered here declares no virtual columns, so every entry is a declared column.
+		*column_index = columns[index].GetPrimaryIndex();
+	});
 }
 
 DUCKDB_V2_ERROR duckdb_v2_table_function_register(duckdb_v2_table_function_handle function,

--- a/src/main/capi/v2/capi_v2_identifier.cpp
+++ b/src/main/capi/v2/capi_v2_identifier.cpp
@@ -1,0 +1,15 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/common/sql_identifier.hpp"
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_identifier_render_quoted(duckdb_v2_identifier_t name, char *out_text, idx_t out_capacity,
+                                                   idx_t *out_length, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(out_length);
+	return WithErrorHandler(err, [&]() {
+		*out_length = 0;
+		auto rendered = duckdb::SQLIdentifier::ToString(duckdb::string(Convert(name)));
+		FillCallerText(out_text, out_capacity, out_length, rendered, "duckdb_v2_identifier_render_quoted");
+	});
+}

--- a/src/main/capi/v2/capi_v2_logical_type.cpp
+++ b/src/main/capi/v2/capi_v2_logical_type.cpp
@@ -94,11 +94,14 @@ bool IsValidTypeEntry(optional_ptr<CatalogEntry> entry) {
 // lookup), expression-valued params (values arrive pre-folded here), and
 // query-location error context. If engine type binding changes, this
 // mirror must follow. Runs inside a transaction; the caller provides it.
-LogicalType BindTypeByNameV2(ClientContext &context, const string &name, const vector<TypeArgument> &args) {
-	EntryLookupInfo lookup(CatalogType::TYPE_ENTRY, QualifiedName(Identifier(name)));
+LogicalType BindTypeByNameV2(ClientContext &context, const QualifiedName &name, const vector<TypeArgument> &args) {
+	EntryLookupInfo lookup(CatalogType::TYPE_ENTRY, name);
 	CatalogEntryRetriever retriever(context);
 	optional_ptr<CatalogEntry> entry;
-	if (!DatabaseManager::Get(context).HasAttachedDatabase()) {
+	if (name.Path().size() > 1) {
+		// The caller named a catalog or schema: resolve exactly that, without falling back to the system catalog.
+		entry = retriever.GetEntry(lookup, OnEntryNotFound::THROW_EXCEPTION);
+	} else if (!DatabaseManager::Get(context).HasAttachedDatabase()) {
 		entry = retriever.GetEntry(
 		    EntryLookupInfo(lookup, QualifiedName(Identifier::SystemCatalog(), Identifier::InvalidSchema(),
 		                                          lookup.GetEntryIdentifier())));
@@ -230,7 +233,8 @@ static void CreateLogicalTypeFromIdV2(duckdb::ClientContext &context, DUCKDB_V2_
 	}
 	// Bind errors propagate.
 	auto args = CollectTypeArgsV2(param_names, param_values, param_count);
-	auto bound = BindTypeByNameV2(context, duckdb::EnumUtil::ToString(id), args);
+	auto bound =
+	    BindTypeByNameV2(context, duckdb::QualifiedName(duckdb::Identifier(duckdb::EnumUtil::ToString(id))), args);
 	*out_type = Convert(new duckdb::LogicalType(std::move(bound)));
 }
 
@@ -298,7 +302,7 @@ DUCKDB_V2_ERROR duckdb_v2_connection_create_type_from_text(duckdb_v2_connection_
 	});
 }
 
-static void CreateLogicalTypeFromArgsV2(duckdb::ClientContext &context, duckdb_v2_identifier_t name,
+static void CreateLogicalTypeFromArgsV2(duckdb::ClientContext &context, duckdb_v2_qname_handle name,
                                         const duckdb_v2_identifier_t *param_names,
                                         const duckdb_v2_value_handle *param_values, idx_t param_count,
                                         duckdb_v2_logical_type_handle *out_type) {
@@ -308,12 +312,11 @@ static void CreateLogicalTypeFromArgsV2(duckdb::ClientContext &context, duckdb_v
 	*out_type = nullptr;
 	auto args = CollectTypeArgsV2(param_names, param_values, param_count);
 	// Bind errors propagate.
-	auto str = duckdb::string(Convert(name));
-	auto bound = BindTypeByNameV2(context, str, args);
+	auto bound = BindTypeByNameV2(context, *Convert(name), args);
 	*out_type = Convert(new duckdb::LogicalType(std::move(bound)));
 }
 
-DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_name(duckdb_v2_context_handle ctx, duckdb_v2_identifier_t name,
+DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_name(duckdb_v2_context_handle ctx, duckdb_v2_qname_handle name,
                                                         const duckdb_v2_identifier_t *param_names,
                                                         const duckdb_v2_value_handle *param_values, idx_t param_count,
                                                         duckdb_v2_logical_type_handle *out_type,
@@ -328,7 +331,7 @@ DUCKDB_V2_ERROR duckdb_v2_context_create_type_from_name(duckdb_v2_context_handle
 }
 
 DUCKDB_V2_ERROR duckdb_v2_connection_create_type_from_name(duckdb_v2_connection_handle conn,
-                                                           duckdb_v2_identifier_t name,
+                                                           duckdb_v2_qname_handle name,
                                                            const duckdb_v2_identifier_t *param_names,
                                                            const duckdb_v2_value_handle *param_values,
                                                            idx_t param_count, duckdb_v2_logical_type_handle *out_type,

--- a/src/main/capi/v2/capi_v2_prepared_statement.cpp
+++ b/src/main/capi/v2/capi_v2_prepared_statement.cpp
@@ -1,4 +1,4 @@
-#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/main/capi_v2/capi_v2_result_internal.hpp"
 
 namespace duckdb::capiv2 {
 namespace {

--- a/src/main/capi/v2/capi_v2_prepared_statement.cpp
+++ b/src/main/capi/v2/capi_v2_prepared_statement.cpp
@@ -1,0 +1,122 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+
+namespace duckdb::capiv2 {
+namespace {
+
+//! Backing struct for the opaque duckdb_v2_prepared_statement_handle.
+struct PreparedStatementWrapperV2 {
+	//! Declared before `prepared` so it is destroyed after it: ~PreparedStatement reaches
+	//! back into the context to drop the plan it registered there. Held by shared_ptr
+	//! rather than left to the engine's weak_ptr so the handle stays usable after the
+	//! connection is disconnected, the same guarantee an undrained result carries.
+	shared_ptr<ClientContext> context;
+	unique_ptr<PreparedStatement> prepared;
+};
+
+//! The reuse predicate: the exact negation of the engine's re-bind gate
+//! (PreparedStatementData::RequireRebind). A parameter whose type was not resolved at
+//! prepare time, or a non-cacheable plan -- which a table scan makes it -- forces a
+//! re-bind on every execution.
+bool PreparedReusesPlanV2(const StatementProperties &properties) {
+	return properties.bound_all_parameters && !properties.always_require_rebind;
+}
+
+} // namespace
+
+auto Convert(duckdb_v2_prepared_statement_handle ptr) -> PreparedStatementWrapperV2 * {
+	return reinterpret_cast<PreparedStatementWrapperV2 *>(ptr);
+}
+auto Convert(PreparedStatementWrapperV2 *ptr) -> duckdb_v2_prepared_statement_handle {
+	return reinterpret_cast<duckdb_v2_prepared_statement_handle>(ptr);
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public API
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_prepared_statement_create(duckdb_v2_connection_handle conn,
+                                                    duckdb_v2_sql_statement_handle statement, bool require_cacheable,
+                                                    duckdb_v2_prepared_statement_handle *out_prepared,
+                                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(out_prepared);
+	*out_prepared = nullptr;
+	DUCKDB_CHECK_ARG(conn);
+	DUCKDB_CHECK_ARG(statement);
+	return WithErrorHandler(err, [&]() {
+		auto *connection = Convert(conn);
+		// Preparing runs the engine's query cleanup, which would cancel a live stream, so
+		// refuse first. Unlike execute this only checks the slot is free: preparing
+		// produces no result, so it never claims it.
+		if (GetBusySlot(*connection->context)->owner.load() != nullptr) {
+			throw duckdb::ResourceInUseException(
+			    "connection has a live result; drain, destroy, or interrupt it before preparing a statement "
+			    "(or open another connection)");
+		}
+		// Borrowed, not consumed: prepare a copy so the caller keeps the original.
+		auto prepared = connection->context->Prepare(Convert(statement)->Copy());
+		if (prepared->HasError()) {
+			// Prepare reports failure on the returned object rather than throwing; re-throw
+			// the typed ErrorData so its ExceptionType routes through
+			// GetErrorCodeFromExceptionType instead of collapsing into a generic code.
+			prepared->GetErrorObject().Throw();
+		}
+		if (require_cacheable && !PreparedReusesPlanV2(prepared->GetStatementProperties())) {
+			throw duckdb::InvalidInputException(
+			    "prepared_statement_create(require_cacheable): this plan is re-bound on every execution (an unresolved "
+			    "parameter type, or a table scan), so executing it is no faster than statement_execute; prepare "
+			    "without require_cacheable to accept that");
+		}
+		auto wrapper = duckdb::make_uniq<PreparedStatementWrapperV2>();
+		wrapper->context = connection->context;
+		wrapper->prepared = std::move(prepared);
+		*out_prepared = Convert(wrapper.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_prepared_statement_execute(duckdb_v2_prepared_statement_handle prepared,
+                                                     const duckdb_v2_identifier_t *parameter_names,
+                                                     const duckdb_v2_value_handle *parameter_values,
+                                                     idx_t parameter_count, duckdb_v2_result_handle *out_result,
+                                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(out_result);
+	*out_result = nullptr;
+	DUCKDB_CHECK_ARG(prepared);
+	if (parameter_count > 0 && !parameter_values) {
+		return NullArgumentError(err, __func__, "parameter_values");
+	}
+	return WithErrorHandler(err, [&]() {
+		auto *wrapper = Convert(prepared);
+		// Fold the parameter values in as constants, keyed by name when parameter_names
+		// supplies one and positionally ("1".."N") otherwise. Per execution: nothing is
+		// retained on the handle between calls.
+		duckdb::identifier_map_t<duckdb::BoundParameterData> values;
+		BuildParameterMap(parameter_names, parameter_values, parameter_count, __func__, values);
+		*out_result = ExecutePreparedStatementV2(wrapper->context, *wrapper->prepared, values);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_prepared_statement_reuses_plan(duckdb_v2_prepared_statement_handle prepared, bool *out_reuses,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(prepared);
+	DUCKDB_CHECK_ARG(out_reuses);
+	return WithErrorHandler(err, [&]() {
+		auto *wrapper = Convert(prepared);
+		*out_reuses = PreparedReusesPlanV2(wrapper->prepared->GetStatementProperties());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_prepared_statement_destroy(duckdb_v2_prepared_statement_handle *prepared) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!prepared) {
+			return;
+		}
+		if (*prepared) {
+			delete Convert(*prepared);
+			*prepared = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_qname.cpp
+++ b/src/main/capi/v2/capi_v2_qname.cpp
@@ -1,0 +1,125 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+
+#include "duckdb/parser/qualified_name.hpp"
+
+namespace duckdb::capiv2 {
+
+// The handle invariant: between one and three parts, none of them empty. Partial qualification is fewer parts, never
+// an empty placeholder, so this also rejects the placeholder spelling the engine's own constructors accept.
+static void CheckQNameParts(const QualifiedName &name, const char *function_name) {
+	auto &path = name.Path();
+	if (path.empty() || path.size() > 3) {
+		throw InvalidInputException("A qualified name must have between one and three parts in %s.", function_name);
+	}
+	for (auto &part : path) {
+		if (part.empty()) {
+			throw InvalidInputException("A qualified name part cannot be empty in %s.", function_name);
+		}
+	}
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_qname_parse(duckdb_v2_str text, duckdb_v2_qname_handle *out_name,
+                                      duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(text);
+	DUCKDB_CHECK_ARG(out_name);
+	*out_name = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto parsed = duckdb::QualifiedName::Parse(duckdb::string(Convert(text)));
+		CheckQNameParts(parsed, "duckdb_v2_qname_parse");
+		*out_name = Convert(new duckdb::QualifiedName(std::move(parsed)));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_qname_create(const duckdb_v2_identifier_t *parts, idx_t part_count,
+                                       duckdb_v2_qname_handle *out_name, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(out_name);
+	*out_name = nullptr;
+	return WithErrorHandler(err, [&]() {
+		if (part_count == 0 || part_count > 3) {
+			throw duckdb::InvalidInputException(
+			    "A qualified name must have between one and three parts in duckdb_v2_qname_create.");
+		}
+		if (!parts) {
+			throw duckdb::InvalidInputException("Parts cannot be null when part_count is non-zero.");
+		}
+
+		// The last part is the object name; everything before it is the qualification.
+		duckdb::vector<duckdb::Identifier> qualification;
+		for (idx_t i = 0; i + 1 < part_count; i++) {
+			qualification.push_back(duckdb::Identifier(Convert(parts[i])));
+		}
+		auto name = duckdb::QualifiedName(std::move(qualification), duckdb::Identifier(Convert(parts[part_count - 1])));
+		CheckQNameParts(name, "duckdb_v2_qname_create");
+		*out_name = Convert(new duckdb::QualifiedName(std::move(name)));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_qname_get_part_count(duckdb_v2_qname_handle name, idx_t *out_count,
+                                               duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(out_count);
+	return WithErrorHandler(err, [&]() { *out_count = Convert(name)->Path().size(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_qname_get_part(duckdb_v2_qname_handle name, idx_t index, duckdb_v2_identifier_t *out_part,
+                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(out_part);
+	*out_part = duckdb_v2_identifier_t {nullptr, 0};
+	return WithErrorHandler(err, [&]() {
+		auto &path = Convert(name)->Path();
+		if (index >= path.size()) {
+			throw duckdb::Exception(duckdb::ExceptionType::OUT_OF_RANGE,
+			                        duckdb::StringUtil::Format("Part index %llu is out of range for a qualified name "
+			                                                   "with %llu parts in duckdb_v2_qname_get_part.",
+			                                                   static_cast<uint64_t>(index),
+			                                                   static_cast<uint64_t>(path.size())));
+		}
+		*out_part = Convert(path[index]);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_qname_render(duckdb_v2_qname_handle name, char *out_text, idx_t out_capacity,
+                                       idx_t *out_length, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(out_length);
+	return WithErrorHandler(err, [&]() {
+		*out_length = 0;
+		FillCallerText(out_text, out_capacity, out_length, Convert(name)->ToString(), "duckdb_v2_qname_render");
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_qname_equals(duckdb_v2_qname_handle left, duckdb_v2_qname_handle right, bool *result,
+                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(left);
+	DUCKDB_CHECK_ARG(right);
+	DUCKDB_CHECK_ARG(result);
+	return WithErrorHandler(err, [&]() { *result = *Convert(left) == *Convert(right); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_qname_hash(duckdb_v2_qname_handle name, uint64_t *out_hash,
+                                     duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(out_hash);
+	return WithErrorHandler(err, [&]() { *out_hash = Convert(name)->Hash(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_qname_destroy(duckdb_v2_qname_handle *name) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!name) {
+			return;
+		}
+		if (*name) {
+			delete Convert(*name);
+			*name = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_replacement_scan.cpp
+++ b/src/main/capi/v2/capi_v2_replacement_scan.cpp
@@ -1,0 +1,410 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+
+#include "duckdb/function/replacement_scan.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/parser/tableref/column_data_ref.hpp"
+#include "duckdb/parser/tableref/subqueryref.hpp"
+#include "duckdb/parser/tableref/table_function_ref.hpp"
+
+namespace duckdb::capiv2 {
+
+// Which of the three mutually exclusive forms the callback used to claim the reference.
+enum class CV2ReplacementScanClaim : uint8_t { NONE, FUNCTION, COLLECTION, SUBQUERY };
+
+// The registration payload, owned by whichever scan list it was registered into: the connection's ClientConfig for a
+// connection-scoped scan, the database's DBConfig otherwise.
+class CV2ReplacementScanData final : public ReplacementScanData {
+public:
+	duckdb_v2_replacement_scan_callback_fn callback = nullptr;
+	shared_ptr<CV2UserData> user_data = nullptr;
+};
+
+class CV2ReplacementScanInfo {
+public:
+	void *in_user_data = nullptr;
+	ReplacementScanInput *in_input = nullptr;
+	// The callback only receives the info handle, but parsing a subquery needs the query's parser options.
+	optional_ptr<ClientContext> in_context;
+
+	CV2ReplacementScanClaim claim = CV2ReplacementScanClaim::NONE;
+	Identifier out_alias;
+
+	// FUNCTION
+	Identifier out_function_name;
+	vector<Value> out_arguments;
+	vector<std::pair<Identifier, Value>> out_named_arguments;
+
+	// COLLECTION
+	optional_ptr<ColumnDataCollection> out_collection;
+	vector<Identifier> out_column_names;
+
+	// SUBQUERY
+	unique_ptr<SelectStatement> out_subquery;
+
+	// Refuses a second, different claim form. Repeating the same form is allowed and overwrites.
+	void SetClaim(CV2ReplacementScanClaim new_claim) {
+		if (claim != CV2ReplacementScanClaim::NONE && claim != new_claim) {
+			throw InvalidInputException(
+			    "The replacement scan already claimed this reference through a different form.");
+		}
+		claim = new_claim;
+	}
+
+	void RequireFunctionClaim(const char *function_name) {
+		if (claim != CV2ReplacementScanClaim::FUNCTION) {
+			throw InvalidInputException("%s requires duckdb_v2_replacement_scan_set_function_name to be called first.",
+			                            function_name);
+		}
+	}
+
+	auto BuildTableRef() -> unique_ptr<TableRef> {
+		unique_ptr<TableRef> result;
+		switch (claim) {
+		case CV2ReplacementScanClaim::NONE:
+			return nullptr;
+		case CV2ReplacementScanClaim::FUNCTION: {
+			vector<unique_ptr<ParsedExpression>> children;
+			for (auto &argument : out_arguments) {
+				children.push_back(make_uniq<ConstantExpression>(std::move(argument)));
+			}
+			for (auto &named_argument : out_named_arguments) {
+				// A named argument is an argument whose alias is the parameter name: the binder recovers the name
+				// from the expression alias, and drops FunctionArgument::name outright.
+				auto child = make_uniq<ConstantExpression>(std::move(named_argument.second));
+				child->SetAlias(named_argument.first);
+				children.push_back(std::move(child));
+			}
+			auto function = make_uniq<TableFunctionRef>();
+			function->function = make_uniq<FunctionExpression>(out_function_name, std::move(children));
+			result = std::move(function);
+			break;
+		}
+		case CV2ReplacementScanClaim::COLLECTION:
+			// Borrowed: the caller owns the collection and keeps it alive.
+			result = make_uniq<ColumnDataRef>(*out_collection, std::move(out_column_names));
+			break;
+		case CV2ReplacementScanClaim::SUBQUERY:
+			result = make_uniq<SubqueryRef>(std::move(out_subquery));
+			break;
+		}
+		result->alias = out_alias;
+		return result;
+	}
+};
+
+static auto Convert(duckdb_v2_replacement_scan_info_handle info) -> CV2ReplacementScanInfo * {
+	return reinterpret_cast<CV2ReplacementScanInfo *>(info);
+}
+static auto Convert(CV2ReplacementScanInfo *info) -> duckdb_v2_replacement_scan_info_handle {
+	return reinterpret_cast<duckdb_v2_replacement_scan_info_handle>(info);
+}
+
+static auto CV2ReplacementScanTrampoline(ClientContext &context, ReplacementScanInput &input,
+                                         optional_ptr<ReplacementScanData> data) -> unique_ptr<TableRef> {
+	const auto &scan_data = data->Cast<CV2ReplacementScanData>();
+
+	CV2ReplacementScanInfo args;
+	args.in_user_data = scan_data.user_data ? scan_data.user_data->GetData() : nullptr;
+	args.in_input = &input;
+	args.in_context = &context;
+
+	CV2ErrorInfo err = {};
+	auto err_ptr = Convert(&err);
+	scan_data.callback(Convert(&args), Convert(&context), &err_ptr);
+
+	if (err.HasError()) {
+		err.ThrowAsException();
+	}
+	return args.BuildTableRef();
+}
+
+class CV2ReplacementScan {
+public:
+	void Register() {
+		if (!info.callback) {
+			throw InvalidInputException("Callback must be set for the replacement scan.");
+		}
+		if (registered) {
+			throw InvalidInputException("The replacement scan is already registered.");
+		}
+		registered = true;
+
+		auto data = make_uniq<CV2ReplacementScanData>();
+		data->callback = info.callback;
+		data->user_data = info.user_data;
+		RegisterScan(ReplacementScan(CV2ReplacementScanTrampoline, std::move(data)));
+	}
+
+	virtual ~CV2ReplacementScan() = default;
+	virtual void RegisterScan(ReplacementScan scan) = 0;
+
+public:
+	CV2ReplacementScanData info;
+	bool registered = false;
+};
+
+class CV2ConnectionReplacementScan : public CV2ReplacementScan {
+public:
+	explicit CV2ConnectionReplacementScan(Connection &connection) : connection(connection) {
+	}
+
+	void RegisterScan(ReplacementScan scan) override {
+		// Connection-scoped: this touches only the connection's own state, never the shared database config.
+		connection.context->config.replacement_scans.push_back(make_shared_ptr<ReplacementScan>(std::move(scan)));
+	}
+
+private:
+	Connection &connection;
+};
+
+class CV2DatabaseReplacementScan : public CV2ReplacementScan {
+public:
+	explicit CV2DatabaseReplacementScan(DatabaseInstance &db) : db(db) {
+	}
+
+	void RegisterScan(ReplacementScan scan) override {
+		DBConfig::GetConfig(db).replacement_scans.push_back(std::move(scan));
+	}
+
+private:
+	DatabaseInstance &db;
+};
+
+static auto Convert(duckdb_v2_replacement_scan_handle scan) -> CV2ReplacementScan * {
+	return reinterpret_cast<CV2ReplacementScan *>(scan);
+}
+static auto Convert(CV2ReplacementScan *scan) -> duckdb_v2_replacement_scan_handle {
+	return reinterpret_cast<duckdb_v2_replacement_scan_handle>(scan);
+}
+
+// The engine reports an absent catalog/schema as an empty string; the borrowed-view convention is the null view.
+static auto BorrowNamePart(const string &part) -> duckdb_v2_identifier_t {
+	if (part.empty()) {
+		return duckdb_v2_identifier_t {nullptr, 0};
+	}
+	return Convert(part);
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public Functions
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_create_with_connection(duckdb_v2_connection_handle connection,
+                                                                  duckdb_v2_replacement_scan_handle *out_scan,
+                                                                  duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(connection);
+	DUCKDB_CHECK_ARG(out_scan);
+	*out_scan = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &conn = *Convert(connection);
+		auto scan = duckdb::make_uniq<CV2ConnectionReplacementScan>(conn);
+		*out_scan = Convert(scan.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_create_with_database(duckdb_v2_database_handle database,
+                                                                duckdb_v2_replacement_scan_handle *out_scan,
+                                                                duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(database);
+	DUCKDB_CHECK_ARG(out_scan);
+	*out_scan = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &db = *Convert(database)->database->instance;
+		auto scan = duckdb::make_uniq<CV2DatabaseReplacementScan>(db);
+		*out_scan = Convert(scan.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_create_with_extension(duckdb_v2_extension_handle extension,
+                                                                 duckdb_v2_replacement_scan_handle *out_scan,
+                                                                 duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(extension);
+	DUCKDB_CHECK_ARG(out_scan);
+	*out_scan = nullptr;
+	return WithErrorHandler(err, [&]() {
+		auto &db = GetExtensionLoader(extension).GetDatabaseInstance();
+		auto scan = duckdb::make_uniq<CV2DatabaseReplacementScan>(db);
+		*out_scan = Convert(scan.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_callback(duckdb_v2_replacement_scan_handle scan,
+                                                        duckdb_v2_replacement_scan_callback_fn callback,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(scan);
+	return WithErrorHandler(err, [&]() { Convert(scan)->info.callback = callback; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_user_data(duckdb_v2_replacement_scan_handle scan,
+                                                         duckdb_v2_opaque *user_data,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(scan);
+	DUCKDB_CHECK_ARG(user_data);
+	return WithErrorHandler(err, [&]() {
+		Convert(scan)->info.user_data =
+		    duckdb::make_shared_ptr<CV2UserData>(user_data->ptr, user_data->destroy, user_data->equals);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_user_data(duckdb_v2_replacement_scan_info_handle info, void **data,
+                                                         duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(data);
+	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_catalog_name(duckdb_v2_replacement_scan_info_handle info,
+                                                            duckdb_v2_identifier_t *name,
+                                                            duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(err, [&]() { *name = BorrowNamePart(Convert(info)->in_input->catalog_name); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_schema_name(duckdb_v2_replacement_scan_info_handle info,
+                                                           duckdb_v2_identifier_t *name,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(err, [&]() { *name = BorrowNamePart(Convert(info)->in_input->schema_name); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_table_name(duckdb_v2_replacement_scan_info_handle info,
+                                                          duckdb_v2_identifier_t *name,
+                                                          duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(err, [&]() { *name = BorrowNamePart(Convert(info)->in_input->table_name); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_function_name(duckdb_v2_replacement_scan_info_handle info,
+                                                             duckdb_v2_identifier_t name,
+                                                             duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	return WithErrorHandler(err, [&]() {
+		auto &args = *Convert(info);
+		auto function_name = duckdb::Identifier(Convert(name));
+		if (function_name.empty()) {
+			throw duckdb::InvalidInputException("Function name cannot be empty.");
+		}
+		args.SetClaim(CV2ReplacementScanClaim::FUNCTION);
+		args.out_function_name = std::move(function_name);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_add_argument(duckdb_v2_replacement_scan_info_handle info,
+                                                        duckdb_v2_value_handle value,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(value);
+	return WithErrorHandler(err, [&]() {
+		auto &args = *Convert(info);
+		args.RequireFunctionClaim("duckdb_v2_replacement_scan_add_argument");
+		args.out_arguments.push_back(*Convert(value));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_add_named_argument(duckdb_v2_replacement_scan_info_handle info,
+                                                              duckdb_v2_identifier_t name, duckdb_v2_value_handle value,
+                                                              duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(name);
+	DUCKDB_CHECK_ARG(value);
+	return WithErrorHandler(err, [&]() {
+		auto &args = *Convert(info);
+		args.RequireFunctionClaim("duckdb_v2_replacement_scan_add_named_argument");
+		args.out_named_arguments.emplace_back(duckdb::Identifier(Convert(name)), *Convert(value));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_collection(duckdb_v2_replacement_scan_info_handle info,
+                                                          duckdb_v2_column_data_collection_handle collection,
+                                                          const duckdb_v2_identifier_t *column_names,
+                                                          idx_t column_count, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(collection);
+	return WithErrorHandler(err, [&]() {
+		auto &args = *Convert(info);
+		auto &cdc = *Convert(collection);
+
+		// The binder pads a short name list but never truncates a long one, and an empty name trips an assertion
+		// deeper in, so both are refused here.
+		if (column_count > 0 && !column_names) {
+			throw duckdb::InvalidInputException("Column names cannot be null when column_count is non-zero.");
+		}
+		if (column_count > 0 && column_count != cdc.ColumnCount()) {
+			throw duckdb::InvalidInputException(
+			    "The number of column names (%llu) does not match the collection's column count (%llu).", column_count,
+			    cdc.ColumnCount());
+		}
+		duckdb::vector<duckdb::Identifier> names;
+		for (idx_t i = 0; i < column_count; i++) {
+			auto name = duckdb::Identifier(Convert(column_names[i]));
+			if (name.empty()) {
+				throw duckdb::InvalidInputException("Column names cannot be empty.");
+			}
+			names.push_back(std::move(name));
+		}
+
+		args.SetClaim(CV2ReplacementScanClaim::COLLECTION);
+		args.out_collection = &cdc;
+		args.out_column_names = std::move(names);
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_subquery(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_str sql,
+                                                        duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(sql);
+	return WithErrorHandler(err, [&]() {
+		auto &args = *Convert(info);
+
+		// Parsed here rather than when the claim is materialized, so a bad query fails this call instead of
+		// surfacing later as an opaque binding error.
+		duckdb::Parser parser(args.in_context->GetParserOptions());
+		parser.ParseQuery(duckdb::string(Convert(sql)));
+		if (parser.statements.size() != 1) {
+			throw duckdb::InvalidInputException("The replacement subquery must be exactly one SELECT statement.");
+		}
+		if (parser.statements[0]->type != duckdb::StatementType::SELECT_STATEMENT) {
+			throw duckdb::InvalidInputException("The replacement subquery must be a SELECT statement.");
+		}
+
+		args.SetClaim(CV2ReplacementScanClaim::SUBQUERY);
+		args.out_subquery =
+		    duckdb::unique_ptr_cast<duckdb::SQLStatement, duckdb::SelectStatement>(std::move(parser.statements[0]));
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_alias(duckdb_v2_replacement_scan_info_handle info,
+                                                     duckdb_v2_identifier_t alias, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(info);
+	DUCKDB_CHECK_ARG(alias);
+	return WithErrorHandler(err, [&]() { Convert(info)->out_alias = duckdb::Identifier(Convert(alias)); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_register(duckdb_v2_replacement_scan_handle scan,
+                                                    duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(scan);
+	return WithErrorHandler(err, [&]() { Convert(scan)->Register(); });
+}
+
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_destroy(duckdb_v2_replacement_scan_handle *scan) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!scan) {
+			return;
+		}
+		if (*scan) {
+			delete Convert(*scan);
+			*scan = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_replacement_scan.cpp
+++ b/src/main/capi/v2/capi_v2_replacement_scan.cpp
@@ -33,7 +33,7 @@ public:
 	Identifier out_alias;
 
 	// FUNCTION
-	Identifier out_function_name;
+	QualifiedName out_function_name;
 	vector<Value> out_arguments;
 	vector<std::pair<Identifier, Value>> out_named_arguments;
 
@@ -78,6 +78,7 @@ public:
 				children.push_back(std::move(child));
 			}
 			auto function = make_uniq<TableFunctionRef>();
+			// The QualifiedName overload keeps any catalog/schema qualification; the Identifier one would drop it.
 			function->function = make_uniq<FunctionExpression>(out_function_name, std::move(children));
 			result = std::move(function);
 			break;
@@ -180,14 +181,6 @@ static auto Convert(CV2ReplacementScan *scan) -> duckdb_v2_replacement_scan_hand
 	return reinterpret_cast<duckdb_v2_replacement_scan_handle>(scan);
 }
 
-// The engine reports an absent catalog/schema as an empty string; the borrowed-view convention is the null view.
-static auto BorrowNamePart(const string &part) -> duckdb_v2_identifier_t {
-	if (part.empty()) {
-		return duckdb_v2_identifier_t {nullptr, 0};
-	}
-	return Convert(part);
-}
-
 } // namespace duckdb::capiv2
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -260,43 +253,27 @@ DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_user_data(duckdb_v2_replacement_s
 	return WithErrorHandler(err, [&]() { *data = Convert(info)->in_user_data; });
 }
 
-DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_catalog_name(duckdb_v2_replacement_scan_info_handle info,
-                                                            duckdb_v2_identifier_t *name,
-                                                            duckdb_v2_error_info_handle *err) {
+DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_name(duckdb_v2_replacement_scan_info_handle info,
+                                                    duckdb_v2_qname_handle *out_name,
+                                                    duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(name);
-	return WithErrorHandler(err, [&]() { *name = BorrowNamePart(Convert(info)->in_input->catalog_name); });
-}
-
-DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_schema_name(duckdb_v2_replacement_scan_info_handle info,
-                                                           duckdb_v2_identifier_t *name,
-                                                           duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(name);
-	return WithErrorHandler(err, [&]() { *name = BorrowNamePart(Convert(info)->in_input->schema_name); });
-}
-
-DUCKDB_V2_ERROR duckdb_v2_replacement_scan_get_table_name(duckdb_v2_replacement_scan_info_handle info,
-                                                          duckdb_v2_identifier_t *name,
-                                                          duckdb_v2_error_info_handle *err) {
-	DUCKDB_CHECK_ARG(info);
-	DUCKDB_CHECK_ARG(name);
-	return WithErrorHandler(err, [&]() { *name = BorrowNamePart(Convert(info)->in_input->table_name); });
+	DUCKDB_CHECK_ARG(out_name);
+	*out_name = nullptr;
+	return WithErrorHandler(err, [&]() {
+		// Owned, so the callback can keep it: the binder's own name dies with the call.
+		*out_name = Convert(new duckdb::QualifiedName(Convert(info)->in_input->name));
+	});
 }
 
 DUCKDB_V2_ERROR duckdb_v2_replacement_scan_set_function_name(duckdb_v2_replacement_scan_info_handle info,
-                                                             duckdb_v2_identifier_t name,
+                                                             duckdb_v2_qname_handle name,
                                                              duckdb_v2_error_info_handle *err) {
 	DUCKDB_CHECK_ARG(info);
 	DUCKDB_CHECK_ARG(name);
 	return WithErrorHandler(err, [&]() {
 		auto &args = *Convert(info);
-		auto function_name = duckdb::Identifier(Convert(name));
-		if (function_name.empty()) {
-			throw duckdb::InvalidInputException("Function name cannot be empty.");
-		}
 		args.SetClaim(CV2ReplacementScanClaim::FUNCTION);
-		args.out_function_name = std::move(function_name);
+		args.out_function_name = *Convert(name);
 	});
 }
 

--- a/src/main/capi/v2/capi_v2_result.cpp
+++ b/src/main/capi/v2/capi_v2_result.cpp
@@ -491,6 +491,33 @@ auto Convert(duckdb_v2_result_handle handle) -> ResultWrapperV2 * {
 	return reinterpret_cast<ResultWrapperV2 *>(handle);
 }
 
+auto ExecutePreparedStatementV2(const shared_ptr<ClientContext> &context, PreparedStatement &prepared,
+                                identifier_map_t<BoundParameterData> &values) -> duckdb_v2_result_handle {
+	auto wrapper = make_uniq<ResultWrapperV2>();
+	// One live result per connection, claimed the way statement_execute claims it and
+	// before PendingQuery runs, which would otherwise cancel the live stream.
+	auto busy_slot = GetBusySlot(*context);
+	void *expected = nullptr;
+	if (!busy_slot->owner.compare_exchange_strong(expected, wrapper.get())) {
+		throw ResourceInUseException("connection has a live result; drain, destroy, or interrupt it before starting "
+		                             "a new query (or open another connection)");
+	}
+	// On any failure below, the wrapper's destructor releases the slot.
+	wrapper->busy_slot = std::move(busy_slot);
+	wrapper->busy_slot->cancel_requested.store(false, std::memory_order_relaxed);
+	wrapper->context = context;
+	// A prepared statement is always one engine statement: preprocessing, expansion and
+	// the wrapping transaction all happened at prepare time, so this bypasses the fragment
+	// machinery and is always principal. fragment_count is 1 for metadata symmetry only.
+	wrapper->fragment_count = 1;
+	wrapper->BeginPending(prepared.PendingQuery(values, /*allow_stream_result=*/true), true);
+	// The engine runs a prepared statement through an internal EXECUTE, whose statement type
+	// would otherwise be what the result reports. Report the type of the statement that was
+	// prepared instead, so a prepared result is indistinguishable from a stateless one.
+	wrapper->statement_type = prepared.GetStatementType();
+	return Convert(wrapper.release());
+}
+
 } // namespace duckdb::capiv2
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/main/capi/v2/capi_v2_result.cpp
+++ b/src/main/capi/v2/capi_v2_result.cpp
@@ -1,4 +1,4 @@
-#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/main/capi_v2/capi_v2_result_internal.hpp"
 
 #include "duckdb/common/box_renderer.hpp"
 #include "duckdb/common/box_renderer_context.hpp"
@@ -11,142 +11,6 @@
 
 namespace duckdb::capiv2 {
 namespace {
-
-struct ResultWrapperV2 {
-	enum class State : uint8_t { PENDING, STREAMING, FINISHED, CANCELLED, ERRORED };
-
-	~ResultWrapperV2() {
-		// Finalize() (engine cleanup) runs in duckdb_v2_result_destroy, not here:
-		// a destructor must not drive locked engine state behind a catch-all.
-		pending.reset();
-		result.reset();
-		ReleaseBusySlot();
-	}
-
-	State state = State::PENDING;
-	//! Live while state == PENDING.
-	unique_ptr<PendingQueryResult> pending;
-	//! Live while state == STREAMING.
-	unique_ptr<QueryResult> result;
-
-	//! Keeps the ClientContext alive for starting subsequent fragments and
-	//! preserves the guarantee that an undrained result survives disconnect:
-	//! the connection handle (a bare Connection *) may be destroyed while a
-	//! result is live, but the context it shared with us stays alive here.
-	shared_ptr<ClientContext> context;
-	//! The preprocessed statement group; fragment_index points at the next
-	//! fragment to start, fragment_count remembers the group size after
-	//! fragments is cleared on terminal transitions.
-	vector<unique_ptr<SQLStatement>> fragments;
-	idx_t fragment_index = 0;
-	idx_t fragment_count = 0;
-	//! Positional parameter values for this execution, keyed by binding identifier
-	//! ("1".."N"). Empty for an unparameterized statement (StartNextFragment takes
-	//! the no-values path). Applied only to the first fragment (a parameterized
-	//! statement does not expand into a group).
-	identifier_map_t<BoundParameterData> param_values;
-	//! True while the currently executing fragment is the principal one
-	//! (its chunks are surfaced; other fragments' output is discarded).
-	bool principal_active = false;
-	//! True once a row-producing fragment has been selected as principal.
-	bool principal_seen = false;
-	//! True once the principal fragment's metadata has been captured.
-	bool metadata_available = false;
-	//! True when statement_execute injected its own wrapping transaction for
-	//! this group (autocommit input that preprocessing expanded and wrapped
-	//! in BEGIN ... COMMIT). Distinguishes a bridge-owned transaction, which
-	//! must be rolled back on incomplete destroy, from a user-managed one,
-	//! which must not be touched. Captured at query time because the engine's
-	//! auto_rollback flag is not reliably observable from the bridge's
-	//! fragment execution path.
-	bool owns_wrapping_transaction = false;
-
-	//! The owning connection's busy slot; released on terminal transition
-	//! or destroy, whichever comes first.
-	shared_ptr<ConnectionBusySlotV2> busy_slot;
-
-	//! Principal fragment's metadata, valid once metadata_available.
-	vector<LogicalType> types;
-	vector<Identifier> names;
-	StatementType statement_type = StatementType::INVALID_STATEMENT;
-	StatementProperties properties;
-
-	//! Sticky error, recorded when state == ERRORED.
-	ErrorData error;
-
-	//! Mirrors ClientContext::Query's error handling for expanded groups
-	//! (client_context.cpp, chain-append loop): when the group cannot
-	//! complete, roll back the transaction statement_execute injected to wrap
-	//! it. A no-op for non-expanded statements, for groups that ran inside a
-	//! user-managed transaction (which the bridge never wraps), and when the
-	//! transaction is already gone.
-	void RollbackIncompleteGroup() {
-		if (!owns_wrapping_transaction || !context) {
-			return;
-		}
-		if (context->transaction.HasActiveTransaction()) {
-			// Mirrors Connection::Rollback (Query("ROLLBACK") + throw on error),
-			// driven through the retained context so it works after disconnect.
-			auto result = context->Query("ROLLBACK", QueryResultOutputType::FORCE_MATERIALIZED);
-			if (result->HasError()) {
-				result->ThrowError();
-			}
-		}
-	}
-
-	//! Close() the live engine result so an abandoned active query is cleaned
-	//! up (freeing the executor, which breaks the ClientContext ref cycle),
-	//! then roll back an injected group transaction. May throw; the terminal
-	//! states leave pending/result null, so this is then a no-op.
-	void Finalize() {
-		if (pending) {
-			pending->Close();
-		} else if (result && result->GetResultType() == QueryResultType::STREAM_RESULT) {
-			result->Cast<StreamQueryResult>().Close();
-		}
-		RollbackIncompleteGroup();
-	}
-
-	//! Frees the connection for its next query. Only the current owner can
-	//! release the slot, so a release after the connection moved on is a
-	//! no-op.
-	void ReleaseBusySlot() {
-		if (busy_slot) {
-			void *expected = this;
-			busy_slot->owner.compare_exchange_strong(expected, nullptr);
-			busy_slot.reset();
-		}
-	}
-
-	// State-machine entry points; defined in query_result-v2.cpp. All of
-	// them throw DuckDB exceptions on failure (callers wrap in
-	// WithErrorHandler) and record sticky errors before throwing.
-
-	//! Adopts an already-produced pending query into the state machine: the single
-	//! seam both the stateless (fragment) and prepared paths reach. When is_principal,
-	//! captures its metadata and surfaces its chunks. Throws on a pending prepare error.
-	void BeginPending(unique_ptr<PendingQueryResult> pending, bool is_principal);
-	//! Starts the pending query for the next fragment, selecting it as
-	//! principal per the engine-mirrored rule and adopting it via BeginPending.
-	//! Throws on prepare errors.
-	void StartNextFragment();
-	//! Drives one unit of work; never blocks. On CHUNK, out_chunk holds the
-	//! produced chunk; on every other status it is reset.
-	DUCKDB_V2_RESULT_STEP_STATUS Step(unique_ptr<DataChunk> &out_chunk);
-	//! Blocks until Step can make progress. No-op on terminal states.
-	void Wait();
-	//! Blocking convenience: steps/waits until a chunk is produced (returned)
-	//! or the stream ends (nullptr). Cancellation throws InterruptException.
-	unique_ptr<DataChunk> FetchChunkBlocking();
-	//! Throws unless the principal fragment's metadata is available.
-	void RequireMetadata() const;
-
-private:
-	//! Shared error sink: interrupts become the sticky CANCELLED state
-	//! (returned as a status), everything else becomes the sticky ERRORED
-	//! state and throws.
-	DUCKDB_V2_RESULT_STEP_STATUS HandleExecutionError(ErrorData error_data);
-};
 
 // Map duckdb::StatementReturnType to DUCKDB_V2_RESULT_TYPE. Values are
 // numerically identical by §4 of the V2 conventions (numeric enum-id
@@ -165,6 +29,8 @@ DUCKDB_V2_RESULT_TYPE MapResultType(StatementReturnType t) {
 	D_ASSERT(false); // unmapped StatementReturnType variant
 	return DUCKDB_V2_RESULT_TYPE_QUERY_RESULT;
 }
+
+} // anonymous namespace
 
 // ---------------------------------------------------------------------------
 // ResultWrapperV2 state machine
@@ -481,8 +347,6 @@ unique_ptr<DataChunk> ResultWrapperV2::FetchChunkBlocking() {
 		}
 	}
 }
-
-} // anonymous namespace
 
 auto Convert(ResultWrapperV2 *wrapper) -> duckdb_v2_result_handle {
 	return reinterpret_cast<duckdb_v2_result_handle>(wrapper);

--- a/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/src/planner/binder/tableref/bind_basetableref.cpp
@@ -46,49 +46,66 @@ static bool TryLoadExtensionForReplacementScan(ClientContext &context, const str
 }
 
 BoundStatement Binder::BindWithReplacementScan(ClientContext &context, BaseTableRef &ref) {
-	auto &config = DBConfig::GetConfig(context);
 	if (!context.config.use_replacement_scans) {
 		return BoundStatement();
 	}
-	for (auto &scan : config.replacement_scans) {
-		ReplacementScanInput input(ref.GetQualifiedName());
-		auto replacement_function = scan.function(context, input, scan.data.get());
-		if (!replacement_function) {
-			continue;
+	ReplacementScanInput input(ref.GetQualifiedName());
+	unique_ptr<TableRef> replacement_function;
+
+	// Connection-scoped replacement scans are consulted first
+	for (const auto &scan : context.config.replacement_scans) {
+		if (auto result = scan->function(context, input, scan->data.get())) {
+			replacement_function = std::move(result);
+			break;
 		}
-		if (!ref.alias.empty()) {
-			// user-provided alias overrides the default alias
-			replacement_function->alias = ref.alias;
-		} else if (replacement_function->alias.empty()) {
-			// if the replacement scan itself did not provide an alias we use the table name
-			replacement_function->alias = ref.Table();
-		}
-		if (replacement_function->type == TableReferenceType::TABLE_FUNCTION) {
-			auto &table_function = replacement_function->Cast<TableFunctionRef>();
-			table_function.column_name_alias = ref.column_name_alias;
-		} else if (replacement_function->type == TableReferenceType::SUBQUERY) {
-			auto &subquery = replacement_function->Cast<SubqueryRef>();
-			subquery.column_name_alias = ref.column_name_alias;
-		} else {
-			// carry the alias to the wrapping SubqueryRef so qualified references
-			// like `SELECT d.x FROM _ AS d` can resolve against the outer ref
-			auto inner_alias = replacement_function->alias;
-			auto select_node = make_uniq<SelectNode>();
-			select_node->select_list.push_back(make_uniq<StarExpression>());
-			select_node->from_table = std::move(replacement_function);
-			auto select_stmt = make_uniq<SelectStatement>();
-			select_stmt->node = std::move(select_node);
-			auto subquery = make_uniq<SubqueryRef>(std::move(select_stmt));
-			subquery->alias = std::move(inner_alias);
-			subquery->column_name_alias = ref.column_name_alias;
-			replacement_function = std::move(subquery);
-		}
-		if (GetBindingMode() == BindingMode::EXTRACT_REPLACEMENT_SCANS) {
-			AddReplacementScan(ref.Table(), replacement_function->Copy());
-		}
-		return Bind(*replacement_function);
 	}
-	return BoundStatement();
+
+	// Then the database-wide ones, including the built-in file scans
+	if (!replacement_function) {
+		for (const auto &scan : DBConfig::GetConfig(context).replacement_scans) {
+			if (auto result = scan.function(context, input, scan.data.get())) {
+				replacement_function = std::move(result);
+				break;
+			}
+		}
+	}
+
+	if (!replacement_function) {
+		return BoundStatement();
+	}
+
+	if (!ref.alias.empty()) {
+		// user-provided alias overrides the default alias
+		replacement_function->alias = ref.alias;
+	} else if (replacement_function->alias.empty()) {
+		// if the replacement scan itself did not provide an alias we use the table name
+		replacement_function->alias = ref.Table();
+	}
+	if (replacement_function->type == TableReferenceType::TABLE_FUNCTION) {
+		auto &table_function = replacement_function->Cast<TableFunctionRef>();
+		table_function.column_name_alias = ref.column_name_alias;
+	} else if (replacement_function->type == TableReferenceType::SUBQUERY) {
+		auto &subquery = replacement_function->Cast<SubqueryRef>();
+		subquery.column_name_alias = ref.column_name_alias;
+	} else {
+		// carry the alias to the wrapping SubqueryRef so qualified references
+		// like `SELECT d.x FROM _ AS d` can resolve against the outer ref
+		auto inner_alias = replacement_function->alias;
+		auto select_node = make_uniq<SelectNode>();
+		select_node->select_list.push_back(make_uniq<StarExpression>());
+		select_node->from_table = std::move(replacement_function);
+		auto select_stmt = make_uniq<SelectStatement>();
+		select_stmt->node = std::move(select_node);
+		auto subquery = make_uniq<SubqueryRef>(std::move(select_stmt));
+		subquery->alias = std::move(inner_alias);
+		subquery->column_name_alias = ref.column_name_alias;
+		replacement_function = std::move(subquery);
+	}
+	if (GetBindingMode() == BindingMode::EXTRACT_REPLACEMENT_SCANS) {
+		AddReplacementScan(ref.Table(), replacement_function->Copy());
+	}
+
+	return Bind(*replacement_function);
 }
 
 unique_ptr<BoundAtClause> Binder::BindAtClause(optional_ptr<AtClause> at_clause) {

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library_unity(
   test_capi_v2_bytes.cpp
   test_capi_v2_cast_function.cpp
   test_capi_v2_column_data_collection.cpp
+  test_capi_v2_copy_function.cpp
   test_capi_v2_custom_type.cpp
   test_capi_v2_data_chunk.cpp
   test_capi_v2_error_info.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   test_capi_v2_file_system.cpp
   test_capi_v2_logical_type.cpp
   test_capi_v2_option.cpp
+  test_capi_v2_prepared_statement.cpp
   test_capi_v2_qname.cpp
   test_capi_v2_query.cpp
   test_capi_v2_replacement_scan.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   test_capi_v2_data_chunk.cpp
   test_capi_v2_error_info.cpp
   test_capi_v2_file_system.cpp
+  test_capi_v2_identifier.cpp
   test_capi_v2_logical_type.cpp
   test_capi_v2_option.cpp
   test_capi_v2_prepared_statement.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library_unity(
   test_capi_v2_aggregate_function.cpp
   test_capi_v2_scalar_function.cpp
   test_capi_v2_statement.cpp
+  test_capi_v2_table_function.cpp
   test_capi_v2_static_extension.cpp
   test_capi_v2_value.cpp
   test_capi_v2_vector_write.cpp)

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   test_capi_v2_logical_type.cpp
   test_capi_v2_option.cpp
   test_capi_v2_query.cpp
+  test_capi_v2_replacement_scan.cpp
   test_capi_v2_result.cpp
   test_capi_v2_aggregate_function.cpp
   test_capi_v2_scalar_function.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library_unity(
   test_capi_v2_error_info.cpp
   test_capi_v2_logical_type.cpp
   test_capi_v2_option.cpp
+  test_capi_v2_qname.cpp
   test_capi_v2_query.cpp
   test_capi_v2_replacement_scan.cpp
   test_capi_v2_result.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -5,7 +5,9 @@ add_library_unity(
   test_capi_v2_basic.cpp
   test_capi_v2_arena.cpp
   test_capi_v2_bytes.cpp
+  test_capi_v2_cast_function.cpp
   test_capi_v2_column_data_collection.cpp
+  test_capi_v2_custom_type.cpp
   test_capi_v2_data_chunk.cpp
   test_capi_v2_error_info.cpp
   test_capi_v2_logical_type.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library_unity(
   test_capi_v2.cpp
   test_capi_v2_basic.cpp
   test_capi_v2_arena.cpp
+  test_capi_v2_arrow.cpp
   test_capi_v2_bytes.cpp
   test_capi_v2_cast_function.cpp
   test_capi_v2_column_data_collection.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library_unity(
   test_capi_v2_custom_type.cpp
   test_capi_v2_data_chunk.cpp
   test_capi_v2_error_info.cpp
+  test_capi_v2_file_system.cpp
   test_capi_v2_logical_type.cpp
   test_capi_v2_option.cpp
   test_capi_v2_qname.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library_unity(
   test_capi_v2_custom_type.cpp
   test_capi_v2_data_chunk.cpp
   test_capi_v2_error_info.cpp
+  test_capi_v2_expression.cpp
   test_capi_v2_file_system.cpp
   test_capi_v2_identifier.cpp
   test_capi_v2_logical_type.cpp

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library_unity(
   test_capi_v2_arena.cpp
   test_capi_v2_arrow.cpp
   test_capi_v2_bytes.cpp
+  test_capi_v2_catalog.cpp
   test_capi_v2_cast_function.cpp
   test_capi_v2_column_data_collection.cpp
   test_capi_v2_copy_function.cpp

--- a/test/api/capi/v2/test_capi_v2.hpp
+++ b/test/api/capi/v2/test_capi_v2.hpp
@@ -657,10 +657,17 @@ inline duckdb_v2_logical_type_handle MakeType(duckdb_v2_connection_handle conn, 
 			name_views.push_back(Convert(n));
 		}
 	}
+	// The type name is a qualified name; an unqualified one is a single part.
+	duckdb_v2_identifier_t parts[1] = {Convert(name)};
+	duckdb_v2_qname_handle qname = nullptr;
+	DUCKDB_V2_ERROR rc = duckdb_v2_qname_create(parts, 1, &qname, nullptr);
 	duckdb_v2_logical_type_handle t = nullptr;
-	DUCKDB_V2_ERROR rc = duckdb_v2_connection_create_type_from_name(
-	    conn, Convert(name), names ? name_views.data() : nullptr, values.empty() ? nullptr : values.data(),
-	    values.size(), &t, nullptr);
+	if (rc == DUCKDB_V2_ERROR_NONE) {
+		rc = duckdb_v2_connection_create_type_from_name(conn, qname, names ? name_views.data() : nullptr,
+		                                                values.empty() ? nullptr : values.data(), values.size(), &t,
+		                                                nullptr);
+	}
+	duckdb_v2_qname_destroy(&qname);
 	for (auto &v : values) {
 		duckdb_v2_value_destroy(&v);
 	}

--- a/test/api/capi/v2/test_capi_v2_arrow.cpp
+++ b/test/api/capi/v2/test_capi_v2_arrow.cpp
@@ -1,0 +1,832 @@
+#include "test_capi_v2.hpp"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// V2 Arrow C Data Interface tests.
+//
+// The chunk converters take a context, which only a callback has, so the value
+// round-trips run through two harnesses registered on the connection:
+// arrow_roundtrip(x), a scalar function pushing its argument through
+// chunk -> Arrow array -> chunk, and arrow_roundtrip_range(n), a table function
+// building its own multi-column chunks and round-tripping each one. A value
+// survives iff arrow_roundtrip(x) IS NOT DISTINCT FROM x, so the assertions are
+// ordinary SQL.
+//
+// Callbacks must not use Catch assertions: a REQUIRE would throw through the C
+// boundary into the engine. They populate the error slot and return instead, and
+// the failure surfaces as a query error.
+//
+// The Arrow structs come from duckdb_v2.h; this file includes no Arrow header.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+namespace {
+
+duckdb_v2_identifier_t ArrowIdent(const char *s) {
+	return duckdb_v2_identifier_t {s, std::strlen(s)};
+}
+
+// Builds a type inside a callback. Returns null after populating the error slot.
+duckdb_v2_logical_type_handle ArrowTypeInCallback(duckdb_v2_context_handle context, DUCKDB_V2_LOGICAL_TYPE_ID id,
+                                                  duckdb_v2_error_info_handle *err) {
+	duckdb_v2_logical_type_handle type = nullptr;
+	if (duckdb_v2_context_create_type_from_id(context, id, nullptr, nullptr, 0, &type, err) != DUCKDB_V2_ERROR_NONE) {
+		return nullptr;
+	}
+	return type;
+}
+
+// ---------------------------------------------------------------------------
+// arrow_roundtrip(x): passes its argument straight through the Arrow chunk
+// converters and returns it unchanged. Declared with an ANY return; the bind
+// callback reads the argument type, matches the return type to it, and resolves
+// the converter once. One function therefore exercises the exec-phase
+// converters over every type, nested ones included.
+// ---------------------------------------------------------------------------
+
+void ArrowRtDestroyConverter(void *ptr) {
+	auto converter = reinterpret_cast<duckdb_v2_arrow_converter_handle>(ptr);
+	duckdb_v2_arrow_converter_destroy(&converter);
+}
+
+void ArrowRtBind(duckdb_v2_scalar_function_bind_info_handle info, duckdb_v2_context_handle context,
+                 duckdb_v2_error_info_handle *err) {
+	duckdb_v2_logical_type_handle arg_type = nullptr;
+	if (duckdb_v2_scalar_function_bind_get_arg_type(info, 0, &arg_type, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	// The result type follows the argument type.
+	auto rc = duckdb_v2_scalar_function_bind_set_return_type(info, arg_type, err);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_logical_type_destroy(&arg_type);
+		return;
+	}
+	// Resolve the one-column Arrow schema for this type into a converter.
+	ArrowSchema schema {};
+	auto name = Convert("x");
+	rc = duckdb_v2_logical_types_to_arrow_schema(context, &arg_type, &name, 1, &schema, err);
+	duckdb_v2_logical_type_destroy(&arg_type);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_arrow_converter_handle converter = nullptr;
+	rc = duckdb_v2_arrow_converter_create(context, &schema, &converter, err);
+	schema.release(&schema);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	// The converter rides the bind data and dies with the binding.
+	duckdb_v2_opaque bind_data = {converter, ArrowRtDestroyConverter, nullptr};
+	duckdb_v2_scalar_function_bind_set_bind_data(info, &bind_data, err);
+}
+
+void ArrowRtExec(duckdb_v2_scalar_function_exec_info_handle info, duckdb_v2_context_handle context,
+                 duckdb_v2_error_info_handle *err) {
+	void *bind_data = nullptr;
+	duckdb_v2_vector_handle arg = nullptr;
+	duckdb_v2_vector_handle result = nullptr;
+	idx_t count = 0;
+	if (duckdb_v2_scalar_function_exec_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_scalar_function_exec_get_arg(info, 0, &arg, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_scalar_function_exec_get_result(info, &result, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_scalar_function_exec_get_row_count(info, &count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto converter = reinterpret_cast<duckdb_v2_arrow_converter_handle>(bind_data);
+
+	// Wrap the argument vector in a one-column chunk, which is what the exporter takes.
+	duckdb_v2_logical_type_handle arg_type = nullptr;
+	if (duckdb_v2_vector_get_logical_type(arg, &arg_type, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_data_chunk_handle input = nullptr;
+	auto rc = duckdb_v2_data_chunk_create(&arg_type, 1, &input, err);
+	duckdb_v2_logical_type_destroy(&arg_type);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_vector_handle input_vector = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(input, 0, &input_vector, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_reference(input_vector, arg, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_set_size(input_vector, count, err) != DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_data_chunk_destroy(&input);
+		return;
+	}
+
+	ArrowArray array {};
+	rc = duckdb_v2_data_chunk_to_arrow_array(context, input, &array, err);
+	duckdb_v2_data_chunk_destroy(&input);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_data_chunk_handle imported = nullptr;
+	rc = duckdb_v2_arrow_converter_array_to_chunk(context, &array, converter, &imported, err);
+	// The import adopts the array and nulls its release, so this only fires when the import
+	// failed before taking ownership.
+	if (array.release) {
+		array.release(&array);
+	}
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	// Reference the re-imported column into the result: zero-copy, and the shared buffers keep
+	// the data alive after the imported chunk goes away.
+	duckdb_v2_vector_handle imported_vector = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(imported, 0, &imported_vector, err) == DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_vector_reference(result, imported_vector, err);
+	}
+	duckdb_v2_data_chunk_destroy(&imported);
+}
+
+void RegisterArrowRoundtrip(duckdb_v2_connection_handle conn) {
+	duckdb_v2_scalar_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_create_with_connection(conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto name = Convert("arrow_roundtrip");
+	REQUIRE(duckdb_v2_scalar_function_set_name(function, &name, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	auto any = MakeType(conn, DUCKDB_V2_LOGICAL_TYPE_ID_ANY);
+	duckdb_v2_function_signature_handle sig = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_get_signature(function, &sig, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_add_parameter(sig, ArrowIdent("x"), any, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_set_return_type(sig, any, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	REQUIRE(duckdb_v2_scalar_function_set_bind_callback(function, ArrowRtBind, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_set_exec_callback(function, ArrowRtExec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_scalar_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&any);
+}
+
+// ---------------------------------------------------------------------------
+// arrow_roundtrip_range(n): emits n rows of (i BIGINT, s VARCHAR) where
+// i = row index and s = 'r' || i, every chunk having gone through the Arrow
+// converters first. This drives the structural edges the scalar harness cannot
+// reach: multi-column import, and an array longer than one vector.
+// ---------------------------------------------------------------------------
+
+struct ArrowRangeBind {
+	int64_t count = 0;
+	duckdb_v2_arrow_converter_handle converter = nullptr;
+};
+struct ArrowRangeGlobal {
+	int64_t emitted = 0;
+};
+
+void ArrowRangeDestroyBind(void *ptr) {
+	auto *bind = static_cast<ArrowRangeBind *>(ptr);
+	duckdb_v2_arrow_converter_destroy(&bind->converter);
+	delete bind;
+}
+void ArrowRangeDestroyGlobal(void *ptr) {
+	delete static_cast<ArrowRangeGlobal *>(ptr);
+}
+
+void ArrowRangeBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                      duckdb_v2_error_info_handle *err) {
+	duckdb_v2_value_handle value = nullptr;
+	if (duckdb_v2_table_function_bind_get_arg_value(info, 0, &value, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	int64_t count = 0;
+	auto rc = duckdb_v2_value_get_bigint(value, &count, err);
+	duckdb_v2_value_destroy(&value);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	auto bigint = ArrowTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, err);
+	auto varchar = ArrowTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR, err);
+	if (!bigint || !varchar) {
+		duckdb_v2_logical_type_destroy(&bigint);
+		duckdb_v2_logical_type_destroy(&varchar);
+		return;
+	}
+	duckdb_v2_table_function_bind_add_result_column(info, ArrowIdent("i"), bigint, err);
+	duckdb_v2_table_function_bind_add_result_column(info, ArrowIdent("s"), varchar, err);
+
+	// Resolve the two-column schema once, for every chunk this scan will produce.
+	duckdb_v2_logical_type_handle types[2] = {bigint, varchar};
+	duckdb_v2_str names[2] = {Convert("i"), Convert("s")};
+	ArrowSchema schema {};
+	rc = duckdb_v2_logical_types_to_arrow_schema(context, types, names, 2, &schema, err);
+	duckdb_v2_logical_type_destroy(&bigint);
+	duckdb_v2_logical_type_destroy(&varchar);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_arrow_converter_handle converter = nullptr;
+	rc = duckdb_v2_arrow_converter_create(context, &schema, &converter, err);
+	schema.release(&schema);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	auto *bind = new ArrowRangeBind {count, converter};
+	duckdb_v2_opaque bind_data = {bind, ArrowRangeDestroyBind, nullptr};
+	duckdb_v2_table_function_bind_set_bind_data(info, &bind_data, err);
+}
+
+void ArrowRangeInitCb(duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_context_handle,
+                      duckdb_v2_error_info_handle *err) {
+	duckdb_v2_opaque state = {new ArrowRangeGlobal(), ArrowRangeDestroyGlobal, nullptr};
+	duckdb_v2_table_function_init_global_set_global_state(info, &state, err);
+}
+
+void ArrowRangeExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle context,
+                      duckdb_v2_error_info_handle *err) {
+	void *raw_bind = nullptr;
+	void *raw_global = nullptr;
+	duckdb_v2_data_chunk_handle output = nullptr;
+	if (duckdb_v2_table_function_exec_get_bind_data(info, &raw_bind, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_global_state(info, &raw_global, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_output_chunk(info, &output, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &bind = *static_cast<ArrowRangeBind *>(raw_bind);
+	auto &global = *static_cast<ArrowRangeGlobal *>(raw_global);
+
+	duckdb_v2_vector_handle out_i = nullptr;
+	duckdb_v2_vector_handle out_s = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(output, 0, &out_i, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_data_chunk_get_vector(output, 1, &out_s, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	if (global.emitted >= bind.count) {
+		duckdb_v2_vector_set_size(out_i, 0, err);
+		return;
+	}
+	auto remaining = static_cast<idx_t>(bind.count - global.emitted);
+	auto rows = remaining < STANDARD_VECTOR_SIZE ? remaining : static_cast<idx_t>(STANDARD_VECTOR_SIZE);
+
+	// Build a fresh input chunk and fill it.
+	auto bigint = ArrowTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, err);
+	auto varchar = ArrowTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR, err);
+	if (!bigint || !varchar) {
+		duckdb_v2_logical_type_destroy(&bigint);
+		duckdb_v2_logical_type_destroy(&varchar);
+		return;
+	}
+	duckdb_v2_logical_type_handle types[2] = {bigint, varchar};
+	duckdb_v2_data_chunk_handle input = nullptr;
+	auto rc = duckdb_v2_data_chunk_create(types, 2, &input, err);
+	duckdb_v2_logical_type_destroy(&bigint);
+	duckdb_v2_logical_type_destroy(&varchar);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_vector_handle in_i = nullptr;
+	duckdb_v2_vector_handle in_s = nullptr;
+	int64_t *i_data = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(input, 0, &in_i, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_data_chunk_get_vector(input, 1, &in_s, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(in_i, reinterpret_cast<void **>(&i_data), err) != DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_data_chunk_destroy(&input);
+		return;
+	}
+	for (idx_t row = 0; row < rows; row++) {
+		auto value = global.emitted + static_cast<int64_t>(row);
+		i_data[row] = value;
+		auto text = "r" + std::to_string(value);
+		if (V2VectorAssignString(in_s, row, text.c_str(), text.size(), err) != DUCKDB_V2_ERROR_NONE) {
+			duckdb_v2_data_chunk_destroy(&input);
+			return;
+		}
+	}
+	duckdb_v2_vector_set_size(in_i, rows, err);
+	duckdb_v2_vector_set_size(in_s, rows, err);
+
+	ArrowArray array {};
+	rc = duckdb_v2_data_chunk_to_arrow_array(context, input, &array, err);
+	duckdb_v2_data_chunk_destroy(&input);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_data_chunk_handle imported = nullptr;
+	rc = duckdb_v2_arrow_converter_array_to_chunk(context, &array, bind.converter, &imported, err);
+	if (array.release) {
+		array.release(&array);
+	}
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_vector_handle imported_i = nullptr;
+	duckdb_v2_vector_handle imported_s = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(imported, 0, &imported_i, err) == DUCKDB_V2_ERROR_NONE &&
+	    duckdb_v2_data_chunk_get_vector(imported, 1, &imported_s, err) == DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_vector_reference(out_i, imported_i, err);
+		duckdb_v2_vector_reference(out_s, imported_s, err);
+	}
+	duckdb_v2_data_chunk_destroy(&imported);
+	duckdb_v2_vector_set_size(out_i, rows, err);
+	global.emitted += static_cast<int64_t>(rows);
+}
+
+void RegisterArrowRoundtripRange(duckdb_v2_connection_handle conn) {
+	duckdb_v2_table_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_table_function_create_with_connection(conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto name = Convert("arrow_roundtrip_range");
+	REQUIRE(duckdb_v2_table_function_set_name(function, &name, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	auto bigint = MakeType(conn, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	duckdb_v2_function_signature_handle sig = nullptr;
+	REQUIRE(duckdb_v2_table_function_get_signature(function, &sig, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_add_parameter(sig, ArrowIdent("n"), bigint, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, ArrowRangeBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, ArrowRangeInitCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, ArrowRangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&bigint);
+}
+
+// ---------------------------------------------------------------------------
+// Stream helpers
+// ---------------------------------------------------------------------------
+
+// Exports a query's result as an Arrow stream. The result is consumed.
+DUCKDB_V2_ERROR ArrowStreamFor(duckdb_v2_connection_handle conn, const char *sql, idx_t batch_size,
+                               ArrowArrayStream *out, duckdb_v2_error_info_handle *err = nullptr) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql, &result) == DUCKDB_V2_ERROR_NONE);
+	auto rc = duckdb_v2_result_to_arrow_stream(&result, batch_size, out, err);
+	// Consumed on every path that reaches the engine.
+	REQUIRE(result == nullptr);
+	return rc;
+}
+
+struct ArrowStreamStats {
+	int64_t rows = 0;
+	idx_t arrays = 0;
+	int64_t first_array_rows = 0;
+};
+
+// Drives get_next to exhaustion, releasing each array.
+ArrowStreamStats DrainArrowStream(ArrowArrayStream &stream) {
+	ArrowStreamStats stats;
+	while (true) {
+		ArrowArray array {};
+		REQUIRE(stream.get_next(&stream, &array) == 0);
+		if (!array.release) {
+			break;
+		}
+		if (stats.arrays == 0) {
+			stats.first_array_rows = array.length;
+		}
+		stats.rows += array.length;
+		stats.arrays++;
+		array.release(&array);
+	}
+	return stats;
+}
+
+// Runs a single-row single-BOOLEAN query. The queries below aggregate with bool_and over a
+// non-empty set, so the row is never NULL.
+bool ArrowQueryBool(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql, &result) == DUCKDB_V2_ERROR_NONE);
+	auto chunk = StepChunk(result);
+	REQUIRE(chunk != nullptr);
+	duckdb_v2_vector_handle vec = nullptr;
+	REQUIRE(duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_vector_view view {};
+	REQUIRE(duckdb_v2_vector_get_view(vec, &view, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(view.data != nullptr);
+	auto value = reinterpret_cast<const bool *>(view.data)[SelAt(view.sel, 0)];
+	duckdb_v2_data_chunk_destroy(&chunk);
+	duckdb_v2_result_destroy(&result);
+	return value;
+}
+
+} // namespace
+
+// ===========================================================================
+// Value round-trips: DuckDB chunk -> Arrow array -> DuckDB chunk.
+// ===========================================================================
+
+TEST_CASE("V2 arrow: a flat round-trip preserves values", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	RegisterArrowRoundtrip(fx.conn);
+
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(i) IS NOT DISTINCT FROM i) "
+	                                "FROM range(-100, 100) t(i)"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(d) IS NOT DISTINCT FROM d) "
+	                                "FROM (SELECT i * 1.5 AS d FROM range(50) t(i))"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(s) IS NOT DISTINCT FROM s) "
+	                                "FROM (SELECT 'value_' || i AS s FROM range(50) t(i))"));
+	// Booleans, dates and blobs travel through their own Arrow layouts.
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(b) IS NOT DISTINCT FROM b) "
+	                                "FROM (SELECT i % 2 = 0 AS b FROM range(20) t(i))"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(d) IS NOT DISTINCT FROM d) "
+	                                "FROM (SELECT DATE '2020-01-01' + i::INTEGER AS d FROM range(20) t(i))"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(x) IS NOT DISTINCT FROM x) "
+	                                "FROM (SELECT ('blob_' || i)::BLOB AS x FROM range(20) t(i))"));
+}
+
+TEST_CASE("V2 arrow: NULLs survive a round-trip", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	RegisterArrowRoundtrip(fx.conn);
+
+	// Every third value is NULL, so validity has to cross both ways.
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(v) IS NOT DISTINCT FROM v) "
+	                                "FROM (SELECT CASE WHEN i % 3 = 0 THEN NULL ELSE i END AS v FROM range(60) t(i))"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(v) IS NOT DISTINCT FROM v) "
+	                                "FROM (SELECT CASE WHEN i % 3 = 0 THEN NULL ELSE 's' || i END AS v "
+	                                "FROM range(60) t(i))"));
+	// An all-NULL column, where the array may carry no buffers at all.
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(v) IS NULL) "
+	                                "FROM (SELECT NULL::INTEGER AS v FROM range(10) t(i))"));
+}
+
+TEST_CASE("V2 arrow: nested values survive a round-trip", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	RegisterArrowRoundtrip(fx.conn);
+
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(l) IS NOT DISTINCT FROM l) "
+	                                "FROM (SELECT [i, i + 1, i + 2] AS l FROM range(30) t(i))"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(s) IS NOT DISTINCT FROM s) "
+	                                "FROM (SELECT {'a': i, 'b': 'x' || i} AS s FROM range(30) t(i))"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(m) IS NOT DISTINCT FROM m) "
+	                                "FROM (SELECT MAP {'k' || i: i} AS m FROM range(30) t(i))"));
+	// A list of structs, and a struct holding a list with NULLs inside.
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(v) IS NOT DISTINCT FROM v) "
+	                                "FROM (SELECT [{'a': i}, {'a': i + 1}] AS v FROM range(20) t(i))"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(arrow_roundtrip(v) IS NOT DISTINCT FROM v) "
+	                                "FROM (SELECT {'l': [i, NULL, i + 2]} AS v FROM range(20) t(i))"));
+}
+
+TEST_CASE("V2 arrow: a multi-column round-trip preserves rows", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	RegisterArrowRoundtripRange(fx.conn);
+
+	// Every row comes back through the converters, so this checks both columns and the
+	// row count at once.
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(s = 'r' || i) FROM arrow_roundtrip_range(100)"));
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT count(*) = 100 AND min(i) = 0 AND max(i) = 99 "
+	                                "FROM arrow_roundtrip_range(100)"));
+	// More rows than fit in one vector, so several arrays are converted in sequence.
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT count(*) = 5000 AND sum(i) = 12497500 "
+	                                "FROM arrow_roundtrip_range(5000)"));
+	// And the empty case.
+	REQUIRE(ArrowQueryBool(fx.conn, "SELECT count(*) = 0 FROM arrow_roundtrip_range(0)"));
+}
+
+// ===========================================================================
+// result_to_arrow_stream
+// ===========================================================================
+
+TEST_CASE("V2 arrow: a stream yields every row and a stable schema", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	ArrowArrayStream stream {};
+	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i, 'r' || i AS s FROM range(1000) t(i)", 0, &stream) ==
+	        DUCKDB_V2_ERROR_NONE);
+
+	// The schema is available before a single row is pulled, and each call hands out an
+	// independently owned copy.
+	ArrowSchema schema {};
+	REQUIRE(stream.get_schema(&stream, &schema) == 0);
+	REQUIRE(schema.release != nullptr);
+	REQUIRE(schema.n_children == 2);
+	REQUIRE(std::string(schema.children[0]->name) == "i");
+	REQUIRE(std::string(schema.children[1]->name) == "s");
+	schema.release(&schema);
+
+	ArrowSchema again {};
+	REQUIRE(stream.get_schema(&stream, &again) == 0);
+	REQUIRE(again.n_children == 2);
+	again.release(&again);
+
+	auto stats = DrainArrowStream(stream);
+	REQUIRE(stats.rows == 1000);
+	REQUIRE(stats.arrays >= 1);
+	// Exhaustion is idempotent.
+	ArrowArray trailing {};
+	REQUIRE(stream.get_next(&stream, &trailing) == 0);
+	REQUIRE(trailing.release == nullptr);
+
+	stream.release(&stream);
+	REQUIRE(stream.release == nullptr);
+}
+
+TEST_CASE("V2 arrow: a stream coalesces chunks to batch_size", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	// batch_size 1 gives one row per array, which pins that the setting is honored rather
+	// than ignored in favor of the engine's own chunking.
+	ArrowArrayStream single {};
+	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i FROM range(7) t(i)", 1, &single) == DUCKDB_V2_ERROR_NONE);
+	auto single_stats = DrainArrowStream(single);
+	REQUIRE(single_stats.rows == 7);
+	REQUIRE(single_stats.arrays == 7);
+	REQUIRE(single_stats.first_array_rows == 1);
+	single.release(&single);
+
+	// A batch larger than the whole result coalesces it into one array, whatever the engine's
+	// vector size is.
+	ArrowArrayStream coalesced {};
+	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i FROM range(100) t(i)", 4096, &coalesced) == DUCKDB_V2_ERROR_NONE);
+	auto coalesced_stats = DrainArrowStream(coalesced);
+	REQUIRE(coalesced_stats.rows == 100);
+	REQUIRE(coalesced_stats.arrays == 1);
+	REQUIRE(coalesced_stats.first_array_rows == 100);
+	coalesced.release(&coalesced);
+}
+
+TEST_CASE("V2 arrow: a stream over a partially consumed result covers the remainder", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT i FROM range(1000) t(i)", &result) == DUCKDB_V2_ERROR_NONE);
+	// Take one chunk natively first.
+	auto chunk = StepChunk(result);
+	REQUIRE(chunk != nullptr);
+	idx_t consumed = 0;
+	REQUIRE(duckdb_v2_data_chunk_get_size(chunk, &consumed, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(consumed > 0);
+	duckdb_v2_data_chunk_destroy(&chunk);
+
+	ArrowArrayStream stream {};
+	REQUIRE(duckdb_v2_result_to_arrow_stream(&result, 0, &stream, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(result == nullptr);
+	auto stats = DrainArrowStream(stream);
+	REQUIRE(stats.rows == static_cast<int64_t>(1000 - consumed));
+	stream.release(&stream);
+}
+
+TEST_CASE("V2 arrow: an empty result gives a schema and no rows", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	ArrowArrayStream stream {};
+	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i, 'x' AS s FROM range(0) t(i)", 0, &stream) == DUCKDB_V2_ERROR_NONE);
+	ArrowSchema schema {};
+	REQUIRE(stream.get_schema(&stream, &schema) == 0);
+	REQUIRE(schema.n_children == 2);
+	schema.release(&schema);
+	auto stats = DrainArrowStream(stream);
+	REQUIRE(stats.rows == 0);
+	REQUIRE(stats.arrays == 0);
+	stream.release(&stream);
+}
+
+TEST_CASE("V2 arrow: the stream owns the connection until released", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	ArrowArrayStream stream {};
+	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i FROM range(100000) t(i)", 0, &stream) == DUCKDB_V2_ERROR_NONE);
+
+	// The stream took over the result's live-result slot, so the connection is still busy.
+	duckdb_v2_result_handle blocked = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT 1", &blocked) == DUCKDB_V2_ERROR_RESOURCE_IN_USE);
+	REQUIRE(blocked == nullptr);
+
+	// Releasing it frees the connection, even with the stream undrained.
+	stream.release(&stream);
+	duckdb_v2_result_handle after = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT 1", &after) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(DrainRowCount(after) == 1);
+	duckdb_v2_result_destroy(&after);
+}
+
+TEST_CASE("V2 arrow: get_schema still works after the stream is drained", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	// The schema is cached while the transaction is live, so reading it after exhaustion, when
+	// the catalog is no longer reachable, must still succeed.
+	ArrowArrayStream stream {};
+	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i FROM range(10) t(i)", 0, &stream) == DUCKDB_V2_ERROR_NONE);
+	auto stats = DrainArrowStream(stream);
+	REQUIRE(stats.rows == 10);
+
+	ArrowSchema schema {};
+	REQUIRE(stream.get_schema(&stream, &schema) == 0);
+	REQUIRE(schema.n_children == 1);
+	REQUIRE(std::string(schema.children[0]->name) == "i");
+	schema.release(&schema);
+	stream.release(&stream);
+}
+
+TEST_CASE("V2 arrow: an ENUM stream carries its dictionary", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	ExecSQL(fx.conn, "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')");
+
+	// An ENUM's Arrow schema is a dictionary read from the catalog, so this only works because
+	// the schema is built while the transaction is live rather than lazily in get_schema.
+	ArrowArrayStream stream {};
+	REQUIRE(ArrowStreamFor(fx.conn, "SELECT 'happy'::mood AS m FROM range(4)", 0, &stream) == DUCKDB_V2_ERROR_NONE);
+	auto stats = DrainArrowStream(stream);
+	REQUIRE(stats.rows == 4);
+	ArrowSchema schema {};
+	REQUIRE(stream.get_schema(&stream, &schema) == 0);
+	REQUIRE(schema.n_children == 1);
+	REQUIRE(schema.children[0]->dictionary != nullptr);
+	schema.release(&schema);
+	stream.release(&stream);
+}
+
+TEST_CASE("V2 arrow: a released stream refuses further calls", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	ArrowArrayStream stream {};
+	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i FROM range(10) t(i)", 0, &stream) == DUCKDB_V2_ERROR_NONE);
+	auto get_schema = stream.get_schema;
+	auto get_next = stream.get_next;
+	auto get_last_error = stream.get_last_error;
+	stream.release(&stream);
+	REQUIRE(stream.release == nullptr);
+
+	// The callbacks survive the release, and report EINVAL rather than reading freed state.
+	ArrowSchema schema {};
+	REQUIRE(get_schema(&stream, &schema) == EINVAL);
+	ArrowArray array {};
+	REQUIRE(get_next(&stream, &array) == EINVAL);
+	REQUIRE(array.release == nullptr);
+	REQUIRE(std::string(get_last_error(&stream)) == "arrow stream was released");
+}
+
+TEST_CASE("V2 arrow: an execution error surfaces from the stream", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	// The error is raised mid-scan, so it can only surface from get_next, which reports it
+	// through get_last_error rather than an error code.
+	ArrowArrayStream stream {};
+	REQUIRE(ArrowStreamFor(fx.conn,
+	                       "SELECT CASE WHEN i = 500 THEN error('boom') ELSE i::VARCHAR END "
+	                       "FROM range(1000) t(i)",
+	                       0, &stream) == DUCKDB_V2_ERROR_NONE);
+	int rc = 0;
+	bool exhausted = false;
+	while (rc == 0) {
+		ArrowArray array {};
+		rc = stream.get_next(&stream, &array);
+		if (rc == 0 && !array.release) {
+			exhausted = true;
+			break;
+		}
+		if (array.release) {
+			array.release(&array);
+		}
+	}
+	REQUIRE_FALSE(exhausted);
+	REQUIRE(rc != 0);
+	REQUIRE(std::string(stream.get_last_error(&stream)).find("boom") != std::string::npos);
+	stream.release(&stream);
+
+	// The failed stream still frees the connection when released.
+	duckdb_v2_result_handle after = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT 1", &after) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(DrainRowCount(after) == 1);
+	duckdb_v2_result_destroy(&after);
+}
+
+// ===========================================================================
+// Reading a converter back, and argument rejection.
+// ===========================================================================
+
+TEST_CASE("V2 arrow: a converter reports the DuckDB shape of an Arrow schema", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	// Registered as a scalar function purely to reach a context; what it observes is latched
+	// and asserted after the query.
+	static idx_t observed_count = 0;
+	static std::string observed_names;
+	static DUCKDB_V2_LOGICAL_TYPE_ID observed_first = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
+
+	observed_count = 0;
+	observed_names.clear();
+	observed_first = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
+
+	auto exec = [](duckdb_v2_scalar_function_exec_info_handle info, duckdb_v2_context_handle context,
+	               duckdb_v2_error_info_handle *err) {
+		duckdb_v2_vector_handle result = nullptr;
+		if (duckdb_v2_scalar_function_exec_get_result(info, &result, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		duckdb_v2_logical_type_handle bigint = nullptr;
+		duckdb_v2_logical_type_handle varchar = nullptr;
+		if (duckdb_v2_context_create_type_from_id(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, nullptr, nullptr, 0,
+		                                          &bigint, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_context_create_type_from_id(context, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR, nullptr, nullptr, 0,
+		                                          &varchar, err) != DUCKDB_V2_ERROR_NONE) {
+			duckdb_v2_logical_type_destroy(&bigint);
+			duckdb_v2_logical_type_destroy(&varchar);
+			return;
+		}
+		duckdb_v2_logical_type_handle types[2] = {bigint, varchar};
+		duckdb_v2_str names[2] = {duckdb_v2_str {"a", 1}, duckdb_v2_str {"b", 1}};
+		ArrowSchema schema {};
+		auto rc = duckdb_v2_logical_types_to_arrow_schema(context, types, names, 2, &schema, err);
+		duckdb_v2_logical_type_destroy(&bigint);
+		duckdb_v2_logical_type_destroy(&varchar);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		// Round the schema back through a converter: the DuckDB shape it reports should be the
+		// types we started from.
+		duckdb_v2_arrow_converter_handle converter = nullptr;
+		rc = duckdb_v2_arrow_converter_create(context, &schema, &converter, err);
+		schema.release(&schema);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		duckdb_v2_schema_handle resolved = nullptr;
+		rc = duckdb_v2_arrow_converter_get_schema(converter, &resolved, err);
+		duckdb_v2_arrow_converter_destroy(&converter);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		duckdb_v2_schema_get_count(resolved, &observed_count, err);
+		for (idx_t i = 0; i < observed_count; i++) {
+			duckdb_v2_str field_name = {nullptr, 0};
+			duckdb_v2_logical_type_handle field_type = nullptr;
+			if (duckdb_v2_schema_get_field(resolved, i, &field_name, &field_type, err) != DUCKDB_V2_ERROR_NONE) {
+				break;
+			}
+			observed_names.append(field_name.ptr, field_name.len);
+			if (i == 0) {
+				duckdb_v2_logical_type_get_id(field_type, &observed_first, err);
+			}
+		}
+		duckdb_v2_schema_destroy(&resolved);
+		int32_t one = 1;
+		void *data = nullptr;
+		if (duckdb_v2_vector_get_data_mutable(result, &data, err) == DUCKDB_V2_ERROR_NONE) {
+			std::memcpy(data, &one, sizeof(one));
+		}
+	};
+
+	duckdb_v2_scalar_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto name = Convert("probe_converter");
+	REQUIRE(duckdb_v2_scalar_function_set_name(function, &name, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	duckdb_v2_function_signature_handle sig = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_get_signature(function, &sig, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_add_parameter(sig, ArrowIdent("x"), integer, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_set_return_type(sig, integer, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_set_exec_callback(function, exec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_scalar_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&integer);
+
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT probe_converter(1)", &result) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(DrainRowCount(result) == 1);
+	duckdb_v2_result_destroy(&result);
+
+	REQUIRE(observed_count == 2);
+	REQUIRE(observed_names == "ab");
+	REQUIRE(observed_first == DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+}
+
+TEST_CASE("V2 arrow: functions guard null arguments", "[capi_v2][arrow]") {
+	EnvFixture fx;
+
+	ArrowArrayStream stream {};
+	REQUIRE(duckdb_v2_result_to_arrow_stream(nullptr, 0, &stream, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	duckdb_v2_result_handle empty = nullptr;
+	REQUIRE(duckdb_v2_result_to_arrow_stream(&empty, 0, &stream, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// A rejection must leave the result usable, since it never reached the engine.
+	duckdb_v2_result_handle live = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT 1", &live) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_result_to_arrow_stream(&live, 0, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(live != nullptr);
+	REQUIRE(DrainRowCount(live) == 1);
+	duckdb_v2_result_destroy(&live);
+
+	ArrowSchema schema {};
+	duckdb_v2_str name = Convert("a");
+	REQUIRE(duckdb_v2_logical_types_to_arrow_schema(nullptr, nullptr, &name, 0, &schema, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	ArrowArray array {};
+	REQUIRE(duckdb_v2_data_chunk_to_arrow_array(nullptr, nullptr, &array, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	duckdb_v2_arrow_converter_handle converter = nullptr;
+	REQUIRE(duckdb_v2_arrow_converter_create(nullptr, &schema, &converter, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(converter == nullptr);
+
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	REQUIRE(duckdb_v2_arrow_converter_array_to_chunk(nullptr, &array, nullptr, &chunk, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(chunk == nullptr);
+
+	duckdb_v2_schema_handle resolved = nullptr;
+	REQUIRE(duckdb_v2_arrow_converter_get_schema(nullptr, &resolved, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(resolved == nullptr);
+
+	// Destroy is null-safe and idempotent.
+	REQUIRE(duckdb_v2_arrow_converter_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_arrow_converter_destroy(&converter) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(converter == nullptr);
+	REQUIRE(duckdb_v2_arrow_converter_destroy(&converter) == DUCKDB_V2_ERROR_NONE);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_arrow.cpp
+++ b/test/api/capi/v2/test_capi_v2_arrow.cpp
@@ -7,13 +7,12 @@
 // ---------------------------------------------------------------------------
 // V2 Arrow C Data Interface tests.
 //
-// The chunk converters take a context, which only a callback has, so the value
-// round-trips run through two harnesses registered on the connection:
-// arrow_roundtrip(x), a scalar function pushing its argument through
-// chunk -> Arrow array -> chunk, and arrow_roundtrip_range(n), a table function
-// building its own multi-column chunks and round-tripping each one. A value
-// survives iff arrow_roundtrip(x) IS NOT DISTINCT FROM x, so the assertions are
-// ordinary SQL.
+// The importer and exporter both need a context, which only a callback has, so
+// the value round-trips run through two harnesses registered on the connection:
+// arrow_roundtrip(x), a scalar function pushing its argument out to Arrow and
+// straight back, and arrow_roundtrip_range(n), a table function doing the same
+// for multi-column chunks. A value survives iff arrow_roundtrip(x) IS NOT
+// DISTINCT FROM x, so the assertions are ordinary SQL.
 //
 // Callbacks must not use Catch assertions: a REQUIRE would throw through the C
 // boundary into the engine. They populate the error slot and return instead, and
@@ -39,18 +38,82 @@ duckdb_v2_logical_type_handle ArrowTypeInCallback(duckdb_v2_context_handle conte
 	return type;
 }
 
-// ---------------------------------------------------------------------------
-// arrow_roundtrip(x): passes its argument straight through the Arrow chunk
-// converters and returns it unchanged. Declared with an ANY return; the bind
-// callback reads the argument type, matches the return type to it, and resolves
-// the converter once. One function therefore exercises the exec-phase
-// converters over every type, nested ones included.
-// ---------------------------------------------------------------------------
+// The two halves of a round-trip, carried as bind data: an exporter for the column list, and an
+// importer resolved from the schema that exporter reports.
+struct ArrowRoundtrip {
+	duckdb_v2_arrow_exporter_handle exporter = nullptr;
+	duckdb_v2_arrow_importer_handle importer = nullptr;
+};
 
-void ArrowRtDestroyConverter(void *ptr) {
-	auto converter = reinterpret_cast<duckdb_v2_arrow_converter_handle>(ptr);
-	duckdb_v2_arrow_converter_destroy(&converter);
+void ArrowRoundtripDestroy(void *ptr) {
+	auto *rt = static_cast<ArrowRoundtrip *>(ptr);
+	duckdb_v2_arrow_exporter_destroy(&rt->exporter);
+	duckdb_v2_arrow_importer_destroy(&rt->importer);
+	delete rt;
 }
+
+// Builds an exporter over `types`/`names` and an importer over the schema it reports, so the pair
+// round-trips those columns. Returns null after populating the error slot.
+ArrowRoundtrip *ArrowMakeRoundtrip(duckdb_v2_context_handle context, const duckdb_v2_logical_type_handle *types,
+                                   const duckdb_v2_str *names, idx_t count, idx_t export_batch, idx_t import_batch,
+                                   duckdb_v2_error_info_handle *err) {
+	duckdb_v2_arrow_exporter_handle exporter = nullptr;
+	if (duckdb_v2_arrow_exporter_create(context, types, names, count, export_batch, &exporter, err) !=
+	    DUCKDB_V2_ERROR_NONE) {
+		return nullptr;
+	}
+	// The importer is resolved from the exporter's own schema, so the two agree by construction.
+	ArrowSchema schema {};
+	auto rc = duckdb_v2_arrow_exporter_get_schema(exporter, &schema, err);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_arrow_exporter_destroy(&exporter);
+		return nullptr;
+	}
+	duckdb_v2_arrow_importer_handle importer = nullptr;
+	rc = duckdb_v2_arrow_importer_create(context, &schema, import_batch, &importer, err);
+	schema.release(&schema);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_arrow_exporter_destroy(&exporter);
+		return nullptr;
+	}
+	return new ArrowRoundtrip {exporter, importer};
+}
+
+// Pushes `input` out to Arrow and back, returning the re-imported chunk (null on failure, with the
+// error slot populated). Borrows `input`.
+duckdb_v2_data_chunk_handle ArrowRoundtripChunk(ArrowRoundtrip &rt, duckdb_v2_data_chunk_handle input,
+                                                duckdb_v2_error_info_handle *err) {
+	auto borrowed = input;
+	if (duckdb_v2_arrow_exporter_append(rt.exporter, &borrowed, false, true, err) != DUCKDB_V2_ERROR_NONE) {
+		return nullptr;
+	}
+	ArrowArray array {};
+	if (duckdb_v2_arrow_exporter_next_array(rt.exporter, &array, err) != DUCKDB_V2_ERROR_NONE) {
+		return nullptr;
+	}
+	if (!array.release) {
+		return nullptr; // no batch size is set, so one append always completes one array
+	}
+	// Hand the array over: the imported chunk then references its buffers and keeps them alive.
+	auto rc = duckdb_v2_arrow_importer_append(rt.importer, &array, true, true, err);
+	if (array.release) {
+		array.release(&array);
+	}
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return nullptr;
+	}
+	duckdb_v2_data_chunk_handle imported = nullptr;
+	if (duckdb_v2_arrow_importer_next_chunk(rt.importer, &imported, err) != DUCKDB_V2_ERROR_NONE) {
+		return nullptr;
+	}
+	return imported;
+}
+
+// ---------------------------------------------------------------------------
+// arrow_roundtrip(x): declared with an ANY return; the bind callback reads the
+// argument type, matches the return type to it, and builds the exporter/importer
+// pair. One function therefore covers every type, nested ones included.
+// ---------------------------------------------------------------------------
 
 void ArrowRtBind(duckdb_v2_scalar_function_bind_info_handle info, duckdb_v2_context_handle context,
                  duckdb_v2_error_info_handle *err) {
@@ -64,22 +127,13 @@ void ArrowRtBind(duckdb_v2_scalar_function_bind_info_handle info, duckdb_v2_cont
 		duckdb_v2_logical_type_destroy(&arg_type);
 		return;
 	}
-	// Resolve the one-column Arrow schema for this type into a converter.
-	ArrowSchema schema {};
 	auto name = Convert("x");
-	rc = duckdb_v2_logical_types_to_arrow_schema(context, &arg_type, &name, 1, &schema, err);
+	auto *rt = ArrowMakeRoundtrip(context, &arg_type, &name, 1, 0, 0, err);
 	duckdb_v2_logical_type_destroy(&arg_type);
-	if (rc != DUCKDB_V2_ERROR_NONE) {
+	if (!rt) {
 		return;
 	}
-	duckdb_v2_arrow_converter_handle converter = nullptr;
-	rc = duckdb_v2_arrow_converter_create(context, &schema, &converter, err);
-	schema.release(&schema);
-	if (rc != DUCKDB_V2_ERROR_NONE) {
-		return;
-	}
-	// The converter rides the bind data and dies with the binding.
-	duckdb_v2_opaque bind_data = {converter, ArrowRtDestroyConverter, nullptr};
+	duckdb_v2_opaque bind_data = {rt, ArrowRoundtripDestroy, nullptr};
 	duckdb_v2_scalar_function_bind_set_bind_data(info, &bind_data, err);
 }
 
@@ -95,7 +149,7 @@ void ArrowRtExec(duckdb_v2_scalar_function_exec_info_handle info, duckdb_v2_cont
 	    duckdb_v2_scalar_function_exec_get_row_count(info, &count, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	auto converter = reinterpret_cast<duckdb_v2_arrow_converter_handle>(bind_data);
+	auto &rt = *static_cast<ArrowRoundtrip *>(bind_data);
 
 	// Wrap the argument vector in a one-column chunk, which is what the exporter takes.
 	duckdb_v2_logical_type_handle arg_type = nullptr;
@@ -116,20 +170,9 @@ void ArrowRtExec(duckdb_v2_scalar_function_exec_info_handle info, duckdb_v2_cont
 		return;
 	}
 
-	ArrowArray array {};
-	rc = duckdb_v2_data_chunk_to_arrow_array(context, input, &array, err);
+	auto imported = ArrowRoundtripChunk(rt, input, err);
 	duckdb_v2_data_chunk_destroy(&input);
-	if (rc != DUCKDB_V2_ERROR_NONE) {
-		return;
-	}
-	duckdb_v2_data_chunk_handle imported = nullptr;
-	rc = duckdb_v2_arrow_converter_array_to_chunk(context, &array, converter, &imported, err);
-	// The import adopts the array and nulls its release, so this only fires when the import
-	// failed before taking ownership.
-	if (array.release) {
-		array.release(&array);
-	}
-	if (rc != DUCKDB_V2_ERROR_NONE) {
+	if (!imported) {
 		return;
 	}
 	// Reference the re-imported column into the result: zero-copy, and the shared buffers keep
@@ -163,14 +206,14 @@ void RegisterArrowRoundtrip(duckdb_v2_connection_handle conn) {
 
 // ---------------------------------------------------------------------------
 // arrow_roundtrip_range(n): emits n rows of (i BIGINT, s VARCHAR) where
-// i = row index and s = 'r' || i, every chunk having gone through the Arrow
-// converters first. This drives the structural edges the scalar harness cannot
-// reach: multi-column import, and an array longer than one vector.
+// i = row index and s = 'r' || i, every chunk having gone through the round-trip
+// first. This drives what the scalar harness cannot: multi-column conversion,
+// and an array longer than one vector.
 // ---------------------------------------------------------------------------
 
 struct ArrowRangeBind {
 	int64_t count = 0;
-	duckdb_v2_arrow_converter_handle converter = nullptr;
+	ArrowRoundtrip *roundtrip = nullptr;
 };
 struct ArrowRangeGlobal {
 	int64_t emitted = 0;
@@ -178,7 +221,7 @@ struct ArrowRangeGlobal {
 
 void ArrowRangeDestroyBind(void *ptr) {
 	auto *bind = static_cast<ArrowRangeBind *>(ptr);
-	duckdb_v2_arrow_converter_destroy(&bind->converter);
+	ArrowRoundtripDestroy(bind->roundtrip);
 	delete bind;
 }
 void ArrowRangeDestroyGlobal(void *ptr) {
@@ -208,24 +251,15 @@ void ArrowRangeBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_
 	duckdb_v2_table_function_bind_add_result_column(info, ArrowIdent("i"), bigint, err);
 	duckdb_v2_table_function_bind_add_result_column(info, ArrowIdent("s"), varchar, err);
 
-	// Resolve the two-column schema once, for every chunk this scan will produce.
 	duckdb_v2_logical_type_handle types[2] = {bigint, varchar};
 	duckdb_v2_str names[2] = {Convert("i"), Convert("s")};
-	ArrowSchema schema {};
-	rc = duckdb_v2_logical_types_to_arrow_schema(context, types, names, 2, &schema, err);
+	auto *rt = ArrowMakeRoundtrip(context, types, names, 2, 0, 0, err);
 	duckdb_v2_logical_type_destroy(&bigint);
 	duckdb_v2_logical_type_destroy(&varchar);
-	if (rc != DUCKDB_V2_ERROR_NONE) {
+	if (!rt) {
 		return;
 	}
-	duckdb_v2_arrow_converter_handle converter = nullptr;
-	rc = duckdb_v2_arrow_converter_create(context, &schema, &converter, err);
-	schema.release(&schema);
-	if (rc != DUCKDB_V2_ERROR_NONE) {
-		return;
-	}
-
-	auto *bind = new ArrowRangeBind {count, converter};
+	auto *bind = new ArrowRangeBind {count, rt};
 	duckdb_v2_opaque bind_data = {bind, ArrowRangeDestroyBind, nullptr};
 	duckdb_v2_table_function_bind_set_bind_data(info, &bind_data, err);
 }
@@ -262,7 +296,6 @@ void ArrowRangeExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_
 	auto remaining = static_cast<idx_t>(bind.count - global.emitted);
 	auto rows = remaining < STANDARD_VECTOR_SIZE ? remaining : static_cast<idx_t>(STANDARD_VECTOR_SIZE);
 
-	// Build a fresh input chunk and fill it.
 	auto bigint = ArrowTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, err);
 	auto varchar = ArrowTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR, err);
 	if (!bigint || !varchar) {
@@ -299,18 +332,9 @@ void ArrowRangeExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_
 	duckdb_v2_vector_set_size(in_i, rows, err);
 	duckdb_v2_vector_set_size(in_s, rows, err);
 
-	ArrowArray array {};
-	rc = duckdb_v2_data_chunk_to_arrow_array(context, input, &array, err);
+	auto imported = ArrowRoundtripChunk(*bind.roundtrip, input, err);
 	duckdb_v2_data_chunk_destroy(&input);
-	if (rc != DUCKDB_V2_ERROR_NONE) {
-		return;
-	}
-	duckdb_v2_data_chunk_handle imported = nullptr;
-	rc = duckdb_v2_arrow_converter_array_to_chunk(context, &array, bind.converter, &imported, err);
-	if (array.release) {
-		array.release(&array);
-	}
-	if (rc != DUCKDB_V2_ERROR_NONE) {
+	if (!imported) {
 		return;
 	}
 	duckdb_v2_vector_handle imported_i = nullptr;
@@ -404,10 +428,166 @@ bool ArrowQueryBool(duckdb_v2_connection_handle conn, const char *sql) {
 	return value;
 }
 
+// What a direct exporter/importer probe observed, latched for the test to assert on afterwards.
+struct ArrowSplitObserved {
+	std::vector<int64_t> array_rows;
+	std::vector<idx_t> chunk_rows;
+	std::vector<int64_t> values;
+	DUCKDB_V2_ERROR second_append_rc = DUCKDB_V2_ERROR_NONE;
+	DUCKDB_V2_ERROR type_mismatch_rc = DUCKDB_V2_ERROR_NONE;
+};
+ArrowSplitObserved arrow_split_observed;
+idx_t arrow_split_export_batch = 0;
+idx_t arrow_split_import_batch = 0;
+idx_t arrow_split_rows = 0;
+idx_t arrow_split_appends = 1;
+bool arrow_split_flush = true;
+
+// Builds a BIGINT chunk of arrow_split_rows rows, pushes it through an exporter and importer with
+// the configured batch sizes, and records the shapes that came out.
+void ArrowSplitExec(duckdb_v2_scalar_function_exec_info_handle info, duckdb_v2_context_handle context,
+                    duckdb_v2_error_info_handle *err) {
+	duckdb_v2_vector_handle result = nullptr;
+	if (duckdb_v2_scalar_function_exec_get_result(info, &result, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto bigint = ArrowTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, err);
+	if (!bigint) {
+		return;
+	}
+	auto column = Convert("v");
+	auto *rt =
+	    ArrowMakeRoundtrip(context, &bigint, &column, 1, arrow_split_export_batch, arrow_split_import_batch, err);
+	if (!rt) {
+		duckdb_v2_logical_type_destroy(&bigint);
+		return;
+	}
+
+	duckdb_v2_data_chunk_handle input = nullptr;
+	auto rc = duckdb_v2_data_chunk_create(&bigint, 1, &input, err);
+	duckdb_v2_logical_type_destroy(&bigint);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		ArrowRoundtripDestroy(rt);
+		return;
+	}
+	duckdb_v2_vector_handle in_v = nullptr;
+	int64_t *data = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(input, 0, &in_v, err) == DUCKDB_V2_ERROR_NONE &&
+	    duckdb_v2_vector_get_data_mutable(in_v, reinterpret_cast<void **>(&data), err) == DUCKDB_V2_ERROR_NONE) {
+		for (idx_t i = 0; i < arrow_split_rows; i++) {
+			data[i] = static_cast<int64_t>(i);
+		}
+		duckdb_v2_vector_set_size(in_v, arrow_split_rows, err);
+	}
+
+	// Feed the same chunk `arrow_split_appends` times, flushing only on the last, so gathering
+	// across chunks is exercised when the batch size does not divide them.
+	for (idx_t a = 0; a < arrow_split_appends; a++) {
+		auto borrowed = input;
+		if (duckdb_v2_arrow_exporter_append(rt->exporter, &borrowed, false,
+		                                    arrow_split_flush && a + 1 == arrow_split_appends,
+		                                    err) != DUCKDB_V2_ERROR_NONE) {
+			ArrowRoundtripDestroy(rt);
+			duckdb_v2_data_chunk_destroy(&input);
+			return;
+		}
+	}
+	std::vector<ArrowArray> arrays;
+	while (true) {
+		ArrowArray array {};
+		if (duckdb_v2_arrow_exporter_next_array(rt->exporter, &array, err) != DUCKDB_V2_ERROR_NONE || !array.release) {
+			break;
+		}
+		arrow_split_observed.array_rows.push_back(array.length);
+		arrays.push_back(array);
+	}
+	// Then push those arrays back through the importer, again flushing only on the last, so its
+	// own gathering is exercised too.
+	for (idx_t i = 0; i < arrays.size(); i++) {
+		if (duckdb_v2_arrow_importer_append(rt->importer, &arrays[i], true, i + 1 == arrays.size(), err) !=
+		    DUCKDB_V2_ERROR_NONE) {
+			break;
+		}
+		while (true) {
+			duckdb_v2_data_chunk_handle imported = nullptr;
+			if (duckdb_v2_arrow_importer_next_chunk(rt->importer, &imported, err) != DUCKDB_V2_ERROR_NONE ||
+			    !imported) {
+				break;
+			}
+			idx_t size = 0;
+			duckdb_v2_data_chunk_get_size(imported, &size, err);
+			arrow_split_observed.chunk_rows.push_back(size);
+			duckdb_v2_vector_handle out_v = nullptr;
+			duckdb_v2_vector_view view {};
+			if (duckdb_v2_data_chunk_get_vector(imported, 0, &out_v, err) == DUCKDB_V2_ERROR_NONE &&
+			    duckdb_v2_vector_get_view(out_v, &view, err) == DUCKDB_V2_ERROR_NONE) {
+				for (idx_t k = 0; k < size; k++) {
+					arrow_split_observed.values.push_back(
+					    reinterpret_cast<const int64_t *>(view.data)[SelAt(view.sel, k)]);
+				}
+			}
+			duckdb_v2_data_chunk_destroy(&imported);
+		}
+	}
+
+	// Gathering means the exporter takes more input whenever the caller has it, without requiring
+	// the arrays produced so far to be taken first. Run after the measured drain, so the extra
+	// rows cannot affect the shapes recorded above.
+	auto again = input;
+	arrow_split_observed.second_append_rc = duckdb_v2_arrow_exporter_append(rt->exporter, &again, false, true, nullptr);
+
+	// A chunk whose types disagree with the exporter is refused.
+	auto varchar = ArrowTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR, nullptr);
+	if (varchar) {
+		duckdb_v2_data_chunk_handle wrong = nullptr;
+		if (duckdb_v2_data_chunk_create(&varchar, 1, &wrong, nullptr) == DUCKDB_V2_ERROR_NONE) {
+			arrow_split_observed.type_mismatch_rc =
+			    duckdb_v2_arrow_exporter_append(rt->exporter, &wrong, false, false, nullptr);
+			duckdb_v2_data_chunk_destroy(&wrong);
+		}
+		duckdb_v2_logical_type_destroy(&varchar);
+	}
+
+	duckdb_v2_data_chunk_destroy(&input);
+	ArrowRoundtripDestroy(rt);
+	int32_t one = 1;
+	void *out = nullptr;
+	if (duckdb_v2_vector_get_data_mutable(result, &out, err) == DUCKDB_V2_ERROR_NONE) {
+		std::memcpy(out, &one, sizeof(one));
+	}
+}
+
+// Registers a no-argument-meaning probe that runs `exec` once.
+void RegisterArrowProbe(duckdb_v2_connection_handle conn, const char *name,
+                        duckdb_v2_scalar_function_exec_callback_fn exec) {
+	duckdb_v2_scalar_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_create_with_connection(conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto fname = Convert(name);
+	REQUIRE(duckdb_v2_scalar_function_set_name(function, &fname, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto integer = MakeType(conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	duckdb_v2_function_signature_handle sig = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_get_signature(function, &sig, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_add_parameter(sig, ArrowIdent("x"), integer, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_set_return_type(sig, integer, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_set_exec_callback(function, exec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_scalar_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&integer);
+}
+
+// Runs a registered probe once.
+void RunArrowProbe(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(Query(conn, sql, &r) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(DrainRowCount(r) == 1);
+	duckdb_v2_result_destroy(&r);
+}
+
 } // namespace
 
 // ===========================================================================
-// Value round-trips: DuckDB chunk -> Arrow array -> DuckDB chunk.
+// Value round-trips: data chunk -> Arrow array -> data chunk.
 // ===========================================================================
 
 TEST_CASE("V2 arrow: a flat round-trip preserves values", "[capi_v2][arrow]") {
@@ -465,17 +645,203 @@ TEST_CASE("V2 arrow: a multi-column round-trip preserves rows", "[capi_v2][arrow
 	EnvFixture fx;
 	RegisterArrowRoundtripRange(fx.conn);
 
-	// Every row comes back through the converters, so this checks both columns and the
-	// row count at once.
 	REQUIRE(ArrowQueryBool(fx.conn, "SELECT bool_and(s = 'r' || i) FROM arrow_roundtrip_range(100)"));
 	REQUIRE(ArrowQueryBool(fx.conn, "SELECT count(*) = 100 AND min(i) = 0 AND max(i) = 99 "
 	                                "FROM arrow_roundtrip_range(100)"));
 	// More rows than fit in one vector, so several arrays are converted in sequence.
 	REQUIRE(ArrowQueryBool(fx.conn, "SELECT count(*) = 5000 AND sum(i) = 12497500 "
 	                                "FROM arrow_roundtrip_range(5000)"));
-	// And the empty case.
 	REQUIRE(ArrowQueryBool(fx.conn, "SELECT count(*) = 0 FROM arrow_roundtrip_range(0)"));
 }
+
+// Latches the DuckDB type an importer resolves for a dictionary-encoded (ENUM) column.
+std::string enum_probe_type;
+
+void EnumProbeExec(duckdb_v2_scalar_function_exec_info_handle info, duckdb_v2_context_handle context,
+                   duckdb_v2_error_info_handle *err) {
+	duckdb_v2_vector_handle result = nullptr;
+	if (duckdb_v2_scalar_function_exec_get_result(info, &result, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_logical_type_handle mood = nullptr;
+	if (duckdb_v2_context_create_type_from_text(context, Convert("mood"), &mood, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto col = Convert("v");
+	auto *rt = ArrowMakeRoundtrip(context, &mood, &col, 1, 0, 0, err);
+	duckdb_v2_logical_type_destroy(&mood);
+	if (!rt) {
+		return;
+	}
+	duckdb_v2_schema_handle resolved = nullptr;
+	if (duckdb_v2_arrow_importer_get_schema(rt->importer, &resolved, err) == DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_str field_name = {nullptr, 0};
+		duckdb_v2_logical_type_handle field_type = nullptr;
+		if (duckdb_v2_schema_get_field(resolved, 0, &field_name, &field_type, err) == DUCKDB_V2_ERROR_NONE) {
+			auto rc2 = DUCKDB_V2_ERROR_NONE;
+			enum_probe_type = RenderText(
+			    [&](char *buf, idx_t cap, idx_t *len) {
+				    return duckdb_v2_logical_type_to_text(field_type, buf, cap, len, nullptr);
+			    },
+			    rc2);
+		}
+		duckdb_v2_schema_destroy(&resolved);
+	}
+	ArrowRoundtripDestroy(rt);
+	int32_t one = 1;
+	void *data = nullptr;
+	if (duckdb_v2_vector_get_data_mutable(result, &data, err) == DUCKDB_V2_ERROR_NONE) {
+		std::memcpy(data, &one, sizeof(one));
+	}
+}
+
+// ===========================================================================
+// What the correspondence does and does not preserve.
+// ===========================================================================
+
+TEST_CASE("V2 arrow: a dictionary column resolves to VARCHAR by default", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	ExecSQL(fx.conn, "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')");
+	enum_probe_type.clear();
+	duckdb_v2_scalar_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto fname = Convert("enum_probe");
+	REQUIRE(duckdb_v2_scalar_function_set_name(function, &fname, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	duckdb_v2_function_signature_handle sig = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_get_signature(function, &sig, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_add_parameter(sig, ArrowIdent("x"), integer, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_set_return_type(sig, integer, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_set_exec_callback(function, EnumProbeExec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_scalar_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&integer);
+
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT enum_probe(1)", &r) == DUCKDB_V2_ERROR_NONE);
+	DrainRowCount(r);
+	duckdb_v2_result_destroy(&r);
+	auto without_lossless = enum_probe_type;
+
+	enum_probe_type.clear();
+	ExecSQL(fx.conn, "SET arrow_lossless_conversion = true");
+	REQUIRE(Query(fx.conn, "SELECT enum_probe(1)", &r) == DUCKDB_V2_ERROR_NONE);
+	DrainRowCount(r);
+	duckdb_v2_result_destroy(&r);
+	// An Arrow dictionary of strings is exactly that: the ENUM identity is not in the schema, so
+	// an importer resolving that schema can only report VARCHAR -- with or without
+	// arrow_lossless_conversion, which only tags types that have no Arrow match at all. So an
+	// ENUM survives the round-trip by value but not by type.
+	REQUIRE(without_lossless == "VARCHAR");
+	REQUIRE(enum_probe_type == "VARCHAR");
+}
+
+// ===========================================================================
+// Batch sizes: a maximum in both directions, never a target.
+// ===========================================================================
+
+#if (STANDARD_VECTOR_SIZE >= 8)
+TEST_CASE("V2 arrow: a batch size caps the output in both directions", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	RegisterArrowProbe(fx.conn, "arrow_split_probe", ArrowSplitExec);
+
+	SECTION("no maximum gives one output per input") {
+		arrow_split_observed = {};
+		arrow_split_rows = 7;
+		arrow_split_export_batch = 0;
+		arrow_split_import_batch = 0;
+		arrow_split_appends = 1;
+		RunArrowProbe(fx.conn, "SELECT arrow_split_probe(1)");
+		REQUIRE(arrow_split_observed.array_rows == std::vector<int64_t> {7});
+		REQUIRE(arrow_split_observed.chunk_rows == std::vector<idx_t> {7});
+		REQUIRE(arrow_split_observed.values == std::vector<int64_t> {0, 1, 2, 3, 4, 5, 6});
+	}
+
+	SECTION("the exporter splits a chunk, the last array being short") {
+		arrow_split_observed = {};
+		arrow_split_rows = 7;
+		arrow_split_export_batch = 3;
+		arrow_split_import_batch = 0;
+		arrow_split_appends = 1;
+		RunArrowProbe(fx.conn, "SELECT arrow_split_probe(1)");
+		REQUIRE(arrow_split_observed.array_rows == std::vector<int64_t> {3, 3, 1});
+		// Each array imports as one chunk, since the importer has no maximum of its own.
+		REQUIRE(arrow_split_observed.chunk_rows == std::vector<idx_t> {3, 3, 1});
+		REQUIRE(arrow_split_observed.values == std::vector<int64_t> {0, 1, 2, 3, 4, 5, 6});
+	}
+
+	SECTION("the importer splits an array, the last chunk being short") {
+		arrow_split_observed = {};
+		arrow_split_rows = 7;
+		arrow_split_export_batch = 0;
+		arrow_split_import_batch = 2;
+		arrow_split_appends = 1;
+		RunArrowProbe(fx.conn, "SELECT arrow_split_probe(1)");
+		REQUIRE(arrow_split_observed.array_rows == std::vector<int64_t> {7});
+		REQUIRE(arrow_split_observed.chunk_rows == std::vector<idx_t> {2, 2, 2, 1});
+		REQUIRE(arrow_split_observed.values == std::vector<int64_t> {0, 1, 2, 3, 4, 5, 6});
+	}
+
+	SECTION("gathering fills a batch across two inputs") {
+		// Two 3-row inputs with a batch of 4: the exporter joins them into a 4-row array plus a
+		// 2-row remainder, and the importer does the same to those two arrays. Neither could
+		// reach a full batch from one input alone, which is what gathering is for.
+		arrow_split_observed = {};
+		arrow_split_rows = 3;
+		arrow_split_export_batch = 4;
+		arrow_split_import_batch = 4;
+		arrow_split_appends = 2;
+		RunArrowProbe(fx.conn, "SELECT arrow_split_probe(1)");
+		REQUIRE(arrow_split_observed.array_rows == std::vector<int64_t> {4, 2});
+		REQUIRE(arrow_split_observed.chunk_rows == std::vector<idx_t> {4, 2});
+		// The same chunk twice, so the values repeat rather than continuing.
+		REQUIRE(arrow_split_observed.values == std::vector<int64_t> {0, 1, 2, 0, 1, 2});
+	}
+
+	SECTION("without a flush the remainder is held back") {
+		// One 3-row input with a batch of 4 and no flush: the rows stay gathered, waiting for
+		// input that never comes, so nothing is produced.
+		arrow_split_observed = {};
+		arrow_split_rows = 3;
+		arrow_split_export_batch = 4;
+		arrow_split_import_batch = 0;
+		arrow_split_appends = 1;
+		arrow_split_flush = false;
+		RunArrowProbe(fx.conn, "SELECT arrow_split_probe(1)");
+		arrow_split_flush = true;
+		REQUIRE(arrow_split_observed.array_rows.empty());
+		REQUIRE(arrow_split_observed.chunk_rows.empty());
+	}
+
+	SECTION("a maximum larger than the input leaves it whole") {
+		// The defining property of a maximum rather than a target: nothing is gathered to reach it.
+		arrow_split_observed = {};
+		arrow_split_rows = 5;
+		arrow_split_export_batch = 1000;
+		arrow_split_import_batch = 1000;
+		arrow_split_appends = 1;
+		RunArrowProbe(fx.conn, "SELECT arrow_split_probe(1)");
+		REQUIRE(arrow_split_observed.array_rows == std::vector<int64_t> {5});
+		REQUIRE(arrow_split_observed.chunk_rows == std::vector<idx_t> {5});
+	}
+}
+
+TEST_CASE("V2 arrow: the exporter accepts input without draining first", "[capi_v2][arrow]") {
+	EnvFixture fx;
+	RegisterArrowProbe(fx.conn, "arrow_split_probe", ArrowSplitExec);
+	arrow_split_observed = {};
+	arrow_split_rows = 4;
+	arrow_split_export_batch = 0;
+	arrow_split_import_batch = 0;
+	arrow_split_appends = 1;
+	RunArrowProbe(fx.conn, "SELECT arrow_split_probe(1)");
+	// The exporter gathers, so it accepts more input without the produced arrays being taken first.
+	REQUIRE(arrow_split_observed.second_append_rc == DUCKDB_V2_ERROR_NONE);
+	// And a chunk whose types disagree with the exporter never reaches the conversion.
+	REQUIRE(arrow_split_observed.type_mismatch_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+#endif
 
 // ===========================================================================
 // result_to_arrow_stream
@@ -498,11 +864,6 @@ TEST_CASE("V2 arrow: a stream yields every row and a stable schema", "[capi_v2][
 	REQUIRE(std::string(schema.children[1]->name) == "s");
 	schema.release(&schema);
 
-	ArrowSchema again {};
-	REQUIRE(stream.get_schema(&stream, &again) == 0);
-	REQUIRE(again.n_children == 2);
-	again.release(&again);
-
 	auto stats = DrainArrowStream(stream);
 	REQUIRE(stats.rows == 1000);
 	REQUIRE(stats.arrays >= 1);
@@ -515,11 +876,11 @@ TEST_CASE("V2 arrow: a stream yields every row and a stable schema", "[capi_v2][
 	REQUIRE(stream.release == nullptr);
 }
 
-TEST_CASE("V2 arrow: a stream coalesces chunks to batch_size", "[capi_v2][arrow]") {
+TEST_CASE("V2 arrow: a stream gathers chunks up to batch_size", "[capi_v2][arrow]") {
 	EnvFixture fx;
 
-	// batch_size 1 gives one row per array, which pins that the setting is honored rather
-	// than ignored in favor of the engine's own chunking.
+	// Unlike the exporter, the stream owns its source and can see where the rows end, so its
+	// batch_size is a target: every array is that size except the last.
 	ArrowArrayStream single {};
 	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i FROM range(7) t(i)", 1, &single) == DUCKDB_V2_ERROR_NONE);
 	auto single_stats = DrainArrowStream(single);
@@ -528,7 +889,7 @@ TEST_CASE("V2 arrow: a stream coalesces chunks to batch_size", "[capi_v2][arrow]
 	REQUIRE(single_stats.first_array_rows == 1);
 	single.release(&single);
 
-	// A batch larger than the whole result coalesces it into one array, whatever the engine's
+	// A batch larger than the whole result gathers it into one array, whatever the engine's
 	// vector size is.
 	ArrowArrayStream coalesced {};
 	REQUIRE(ArrowStreamFor(fx.conn, "SELECT i FROM range(100) t(i)", 4096, &coalesced) == DUCKDB_V2_ERROR_NONE);
@@ -544,7 +905,6 @@ TEST_CASE("V2 arrow: a stream over a partially consumed result covers the remain
 
 	duckdb_v2_result_handle result = nullptr;
 	REQUIRE(Query(fx.conn, "SELECT i FROM range(1000) t(i)", &result) == DUCKDB_V2_ERROR_NONE);
-	// Take one chunk natively first.
 	auto chunk = StepChunk(result);
 	REQUIRE(chunk != nullptr);
 	idx_t consumed = 0;
@@ -686,104 +1046,8 @@ TEST_CASE("V2 arrow: an execution error surfaces from the stream", "[capi_v2][ar
 }
 
 // ===========================================================================
-// Reading a converter back, and argument rejection.
+// Argument rejection.
 // ===========================================================================
-
-TEST_CASE("V2 arrow: a converter reports the DuckDB shape of an Arrow schema", "[capi_v2][arrow]") {
-	EnvFixture fx;
-	// Registered as a scalar function purely to reach a context; what it observes is latched
-	// and asserted after the query.
-	static idx_t observed_count = 0;
-	static std::string observed_names;
-	static DUCKDB_V2_LOGICAL_TYPE_ID observed_first = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
-
-	observed_count = 0;
-	observed_names.clear();
-	observed_first = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
-
-	auto exec = [](duckdb_v2_scalar_function_exec_info_handle info, duckdb_v2_context_handle context,
-	               duckdb_v2_error_info_handle *err) {
-		duckdb_v2_vector_handle result = nullptr;
-		if (duckdb_v2_scalar_function_exec_get_result(info, &result, err) != DUCKDB_V2_ERROR_NONE) {
-			return;
-		}
-		duckdb_v2_logical_type_handle bigint = nullptr;
-		duckdb_v2_logical_type_handle varchar = nullptr;
-		if (duckdb_v2_context_create_type_from_id(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, nullptr, nullptr, 0,
-		                                          &bigint, err) != DUCKDB_V2_ERROR_NONE ||
-		    duckdb_v2_context_create_type_from_id(context, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR, nullptr, nullptr, 0,
-		                                          &varchar, err) != DUCKDB_V2_ERROR_NONE) {
-			duckdb_v2_logical_type_destroy(&bigint);
-			duckdb_v2_logical_type_destroy(&varchar);
-			return;
-		}
-		duckdb_v2_logical_type_handle types[2] = {bigint, varchar};
-		duckdb_v2_str names[2] = {duckdb_v2_str {"a", 1}, duckdb_v2_str {"b", 1}};
-		ArrowSchema schema {};
-		auto rc = duckdb_v2_logical_types_to_arrow_schema(context, types, names, 2, &schema, err);
-		duckdb_v2_logical_type_destroy(&bigint);
-		duckdb_v2_logical_type_destroy(&varchar);
-		if (rc != DUCKDB_V2_ERROR_NONE) {
-			return;
-		}
-		// Round the schema back through a converter: the DuckDB shape it reports should be the
-		// types we started from.
-		duckdb_v2_arrow_converter_handle converter = nullptr;
-		rc = duckdb_v2_arrow_converter_create(context, &schema, &converter, err);
-		schema.release(&schema);
-		if (rc != DUCKDB_V2_ERROR_NONE) {
-			return;
-		}
-		duckdb_v2_schema_handle resolved = nullptr;
-		rc = duckdb_v2_arrow_converter_get_schema(converter, &resolved, err);
-		duckdb_v2_arrow_converter_destroy(&converter);
-		if (rc != DUCKDB_V2_ERROR_NONE) {
-			return;
-		}
-		duckdb_v2_schema_get_count(resolved, &observed_count, err);
-		for (idx_t i = 0; i < observed_count; i++) {
-			duckdb_v2_str field_name = {nullptr, 0};
-			duckdb_v2_logical_type_handle field_type = nullptr;
-			if (duckdb_v2_schema_get_field(resolved, i, &field_name, &field_type, err) != DUCKDB_V2_ERROR_NONE) {
-				break;
-			}
-			observed_names.append(field_name.ptr, field_name.len);
-			if (i == 0) {
-				duckdb_v2_logical_type_get_id(field_type, &observed_first, err);
-			}
-		}
-		duckdb_v2_schema_destroy(&resolved);
-		int32_t one = 1;
-		void *data = nullptr;
-		if (duckdb_v2_vector_get_data_mutable(result, &data, err) == DUCKDB_V2_ERROR_NONE) {
-			std::memcpy(data, &one, sizeof(one));
-		}
-	};
-
-	duckdb_v2_scalar_function_handle function = nullptr;
-	REQUIRE(duckdb_v2_scalar_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
-	auto name = Convert("probe_converter");
-	REQUIRE(duckdb_v2_scalar_function_set_name(function, &name, nullptr) == DUCKDB_V2_ERROR_NONE);
-	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
-	duckdb_v2_function_signature_handle sig = nullptr;
-	REQUIRE(duckdb_v2_scalar_function_get_signature(function, &sig, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_function_signature_add_parameter(sig, ArrowIdent("x"), integer, nullptr, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_function_signature_set_return_type(sig, integer, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_scalar_function_set_exec_callback(function, exec, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_scalar_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
-	duckdb_v2_scalar_function_destroy(&function);
-	duckdb_v2_logical_type_destroy(&integer);
-
-	duckdb_v2_result_handle result = nullptr;
-	REQUIRE(Query(fx.conn, "SELECT probe_converter(1)", &result) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(DrainRowCount(result) == 1);
-	duckdb_v2_result_destroy(&result);
-
-	REQUIRE(observed_count == 2);
-	REQUIRE(observed_names == "ab");
-	REQUIRE(observed_first == DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
-}
 
 TEST_CASE("V2 arrow: functions guard null arguments", "[capi_v2][arrow]") {
 	EnvFixture fx;
@@ -802,31 +1066,32 @@ TEST_CASE("V2 arrow: functions guard null arguments", "[capi_v2][arrow]") {
 	duckdb_v2_result_destroy(&live);
 
 	ArrowSchema schema {};
-	duckdb_v2_str name = Convert("a");
-	REQUIRE(duckdb_v2_logical_types_to_arrow_schema(nullptr, nullptr, &name, 0, &schema, nullptr) ==
-	        DUCKDB_V2_ERROR_INPUT_INVALID);
-
+	duckdb_v2_arrow_importer_handle importer = nullptr;
+	REQUIRE(duckdb_v2_arrow_importer_create(nullptr, &schema, 0, &importer, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(importer == nullptr);
+	duckdb_v2_schema_handle resolved = nullptr;
+	REQUIRE(duckdb_v2_arrow_importer_get_schema(nullptr, &resolved, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(resolved == nullptr);
 	ArrowArray array {};
-	REQUIRE(duckdb_v2_data_chunk_to_arrow_array(nullptr, nullptr, &array, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-
-	duckdb_v2_arrow_converter_handle converter = nullptr;
-	REQUIRE(duckdb_v2_arrow_converter_create(nullptr, &schema, &converter, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(converter == nullptr);
-
+	REQUIRE(duckdb_v2_arrow_importer_append(nullptr, &array, true, false, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 	duckdb_v2_data_chunk_handle chunk = nullptr;
-	REQUIRE(duckdb_v2_arrow_converter_array_to_chunk(nullptr, &array, nullptr, &chunk, nullptr) ==
-	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_arrow_importer_next_chunk(nullptr, &chunk, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(chunk == nullptr);
 
-	duckdb_v2_schema_handle resolved = nullptr;
-	REQUIRE(duckdb_v2_arrow_converter_get_schema(nullptr, &resolved, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(resolved == nullptr);
+	duckdb_v2_arrow_exporter_handle exporter = nullptr;
+	duckdb_v2_str name = Convert("a");
+	REQUIRE(duckdb_v2_arrow_exporter_create(nullptr, nullptr, &name, 0, 0, &exporter, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(exporter == nullptr);
+	REQUIRE(duckdb_v2_arrow_exporter_get_schema(nullptr, &schema, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_arrow_exporter_append(nullptr, &chunk, false, false, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_arrow_exporter_next_array(nullptr, &array, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 
-	// Destroy is null-safe and idempotent.
-	REQUIRE(duckdb_v2_arrow_converter_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_arrow_converter_destroy(&converter) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(converter == nullptr);
-	REQUIRE(duckdb_v2_arrow_converter_destroy(&converter) == DUCKDB_V2_ERROR_NONE);
+	// Both destroys are null-safe and idempotent.
+	REQUIRE(duckdb_v2_arrow_importer_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_arrow_importer_destroy(&importer) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_arrow_exporter_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_arrow_exporter_destroy(&exporter) == DUCKDB_V2_ERROR_NONE);
 }
 
 } // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_cast_function.cpp
+++ b/test/api/capi/v2/test_capi_v2_cast_function.cpp
@@ -1,0 +1,461 @@
+#include "test_capi_v2.hpp"
+
+#include <cstring>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// V2 cast function tests: register a custom type TEMPERATURE (an alias of
+// INTEGER) plus two casts between it and VARCHAR, then reach them from SQL
+// through CAST / TRY_CAST and through implicit argument conversion.
+//
+// Callbacks avoid Catch assertions: a REQUIRE would throw through the C
+// callback boundary into the engine. On failure they populate the provided
+// error slot and return; the failure then surfaces as a query error the test
+// asserts on. Cross-callback observations are latched into file-scope statics.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+duckdb_v2_identifier_t CastIdent(const char *s) {
+	return duckdb_v2_identifier_t {s, std::strlen(s)};
+}
+
+// The mode the last cast callback ran in, latched for the test to assert on.
+DUCKDB_V2_CAST_MODE last_cast_mode = DUCKDB_V2_CAST_MODE_MAX_ENUM;
+
+void FailCast(duckdb_v2_error_info_handle *err, DUCKDB_V2_ERROR code, const std::string &message) {
+	duckdb_v2_error_info_set_code(*err, code);
+	duckdb_v2_error_info_set_text(*err, Convert(message));
+}
+
+// Clears the output vector's validity bit for row `index`.
+DUCKDB_V2_ERROR SetOutputNull(duckdb_v2_vector_handle output, idx_t index, duckdb_v2_error_info_handle *err) {
+	uint64_t *validity = nullptr;
+	auto rc = duckdb_v2_vector_flat_get_validity_mutable(output, &validity, err);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return rc;
+	}
+	validity[index / 64] &= ~(UINT64_C(1) << (index % 64));
+	return DUCKDB_V2_ERROR_NONE;
+}
+
+// Pulls the three things every cast callback needs out of the info handle.
+struct CastArgs {
+	duckdb_v2_vector_handle input = nullptr;
+	duckdb_v2_vector_handle output = nullptr;
+	idx_t count = 0;
+	duckdb_v2_vector_view view {};
+};
+
+bool ReadCastArgs(duckdb_v2_cast_function_exec_info_handle info, CastArgs &out, duckdb_v2_error_info_handle *err) {
+	if (duckdb_v2_cast_function_exec_get_input(info, &out.input, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_cast_function_exec_get_output(info, &out.output, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_cast_function_exec_get_row_count(info, &out.count, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_cast_function_exec_get_mode(info, &last_cast_mode, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_view(out.input, &out.view, err) != DUCKDB_V2_ERROR_NONE) {
+		return false;
+	}
+	return true;
+}
+
+// Parses "<digits>C" into an int32. Returns false on any malformed input.
+bool ParseTemperature(const char *data, idx_t len, int32_t &out) {
+	if (len < 2 || data[len - 1] != 'C') {
+		return false;
+	}
+	idx_t i = data[0] == '-' ? 1 : 0;
+	if (i == len - 1) {
+		return false; // no digits before the 'C'
+	}
+	int64_t value = 0;
+	for (; i < len - 1; i++) {
+		if (data[i] < '0' || data[i] > '9') {
+			return false;
+		}
+		value = value * 10 + (data[i] - '0');
+	}
+	out = static_cast<int32_t>(data[0] == '-' ? -value : value);
+	return true;
+}
+
+// TEMPERATURE -> VARCHAR. Infallible: every input value formats.
+void TempToVarchar(duckdb_v2_cast_function_exec_info_handle info, duckdb_v2_context_handle context,
+                   duckdb_v2_error_info_handle *err) {
+	if (!context) {
+		FailCast(err, DUCKDB_V2_ERROR_INPUT_INVALID, "cast callback ran without a context");
+		return;
+	}
+	CastArgs args;
+	if (!ReadCastArgs(info, args, err)) {
+		return;
+	}
+	const auto *in = static_cast<const int32_t *>(args.view.data);
+	for (idx_t i = 0; i < args.count; i++) {
+		auto idx = SelAt(args.view.sel, i);
+		if (!RowValid(args.view, idx)) {
+			if (SetOutputNull(args.output, i, err) != DUCKDB_V2_ERROR_NONE) {
+				return;
+			}
+			continue;
+		}
+		auto formatted = std::to_string(in[idx]) + "C";
+		if (V2VectorAssignString(args.output, i, formatted.data(), formatted.size(), err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+}
+
+// VARCHAR -> TEMPERATURE. Fails on malformed input: the failing row is left NULL, which is what a TRY cast keeps,
+// and the reported error is what a normal cast aborts on. Also checks that the user data was threaded through.
+void VarcharToTemp(duckdb_v2_cast_function_exec_info_handle info, duckdb_v2_context_handle,
+                   duckdb_v2_error_info_handle *err) {
+	void *user_data = nullptr;
+	if (duckdb_v2_cast_function_exec_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto *secret = static_cast<std::string *>(user_data);
+	if (!secret || *secret != "secret") {
+		FailCast(err, DUCKDB_V2_ERROR_INPUT_INVALID, "user data did not reach the cast callback");
+		return;
+	}
+
+	CastArgs args;
+	if (!ReadCastArgs(info, args, err)) {
+		return;
+	}
+	void *raw = nullptr;
+	if (duckdb_v2_vector_get_data_mutable(args.output, &raw, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	const auto *in = static_cast<const duckdb_v2_bytes *>(args.view.data);
+	auto *out = static_cast<int32_t *>(raw);
+	for (idx_t i = 0; i < args.count; i++) {
+		auto idx = SelAt(args.view.sel, i);
+		if (!RowValid(args.view, idx)) {
+			if (SetOutputNull(args.output, i, err) != DUCKDB_V2_ERROR_NONE) {
+				return;
+			}
+			continue;
+		}
+		auto text = Convert(in[idx]);
+		int32_t parsed = 0;
+		if (!ParseTemperature(text.ptr, text.len, parsed)) {
+			if (SetOutputNull(args.output, i, err) != DUCKDB_V2_ERROR_NONE) {
+				return;
+			}
+			FailCast(err, DUCKDB_V2_ERROR_TYPE_CONVERSION, "Could not convert '" + Convert(text) + "' to TEMPERATURE");
+			continue;
+		}
+		out[i] = parsed;
+	}
+}
+
+void NoopCast(duckdb_v2_cast_function_exec_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
+}
+
+// Registers the TEMPERATURE custom type and hands back a logical type handle for it.
+duckdb_v2_logical_type_handle RegisterTemperatureType(duckdb_v2_connection_handle conn,
+                                                      duckdb_v2_logical_type_handle integer) {
+	duckdb_v2_custom_type_handle custom = nullptr;
+	REQUIRE(duckdb_v2_custom_type_create_with_connection(conn, &custom, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_custom_type_set_name(custom, CastIdent("TEMPERATURE"), nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_custom_type_set_base_type(custom, integer, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_custom_type_register(custom, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_custom_type_destroy(&custom);
+
+	duckdb_v2_logical_type_handle temperature = nullptr;
+	REQUIRE(duckdb_v2_connection_create_type_with_alias(conn, integer, CastIdent("TEMPERATURE"), &temperature,
+	                                                    nullptr) == DUCKDB_V2_ERROR_NONE);
+	return temperature;
+}
+
+// Creates a cast function on the connection, configured but not yet registered.
+duckdb_v2_cast_function_handle MakeCast(duckdb_v2_connection_handle conn, duckdb_v2_logical_type_handle source,
+                                        duckdb_v2_logical_type_handle target,
+                                        duckdb_v2_cast_function_exec_callback_fn callback) {
+	duckdb_v2_cast_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_cast_function_create_with_connection(conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_cast_function_set_source_type(function, source, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_cast_function_set_target_type(function, target, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_cast_function_set_exec_callback(function, callback, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return function;
+}
+
+void DestroySecret(void *data) {
+	delete static_cast<std::string *>(data);
+}
+
+// Registers both TEMPERATURE casts, with `cost` as the VARCHAR -> TEMPERATURE implicit cast cost.
+void RegisterTemperatureCasts(duckdb_v2_connection_handle conn, duckdb_v2_logical_type_handle temperature,
+                              duckdb_v2_logical_type_handle varchar, int64_t cost) {
+	auto to_varchar = MakeCast(conn, temperature, varchar, TempToVarchar);
+	REQUIRE(duckdb_v2_cast_function_register(to_varchar, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_cast_function_destroy(&to_varchar) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(to_varchar == nullptr);
+
+	auto from_varchar = MakeCast(conn, varchar, temperature, VarcharToTemp);
+	REQUIRE(duckdb_v2_cast_function_set_implicit_cast_cost(from_varchar, cost, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_opaque user_data = {new std::string("secret"), DestroySecret, nullptr};
+	REQUIRE(duckdb_v2_cast_function_set_user_data(from_varchar, &user_data, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_cast_function_register(from_varchar, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_cast_function_destroy(&from_varchar);
+}
+
+// Run a query producing a single VARCHAR cell.
+std::string CastQueryText(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql, &result) == DUCKDB_V2_ERROR_NONE);
+	auto chunk = StepChunk(result);
+	REQUIRE(chunk != nullptr);
+	duckdb_v2_vector_handle vec = nullptr;
+	duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr);
+	duckdb_v2_vector_view view {};
+	duckdb_v2_vector_get_view(vec, &view, nullptr);
+	auto out = Convert(Convert(static_cast<const duckdb_v2_bytes *>(view.data)[SelAt(view.sel, 0)]));
+	duckdb_v2_data_chunk_destroy(&chunk);
+	duckdb_v2_result_destroy(&result);
+	return out;
+}
+
+// Runs a query to exhaustion, returning the code the failure surfaced with (execution is lazy, so a runtime
+// failure only shows up while stepping).
+DUCKDB_V2_ERROR CastQueryError(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	auto rc = Query(conn, sql, &result);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_result_destroy(&result);
+		return rc;
+	}
+	auto status = DUCKDB_V2_RESULT_STEP_STATUS_WAITING;
+	while (rc == DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_data_chunk_handle chunk = nullptr;
+		rc = duckdb_v2_result_step(result, &chunk, &status, nullptr);
+		if (chunk) {
+			duckdb_v2_data_chunk_destroy(&chunk);
+		}
+		if (rc != DUCKDB_V2_ERROR_NONE || status == DUCKDB_V2_RESULT_STEP_STATUS_FINISHED ||
+		    status == DUCKDB_V2_RESULT_STEP_STATUS_CANCELLED) {
+			break;
+		}
+		if (status == DUCKDB_V2_RESULT_STEP_STATUS_WAITING) {
+			rc = duckdb_v2_result_wait(result, nullptr);
+		}
+	}
+	duckdb_v2_result_destroy(&result);
+	return rc;
+}
+
+// out[i] = in[i]: an identity scalar function used to observe implicit argument conversion.
+void IdentityExec(duckdb_v2_scalar_function_exec_info_handle info, duckdb_v2_context_handle,
+                  duckdb_v2_error_info_handle *err) {
+	duckdb_v2_vector_handle in = nullptr;
+	duckdb_v2_vector_handle out = nullptr;
+	idx_t count = 0;
+	if (duckdb_v2_scalar_function_exec_get_arg(info, 0, &in, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_scalar_function_exec_get_result(info, &out, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_scalar_function_exec_get_row_count(info, &count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_vector_view view {};
+	void *raw = nullptr;
+	if (duckdb_v2_vector_get_view(in, &view, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(out, &raw, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	const auto *src = static_cast<const int32_t *>(view.data);
+	auto *dst = static_cast<int32_t *>(raw);
+	for (idx_t i = 0; i < count; i++) {
+		dst[i] = src[SelAt(view.sel, i)];
+	}
+}
+
+// Registers reading(t TEMPERATURE) -> INTEGER, whose single argument is what an implicit cast has to reach.
+void RegisterReading(duckdb_v2_connection_handle conn, duckdb_v2_logical_type_handle temperature,
+                     duckdb_v2_logical_type_handle integer) {
+	duckdb_v2_scalar_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_create_with_connection(conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto name = Convert("reading");
+	REQUIRE(duckdb_v2_scalar_function_set_name(function, &name, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_function_signature_handle sig = nullptr;
+	REQUIRE(duckdb_v2_scalar_function_get_signature(function, &sig, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_add_parameter(sig, CastIdent("t"), temperature, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_function_signature_set_return_type(sig, integer, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_set_exec_callback(function, IdentityExec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_scalar_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_scalar_function_destroy(&function);
+}
+
+} // namespace
+
+TEST_CASE("V2 cast: round-trip between a custom type and VARCHAR", "[capi_v2][cast_function]") {
+	EnvFixture fx;
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	auto varchar = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
+	auto temperature = RegisterTemperatureType(fx.conn, integer);
+	RegisterTemperatureCasts(fx.conn, temperature, varchar, -1);
+	duckdb_v2_logical_type_destroy(&temperature);
+	duckdb_v2_logical_type_destroy(&varchar);
+	duckdb_v2_logical_type_destroy(&integer);
+
+	last_cast_mode = DUCKDB_V2_CAST_MODE_MAX_ENUM;
+	REQUIRE(CastQueryText(fx.conn, "SELECT CAST(CAST(42 AS TEMPERATURE) AS VARCHAR)") == "42C");
+	// An explicit CAST runs in normal mode.
+	REQUIRE(last_cast_mode == DUCKDB_V2_CAST_MODE_NORMAL);
+	REQUIRE(CastQueryText(fx.conn, "SELECT CAST(CAST(-7 AS TEMPERATURE) AS VARCHAR)") == "-7C");
+
+	// And back the other way, through the base type so the result is readable as text.
+	REQUIRE(CastQueryText(fx.conn, "SELECT CAST(CAST('100C' AS TEMPERATURE) AS INTEGER)::VARCHAR") == "100");
+	REQUIRE(CastQueryText(fx.conn, "SELECT CAST(CAST('-5C' AS TEMPERATURE) AS INTEGER)::VARCHAR") == "-5");
+
+	// NULLs reach the callback, which propagates them.
+	REQUIRE(CastQueryText(fx.conn, "SELECT (CAST(CAST(NULL AS TEMPERATURE) AS VARCHAR) IS NULL)::VARCHAR") == "true");
+
+	// Several rows in one batch, so the callback sees a full vector rather than a constant.
+	REQUIRE(CastQueryText(fx.conn, "SELECT string_agg(CAST(CAST(t AS TEMPERATURE) AS VARCHAR), ',' ORDER BY t) "
+	                               "FROM (VALUES (1), (2)) v(t)") == "1C,2C");
+}
+
+TEST_CASE("V2 cast: normal casts abort, try casts yield NULL", "[capi_v2][cast_function]") {
+	EnvFixture fx;
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	auto varchar = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
+	auto temperature = RegisterTemperatureType(fx.conn, integer);
+	RegisterTemperatureCasts(fx.conn, temperature, varchar, -1);
+	duckdb_v2_logical_type_destroy(&temperature);
+	duckdb_v2_logical_type_destroy(&varchar);
+	duckdb_v2_logical_type_destroy(&integer);
+
+	// A normal cast: the callback's error aborts the query, and its code round-trips.
+	last_cast_mode = DUCKDB_V2_CAST_MODE_MAX_ENUM;
+	REQUIRE(CastQueryError(fx.conn, "SELECT CAST('not-a-temp' AS TEMPERATURE)") == DUCKDB_V2_ERROR_TYPE_CONVERSION);
+	REQUIRE(last_cast_mode == DUCKDB_V2_CAST_MODE_NORMAL);
+
+	// A try cast: the error is discarded and the row the callback left NULL is kept.
+	last_cast_mode = DUCKDB_V2_CAST_MODE_MAX_ENUM;
+	REQUIRE(CastQueryText(fx.conn, "SELECT (TRY_CAST('not-a-temp' AS TEMPERATURE) IS NULL)::VARCHAR") == "true");
+	REQUIRE(last_cast_mode == DUCKDB_V2_CAST_MODE_TRY);
+
+	// A try cast over valid input still converts.
+	REQUIRE(CastQueryText(fx.conn, "SELECT CAST(TRY_CAST('12C' AS TEMPERATURE) AS INTEGER)::VARCHAR") == "12");
+}
+
+TEST_CASE("V2 cast: implicit cast cost governs argument conversion", "[capi_v2][cast_function]") {
+	// A negative cost -- the default -- keeps the cast out of implicit conversion, so binding a VARCHAR
+	// argument to a TEMPERATURE parameter fails. The argument has to come from a column: a string literal is
+	// bound loosely and reaches any parameter type regardless of the cast's cost.
+	{
+		EnvFixture fx;
+		auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+		auto varchar = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
+		auto temperature = RegisterTemperatureType(fx.conn, integer);
+		RegisterTemperatureCasts(fx.conn, temperature, varchar, -1);
+		RegisterReading(fx.conn, temperature, integer);
+		duckdb_v2_logical_type_destroy(&temperature);
+		duckdb_v2_logical_type_destroy(&varchar);
+		duckdb_v2_logical_type_destroy(&integer);
+
+		REQUIRE(CastQueryText(fx.conn, "SELECT reading(CAST('30C' AS TEMPERATURE))::VARCHAR") == "30");
+		REQUIRE(CastQueryError(fx.conn, "SELECT reading(v) FROM (VALUES ('30C')) t(v)") != DUCKDB_V2_ERROR_NONE);
+	}
+
+	// A non-negative cost makes the same cast available to the binder.
+	{
+		EnvFixture fx;
+		auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+		auto varchar = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
+		auto temperature = RegisterTemperatureType(fx.conn, integer);
+		RegisterTemperatureCasts(fx.conn, temperature, varchar, 0);
+		RegisterReading(fx.conn, temperature, integer);
+		duckdb_v2_logical_type_destroy(&temperature);
+		duckdb_v2_logical_type_destroy(&varchar);
+		duckdb_v2_logical_type_destroy(&integer);
+
+		REQUIRE(CastQueryText(fx.conn, "SELECT reading(v)::VARCHAR FROM (VALUES ('30C')) t(v)") == "30");
+	}
+}
+
+TEST_CASE("V2 cast: registration refusals", "[capi_v2][cast_function]") {
+	EnvFixture fx;
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	auto varchar = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
+	auto any = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_ANY);
+
+	// Nothing configured at all, then each missing piece in turn.
+	{
+		duckdb_v2_cast_function_handle function = nullptr;
+		REQUIRE(duckdb_v2_cast_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_cast_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+		REQUIRE(duckdb_v2_cast_function_set_source_type(function, integer, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_cast_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+		REQUIRE(duckdb_v2_cast_function_set_target_type(function, varchar, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_cast_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+		REQUIRE(duckdb_v2_cast_function_set_exec_callback(function, NoopCast, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_cast_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+		duckdb_v2_cast_function_destroy(&function);
+	}
+
+	// ANY is a signature wildcard, not a cast endpoint -- on either side.
+	{
+		auto function = MakeCast(fx.conn, any, varchar, NoopCast);
+		REQUIRE(duckdb_v2_cast_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_cast_function_destroy(&function);
+	}
+	{
+		auto function = MakeCast(fx.conn, varchar, any, NoopCast);
+		REQUIRE(duckdb_v2_cast_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_cast_function_destroy(&function);
+	}
+
+	duckdb_v2_logical_type_destroy(&integer);
+	duckdb_v2_logical_type_destroy(&varchar);
+	duckdb_v2_logical_type_destroy(&any);
+}
+
+TEST_CASE("V2 cast: null arguments and destroy null-safety", "[capi_v2][cast_function]") {
+	EnvFixture fx;
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+
+	duckdb_v2_cast_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_cast_function_create_with_connection(nullptr, &function, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(function == nullptr);
+	REQUIRE(duckdb_v2_cast_function_create_with_connection(fx.conn, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_create_with_extension(nullptr, &function, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	REQUIRE(duckdb_v2_cast_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_cast_function_set_source_type(function, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_set_source_type(nullptr, integer, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_set_target_type(function, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_set_target_type(nullptr, integer, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_set_implicit_cast_cost(nullptr, 0, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_set_user_data(function, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_set_exec_callback(nullptr, NoopCast, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_register(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// The exec accessors reject a null info handle and a null out-parameter alike.
+	void *data = nullptr;
+	idx_t count = 0;
+	duckdb_v2_vector_handle vector = nullptr;
+	auto mode = DUCKDB_V2_CAST_MODE_NORMAL;
+	REQUIRE(duckdb_v2_cast_function_exec_get_user_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_exec_get_row_count(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_exec_get_input(nullptr, &vector, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_exec_get_output(nullptr, &vector, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_cast_function_exec_get_mode(nullptr, &mode, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	REQUIRE(duckdb_v2_cast_function_destroy(&function) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(function == nullptr);
+	REQUIRE(duckdb_v2_cast_function_destroy(&function) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_cast_function_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	duckdb_v2_logical_type_destroy(&integer);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_catalog.cpp
+++ b/test/api/capi/v2/test_capi_v2_catalog.cpp
@@ -1,0 +1,264 @@
+#include "test_capi_v2.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// V2 table description: resolve one table name and snapshot where it
+// resolved, its columns, and per-column catalog facts. These tests pin the
+// resolution semantics (search path, two-part schema-versus-catalog reading,
+// the error cases), the resolved-name reporting, the column getters, and the
+// snapshot lifecycle, plus the column description handle.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+// Owned qname built from parts; the caller destroys it.
+duckdb_v2_qname_handle MakeQName(const std::vector<const char *> &parts) {
+	std::vector<duckdb_v2_identifier_t> views;
+	for (auto *part : parts) {
+		views.push_back(Convert(part));
+	}
+	duckdb_v2_qname_handle qname = nullptr;
+	REQUIRE(duckdb_v2_qname_create(views.data(), views.size(), &qname, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return qname;
+}
+
+// Owned description for a name given as parts; asserts success.
+duckdb_v2_table_description_handle Describe(duckdb_v2_connection_handle conn, const std::vector<const char *> &parts) {
+	auto qname = MakeQName(parts);
+	duckdb_v2_table_description_handle desc = nullptr;
+	REQUIRE(duckdb_v2_connection_describe_table(conn, qname, &desc, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(desc != nullptr);
+	duckdb_v2_qname_destroy(&qname);
+	return desc;
+}
+
+// The description's resolved name as rendered SQL text.
+std::string ResolvedName(duckdb_v2_table_description_handle desc) {
+	duckdb_v2_qname_handle qname = nullptr;
+	REQUIRE(duckdb_v2_table_description_get_qname(desc, &qname, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto rc = DUCKDB_V2_ERROR_NONE;
+	auto out = RenderText(
+	    [&](char *buf, idx_t cap, idx_t *len) { return duckdb_v2_qname_render(qname, buf, cap, len, nullptr); }, rc);
+	REQUIRE(rc == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_qname_destroy(&qname);
+	return out;
+}
+
+bool IsReadOnly(duckdb_v2_table_description_handle desc) {
+	bool readonly = false;
+	REQUIRE(duckdb_v2_table_description_is_readonly(desc, &readonly, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return readonly;
+}
+
+// Fails to describe a name, handing back the error text.
+std::string DescribeError(duckdb_v2_connection_handle conn, const std::vector<const char *> &parts) {
+	auto qname = MakeQName(parts);
+	duckdb_v2_table_description_handle desc = nullptr;
+	duckdb_v2_error_info_handle err = nullptr;
+	REQUIRE(duckdb_v2_connection_describe_table(conn, qname, &desc, &err) != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(desc == nullptr);
+	REQUIRE(err != nullptr);
+	duckdb_v2_str message = {nullptr, 0};
+	REQUIRE(duckdb_v2_error_info_get_text(err, &message) == DUCKDB_V2_ERROR_NONE);
+	auto text = Convert(message);
+	duckdb_v2_error_info_destroy(&err);
+	duckdb_v2_qname_destroy(&qname);
+	return text;
+}
+
+} // namespace
+
+TEST_CASE("V2 table description: resolution reports the resolved location", "[capi_v2][catalog]") {
+	EnvFixture fx;
+	ExecSQL(fx.conn, "CREATE TABLE t(i INTEGER)");
+	ExecSQL(fx.conn, "CREATE TEMP TABLE tt(i INTEGER)");
+	ExecSQL(fx.conn, "CREATE TABLE \"FooBar\"(i INTEGER)");
+
+	// An unqualified name fills in the resolved catalog and schema.
+	auto desc = Describe(fx.conn, {"t"});
+	REQUIRE(ResolvedName(desc) == "memory.main.t");
+	REQUIRE_FALSE(IsReadOnly(desc));
+	duckdb_v2_table_description_destroy(&desc);
+
+	// A temp table resolves through the temp catalog, which is writable. The
+	// catalog renders quoted because temp is a parser keyword.
+	desc = Describe(fx.conn, {"tt"});
+	REQUIRE(ResolvedName(desc) == "\"temp\".main.tt");
+	REQUIRE_FALSE(IsReadOnly(desc));
+	duckdb_v2_table_description_destroy(&desc);
+
+	// The name comes back with its DDL time casing, not the lookup casing.
+	desc = Describe(fx.conn, {"foobar"});
+	REQUIRE(ResolvedName(desc) == "memory.main.FooBar");
+	duckdb_v2_table_description_destroy(&desc);
+
+	// A fully qualified name resolves as written.
+	desc = Describe(fx.conn, {"memory", "main", "t"});
+	REQUIRE(ResolvedName(desc) == "memory.main.t");
+	duckdb_v2_table_description_destroy(&desc);
+}
+
+TEST_CASE("V2 table description: two-part names read as SQL reads them", "[capi_v2][catalog]") {
+	EnvFixture fx;
+	ExecSQL(fx.conn, "CREATE SCHEMA s");
+	ExecSQL(fx.conn, "CREATE TABLE s.t2(i INTEGER)");
+	ExecSQL(fx.conn, "ATTACH ':memory:' AS other");
+	ExecSQL(fx.conn, "CREATE TABLE other.t3(i INTEGER)");
+
+	// schema.table resolves within the default catalog.
+	auto desc = Describe(fx.conn, {"s", "t2"});
+	REQUIRE(ResolvedName(desc) == "memory.s.t2");
+	duckdb_v2_table_description_destroy(&desc);
+
+	// catalog.table promotes the first part to an attached database.
+	desc = Describe(fx.conn, {"other", "t3"});
+	REQUIRE(ResolvedName(desc) == "other.main.t3");
+	duckdb_v2_table_description_destroy(&desc);
+
+	// A first part naming both a schema and an attached database is ambiguous.
+	ExecSQL(fx.conn, "CREATE SCHEMA amb");
+	ExecSQL(fx.conn, "ATTACH ':memory:' AS amb");
+	REQUIRE(DescribeError(fx.conn, {"amb", "t2"}).find("Ambiguous") != std::string::npos);
+}
+
+TEST_CASE("V2 table description: missing tables and views are rejected", "[capi_v2][catalog]") {
+	EnvFixture fx;
+	ExecSQL(fx.conn, "CREATE VIEW v AS SELECT 42 AS i");
+
+	// A name that resolves to nothing.
+	REQUIRE(DescribeError(fx.conn, {"no_such_table"}).find("does not exist") != std::string::npos);
+
+	// A name that resolves to a view: a description snapshots a base table.
+	REQUIRE(DescribeError(fx.conn, {"v"}).find("is not a") != std::string::npos);
+
+	// Null arguments are rejected.
+	auto qname = MakeQName({"v"});
+	duckdb_v2_table_description_handle desc = nullptr;
+	REQUIRE(duckdb_v2_connection_describe_table(nullptr, qname, &desc, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_connection_describe_table(fx.conn, nullptr, &desc, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_connection_describe_table(fx.conn, qname, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	duckdb_v2_qname_destroy(&qname);
+}
+
+TEST_CASE("V2 table description: column descriptions", "[capi_v2][catalog]") {
+	EnvFixture fx;
+	ExecSQL(fx.conn, "CREATE TABLE facts("
+	                 "i INTEGER, "
+	                 "\"J\" VARCHAR DEFAULT 'x', "
+	                 "k INTEGER GENERATED ALWAYS AS (i + 1))");
+
+	auto desc = Describe(fx.conn, {"facts"});
+
+	// Every column in declared order, the generated one included.
+	idx_t count = 0;
+	REQUIRE(duckdb_v2_table_description_get_column_count(desc, &count, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(count == 3);
+
+	const char *expected_names[] = {"i", "J", "k"};
+	DUCKDB_V2_LOGICAL_TYPE_ID expected_types[] = {DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR,
+	                                              DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER};
+	const bool expected_generated[] = {false, false, true};
+	const bool expected_default[] = {false, true, false};
+	std::vector<duckdb_v2_column_description_handle> columns;
+	for (idx_t i = 0; i < count; i++) {
+		duckdb_v2_column_description_handle column = nullptr;
+		REQUIRE(duckdb_v2_table_description_get_column(desc, i, &column, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(column != nullptr);
+		columns.push_back(column);
+	}
+
+	// A column description is independent of the table description it came from.
+	duckdb_v2_table_description_destroy(&desc);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto column = columns[i];
+		duckdb_v2_identifier_t name = {nullptr, 0};
+		REQUIRE(duckdb_v2_column_description_get_name(column, &name, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(name == expected_names[i]);
+
+		duckdb_v2_logical_type_handle type = nullptr; // borrowed; do not destroy
+		REQUIRE(duckdb_v2_column_description_get_type(column, &type, nullptr) == DUCKDB_V2_ERROR_NONE);
+		DUCKDB_V2_LOGICAL_TYPE_ID id = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
+		REQUIRE(duckdb_v2_logical_type_get_id(type, &id, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(id == expected_types[i]);
+
+		bool has_generated = false;
+		REQUIRE(duckdb_v2_column_description_has_generated(column, &has_generated, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(has_generated == expected_generated[i]);
+
+		bool has_default = false;
+		REQUIRE(duckdb_v2_column_description_has_default(column, &has_default, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(has_default == expected_default[i]);
+
+		duckdb_v2_column_description_destroy(&column);
+		REQUIRE(column == nullptr);
+	}
+
+	// An out-of-range index is rejected.
+	desc = Describe(fx.conn, {"facts"});
+	duckdb_v2_column_description_handle column = nullptr;
+	REQUIRE(duckdb_v2_table_description_get_column(desc, 3, &column, nullptr) == DUCKDB_V2_ERROR_INPUT_OUT_OF_RANGE);
+	REQUIRE(column == nullptr);
+	duckdb_v2_table_description_destroy(&desc);
+
+	// Destroy is null-safe and idempotent; null subjects are rejected.
+	REQUIRE(duckdb_v2_column_description_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_column_description_destroy(&column) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	REQUIRE(duckdb_v2_column_description_get_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	bool flag = false;
+	REQUIRE(duckdb_v2_column_description_has_default(nullptr, &flag, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
+TEST_CASE("V2 table description: a read only catalog reports readonly", "[capi_v2][catalog]") {
+	EnvFixture fx;
+	auto path = duckdb::TestCreatePath("v2_catalog_readonly.db");
+	duckdb::DeleteDatabase(path);
+
+	// Create the file backed table through a writable attach, then reattach read only.
+	ExecSQL(fx.conn, ("ATTACH '" + path + "' AS rw").c_str());
+	ExecSQL(fx.conn, "CREATE TABLE rw.rt(i INTEGER)");
+	ExecSQL(fx.conn, "DETACH rw");
+	ExecSQL(fx.conn, ("ATTACH '" + path + "' AS ro (READ_ONLY)").c_str());
+
+	auto desc = Describe(fx.conn, {"ro", "rt"});
+	REQUIRE(ResolvedName(desc) == "ro.main.rt");
+	REQUIRE(IsReadOnly(desc));
+	duckdb_v2_table_description_destroy(&desc);
+
+	ExecSQL(fx.conn, "DETACH ro");
+	duckdb::DeleteDatabase(path);
+}
+
+TEST_CASE("V2 table description: a description is a snapshot", "[capi_v2][catalog]") {
+	EnvFixture fx;
+	ExecSQL(fx.conn, "CREATE TABLE snap(i INTEGER)");
+
+	auto desc = Describe(fx.conn, {"snap"});
+	ExecSQL(fx.conn, "DROP TABLE snap");
+
+	// The snapshot stays readable after the table is gone.
+	REQUIRE(ResolvedName(desc) == "memory.main.snap");
+	idx_t count = 0;
+	REQUIRE(duckdb_v2_table_description_get_column_count(desc, &count, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(count == 1);
+	duckdb_v2_table_description_destroy(&desc);
+	REQUIRE(desc == nullptr);
+
+	// Destroy is null-safe and idempotent.
+	REQUIRE(duckdb_v2_table_description_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_description_destroy(&desc) == DUCKDB_V2_ERROR_NONE);
+
+	// Null getter subjects and out-slots are rejected.
+	duckdb_v2_qname_handle qname = nullptr;
+	REQUIRE(duckdb_v2_table_description_get_qname(nullptr, &qname, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_description_get_column_count(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	bool flag = false;
+	REQUIRE(duckdb_v2_table_description_is_readonly(nullptr, &flag, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_column_data_collection.cpp
+++ b/test/api/capi/v2/test_capi_v2_column_data_collection.cpp
@@ -315,6 +315,35 @@ TEST_CASE("V2: column_data_collection reset keeps types, drops rows", "[capi_v2]
 	duckdb_v2_column_data_collection_destroy(&cdc);
 }
 
+TEST_CASE("V2: column_data_collection clear keeps types, drops rows", "[capi_v2][column_data_collection]") {
+	EnvFixture fx;
+	auto cdc = MakeIntCollection(fx.conn);
+	AppendInts(fx.conn, cdc, {1, 2, 3});
+	REQUIRE(RowCount(cdc) == 3);
+
+	// Same observable effect as reset; the difference is that the buffers are retained for the next appends.
+	REQUIRE(duckdb_v2_column_data_collection_clear(cdc, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(RowCount(cdc) == 0);
+	REQUIRE(ScanInts(fx.conn, cdc).empty());
+
+	AppendInts(fx.conn, cdc, {9, 8});
+	REQUIRE(RowCount(cdc) == 2);
+	REQUIRE(ScanInts(fx.conn, cdc) == std::vector<int32_t> {9, 8});
+
+	// Repeated fill/clear cycles are the point of it.
+	for (int round = 0; round < 3; round++) {
+		REQUIRE(duckdb_v2_column_data_collection_clear(cdc, nullptr) == DUCKDB_V2_ERROR_NONE);
+		AppendInts(fx.conn, cdc, {round});
+		REQUIRE(ScanInts(fx.conn, cdc) == std::vector<int32_t> {round});
+	}
+
+	duckdb_v2_column_data_collection_destroy(&cdc);
+}
+
+TEST_CASE("V2: column_data_collection clear null arg", "[capi_v2][column_data_collection]") {
+	REQUIRE(duckdb_v2_column_data_collection_clear(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
 // ===========================================================================
 // Refusals: create / append / scan
 // ===========================================================================

--- a/test/api/capi/v2/test_capi_v2_copy_function.cpp
+++ b/test/api/capi/v2/test_capi_v2_copy_function.cpp
@@ -6,14 +6,14 @@
 
 // ---------------------------------------------------------------------------
 // V2 copy function tests: build a function on a connection, register it, and
-// drive it through COPY ... TO.
+// drive it through COPY ... TO and COPY ... FROM.
 //
 // Callbacks avoid Catch assertions: a REQUIRE would throw through the C
 // callback boundary into the engine. On failure they populate the provided
 // error slot and return; the failure then surfaces as a query error that the
 // test asserts on. Cross-callback observations are latched into file-scope
-// statics and asserted after the query. The batch callback may run on several
-// threads at once, so the latches it writes are atomic.
+// statics and asserted after the query. The batch and exec callbacks may run
+// on several threads at once, so the latches they write are atomic.
 // ---------------------------------------------------------------------------
 
 namespace test_capi_v2 {
@@ -29,10 +29,17 @@ duckdb_v2_copy_function_handle MakeCopy(duckdb_v2_connection_handle conn, const 
 	return function;
 }
 
-// COPY the rows of `source` to `path` with the given format. The target never exists beforehand, so the engine
-// writes it in place; USE_TMP_FILE is pinned anyway so a leftover file from an earlier run cannot change that.
-std::string CopyStatement(const std::string &source, const std::string &path, const char *format) {
-	return "COPY (" + source + ") TO '" + path + "' (FORMAT " + format + ", USE_TMP_FILE FALSE)";
+// COPY the rows of `source` to `path` with the given format and extra options. The target never exists beforehand,
+// so the engine writes it in place; USE_TMP_FILE is pinned anyway so a leftover file from an earlier run cannot
+// change that.
+std::string CopyToStatement(const std::string &source, const std::string &path, const char *format,
+                            const std::string &options = "") {
+	return "COPY (" + source + ") TO '" + path + "' (FORMAT " + format + ", USE_TMP_FILE FALSE" + options + ")";
+}
+
+std::string CopyFromStatement(const std::string &table, const std::string &path, const char *format,
+                              const std::string &options = "") {
+	return "COPY " + table + " FROM '" + path + "' (FORMAT " + format + options + ")";
 }
 
 // Runs a COPY statement and returns the row count it reports.
@@ -68,9 +75,32 @@ DUCKDB_V2_ERROR RunFailingCopy(duckdb_v2_connection_handle conn, const std::stri
 	return rc;
 }
 
+// Runs a query producing a single BIGINT cell.
+int64_t QueryI64(duckdb_v2_connection_handle conn, const std::string &sql) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql.c_str(), &result) == DUCKDB_V2_ERROR_NONE);
+	auto chunk = StepChunk(result);
+	REQUIRE(chunk != nullptr);
+	duckdb_v2_vector_handle vec = nullptr;
+	duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr);
+	duckdb_v2_vector_view view {};
+	duckdb_v2_vector_get_view(vec, &view, nullptr);
+	auto out = static_cast<const int64_t *>(view.data)[SelAt(view.sel, 0)];
+	duckdb_v2_data_chunk_destroy(&chunk);
+	duckdb_v2_result_destroy(&result);
+	return out;
+}
+
+std::string Lower(std::string s) {
+	for (auto &c : s) {
+		c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+	}
+	return s;
+}
+
 // ---------------------------------------------------------------------------
-// probe_copy: every callback latches what it saw. The user, bind, init and
-// batch data are file-scope markers with counting destructors.
+// The COPY TO probe: every callback latches what it saw. The user, bind, init
+// and batch data are file-scope markers with counting destructors.
 // ---------------------------------------------------------------------------
 
 int copy_user_marker = 0;
@@ -78,15 +108,15 @@ int copy_bind_marker = 0;
 int copy_init_marker = 0;
 int copy_batch_marker = 0;
 
-enum Phase { BIND = 0, BATCH_SIZE, INIT, BATCH, FLUSH, FINALIZE, PHASE_COUNT };
+enum ToPhase { TO_BIND = 0, TO_BATCH_SIZE, TO_INIT, TO_BATCH, TO_FLUSH, TO_FINALIZE, TO_PHASE_COUNT };
 
-struct CopyProbe {
+struct CopyToProbe {
 	// What each phase's data accessors returned.
-	std::atomic<void *> user_data[PHASE_COUNT];
-	std::atomic<void *> bind_data[PHASE_COUNT];
-	std::atomic<void *> init_data[PHASE_COUNT];
+	std::atomic<void *> user_data[TO_PHASE_COUNT];
+	std::atomic<void *> bind_data[TO_PHASE_COUNT];
+	std::atomic<void *> init_data[TO_PHASE_COUNT];
 	std::atomic<void *> batch_data_in_flush;
-	std::atomic<idx_t> calls[PHASE_COUNT];
+	std::atomic<idx_t> calls[TO_PHASE_COUNT];
 	// Taking the batch a second time is refused.
 	std::atomic<DUCKDB_V2_ERROR> second_take_rc;
 	// Rows seen by the batch callback, summed over every batch.
@@ -97,16 +127,20 @@ struct CopyProbe {
 	std::atomic<int> batch_data_destroys;
 
 	// Written by the bind and init callbacks only, which run once per statement.
+	std::string bind_file_path;
 	idx_t column_count = 0;
 	std::string column_names[2];
 	DUCKDB_V2_LOGICAL_TYPE_ID column_types[2] = {DUCKDB_V2_LOGICAL_TYPE_ID_INVALID, DUCKDB_V2_LOGICAL_TYPE_ID_INVALID};
 	// Out-of-range probes, latched with their own (null) error slot.
 	DUCKDB_V2_ERROR oob_type_rc = DUCKDB_V2_ERROR_NONE;
 	DUCKDB_V2_ERROR oob_name_rc = DUCKDB_V2_ERROR_NONE;
+	DUCKDB_V2_ERROR oob_option_rc = DUCKDB_V2_ERROR_NONE;
+	// The statement's options as "name=rendered value" lines, in order.
+	std::string options;
 	std::string file_path;
 
 	void Reset() {
-		for (int phase = 0; phase < PHASE_COUNT; phase++) {
+		for (int phase = 0; phase < TO_PHASE_COUNT; phase++) {
 			user_data[phase] = nullptr;
 			bind_data[phase] = nullptr;
 			init_data[phase] = nullptr;
@@ -119,6 +153,7 @@ struct CopyProbe {
 		bind_data_destroys = 0;
 		init_data_destroys = 0;
 		batch_data_destroys = 0;
+		bind_file_path.clear();
 		column_count = 0;
 		column_names[0].clear();
 		column_names[1].clear();
@@ -126,113 +161,148 @@ struct CopyProbe {
 		column_types[1] = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
 		oob_type_rc = DUCKDB_V2_ERROR_NONE;
 		oob_name_rc = DUCKDB_V2_ERROR_NONE;
+		oob_option_rc = DUCKDB_V2_ERROR_NONE;
+		options.clear();
 		file_path.clear();
 	}
-} copy_probe;
+} copy_to_probe;
 
 void DestroyUserData(void *) {
-	copy_probe.user_data_destroys++;
+	copy_to_probe.user_data_destroys++;
 }
 void DestroyBindData(void *) {
-	copy_probe.bind_data_destroys++;
+	copy_to_probe.bind_data_destroys++;
 }
 void DestroyInitData(void *) {
-	copy_probe.init_data_destroys++;
+	copy_to_probe.init_data_destroys++;
 }
 void DestroyBatchData(void *) {
-	copy_probe.batch_data_destroys++;
+	copy_to_probe.batch_data_destroys++;
 }
 
-void ProbeBind(duckdb_v2_copy_function_bind_info_handle info, duckdb_v2_context_handle,
-               duckdb_v2_error_info_handle *err) {
-	copy_probe.calls[BIND]++;
-	void *user_data = nullptr;
-	if (duckdb_v2_copy_function_bind_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE) {
-		return;
+// Renders an option value without Catch assertions; the caller owns the value.
+std::string RenderOption(duckdb_v2_value_handle value) {
+	idx_t len = 0;
+	if (duckdb_v2_value_to_string(value, nullptr, 0, &len, nullptr) != DUCKDB_V2_ERROR_NONE) {
+		return "<error>";
 	}
-	copy_probe.user_data[BIND] = user_data;
+	std::string out(len + 1, '\0');
+	if (duckdb_v2_value_to_string(value, &out[0], out.size(), &len, nullptr) != DUCKDB_V2_ERROR_NONE) {
+		return "<error>";
+	}
+	out.resize(len);
+	return out;
+}
 
-	if (duckdb_v2_copy_function_bind_get_column_count(info, &copy_probe.column_count, err) != DUCKDB_V2_ERROR_NONE) {
+void ProbeToBind(duckdb_v2_copy_to_bind_info_handle info, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
+	copy_to_probe.calls[TO_BIND]++;
+	void *user_data = nullptr;
+	duckdb_v2_str path = {nullptr, 0};
+	if (duckdb_v2_copy_to_bind_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_bind_get_file_path(info, &path, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	for (idx_t i = 0; i < copy_probe.column_count && i < 2; i++) {
+	copy_to_probe.user_data[TO_BIND] = user_data;
+	copy_to_probe.bind_file_path = Convert(path);
+
+	if (duckdb_v2_copy_to_bind_get_column_count(info, &copy_to_probe.column_count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (idx_t i = 0; i < copy_to_probe.column_count && i < 2; i++) {
 		duckdb_v2_identifier_t name = {nullptr, 0};
-		if (duckdb_v2_copy_function_bind_get_column_name(info, i, &name, err) != DUCKDB_V2_ERROR_NONE) {
+		if (duckdb_v2_copy_to_bind_get_column_name(info, i, &name, err) != DUCKDB_V2_ERROR_NONE) {
 			return;
 		}
-		copy_probe.column_names[i] = Convert(name);
+		copy_to_probe.column_names[i] = Convert(name);
 		duckdb_v2_logical_type_handle type = nullptr;
-		if (duckdb_v2_copy_function_bind_get_column_type(info, i, &type, err) != DUCKDB_V2_ERROR_NONE) {
+		if (duckdb_v2_copy_to_bind_get_column_type(info, i, &type, err) != DUCKDB_V2_ERROR_NONE) {
 			return;
 		}
-		auto rc = duckdb_v2_logical_type_get_id(type, &copy_probe.column_types[i], err);
+		auto rc = duckdb_v2_logical_type_get_id(type, &copy_to_probe.column_types[i], err);
 		duckdb_v2_logical_type_destroy(&type);
 		if (rc != DUCKDB_V2_ERROR_NONE) {
 			return;
 		}
 	}
-	// An index past the last column is an input error.
+
+	idx_t option_count = 0;
+	if (duckdb_v2_copy_to_bind_get_option_count(info, &option_count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (idx_t i = 0; i < option_count; i++) {
+		duckdb_v2_identifier_t name = {nullptr, 0};
+		duckdb_v2_value_handle value = nullptr;
+		if (duckdb_v2_copy_to_bind_get_option_name(info, i, &name, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_copy_to_bind_get_option_value(info, i, &value, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		copy_to_probe.options += Lower(Convert(name)) + "=" + RenderOption(value) + "\n";
+		duckdb_v2_value_destroy(&value);
+	}
+
+	// An index past the last column or option is an input error.
 	duckdb_v2_logical_type_handle oob_type = nullptr;
 	duckdb_v2_identifier_t oob_name = {nullptr, 0};
-	copy_probe.oob_type_rc =
-	    duckdb_v2_copy_function_bind_get_column_type(info, copy_probe.column_count, &oob_type, nullptr);
-	copy_probe.oob_name_rc =
-	    duckdb_v2_copy_function_bind_get_column_name(info, copy_probe.column_count, &oob_name, nullptr);
+	duckdb_v2_value_handle oob_value = nullptr;
+	copy_to_probe.oob_type_rc =
+	    duckdb_v2_copy_to_bind_get_column_type(info, copy_to_probe.column_count, &oob_type, nullptr);
+	copy_to_probe.oob_name_rc =
+	    duckdb_v2_copy_to_bind_get_column_name(info, copy_to_probe.column_count, &oob_name, nullptr);
+	copy_to_probe.oob_option_rc = duckdb_v2_copy_to_bind_get_option_value(info, option_count, &oob_value, nullptr);
 
 	duckdb_v2_opaque bind_data = {&copy_bind_marker, DestroyBindData, nullptr};
-	duckdb_v2_copy_function_bind_set_bind_data(info, &bind_data, err);
+	duckdb_v2_copy_to_bind_set_bind_data(info, &bind_data, err);
 }
 
 // Asks for batches larger than any input in these tests, so a whole copy arrives as one batch per thread.
-void ProbeBatchSize(duckdb_v2_copy_function_batch_size_info_handle info, duckdb_v2_context_handle,
-                    duckdb_v2_error_info_handle *err) {
-	copy_probe.calls[BATCH_SIZE]++;
+void ProbeToBatchSize(duckdb_v2_copy_to_batch_size_info_handle info, duckdb_v2_context_handle,
+                      duckdb_v2_error_info_handle *err) {
+	copy_to_probe.calls[TO_BATCH_SIZE]++;
 	void *user_data = nullptr;
 	void *bind_data = nullptr;
-	if (duckdb_v2_copy_function_batch_size_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_batch_size_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE) {
+	if (duckdb_v2_copy_to_batch_size_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_batch_size_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	copy_probe.user_data[BATCH_SIZE] = user_data;
-	copy_probe.bind_data[BATCH_SIZE] = bind_data;
-	duckdb_v2_copy_function_batch_size_set_target(info, 100000, err);
+	copy_to_probe.user_data[TO_BATCH_SIZE] = user_data;
+	copy_to_probe.bind_data[TO_BATCH_SIZE] = bind_data;
+	duckdb_v2_copy_to_batch_size_set_target(info, 100000, err);
 }
 
-void ProbeInit(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_context_handle,
-               duckdb_v2_error_info_handle *err) {
-	copy_probe.calls[INIT]++;
+void ProbeToInit(duckdb_v2_copy_to_init_info_handle info, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
+	copy_to_probe.calls[TO_INIT]++;
 	void *user_data = nullptr;
 	void *bind_data = nullptr;
 	duckdb_v2_str path = {nullptr, 0};
-	if (duckdb_v2_copy_function_init_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_init_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_init_get_file_path(info, &path, err) != DUCKDB_V2_ERROR_NONE) {
+	if (duckdb_v2_copy_to_init_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_init_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_init_get_file_path(info, &path, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	copy_probe.user_data[INIT] = user_data;
-	copy_probe.bind_data[INIT] = bind_data;
-	copy_probe.file_path = Convert(path);
+	copy_to_probe.user_data[TO_INIT] = user_data;
+	copy_to_probe.bind_data[TO_INIT] = bind_data;
+	copy_to_probe.file_path = Convert(path);
 
 	duckdb_v2_opaque init_data = {&copy_init_marker, DestroyInitData, nullptr};
-	duckdb_v2_copy_function_init_set_init_data(info, &init_data, err);
+	duckdb_v2_copy_to_init_set_init_data(info, &init_data, err);
 }
 
-void ProbeBatch(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_context_handle,
-                duckdb_v2_error_info_handle *err) {
-	copy_probe.calls[BATCH]++;
+void ProbeToBatch(duckdb_v2_copy_to_batch_info_handle info, duckdb_v2_context_handle,
+                  duckdb_v2_error_info_handle *err) {
+	copy_to_probe.calls[TO_BATCH]++;
 	void *user_data = nullptr;
 	void *bind_data = nullptr;
 	void *init_data = nullptr;
 	duckdb_v2_column_data_collection_handle input = nullptr;
-	if (duckdb_v2_copy_function_batch_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_batch_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_batch_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_batch_take_input(info, &input, err) != DUCKDB_V2_ERROR_NONE) {
+	if (duckdb_v2_copy_to_batch_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_batch_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_batch_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_batch_take_input(info, &input, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	copy_probe.user_data[BATCH] = user_data;
-	copy_probe.bind_data[BATCH] = bind_data;
-	copy_probe.init_data[BATCH] = init_data;
+	copy_to_probe.user_data[TO_BATCH] = user_data;
+	copy_to_probe.bind_data[TO_BATCH] = bind_data;
+	copy_to_probe.init_data[TO_BATCH] = init_data;
 
 	// The batch is ours now: count its rows and release it. A second take has nothing left to hand out.
 	idx_t count = 0;
@@ -241,64 +311,64 @@ void ProbeBatch(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_contex
 	if (rc != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	copy_probe.rows += count;
+	copy_to_probe.rows += count;
 	duckdb_v2_column_data_collection_handle again = nullptr;
-	copy_probe.second_take_rc = duckdb_v2_copy_function_batch_take_input(info, &again, nullptr);
+	copy_to_probe.second_take_rc = duckdb_v2_copy_to_batch_take_input(info, &again, nullptr);
 
 	duckdb_v2_opaque batch_data = {&copy_batch_marker, DestroyBatchData, nullptr};
-	duckdb_v2_copy_function_batch_set_batch_data(info, &batch_data, err);
+	duckdb_v2_copy_to_batch_set_batch_data(info, &batch_data, err);
 }
 
-void ProbeFlush(duckdb_v2_copy_function_flush_info_handle info, duckdb_v2_context_handle,
-                duckdb_v2_error_info_handle *err) {
-	copy_probe.calls[FLUSH]++;
+void ProbeToFlush(duckdb_v2_copy_to_flush_info_handle info, duckdb_v2_context_handle,
+                  duckdb_v2_error_info_handle *err) {
+	copy_to_probe.calls[TO_FLUSH]++;
 	void *user_data = nullptr;
 	void *bind_data = nullptr;
 	void *init_data = nullptr;
 	void *batch_data = nullptr;
-	if (duckdb_v2_copy_function_flush_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_flush_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_flush_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_flush_get_batch_data(info, &batch_data, err) != DUCKDB_V2_ERROR_NONE) {
+	if (duckdb_v2_copy_to_flush_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_flush_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_flush_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_flush_get_batch_data(info, &batch_data, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	copy_probe.user_data[FLUSH] = user_data;
-	copy_probe.bind_data[FLUSH] = bind_data;
-	copy_probe.init_data[FLUSH] = init_data;
-	copy_probe.batch_data_in_flush = batch_data;
+	copy_to_probe.user_data[TO_FLUSH] = user_data;
+	copy_to_probe.bind_data[TO_FLUSH] = bind_data;
+	copy_to_probe.init_data[TO_FLUSH] = init_data;
+	copy_to_probe.batch_data_in_flush = batch_data;
 }
 
-void ProbeFinalize(duckdb_v2_copy_function_finalize_info_handle info, duckdb_v2_context_handle,
-                   duckdb_v2_error_info_handle *err) {
-	copy_probe.calls[FINALIZE]++;
+void ProbeToFinalize(duckdb_v2_copy_to_finalize_info_handle info, duckdb_v2_context_handle,
+                     duckdb_v2_error_info_handle *err) {
+	copy_to_probe.calls[TO_FINALIZE]++;
 	void *user_data = nullptr;
 	void *bind_data = nullptr;
 	void *init_data = nullptr;
-	if (duckdb_v2_copy_function_finalize_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_finalize_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_copy_function_finalize_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE) {
+	if (duckdb_v2_copy_to_finalize_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_finalize_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_to_finalize_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	copy_probe.user_data[FINALIZE] = user_data;
-	copy_probe.bind_data[FINALIZE] = bind_data;
-	copy_probe.init_data[FINALIZE] = init_data;
+	copy_to_probe.user_data[TO_FINALIZE] = user_data;
+	copy_to_probe.bind_data[TO_FINALIZE] = bind_data;
+	copy_to_probe.init_data[TO_FINALIZE] = init_data;
 }
 
-// Registers the probe function under the given name, with every callback and user data set, and destroys the
+// Registers the COPY TO probe under the given name, with every callback and user data set, and destroys the
 // handle. Without the batch size callback, the batch size is left to the statement.
-void RegisterProbeCopy(duckdb_v2_connection_handle conn, const char *name = "probe_copy", bool with_batch_size = true) {
+void RegisterProbeCopyTo(duckdb_v2_connection_handle conn, const char *name = "probe_copy",
+                         bool with_batch_size = true) {
 	auto function = MakeCopy(conn, name);
 	if (with_batch_size) {
-		REQUIRE(duckdb_v2_copy_function_set_batch_size_callback(function, ProbeBatchSize, nullptr) ==
-		        DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_to_set_batch_size_callback(function, ProbeToBatchSize, nullptr) == DUCKDB_V2_ERROR_NONE);
 	}
 	duckdb_v2_opaque user_data = {&copy_user_marker, DestroyUserData, nullptr};
 	REQUIRE(duckdb_v2_copy_function_set_user_data(function, &user_data, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_bind_callback(function, ProbeBind, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_init_callback(function, ProbeInit, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_batch_callback(function, ProbeBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_flush_callback(function, ProbeFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_finalize_callback(function, ProbeFinalize, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_bind_callback(function, ProbeToBind, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_init_callback(function, ProbeToInit, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_batch_callback(function, ProbeToBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_flush_callback(function, ProbeToFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_finalize_callback(function, ProbeToFinalize, nullptr) == DUCKDB_V2_ERROR_NONE);
 
 	REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(duckdb_v2_copy_function_destroy(&function) == DUCKDB_V2_ERROR_NONE);
@@ -306,169 +376,505 @@ void RegisterProbeCopy(duckdb_v2_connection_handle conn, const char *name = "pro
 }
 
 // Noop callbacks for registration-refusal tests.
-void CopyNoopBatch(duckdb_v2_copy_function_batch_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
+void ToNoopBatch(duckdb_v2_copy_to_batch_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
 }
-void CopyNoopFlush(duckdb_v2_copy_function_flush_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
+void ToNoopFlush(duckdb_v2_copy_to_flush_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
 }
 
 // Fail the query through a callback's error slot.
-void FailingBind(duckdb_v2_copy_function_bind_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
+void FailingToBind(duckdb_v2_copy_to_bind_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
 	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
-	duckdb_v2_error_info_set_text(*err, Convert("copy bind failed on purpose"));
+	duckdb_v2_error_info_set_text(*err, Convert("copy to bind failed on purpose"));
 }
-void FailingBatch(duckdb_v2_copy_function_batch_info_handle, duckdb_v2_context_handle,
-                  duckdb_v2_error_info_handle *err) {
+void FailingToBatch(duckdb_v2_copy_to_batch_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
 	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
-	duckdb_v2_error_info_set_text(*err, Convert("copy batch failed on purpose"));
+	duckdb_v2_error_info_set_text(*err, Convert("copy to batch failed on purpose"));
 }
-void FailingBatchSize(duckdb_v2_copy_function_batch_size_info_handle, duckdb_v2_context_handle,
-                      duckdb_v2_error_info_handle *err) {
+void FailingToBatchSize(duckdb_v2_copy_to_batch_size_info_handle, duckdb_v2_context_handle,
+                        duckdb_v2_error_info_handle *err) {
 	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
-	duckdb_v2_error_info_set_text(*err, Convert("copy batch size failed on purpose"));
+	duckdb_v2_error_info_set_text(*err, Convert("copy to batch size failed on purpose"));
 }
 // Leaves the target unset, which the engine refuses.
-void EmptyBatchSize(duckdb_v2_copy_function_batch_size_info_handle, duckdb_v2_context_handle,
-                    duckdb_v2_error_info_handle *) {
+void EmptyToBatchSize(duckdb_v2_copy_to_batch_size_info_handle, duckdb_v2_context_handle,
+                      duckdb_v2_error_info_handle *) {
+}
+
+// ---------------------------------------------------------------------------
+// The COPY FROM probe: a reader producing (a BIGINT, b INTEGER) rows with a = i
+// and b = 2 * i for i in [0, rows), where `rows` comes from the ROWS option.
+// ---------------------------------------------------------------------------
+
+enum FromPhase { FROM_BIND = 0, FROM_INIT_GLOBAL, FROM_INIT_LOCAL, FROM_EXEC, FROM_PROGRESS, FROM_PHASE_COUNT };
+
+int reader_bind_marker = 0;
+int reader_local_marker = 0;
+
+struct ReaderGlobal {
+	std::atomic<int64_t> position {0};
+	int64_t rows = 0;
+};
+
+struct CopyFromProbe {
+	std::atomic<void *> user_data[FROM_PHASE_COUNT];
+	std::atomic<void *> bind_data[FROM_PHASE_COUNT];
+	std::atomic<void *> global_state[FROM_PHASE_COUNT];
+	std::atomic<void *> local_state_in_exec;
+	std::atomic<idx_t> calls[FROM_PHASE_COUNT];
+	std::atomic<int> bind_data_destroys;
+	std::atomic<int> global_state_destroys;
+	std::atomic<int> local_state_destroys;
+
+	// Written by the bind callback only.
+	std::string file_path;
+	idx_t column_count = 0;
+	std::string column_names[2];
+	DUCKDB_V2_LOGICAL_TYPE_ID column_types[2] = {DUCKDB_V2_LOGICAL_TYPE_ID_INVALID, DUCKDB_V2_LOGICAL_TYPE_ID_INVALID};
+	std::string options;
+	int32_t rows = 0;
+
+	void Reset() {
+		for (int phase = 0; phase < FROM_PHASE_COUNT; phase++) {
+			user_data[phase] = nullptr;
+			bind_data[phase] = nullptr;
+			global_state[phase] = nullptr;
+			calls[phase] = 0;
+		}
+		local_state_in_exec = nullptr;
+		bind_data_destroys = 0;
+		global_state_destroys = 0;
+		local_state_destroys = 0;
+		file_path.clear();
+		column_count = 0;
+		column_names[0].clear();
+		column_names[1].clear();
+		column_types[0] = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
+		column_types[1] = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
+		options.clear();
+		rows = 0;
+	}
+} copy_from_probe;
+
+void DestroyReaderBindData(void *) {
+	copy_from_probe.bind_data_destroys++;
+}
+void DestroyReaderGlobal(void *ptr) {
+	copy_from_probe.global_state_destroys++;
+	delete static_cast<ReaderGlobal *>(ptr);
+}
+void DestroyReaderLocal(void *) {
+	copy_from_probe.local_state_destroys++;
+}
+
+void ProbeFromBind(duckdb_v2_copy_from_bind_info_handle info, duckdb_v2_context_handle,
+                   duckdb_v2_error_info_handle *err) {
+	copy_from_probe.calls[FROM_BIND]++;
+	void *user_data = nullptr;
+	duckdb_v2_str path = {nullptr, 0};
+	if (duckdb_v2_copy_from_bind_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_bind_get_file_path(info, &path, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_from_probe.user_data[FROM_BIND] = user_data;
+	copy_from_probe.file_path = Convert(path);
+
+	if (duckdb_v2_copy_from_bind_get_column_count(info, &copy_from_probe.column_count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (idx_t i = 0; i < copy_from_probe.column_count && i < 2; i++) {
+		duckdb_v2_identifier_t name = {nullptr, 0};
+		if (duckdb_v2_copy_from_bind_get_column_name(info, i, &name, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		copy_from_probe.column_names[i] = Convert(name);
+		duckdb_v2_logical_type_handle type = nullptr;
+		if (duckdb_v2_copy_from_bind_get_column_type(info, i, &type, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		auto rc = duckdb_v2_logical_type_get_id(type, &copy_from_probe.column_types[i], err);
+		duckdb_v2_logical_type_destroy(&type);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+
+	// The ROWS option decides how many rows to produce; everything else is latched as text.
+	idx_t option_count = 0;
+	if (duckdb_v2_copy_from_bind_get_option_count(info, &option_count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (idx_t i = 0; i < option_count; i++) {
+		duckdb_v2_identifier_t name = {nullptr, 0};
+		duckdb_v2_value_handle value = nullptr;
+		if (duckdb_v2_copy_from_bind_get_option_name(info, i, &name, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_copy_from_bind_get_option_value(info, i, &value, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		auto lower = Lower(Convert(name));
+		copy_from_probe.options += lower + "=" + RenderOption(value) + "\n";
+		auto rc = DUCKDB_V2_ERROR_NONE;
+		if (lower == "rows") {
+			rc = duckdb_v2_value_get_int(value, &copy_from_probe.rows, err);
+		}
+		duckdb_v2_value_destroy(&value);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+
+	duckdb_v2_copy_from_bind_set_cardinality(info, static_cast<idx_t>(copy_from_probe.rows), true, err);
+	duckdb_v2_opaque bind_data = {&reader_bind_marker, DestroyReaderBindData, nullptr};
+	duckdb_v2_copy_from_bind_set_bind_data(info, &bind_data, err);
+}
+
+void ProbeFromInitGlobal(duckdb_v2_copy_from_init_global_info_handle info, duckdb_v2_context_handle,
+                         duckdb_v2_error_info_handle *err) {
+	copy_from_probe.calls[FROM_INIT_GLOBAL]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	if (duckdb_v2_copy_from_init_global_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_init_global_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_from_probe.user_data[FROM_INIT_GLOBAL] = user_data;
+	copy_from_probe.bind_data[FROM_INIT_GLOBAL] = bind_data;
+
+	auto global = new ReaderGlobal();
+	global->rows = copy_from_probe.rows;
+	duckdb_v2_opaque state = {global, DestroyReaderGlobal, nullptr};
+	if (duckdb_v2_copy_from_init_global_set_global_state(info, &state, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_copy_from_init_global_set_max_threads(info, 2, err);
+}
+
+void ProbeFromInitLocal(duckdb_v2_copy_from_init_local_info_handle info, duckdb_v2_context_handle,
+                        duckdb_v2_error_info_handle *err) {
+	copy_from_probe.calls[FROM_INIT_LOCAL]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	void *global_state = nullptr;
+	if (duckdb_v2_copy_from_init_local_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_init_local_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_init_local_get_global_state(info, &global_state, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_from_probe.user_data[FROM_INIT_LOCAL] = user_data;
+	copy_from_probe.bind_data[FROM_INIT_LOCAL] = bind_data;
+	copy_from_probe.global_state[FROM_INIT_LOCAL] = global_state;
+
+	duckdb_v2_opaque state = {&reader_local_marker, DestroyReaderLocal, nullptr};
+	duckdb_v2_copy_from_init_local_set_local_state(info, &state, err);
+}
+
+// How many rows a batch produces: within the smallest vector size the build can be configured with.
+constexpr int64_t READER_BATCH_ROWS = 2;
+
+void ProbeFromExec(duckdb_v2_copy_from_exec_info_handle info, duckdb_v2_context_handle,
+                   duckdb_v2_error_info_handle *err) {
+	copy_from_probe.calls[FROM_EXEC]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	void *global_ptr = nullptr;
+	void *local_state = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	if (duckdb_v2_copy_from_exec_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_exec_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_exec_get_global_state(info, &global_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_exec_get_local_state(info, &local_state, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_exec_get_output_chunk(info, &chunk, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_from_probe.user_data[FROM_EXEC] = user_data;
+	copy_from_probe.bind_data[FROM_EXEC] = bind_data;
+	copy_from_probe.global_state[FROM_EXEC] = global_ptr;
+	copy_from_probe.local_state_in_exec = local_state;
+	auto &global = *static_cast<ReaderGlobal *>(global_ptr);
+
+	duckdb_v2_vector_handle a = nullptr;
+	duckdb_v2_vector_handle b = nullptr;
+	void *raw_a = nullptr;
+	void *raw_b = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(chunk, 0, &a, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_data_chunk_get_vector(chunk, 1, &b, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(a, &raw_a, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(b, &raw_b, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	// Claim the next slice of rows from the shared position; several threads may be reading.
+	const auto start = global.position.fetch_add(READER_BATCH_ROWS);
+	auto produced = global.rows - start;
+	if (produced > READER_BATCH_ROWS) {
+		produced = READER_BATCH_ROWS;
+	}
+	if (produced < 0) {
+		produced = 0;
+	}
+	auto *out_a = static_cast<int64_t *>(raw_a);
+	auto *out_b = static_cast<int32_t *>(raw_b);
+	for (int64_t i = 0; i < produced; i++) {
+		out_a[i] = start + i;
+		out_b[i] = static_cast<int32_t>(2 * (start + i));
+	}
+
+	// The first vector's size is the batch's row count; 0 ends the read.
+	duckdb_v2_vector_set_size(a, static_cast<idx_t>(produced), err);
+}
+
+void ProbeFromProgress(duckdb_v2_copy_from_progress_info_handle info, duckdb_v2_context_handle,
+                       duckdb_v2_error_info_handle *err) {
+	copy_from_probe.calls[FROM_PROGRESS]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	void *global_state = nullptr;
+	if (duckdb_v2_copy_from_progress_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_progress_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_from_progress_get_global_state(info, &global_state, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_from_probe.user_data[FROM_PROGRESS] = user_data;
+	copy_from_probe.bind_data[FROM_PROGRESS] = bind_data;
+	copy_from_probe.global_state[FROM_PROGRESS] = global_state;
+	duckdb_v2_copy_from_progress_set_progress(info, 0.5, err);
+}
+
+// Registers the COPY FROM probe under the given name, with every callback and user data set, and destroys the
+// handle.
+void RegisterProbeCopyFrom(duckdb_v2_connection_handle conn, const char *name = "probe_reader") {
+	auto function = MakeCopy(conn, name);
+	duckdb_v2_opaque user_data = {&copy_user_marker, DestroyUserData, nullptr};
+	REQUIRE(duckdb_v2_copy_function_set_user_data(function, &user_data, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_from_set_bind_callback(function, ProbeFromBind, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_from_set_init_global_callback(function, ProbeFromInitGlobal, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_from_set_init_local_callback(function, ProbeFromInitLocal, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_from_set_exec_callback(function, ProbeFromExec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_from_set_progress_callback(function, ProbeFromProgress, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_destroy(&function) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(function == nullptr);
+}
+
+void FromNoopBind(duckdb_v2_copy_from_bind_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
+}
+void FromNoopExec(duckdb_v2_copy_from_exec_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
+}
+void FailingFromBind(duckdb_v2_copy_from_bind_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
+	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
+	duckdb_v2_error_info_set_text(*err, Convert("copy from bind failed on purpose"));
+}
+void FailingFromExec(duckdb_v2_copy_from_exec_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
+	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
+	duckdb_v2_error_info_set_text(*err, Convert("copy from exec failed on purpose"));
 }
 
 } // namespace
 
 // ===========================================================================
-// Register on a connection and drive through COPY ... TO.
+// COPY TO: register on a connection and drive through COPY ... TO.
 // ===========================================================================
 
-TEST_CASE("V2 copy: register on connection and execute", "[capi_v2][copy_function]") {
+TEST_CASE("V2 copy: COPY TO on a connection", "[capi_v2][copy_function]") {
 	EnvFixture fx;
-	RegisterProbeCopy(fx.conn);
+	RegisterProbeCopyTo(fx.conn);
 
-	// More rows than one chunk, so the batch callback sees real batches.
+	// More rows than one chunk, so the batch callback sees real batches. Two options of the function's own; the
+	// engine's USE_TMP_FILE is consumed before bind and not reported.
 	const auto path = duckdb::TestCreatePath("v2_copy_probe.out");
-	copy_probe.Reset();
-	REQUIRE(RunCopy(fx.conn,
-	                CopyStatement("SELECT r AS a, r::VARCHAR AS b FROM range(5000) t(r)", path, "probe_copy")) == 5000);
+	copy_to_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyToStatement("SELECT r AS a, r::VARCHAR AS b FROM range(5000) t(r)", path, "probe_copy",
+	                                         ", TAG 'x', FLAG")) == 5000);
 
-	// Bind saw the columns of the SELECT; an index past them is refused.
-	REQUIRE(copy_probe.calls[BIND].load() == 1);
-	REQUIRE(copy_probe.column_count == 2);
-	REQUIRE(copy_probe.column_names[0] == "a");
-	REQUIRE(copy_probe.column_names[1] == "b");
-	REQUIRE(copy_probe.column_types[0] == DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
-	REQUIRE(copy_probe.column_types[1] == DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
-	REQUIRE(copy_probe.oob_type_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(copy_probe.oob_name_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	// Bind saw the columns of the SELECT and the target path; an index past the columns is refused.
+	REQUIRE(copy_to_probe.calls[TO_BIND].load() == 1);
+	REQUIRE(copy_to_probe.bind_file_path == path);
+	REQUIRE(copy_to_probe.column_count == 2);
+	REQUIRE(copy_to_probe.column_names[0] == "a");
+	REQUIRE(copy_to_probe.column_names[1] == "b");
+	REQUIRE(copy_to_probe.column_types[0] == DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	REQUIRE(copy_to_probe.column_types[1] == DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
+	REQUIRE(copy_to_probe.oob_type_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(copy_to_probe.oob_name_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(copy_to_probe.oob_option_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	// Options arrive by name: a bare option reads as true.
+	REQUIRE(copy_to_probe.options == "flag=true\ntag=x\n");
 
 	// The batch size callback ran once, after bind.
-	REQUIRE(copy_probe.calls[BATCH_SIZE].load() == 1);
+	REQUIRE(copy_to_probe.calls[TO_BATCH_SIZE].load() == 1);
 
 	// One file: init and finalize ran once, with the COPY target as the path.
-	REQUIRE(copy_probe.calls[INIT].load() == 1);
-	REQUIRE(copy_probe.file_path == path);
-	REQUIRE(copy_probe.calls[FINALIZE].load() == 1);
+	REQUIRE(copy_to_probe.calls[TO_INIT].load() == 1);
+	REQUIRE(copy_to_probe.file_path == path);
+	REQUIRE(copy_to_probe.calls[TO_FINALIZE].load() == 1);
 
 	// Every row went through a batch, and every batch was flushed.
-	REQUIRE(copy_probe.calls[BATCH].load() >= 1);
-	REQUIRE(copy_probe.calls[FLUSH].load() == copy_probe.calls[BATCH].load());
-	REQUIRE(copy_probe.rows.load() == 5000);
-	REQUIRE(copy_probe.second_take_rc.load() == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(copy_to_probe.calls[TO_BATCH].load() >= 1);
+	REQUIRE(copy_to_probe.calls[TO_FLUSH].load() == copy_to_probe.calls[TO_BATCH].load());
+	REQUIRE(copy_to_probe.rows.load() == 5000);
+	REQUIRE(copy_to_probe.second_take_rc.load() == DUCKDB_V2_ERROR_INPUT_INVALID);
 
 	// The data slots reached every phase they are defined for.
-	for (int phase = 0; phase < PHASE_COUNT; phase++) {
-		REQUIRE(copy_probe.user_data[phase].load() == &copy_user_marker);
+	for (int phase = 0; phase < TO_PHASE_COUNT; phase++) {
+		REQUIRE(copy_to_probe.user_data[phase].load() == &copy_user_marker);
 	}
-	for (int phase = BATCH_SIZE; phase < PHASE_COUNT; phase++) {
-		REQUIRE(copy_probe.bind_data[phase].load() == &copy_bind_marker);
+	for (int phase = TO_BATCH_SIZE; phase < TO_PHASE_COUNT; phase++) {
+		REQUIRE(copy_to_probe.bind_data[phase].load() == &copy_bind_marker);
 	}
-	for (int phase = BATCH; phase < PHASE_COUNT; phase++) {
-		REQUIRE(copy_probe.init_data[phase].load() == &copy_init_marker);
+	for (int phase = TO_BATCH; phase < TO_PHASE_COUNT; phase++) {
+		REQUIRE(copy_to_probe.init_data[phase].load() == &copy_init_marker);
 	}
-	REQUIRE(copy_probe.batch_data_in_flush.load() == &copy_batch_marker);
+	REQUIRE(copy_to_probe.batch_data_in_flush.load() == &copy_batch_marker);
 
 	// Each batch's data was released after its flush, and the file's init data and the statement's bind data with
 	// the statement.
-	REQUIRE(copy_probe.batch_data_destroys.load() == copy_probe.calls[BATCH].load());
-	REQUIRE(copy_probe.init_data_destroys.load() == 1);
-	REQUIRE(copy_probe.bind_data_destroys.load() == 1);
+	REQUIRE(copy_to_probe.batch_data_destroys.load() == copy_to_probe.calls[TO_BATCH].load());
+	REQUIRE(copy_to_probe.init_data_destroys.load() == 1);
+	REQUIRE(copy_to_probe.bind_data_destroys.load() == 1);
 	// The user data lives with the registered function.
-	REQUIRE(copy_probe.user_data_destroys.load() == 0);
+	REQUIRE(copy_to_probe.user_data_destroys.load() == 0);
 }
 
 // ===========================================================================
 // The batch size callback decides where batches are cut when the statement sets no BATCH_SIZE.
 // ===========================================================================
 
-TEST_CASE("V2 copy: batch size callback", "[capi_v2][copy_function]") {
+TEST_CASE("V2 copy: COPY TO batch size callback", "[capi_v2][copy_function]") {
 	EnvFixture fx;
 	// One sink thread, so the batch count follows from the chunk sizes alone.
 	ExecSQL(fx.conn, "SET threads = 1");
-	RegisterProbeCopy(fx.conn, "chunked_copy", false);
-	RegisterProbeCopy(fx.conn, "whole_copy", true);
+	RegisterProbeCopyTo(fx.conn, "chunked_copy", false);
+	RegisterProbeCopyTo(fx.conn, "whole_copy", true);
 
 	// Without a batch size every sunk chunk is a batch: 2048, 2048 and 904 rows.
 	const auto path = duckdb::TestCreatePath("v2_copy_batch_size.out");
-	copy_probe.Reset();
-	REQUIRE(RunCopy(fx.conn, CopyStatement("SELECT r FROM range(5000) t(r)", path, "chunked_copy")) == 5000);
-	REQUIRE(copy_probe.calls[BATCH_SIZE].load() == 0);
-	REQUIRE(copy_probe.calls[BATCH].load() == 3);
-	REQUIRE(copy_probe.rows.load() == 5000);
+	copy_to_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyToStatement("SELECT r FROM range(5000) t(r)", path, "chunked_copy")) == 5000);
+	REQUIRE(copy_to_probe.calls[TO_BATCH_SIZE].load() == 0);
+	REQUIRE(copy_to_probe.calls[TO_BATCH].load() == 3);
+	REQUIRE(copy_to_probe.rows.load() == 5000);
 
 	// The callback asks for batches larger than the input: everything arrives as one batch.
-	copy_probe.Reset();
-	REQUIRE(RunCopy(fx.conn, CopyStatement("SELECT r FROM range(5000) t(r)", path, "whole_copy")) == 5000);
-	REQUIRE(copy_probe.calls[BATCH_SIZE].load() == 1);
-	REQUIRE(copy_probe.calls[BATCH].load() == 1);
-	REQUIRE(copy_probe.rows.load() == 5000);
+	copy_to_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyToStatement("SELECT r FROM range(5000) t(r)", path, "whole_copy")) == 5000);
+	REQUIRE(copy_to_probe.calls[TO_BATCH_SIZE].load() == 1);
+	REQUIRE(copy_to_probe.calls[TO_BATCH].load() == 1);
+	REQUIRE(copy_to_probe.rows.load() == 5000);
 
 	// The statement's own BATCH_SIZE wins, and the callback is not consulted.
-	copy_probe.Reset();
-	REQUIRE(RunCopy(fx.conn, "COPY (SELECT r FROM range(5000) t(r)) TO '" + path +
-	                             "' (FORMAT whole_copy, USE_TMP_FILE FALSE, BATCH_SIZE 4096)") == 5000);
-	REQUIRE(copy_probe.calls[BATCH_SIZE].load() == 0);
-	REQUIRE(copy_probe.calls[BATCH].load() == 2);
-	REQUIRE(copy_probe.rows.load() == 5000);
+	copy_to_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyToStatement("SELECT r FROM range(5000) t(r)", path, "whole_copy",
+	                                         ", BATCH_SIZE 4096")) == 5000);
+	REQUIRE(copy_to_probe.calls[TO_BATCH_SIZE].load() == 0);
+	REQUIRE(copy_to_probe.calls[TO_BATCH].load() == 2);
+	REQUIRE(copy_to_probe.rows.load() == 5000);
 }
 
 // ===========================================================================
-// Only the batch and flush callbacks are required; the others leave their data slots empty.
+// Only the batch and flush callbacks are required on the COPY TO side; the others leave their slots empty.
 // ===========================================================================
 
-TEST_CASE("V2 copy: optional callbacks and empty data slots", "[capi_v2][copy_function]") {
+TEST_CASE("V2 copy: COPY TO optional callbacks and empty data slots", "[capi_v2][copy_function]") {
 	EnvFixture fx;
 
 	auto function = MakeCopy(fx.conn, "bare_copy");
-	REQUIRE(duckdb_v2_copy_function_set_batch_callback(function, ProbeBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_flush_callback(function, ProbeFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_batch_callback(function, ProbeToBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_flush_callback(function, ProbeToFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
 	duckdb_v2_copy_function_destroy(&function);
 
 	const auto path = duckdb::TestCreatePath("v2_copy_bare.out");
-	copy_probe.Reset();
-	REQUIRE(RunCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "bare_copy")) == 10);
+	copy_to_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyToStatement("SELECT r FROM range(10) t(r)", path, "bare_copy")) == 10);
 
-	REQUIRE(copy_probe.calls[BIND].load() == 0);
-	REQUIRE(copy_probe.calls[INIT].load() == 0);
-	REQUIRE(copy_probe.calls[FINALIZE].load() == 0);
-	REQUIRE(copy_probe.calls[BATCH].load() >= 1);
-	REQUIRE(copy_probe.calls[FLUSH].load() == copy_probe.calls[BATCH].load());
-	REQUIRE(copy_probe.rows.load() == 10);
+	REQUIRE(copy_to_probe.calls[TO_BIND].load() == 0);
+	REQUIRE(copy_to_probe.calls[TO_INIT].load() == 0);
+	REQUIRE(copy_to_probe.calls[TO_FINALIZE].load() == 0);
+	REQUIRE(copy_to_probe.calls[TO_BATCH].load() >= 1);
+	REQUIRE(copy_to_probe.calls[TO_FLUSH].load() == copy_to_probe.calls[TO_BATCH].load());
+	REQUIRE(copy_to_probe.rows.load() == 10);
 
 	// Nothing was set, so every slot reads as null.
-	REQUIRE(copy_probe.user_data[BATCH].load() == nullptr);
-	REQUIRE(copy_probe.bind_data[BATCH].load() == nullptr);
-	REQUIRE(copy_probe.init_data[BATCH].load() == nullptr);
-	REQUIRE(copy_probe.user_data[FLUSH].load() == nullptr);
-	REQUIRE(copy_probe.bind_data[FLUSH].load() == nullptr);
-	REQUIRE(copy_probe.init_data[FLUSH].load() == nullptr);
+	REQUIRE(copy_to_probe.user_data[TO_BATCH].load() == nullptr);
+	REQUIRE(copy_to_probe.bind_data[TO_BATCH].load() == nullptr);
+	REQUIRE(copy_to_probe.init_data[TO_BATCH].load() == nullptr);
+	REQUIRE(copy_to_probe.user_data[TO_FLUSH].load() == nullptr);
+	REQUIRE(copy_to_probe.bind_data[TO_FLUSH].load() == nullptr);
+	REQUIRE(copy_to_probe.init_data[TO_FLUSH].load() == nullptr);
 	// The batch data was set by the batch callback, so it did reach the flush.
-	REQUIRE(copy_probe.batch_data_in_flush.load() == &copy_batch_marker);
-	REQUIRE(copy_probe.batch_data_destroys.load() == copy_probe.calls[BATCH].load());
+	REQUIRE(copy_to_probe.batch_data_in_flush.load() == &copy_batch_marker);
+	REQUIRE(copy_to_probe.batch_data_destroys.load() == copy_to_probe.calls[TO_BATCH].load());
 
 	// A batch callback that never takes its input leaves the engine to release it.
 	auto untaken = MakeCopy(fx.conn, "untaken_copy");
-	REQUIRE(duckdb_v2_copy_function_set_batch_callback(untaken, CopyNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_flush_callback(untaken, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_batch_callback(untaken, ToNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_to_set_flush_callback(untaken, ToNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(duckdb_v2_copy_function_register(untaken, nullptr) == DUCKDB_V2_ERROR_NONE);
 	duckdb_v2_copy_function_destroy(&untaken);
-	REQUIRE(RunCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "untaken_copy")) == 10);
+	REQUIRE(RunCopy(fx.conn, CopyToStatement("SELECT r FROM range(10) t(r)", path, "untaken_copy")) == 10);
+
+	// A COPY TO only function cannot be read from.
+	ExecSQL(fx.conn, "CREATE TABLE t(a BIGINT)");
+	REQUIRE(RunFailingCopy(fx.conn, CopyFromStatement("t", "nowhere", "untaken_copy")) ==
+	        DUCKDB_V2_ERROR_QUERY_NOT_IMPLEMENTED);
+}
+
+// ===========================================================================
+// COPY FROM: register on a connection and drive through COPY ... FROM.
+// ===========================================================================
+
+TEST_CASE("V2 copy: COPY FROM on a connection", "[capi_v2][copy_function]") {
+	EnvFixture fx;
+	RegisterProbeCopyFrom(fx.conn);
+	ExecSQL(fx.conn, "CREATE TABLE target(a BIGINT, b INTEGER)");
+
+	// ROWS drives the reader; TAG and FLAG are along for the ride, and a parenthesized list arrives as a tuple.
+	copy_from_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyFromStatement("target", "some/where.probe", "probe_reader",
+	                                           ", ROWS 5000, TAG 'x', FLAG, PAIR (1, 'two')")) == 5000);
+
+	// Bind saw the target table's columns, the path as written, and the options by name.
+	REQUIRE(copy_from_probe.calls[FROM_BIND].load() == 1);
+	REQUIRE(copy_from_probe.file_path == "some/where.probe");
+	REQUIRE(copy_from_probe.column_count == 2);
+	REQUIRE(copy_from_probe.column_names[0] == "a");
+	REQUIRE(copy_from_probe.column_names[1] == "b");
+	REQUIRE(copy_from_probe.column_types[0] == DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	REQUIRE(copy_from_probe.column_types[1] == DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	REQUIRE(copy_from_probe.options == "flag=true\npair=(1, two)\nrows=5000\ntag=x\n");
+
+	// The read ran with the requested state and produced the rows into the table.
+	REQUIRE(copy_from_probe.calls[FROM_INIT_GLOBAL].load() == 1);
+	REQUIRE(copy_from_probe.calls[FROM_INIT_LOCAL].load() >= 1);
+	REQUIRE(copy_from_probe.calls[FROM_EXEC].load() >= 1);
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM target") == 5000);
+	REQUIRE(QueryI64(fx.conn, "SELECT sum(a) FROM target") == 5000LL * 4999 / 2);
+	REQUIRE(QueryI64(fx.conn, "SELECT sum(b)::BIGINT FROM target") == 5000LL * 4999);
+
+	// The data slots reached every phase they are defined for; progress only runs when the engine asks for it.
+	for (int phase = 0; phase < FROM_PHASE_COUNT; phase++) {
+		if (copy_from_probe.calls[phase].load() > 0) {
+			REQUIRE(copy_from_probe.user_data[phase].load() == &copy_user_marker);
+		}
+	}
+	for (int phase = FROM_INIT_GLOBAL; phase < FROM_PHASE_COUNT; phase++) {
+		if (copy_from_probe.calls[phase].load() > 0) {
+			REQUIRE(copy_from_probe.bind_data[phase].load() == &reader_bind_marker);
+		}
+	}
+	REQUIRE(copy_from_probe.global_state[FROM_INIT_LOCAL].load() != nullptr);
+	REQUIRE(copy_from_probe.global_state[FROM_EXEC].load() == copy_from_probe.global_state[FROM_INIT_LOCAL].load());
+	REQUIRE(copy_from_probe.local_state_in_exec.load() == &reader_local_marker);
+
+	// The states were released with the read, the bind data with the statement.
+	REQUIRE(copy_from_probe.global_state_destroys.load() == 1);
+	REQUIRE(copy_from_probe.local_state_destroys.load() == copy_from_probe.calls[FROM_INIT_LOCAL].load());
+	REQUIRE(copy_from_probe.bind_data_destroys.load() == 1);
+
+	// A COPY FROM only function cannot be written to.
+	REQUIRE(RunFailingCopy(fx.conn, CopyToStatement("SELECT 1", "nowhere", "probe_reader")) ==
+	        DUCKDB_V2_ERROR_QUERY_NOT_IMPLEMENTED);
 }
 
 // ===========================================================================
@@ -478,51 +884,55 @@ TEST_CASE("V2 copy: optional callbacks and empty data slots", "[capi_v2][copy_fu
 // An error set in a callback's slot fails the statement with its code.
 TEST_CASE("V2 copy: callback errors propagate to the result", "[capi_v2][copy_function]") {
 	EnvFixture fx;
+	ExecSQL(fx.conn, "CREATE TABLE target(a BIGINT)");
 
-	auto batch_fails = MakeCopy(fx.conn, "copy_batch_fails");
-	REQUIRE(duckdb_v2_copy_function_set_batch_callback(batch_fails, FailingBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_flush_callback(batch_fails, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_register(batch_fails, nullptr) == DUCKDB_V2_ERROR_NONE);
-	duckdb_v2_copy_function_destroy(&batch_fails);
+	// Registers a COPY TO function with the given bind, batch size and batch callbacks.
+	auto register_to = [&](const char *name, duckdb_v2_copy_to_bind_callback_fn bind,
+	                       duckdb_v2_copy_to_batch_size_callback_fn batch_size,
+	                       duckdb_v2_copy_to_batch_callback_fn batch) {
+		auto function = MakeCopy(fx.conn, name);
+		if (bind) {
+			REQUIRE(duckdb_v2_copy_to_set_bind_callback(function, bind, nullptr) == DUCKDB_V2_ERROR_NONE);
+		}
+		if (batch_size) {
+			REQUIRE(duckdb_v2_copy_to_set_batch_size_callback(function, batch_size, nullptr) == DUCKDB_V2_ERROR_NONE);
+		}
+		REQUIRE(duckdb_v2_copy_to_set_batch_callback(function, batch, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_to_set_flush_callback(function, ToNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+		duckdb_v2_copy_function_destroy(&function);
+	};
+	register_to("to_batch_fails", nullptr, nullptr, FailingToBatch);
+	register_to("to_bind_fails", FailingToBind, nullptr, ToNoopBatch);
+	register_to("to_batch_size_fails", nullptr, FailingToBatchSize, ToNoopBatch);
+	register_to("to_batch_size_empty", nullptr, EmptyToBatchSize, ToNoopBatch);
 
-	auto bind_fails = MakeCopy(fx.conn, "copy_bind_fails");
-	REQUIRE(duckdb_v2_copy_function_set_bind_callback(bind_fails, FailingBind, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_batch_callback(bind_fails, CopyNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_flush_callback(bind_fails, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_register(bind_fails, nullptr) == DUCKDB_V2_ERROR_NONE);
-	duckdb_v2_copy_function_destroy(&bind_fails);
-
-	auto batch_size_fails = MakeCopy(fx.conn, "copy_batch_size_fails");
-	REQUIRE(duckdb_v2_copy_function_set_batch_size_callback(batch_size_fails, FailingBatchSize, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_batch_callback(batch_size_fails, CopyNoopBatch, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_flush_callback(batch_size_fails, CopyNoopFlush, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_register(batch_size_fails, nullptr) == DUCKDB_V2_ERROR_NONE);
-	duckdb_v2_copy_function_destroy(&batch_size_fails);
-
-	auto batch_size_empty = MakeCopy(fx.conn, "copy_batch_size_empty");
-	REQUIRE(duckdb_v2_copy_function_set_batch_size_callback(batch_size_empty, EmptyBatchSize, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_batch_callback(batch_size_empty, CopyNoopBatch, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_set_flush_callback(batch_size_empty, CopyNoopFlush, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_copy_function_register(batch_size_empty, nullptr) == DUCKDB_V2_ERROR_NONE);
-	duckdb_v2_copy_function_destroy(&batch_size_empty);
+	// Registers a COPY FROM function with the given bind and exec callbacks.
+	auto register_from = [&](const char *name, duckdb_v2_copy_from_bind_callback_fn bind,
+	                         duckdb_v2_copy_from_exec_callback_fn exec) {
+		auto function = MakeCopy(fx.conn, name);
+		REQUIRE(duckdb_v2_copy_from_set_bind_callback(function, bind, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_from_set_exec_callback(function, exec, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+		duckdb_v2_copy_function_destroy(&function);
+	};
+	register_from("from_bind_fails", FailingFromBind, FromNoopExec);
+	register_from("from_exec_fails", FromNoopBind, FailingFromExec);
 
 	// The callback's code round-trips through the engine's exception machinery.
 	const auto path = duckdb::TestCreatePath("v2_copy_fails.out");
-	REQUIRE(RunFailingCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "copy_batch_fails")) ==
-	        DUCKDB_V2_ERROR_IO_GENERAL);
-	REQUIRE(RunFailingCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "copy_bind_fails")) ==
-	        DUCKDB_V2_ERROR_IO_GENERAL);
-	REQUIRE(RunFailingCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "copy_batch_size_fails")) ==
+	const std::string source = "SELECT r FROM range(10) t(r)";
+	REQUIRE(RunFailingCopy(fx.conn, CopyToStatement(source, path, "to_batch_fails")) == DUCKDB_V2_ERROR_IO_GENERAL);
+	REQUIRE(RunFailingCopy(fx.conn, CopyToStatement(source, path, "to_bind_fails")) == DUCKDB_V2_ERROR_IO_GENERAL);
+	REQUIRE(RunFailingCopy(fx.conn, CopyToStatement(source, path, "to_batch_size_fails")) ==
 	        DUCKDB_V2_ERROR_IO_GENERAL);
 	// A batch size callback that sets no target fails the statement.
-	REQUIRE(RunFailingCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "copy_batch_size_empty")) ==
+	REQUIRE(RunFailingCopy(fx.conn, CopyToStatement(source, path, "to_batch_size_empty")) ==
 	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(RunFailingCopy(fx.conn, CopyFromStatement("target", path, "from_bind_fails")) ==
+	        DUCKDB_V2_ERROR_IO_GENERAL);
+	REQUIRE(RunFailingCopy(fx.conn, CopyFromStatement("target", path, "from_exec_fails")) ==
+	        DUCKDB_V2_ERROR_IO_GENERAL);
 }
 
 TEST_CASE("V2 copy: registration refusals", "[capi_v2][copy_function]") {
@@ -532,24 +942,53 @@ TEST_CASE("V2 copy: registration refusals", "[capi_v2][copy_function]") {
 	{
 		duckdb_v2_copy_function_handle function = nullptr;
 		REQUIRE(duckdb_v2_copy_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
-		REQUIRE(duckdb_v2_copy_function_set_batch_callback(function, CopyNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
-		REQUIRE(duckdb_v2_copy_function_set_flush_callback(function, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_to_set_batch_callback(function, ToNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_to_set_flush_callback(function, ToNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
 		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 		duckdb_v2_copy_function_destroy(&function);
 	}
 
-	// No batch callback.
+	// Neither side set.
 	{
-		auto function = MakeCopy(fx.conn, "copy_no_batch");
-		REQUIRE(duckdb_v2_copy_function_set_flush_callback(function, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+		auto function = MakeCopy(fx.conn, "copy_no_side");
 		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 		duckdb_v2_copy_function_destroy(&function);
 	}
 
-	// No flush callback.
+	// A COPY TO side without its batch, then without its flush callback.
 	{
-		auto function = MakeCopy(fx.conn, "copy_no_flush");
-		REQUIRE(duckdb_v2_copy_function_set_batch_callback(function, CopyNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+		auto function = MakeCopy(fx.conn, "copy_to_no_batch");
+		REQUIRE(duckdb_v2_copy_to_set_flush_callback(function, ToNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_copy_function_destroy(&function);
+	}
+	{
+		auto function = MakeCopy(fx.conn, "copy_to_no_flush");
+		REQUIRE(duckdb_v2_copy_to_set_batch_callback(function, ToNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_copy_function_destroy(&function);
+	}
+
+	// A COPY FROM side without its bind, then without its exec callback.
+	{
+		auto function = MakeCopy(fx.conn, "copy_from_no_bind");
+		REQUIRE(duckdb_v2_copy_from_set_exec_callback(function, FromNoopExec, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_copy_function_destroy(&function);
+	}
+	{
+		auto function = MakeCopy(fx.conn, "copy_from_no_exec");
+		REQUIRE(duckdb_v2_copy_from_set_bind_callback(function, FromNoopBind, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_copy_function_destroy(&function);
+	}
+
+	// A complete COPY TO side alongside an incomplete COPY FROM side is still refused.
+	{
+		auto function = MakeCopy(fx.conn, "copy_mixed");
+		REQUIRE(duckdb_v2_copy_to_set_batch_callback(function, ToNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_to_set_flush_callback(function, ToNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_from_set_bind_callback(function, FromNoopBind, nullptr) == DUCKDB_V2_ERROR_NONE);
 		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 		duckdb_v2_copy_function_destroy(&function);
 	}
@@ -567,26 +1006,32 @@ TEST_CASE("V2 copy: null arguments and destroy null-safety", "[capi_v2][copy_fun
 	REQUIRE(duckdb_v2_copy_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(duckdb_v2_copy_function_set_name(function, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(duckdb_v2_copy_function_set_user_data(function, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_set_batch_size_callback(nullptr, ProbeBatchSize, nullptr) ==
-	        DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_set_batch_callback(nullptr, CopyNoopBatch, nullptr) ==
-	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_set_batch_callback(nullptr, ToNoopBatch, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_from_set_exec_callback(nullptr, FromNoopExec, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(duckdb_v2_copy_function_register(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 
 	idx_t count = 0;
 	duckdb_v2_logical_type_handle type = nullptr;
 	duckdb_v2_identifier_t name = {nullptr, 0};
 	duckdb_v2_str path = {nullptr, 0};
+	duckdb_v2_value_handle value = nullptr;
 	duckdb_v2_column_data_collection_handle input = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
 	void *data = nullptr;
-	REQUIRE(duckdb_v2_copy_function_bind_get_column_count(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_bind_get_column_type(nullptr, 0, &type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_bind_get_column_name(nullptr, 0, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_batch_size_set_target(nullptr, 1, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_init_get_file_path(nullptr, &path, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_batch_take_input(nullptr, &input, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_flush_get_batch_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_copy_function_finalize_get_init_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_bind_get_column_count(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_bind_get_column_type(nullptr, 0, &type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_bind_get_column_name(nullptr, 0, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_bind_get_option_value(nullptr, 0, &value, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_batch_size_set_target(nullptr, 1, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_init_get_file_path(nullptr, &path, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_batch_take_input(nullptr, &input, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_flush_get_batch_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_to_finalize_get_init_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_from_bind_get_file_path(nullptr, &path, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_from_bind_set_cardinality(nullptr, 1, true, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_from_init_global_set_max_threads(nullptr, 1, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_from_exec_get_output_chunk(nullptr, &chunk, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_from_progress_set_progress(nullptr, 0.5, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 	duckdb_v2_copy_function_destroy(&function);
 
 	REQUIRE(duckdb_v2_copy_function_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);

--- a/test/api/capi/v2/test_capi_v2_copy_function.cpp
+++ b/test/api/capi/v2/test_capi_v2_copy_function.cpp
@@ -1,0 +1,597 @@
+#include "test_capi_v2.hpp"
+
+#include <atomic>
+#include <cstring>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// V2 copy function tests: build a function on a connection, register it, and
+// drive it through COPY ... TO.
+//
+// Callbacks avoid Catch assertions: a REQUIRE would throw through the C
+// callback boundary into the engine. On failure they populate the provided
+// error slot and return; the failure then surfaces as a query error that the
+// test asserts on. Cross-callback observations are latched into file-scope
+// statics and asserted after the query. The batch callback may run on several
+// threads at once, so the latches it writes are atomic.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+// Create a copy function on the connection with the given name.
+duckdb_v2_copy_function_handle MakeCopy(duckdb_v2_connection_handle conn, const char *name) {
+	duckdb_v2_copy_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_copy_function_create_with_connection(conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto str = Convert(name);
+	REQUIRE(duckdb_v2_copy_function_set_name(function, &str, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return function;
+}
+
+// COPY the rows of `source` to `path` with the given format. The target never exists beforehand, so the engine
+// writes it in place; USE_TMP_FILE is pinned anyway so a leftover file from an earlier run cannot change that.
+std::string CopyStatement(const std::string &source, const std::string &path, const char *format) {
+	return "COPY (" + source + ") TO '" + path + "' (FORMAT " + format + ", USE_TMP_FILE FALSE)";
+}
+
+// Runs a COPY statement and returns the row count it reports.
+int64_t RunCopy(duckdb_v2_connection_handle conn, const std::string &sql) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql.c_str(), &result) == DUCKDB_V2_ERROR_NONE);
+	auto rows = DrainChangedRows(result);
+	duckdb_v2_result_destroy(&result);
+	return rows;
+}
+
+// Runs a statement expected to fail, returning the code it fails with: either straight from the execute call, or
+// while stepping the result when the failure only surfaces during execution.
+DUCKDB_V2_ERROR RunFailingCopy(duckdb_v2_connection_handle conn, const std::string &sql) {
+	duckdb_v2_result_handle result = nullptr;
+	auto rc = Query(conn, sql.c_str(), &result);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_result_destroy(&result);
+		return rc;
+	}
+	auto status = DUCKDB_V2_RESULT_STEP_STATUS_WAITING;
+	for (int i = 0; i < 100000 && rc == DUCKDB_V2_ERROR_NONE && status != DUCKDB_V2_RESULT_STEP_STATUS_FINISHED; i++) {
+		duckdb_v2_data_chunk_handle chunk = nullptr;
+		rc = duckdb_v2_result_step(result, &chunk, &status, nullptr);
+		if (chunk) {
+			duckdb_v2_data_chunk_destroy(&chunk);
+		}
+		if (rc == DUCKDB_V2_ERROR_NONE && status == DUCKDB_V2_RESULT_STEP_STATUS_WAITING) {
+			rc = duckdb_v2_result_wait(result, nullptr);
+		}
+	}
+	duckdb_v2_result_destroy(&result);
+	return rc;
+}
+
+// ---------------------------------------------------------------------------
+// probe_copy: every callback latches what it saw. The user, bind, init and
+// batch data are file-scope markers with counting destructors.
+// ---------------------------------------------------------------------------
+
+int copy_user_marker = 0;
+int copy_bind_marker = 0;
+int copy_init_marker = 0;
+int copy_batch_marker = 0;
+
+enum Phase { BIND = 0, BATCH_SIZE, INIT, BATCH, FLUSH, FINALIZE, PHASE_COUNT };
+
+struct CopyProbe {
+	// What each phase's data accessors returned.
+	std::atomic<void *> user_data[PHASE_COUNT];
+	std::atomic<void *> bind_data[PHASE_COUNT];
+	std::atomic<void *> init_data[PHASE_COUNT];
+	std::atomic<void *> batch_data_in_flush;
+	std::atomic<idx_t> calls[PHASE_COUNT];
+	// Taking the batch a second time is refused.
+	std::atomic<DUCKDB_V2_ERROR> second_take_rc;
+	// Rows seen by the batch callback, summed over every batch.
+	std::atomic<idx_t> rows;
+	std::atomic<int> user_data_destroys;
+	std::atomic<int> bind_data_destroys;
+	std::atomic<int> init_data_destroys;
+	std::atomic<int> batch_data_destroys;
+
+	// Written by the bind and init callbacks only, which run once per statement.
+	idx_t column_count = 0;
+	std::string column_names[2];
+	DUCKDB_V2_LOGICAL_TYPE_ID column_types[2] = {DUCKDB_V2_LOGICAL_TYPE_ID_INVALID, DUCKDB_V2_LOGICAL_TYPE_ID_INVALID};
+	// Out-of-range probes, latched with their own (null) error slot.
+	DUCKDB_V2_ERROR oob_type_rc = DUCKDB_V2_ERROR_NONE;
+	DUCKDB_V2_ERROR oob_name_rc = DUCKDB_V2_ERROR_NONE;
+	std::string file_path;
+
+	void Reset() {
+		for (int phase = 0; phase < PHASE_COUNT; phase++) {
+			user_data[phase] = nullptr;
+			bind_data[phase] = nullptr;
+			init_data[phase] = nullptr;
+			calls[phase] = 0;
+		}
+		batch_data_in_flush = nullptr;
+		second_take_rc = DUCKDB_V2_ERROR_NONE;
+		rows = 0;
+		user_data_destroys = 0;
+		bind_data_destroys = 0;
+		init_data_destroys = 0;
+		batch_data_destroys = 0;
+		column_count = 0;
+		column_names[0].clear();
+		column_names[1].clear();
+		column_types[0] = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
+		column_types[1] = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
+		oob_type_rc = DUCKDB_V2_ERROR_NONE;
+		oob_name_rc = DUCKDB_V2_ERROR_NONE;
+		file_path.clear();
+	}
+} copy_probe;
+
+void DestroyUserData(void *) {
+	copy_probe.user_data_destroys++;
+}
+void DestroyBindData(void *) {
+	copy_probe.bind_data_destroys++;
+}
+void DestroyInitData(void *) {
+	copy_probe.init_data_destroys++;
+}
+void DestroyBatchData(void *) {
+	copy_probe.batch_data_destroys++;
+}
+
+void ProbeBind(duckdb_v2_copy_function_bind_info_handle info, duckdb_v2_context_handle,
+               duckdb_v2_error_info_handle *err) {
+	copy_probe.calls[BIND]++;
+	void *user_data = nullptr;
+	if (duckdb_v2_copy_function_bind_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_probe.user_data[BIND] = user_data;
+
+	if (duckdb_v2_copy_function_bind_get_column_count(info, &copy_probe.column_count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (idx_t i = 0; i < copy_probe.column_count && i < 2; i++) {
+		duckdb_v2_identifier_t name = {nullptr, 0};
+		if (duckdb_v2_copy_function_bind_get_column_name(info, i, &name, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		copy_probe.column_names[i] = Convert(name);
+		duckdb_v2_logical_type_handle type = nullptr;
+		if (duckdb_v2_copy_function_bind_get_column_type(info, i, &type, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		auto rc = duckdb_v2_logical_type_get_id(type, &copy_probe.column_types[i], err);
+		duckdb_v2_logical_type_destroy(&type);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+	// An index past the last column is an input error.
+	duckdb_v2_logical_type_handle oob_type = nullptr;
+	duckdb_v2_identifier_t oob_name = {nullptr, 0};
+	copy_probe.oob_type_rc =
+	    duckdb_v2_copy_function_bind_get_column_type(info, copy_probe.column_count, &oob_type, nullptr);
+	copy_probe.oob_name_rc =
+	    duckdb_v2_copy_function_bind_get_column_name(info, copy_probe.column_count, &oob_name, nullptr);
+
+	duckdb_v2_opaque bind_data = {&copy_bind_marker, DestroyBindData, nullptr};
+	duckdb_v2_copy_function_bind_set_bind_data(info, &bind_data, err);
+}
+
+// Asks for batches larger than any input in these tests, so a whole copy arrives as one batch per thread.
+void ProbeBatchSize(duckdb_v2_copy_function_batch_size_info_handle info, duckdb_v2_context_handle,
+                    duckdb_v2_error_info_handle *err) {
+	copy_probe.calls[BATCH_SIZE]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	if (duckdb_v2_copy_function_batch_size_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_batch_size_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_probe.user_data[BATCH_SIZE] = user_data;
+	copy_probe.bind_data[BATCH_SIZE] = bind_data;
+	duckdb_v2_copy_function_batch_size_set_target(info, 100000, err);
+}
+
+void ProbeInit(duckdb_v2_copy_function_init_info_handle info, duckdb_v2_context_handle,
+               duckdb_v2_error_info_handle *err) {
+	copy_probe.calls[INIT]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	duckdb_v2_str path = {nullptr, 0};
+	if (duckdb_v2_copy_function_init_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_init_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_init_get_file_path(info, &path, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_probe.user_data[INIT] = user_data;
+	copy_probe.bind_data[INIT] = bind_data;
+	copy_probe.file_path = Convert(path);
+
+	duckdb_v2_opaque init_data = {&copy_init_marker, DestroyInitData, nullptr};
+	duckdb_v2_copy_function_init_set_init_data(info, &init_data, err);
+}
+
+void ProbeBatch(duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_context_handle,
+                duckdb_v2_error_info_handle *err) {
+	copy_probe.calls[BATCH]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	void *init_data = nullptr;
+	duckdb_v2_column_data_collection_handle input = nullptr;
+	if (duckdb_v2_copy_function_batch_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_batch_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_batch_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_batch_take_input(info, &input, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_probe.user_data[BATCH] = user_data;
+	copy_probe.bind_data[BATCH] = bind_data;
+	copy_probe.init_data[BATCH] = init_data;
+
+	// The batch is ours now: count its rows and release it. A second take has nothing left to hand out.
+	idx_t count = 0;
+	auto rc = duckdb_v2_column_data_collection_row_count(input, &count, err);
+	duckdb_v2_column_data_collection_destroy(&input);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_probe.rows += count;
+	duckdb_v2_column_data_collection_handle again = nullptr;
+	copy_probe.second_take_rc = duckdb_v2_copy_function_batch_take_input(info, &again, nullptr);
+
+	duckdb_v2_opaque batch_data = {&copy_batch_marker, DestroyBatchData, nullptr};
+	duckdb_v2_copy_function_batch_set_batch_data(info, &batch_data, err);
+}
+
+void ProbeFlush(duckdb_v2_copy_function_flush_info_handle info, duckdb_v2_context_handle,
+                duckdb_v2_error_info_handle *err) {
+	copy_probe.calls[FLUSH]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	void *init_data = nullptr;
+	void *batch_data = nullptr;
+	if (duckdb_v2_copy_function_flush_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_flush_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_flush_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_flush_get_batch_data(info, &batch_data, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_probe.user_data[FLUSH] = user_data;
+	copy_probe.bind_data[FLUSH] = bind_data;
+	copy_probe.init_data[FLUSH] = init_data;
+	copy_probe.batch_data_in_flush = batch_data;
+}
+
+void ProbeFinalize(duckdb_v2_copy_function_finalize_info_handle info, duckdb_v2_context_handle,
+                   duckdb_v2_error_info_handle *err) {
+	copy_probe.calls[FINALIZE]++;
+	void *user_data = nullptr;
+	void *bind_data = nullptr;
+	void *init_data = nullptr;
+	if (duckdb_v2_copy_function_finalize_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_finalize_get_bind_data(info, &bind_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_copy_function_finalize_get_init_data(info, &init_data, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	copy_probe.user_data[FINALIZE] = user_data;
+	copy_probe.bind_data[FINALIZE] = bind_data;
+	copy_probe.init_data[FINALIZE] = init_data;
+}
+
+// Registers the probe function under the given name, with every callback and user data set, and destroys the
+// handle. Without the batch size callback, the batch size is left to the statement.
+void RegisterProbeCopy(duckdb_v2_connection_handle conn, const char *name = "probe_copy", bool with_batch_size = true) {
+	auto function = MakeCopy(conn, name);
+	if (with_batch_size) {
+		REQUIRE(duckdb_v2_copy_function_set_batch_size_callback(function, ProbeBatchSize, nullptr) ==
+		        DUCKDB_V2_ERROR_NONE);
+	}
+	duckdb_v2_opaque user_data = {&copy_user_marker, DestroyUserData, nullptr};
+	REQUIRE(duckdb_v2_copy_function_set_user_data(function, &user_data, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_bind_callback(function, ProbeBind, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_init_callback(function, ProbeInit, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_batch_callback(function, ProbeBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_flush_callback(function, ProbeFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_finalize_callback(function, ProbeFinalize, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_destroy(&function) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(function == nullptr);
+}
+
+// Noop callbacks for registration-refusal tests.
+void CopyNoopBatch(duckdb_v2_copy_function_batch_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
+}
+void CopyNoopFlush(duckdb_v2_copy_function_flush_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *) {
+}
+
+// Fail the query through a callback's error slot.
+void FailingBind(duckdb_v2_copy_function_bind_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
+	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
+	duckdb_v2_error_info_set_text(*err, Convert("copy bind failed on purpose"));
+}
+void FailingBatch(duckdb_v2_copy_function_batch_info_handle, duckdb_v2_context_handle,
+                  duckdb_v2_error_info_handle *err) {
+	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
+	duckdb_v2_error_info_set_text(*err, Convert("copy batch failed on purpose"));
+}
+void FailingBatchSize(duckdb_v2_copy_function_batch_size_info_handle, duckdb_v2_context_handle,
+                      duckdb_v2_error_info_handle *err) {
+	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
+	duckdb_v2_error_info_set_text(*err, Convert("copy batch size failed on purpose"));
+}
+// Leaves the target unset, which the engine refuses.
+void EmptyBatchSize(duckdb_v2_copy_function_batch_size_info_handle, duckdb_v2_context_handle,
+                    duckdb_v2_error_info_handle *) {
+}
+
+} // namespace
+
+// ===========================================================================
+// Register on a connection and drive through COPY ... TO.
+// ===========================================================================
+
+TEST_CASE("V2 copy: register on connection and execute", "[capi_v2][copy_function]") {
+	EnvFixture fx;
+	RegisterProbeCopy(fx.conn);
+
+	// More rows than one chunk, so the batch callback sees real batches.
+	const auto path = duckdb::TestCreatePath("v2_copy_probe.out");
+	copy_probe.Reset();
+	REQUIRE(RunCopy(fx.conn,
+	                CopyStatement("SELECT r AS a, r::VARCHAR AS b FROM range(5000) t(r)", path, "probe_copy")) == 5000);
+
+	// Bind saw the columns of the SELECT; an index past them is refused.
+	REQUIRE(copy_probe.calls[BIND].load() == 1);
+	REQUIRE(copy_probe.column_count == 2);
+	REQUIRE(copy_probe.column_names[0] == "a");
+	REQUIRE(copy_probe.column_names[1] == "b");
+	REQUIRE(copy_probe.column_types[0] == DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	REQUIRE(copy_probe.column_types[1] == DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
+	REQUIRE(copy_probe.oob_type_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(copy_probe.oob_name_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// The batch size callback ran once, after bind.
+	REQUIRE(copy_probe.calls[BATCH_SIZE].load() == 1);
+
+	// One file: init and finalize ran once, with the COPY target as the path.
+	REQUIRE(copy_probe.calls[INIT].load() == 1);
+	REQUIRE(copy_probe.file_path == path);
+	REQUIRE(copy_probe.calls[FINALIZE].load() == 1);
+
+	// Every row went through a batch, and every batch was flushed.
+	REQUIRE(copy_probe.calls[BATCH].load() >= 1);
+	REQUIRE(copy_probe.calls[FLUSH].load() == copy_probe.calls[BATCH].load());
+	REQUIRE(copy_probe.rows.load() == 5000);
+	REQUIRE(copy_probe.second_take_rc.load() == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// The data slots reached every phase they are defined for.
+	for (int phase = 0; phase < PHASE_COUNT; phase++) {
+		REQUIRE(copy_probe.user_data[phase].load() == &copy_user_marker);
+	}
+	for (int phase = BATCH_SIZE; phase < PHASE_COUNT; phase++) {
+		REQUIRE(copy_probe.bind_data[phase].load() == &copy_bind_marker);
+	}
+	for (int phase = BATCH; phase < PHASE_COUNT; phase++) {
+		REQUIRE(copy_probe.init_data[phase].load() == &copy_init_marker);
+	}
+	REQUIRE(copy_probe.batch_data_in_flush.load() == &copy_batch_marker);
+
+	// Each batch's data was released after its flush, and the file's init data and the statement's bind data with
+	// the statement.
+	REQUIRE(copy_probe.batch_data_destroys.load() == copy_probe.calls[BATCH].load());
+	REQUIRE(copy_probe.init_data_destroys.load() == 1);
+	REQUIRE(copy_probe.bind_data_destroys.load() == 1);
+	// The user data lives with the registered function.
+	REQUIRE(copy_probe.user_data_destroys.load() == 0);
+}
+
+// ===========================================================================
+// The batch size callback decides where batches are cut when the statement sets no BATCH_SIZE.
+// ===========================================================================
+
+TEST_CASE("V2 copy: batch size callback", "[capi_v2][copy_function]") {
+	EnvFixture fx;
+	// One sink thread, so the batch count follows from the chunk sizes alone.
+	ExecSQL(fx.conn, "SET threads = 1");
+	RegisterProbeCopy(fx.conn, "chunked_copy", false);
+	RegisterProbeCopy(fx.conn, "whole_copy", true);
+
+	// Without a batch size every sunk chunk is a batch: 2048, 2048 and 904 rows.
+	const auto path = duckdb::TestCreatePath("v2_copy_batch_size.out");
+	copy_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyStatement("SELECT r FROM range(5000) t(r)", path, "chunked_copy")) == 5000);
+	REQUIRE(copy_probe.calls[BATCH_SIZE].load() == 0);
+	REQUIRE(copy_probe.calls[BATCH].load() == 3);
+	REQUIRE(copy_probe.rows.load() == 5000);
+
+	// The callback asks for batches larger than the input: everything arrives as one batch.
+	copy_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyStatement("SELECT r FROM range(5000) t(r)", path, "whole_copy")) == 5000);
+	REQUIRE(copy_probe.calls[BATCH_SIZE].load() == 1);
+	REQUIRE(copy_probe.calls[BATCH].load() == 1);
+	REQUIRE(copy_probe.rows.load() == 5000);
+
+	// The statement's own BATCH_SIZE wins, and the callback is not consulted.
+	copy_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, "COPY (SELECT r FROM range(5000) t(r)) TO '" + path +
+	                             "' (FORMAT whole_copy, USE_TMP_FILE FALSE, BATCH_SIZE 4096)") == 5000);
+	REQUIRE(copy_probe.calls[BATCH_SIZE].load() == 0);
+	REQUIRE(copy_probe.calls[BATCH].load() == 2);
+	REQUIRE(copy_probe.rows.load() == 5000);
+}
+
+// ===========================================================================
+// Only the batch and flush callbacks are required; the others leave their data slots empty.
+// ===========================================================================
+
+TEST_CASE("V2 copy: optional callbacks and empty data slots", "[capi_v2][copy_function]") {
+	EnvFixture fx;
+
+	auto function = MakeCopy(fx.conn, "bare_copy");
+	REQUIRE(duckdb_v2_copy_function_set_batch_callback(function, ProbeBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_flush_callback(function, ProbeFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_copy_function_destroy(&function);
+
+	const auto path = duckdb::TestCreatePath("v2_copy_bare.out");
+	copy_probe.Reset();
+	REQUIRE(RunCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "bare_copy")) == 10);
+
+	REQUIRE(copy_probe.calls[BIND].load() == 0);
+	REQUIRE(copy_probe.calls[INIT].load() == 0);
+	REQUIRE(copy_probe.calls[FINALIZE].load() == 0);
+	REQUIRE(copy_probe.calls[BATCH].load() >= 1);
+	REQUIRE(copy_probe.calls[FLUSH].load() == copy_probe.calls[BATCH].load());
+	REQUIRE(copy_probe.rows.load() == 10);
+
+	// Nothing was set, so every slot reads as null.
+	REQUIRE(copy_probe.user_data[BATCH].load() == nullptr);
+	REQUIRE(copy_probe.bind_data[BATCH].load() == nullptr);
+	REQUIRE(copy_probe.init_data[BATCH].load() == nullptr);
+	REQUIRE(copy_probe.user_data[FLUSH].load() == nullptr);
+	REQUIRE(copy_probe.bind_data[FLUSH].load() == nullptr);
+	REQUIRE(copy_probe.init_data[FLUSH].load() == nullptr);
+	// The batch data was set by the batch callback, so it did reach the flush.
+	REQUIRE(copy_probe.batch_data_in_flush.load() == &copy_batch_marker);
+	REQUIRE(copy_probe.batch_data_destroys.load() == copy_probe.calls[BATCH].load());
+
+	// A batch callback that never takes its input leaves the engine to release it.
+	auto untaken = MakeCopy(fx.conn, "untaken_copy");
+	REQUIRE(duckdb_v2_copy_function_set_batch_callback(untaken, CopyNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_flush_callback(untaken, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_register(untaken, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_copy_function_destroy(&untaken);
+	REQUIRE(RunCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "untaken_copy")) == 10);
+}
+
+// ===========================================================================
+// Errors
+// ===========================================================================
+
+// An error set in a callback's slot fails the statement with its code.
+TEST_CASE("V2 copy: callback errors propagate to the result", "[capi_v2][copy_function]") {
+	EnvFixture fx;
+
+	auto batch_fails = MakeCopy(fx.conn, "copy_batch_fails");
+	REQUIRE(duckdb_v2_copy_function_set_batch_callback(batch_fails, FailingBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_flush_callback(batch_fails, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_register(batch_fails, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_copy_function_destroy(&batch_fails);
+
+	auto bind_fails = MakeCopy(fx.conn, "copy_bind_fails");
+	REQUIRE(duckdb_v2_copy_function_set_bind_callback(bind_fails, FailingBind, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_batch_callback(bind_fails, CopyNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_flush_callback(bind_fails, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_register(bind_fails, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_copy_function_destroy(&bind_fails);
+
+	auto batch_size_fails = MakeCopy(fx.conn, "copy_batch_size_fails");
+	REQUIRE(duckdb_v2_copy_function_set_batch_size_callback(batch_size_fails, FailingBatchSize, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_batch_callback(batch_size_fails, CopyNoopBatch, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_flush_callback(batch_size_fails, CopyNoopFlush, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_register(batch_size_fails, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_copy_function_destroy(&batch_size_fails);
+
+	auto batch_size_empty = MakeCopy(fx.conn, "copy_batch_size_empty");
+	REQUIRE(duckdb_v2_copy_function_set_batch_size_callback(batch_size_empty, EmptyBatchSize, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_batch_callback(batch_size_empty, CopyNoopBatch, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_flush_callback(batch_size_empty, CopyNoopFlush, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_register(batch_size_empty, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_copy_function_destroy(&batch_size_empty);
+
+	// The callback's code round-trips through the engine's exception machinery.
+	const auto path = duckdb::TestCreatePath("v2_copy_fails.out");
+	REQUIRE(RunFailingCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "copy_batch_fails")) ==
+	        DUCKDB_V2_ERROR_IO_GENERAL);
+	REQUIRE(RunFailingCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "copy_bind_fails")) ==
+	        DUCKDB_V2_ERROR_IO_GENERAL);
+	REQUIRE(RunFailingCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "copy_batch_size_fails")) ==
+	        DUCKDB_V2_ERROR_IO_GENERAL);
+	// A batch size callback that sets no target fails the statement.
+	REQUIRE(RunFailingCopy(fx.conn, CopyStatement("SELECT r FROM range(10) t(r)", path, "copy_batch_size_empty")) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
+TEST_CASE("V2 copy: registration refusals", "[capi_v2][copy_function]") {
+	EnvFixture fx;
+
+	// No name.
+	{
+		duckdb_v2_copy_function_handle function = nullptr;
+		REQUIRE(duckdb_v2_copy_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_set_batch_callback(function, CopyNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_set_flush_callback(function, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_copy_function_destroy(&function);
+	}
+
+	// No batch callback.
+	{
+		auto function = MakeCopy(fx.conn, "copy_no_batch");
+		REQUIRE(duckdb_v2_copy_function_set_flush_callback(function, CopyNoopFlush, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_copy_function_destroy(&function);
+	}
+
+	// No flush callback.
+	{
+		auto function = MakeCopy(fx.conn, "copy_no_flush");
+		REQUIRE(duckdb_v2_copy_function_set_batch_callback(function, CopyNoopBatch, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_copy_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_copy_function_destroy(&function);
+	}
+}
+
+TEST_CASE("V2 copy: null arguments and destroy null-safety", "[capi_v2][copy_function]") {
+	EnvFixture fx;
+
+	duckdb_v2_copy_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_copy_function_create_with_connection(nullptr, &function, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(function == nullptr);
+	REQUIRE(duckdb_v2_copy_function_create_with_connection(fx.conn, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	REQUIRE(duckdb_v2_copy_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_copy_function_set_name(function, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_set_user_data(function, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_set_batch_size_callback(nullptr, ProbeBatchSize, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_set_batch_callback(nullptr, CopyNoopBatch, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_register(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	idx_t count = 0;
+	duckdb_v2_logical_type_handle type = nullptr;
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	duckdb_v2_str path = {nullptr, 0};
+	duckdb_v2_column_data_collection_handle input = nullptr;
+	void *data = nullptr;
+	REQUIRE(duckdb_v2_copy_function_bind_get_column_count(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_bind_get_column_type(nullptr, 0, &type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_bind_get_column_name(nullptr, 0, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_batch_size_set_target(nullptr, 1, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_init_get_file_path(nullptr, &path, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_batch_take_input(nullptr, &input, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_flush_get_batch_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_copy_function_finalize_get_init_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	duckdb_v2_copy_function_destroy(&function);
+
+	REQUIRE(duckdb_v2_copy_function_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_copy_function_handle null_function = nullptr;
+	REQUIRE(duckdb_v2_copy_function_destroy(&null_function) == DUCKDB_V2_ERROR_NONE);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_copy_function.cpp
+++ b/test/api/capi/v2/test_capi_v2_copy_function.cpp
@@ -740,6 +740,8 @@ TEST_CASE("V2 copy: COPY TO on a connection", "[capi_v2][copy_function]") {
 // The batch size callback decides where batches are cut when the statement sets no BATCH_SIZE.
 // ===========================================================================
 
+// The batch counts below follow from the default chunk size, so the test only holds for the default vector size.
+#if (STANDARD_VECTOR_SIZE == DEFAULT_STANDARD_VECTOR_SIZE)
 TEST_CASE("V2 copy: COPY TO batch size callback", "[capi_v2][copy_function]") {
 	EnvFixture fx;
 	// One sink thread, so the batch count follows from the chunk sizes alone.
@@ -770,6 +772,7 @@ TEST_CASE("V2 copy: COPY TO batch size callback", "[capi_v2][copy_function]") {
 	REQUIRE(copy_to_probe.calls[TO_BATCH].load() == 2);
 	REQUIRE(copy_to_probe.rows.load() == 5000);
 }
+#endif
 
 // ===========================================================================
 // Only the batch and flush callbacks are required on the COPY TO side; the others leave their slots empty.

--- a/test/api/capi/v2/test_capi_v2_custom_type.cpp
+++ b/test/api/capi/v2/test_capi_v2_custom_type.cpp
@@ -1,0 +1,171 @@
+#include "test_capi_v2.hpp"
+
+#include <cstring>
+
+// ---------------------------------------------------------------------------
+// V2 custom type tests: bind a name to a base type, register it, and refer to
+// it from SQL. A custom type shares its base type's representation, so values
+// flow through the base type's accessors; only the name it goes by changes.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+duckdb_v2_identifier_t TypeIdent(const char *s) {
+	return Convert(s);
+}
+
+// Create a custom type on the connection with the given name and base type.
+duckdb_v2_custom_type_handle MakeCustomType(duckdb_v2_connection_handle conn, const char *name,
+                                            duckdb_v2_logical_type_handle base) {
+	duckdb_v2_custom_type_handle type = nullptr;
+	REQUIRE(duckdb_v2_custom_type_create_with_connection(conn, &type, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_custom_type_set_name(type, TypeIdent(name), nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_custom_type_set_base_type(type, base, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return type;
+}
+
+// Run a query producing a single VARCHAR cell.
+std::string QueryText(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql, &result) == DUCKDB_V2_ERROR_NONE);
+	auto chunk = StepChunk(result);
+	REQUIRE(chunk != nullptr);
+	duckdb_v2_vector_handle vec = nullptr;
+	duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr);
+	duckdb_v2_vector_view view {};
+	duckdb_v2_vector_get_view(vec, &view, nullptr);
+	auto out = Convert(Convert(static_cast<const duckdb_v2_bytes *>(view.data)[SelAt(view.sel, 0)]));
+	duckdb_v2_data_chunk_destroy(&chunk);
+	duckdb_v2_result_destroy(&result);
+	return out;
+}
+
+// Whether a query fails, either at bind time or while its (lazily executed) stream is stepped.
+bool TypeQueryFails(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	auto rc = Query(conn, sql, &result);
+	auto status = DUCKDB_V2_RESULT_STEP_STATUS_WAITING;
+	while (rc == DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_data_chunk_handle chunk = nullptr;
+		rc = duckdb_v2_result_step(result, &chunk, &status, nullptr);
+		if (chunk) {
+			duckdb_v2_data_chunk_destroy(&chunk);
+		}
+		if (rc != DUCKDB_V2_ERROR_NONE || status == DUCKDB_V2_RESULT_STEP_STATUS_FINISHED ||
+		    status == DUCKDB_V2_RESULT_STEP_STATUS_CANCELLED) {
+			break;
+		}
+		if (status == DUCKDB_V2_RESULT_STEP_STATUS_WAITING) {
+			rc = duckdb_v2_result_wait(result, nullptr);
+		}
+	}
+	duckdb_v2_result_destroy(&result);
+	return rc != DUCKDB_V2_ERROR_NONE;
+}
+
+} // namespace
+
+TEST_CASE("V2 custom type: register on connection and use in SQL", "[capi_v2][custom_type]") {
+	EnvFixture fx;
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+
+	auto type = MakeCustomType(fx.conn, "TEMPERATURE", integer);
+	REQUIRE(duckdb_v2_custom_type_register(type, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_custom_type_destroy(&type) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(type == nullptr);
+	duckdb_v2_logical_type_destroy(&integer);
+
+	// The name resolves in SQL, and a value of it reports the custom name rather than the base type's.
+	REQUIRE(QueryText(fx.conn, "SELECT typeof(CAST(42 AS temperature))") == "TEMPERATURE");
+	// The representation is the base type's, so the base type's operations still apply.
+	REQUIRE(QueryText(fx.conn, "SELECT (CAST(42 AS temperature)::INTEGER + 1)::VARCHAR") == "43");
+	// And it can be used as a column type.
+	ExecSQL(fx.conn, "CREATE TABLE readings (t temperature)");
+	ExecSQL(fx.conn, "INSERT INTO readings VALUES (7), (9)");
+	REQUIRE(QueryText(fx.conn, "SELECT sum(t::INTEGER)::VARCHAR FROM readings") == "16");
+	REQUIRE(QueryText(fx.conn, "SELECT typeof(t) FROM readings LIMIT 1") == "TEMPERATURE");
+}
+
+TEST_CASE("V2 custom type: base type keeps its parameters", "[capi_v2][custom_type]") {
+	EnvFixture fx;
+
+	// A parameterised base type carries its parameters into the custom type.
+	auto decimal = MakeType(fx.conn, "decimal", nullptr, {MakeInt32Value(fx.conn, 5), MakeInt32Value(fx.conn, 2)});
+	auto type = MakeCustomType(fx.conn, "MONEY", decimal);
+	REQUIRE(duckdb_v2_custom_type_register(type, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_custom_type_destroy(&type);
+	duckdb_v2_logical_type_destroy(&decimal);
+
+	REQUIRE(QueryText(fx.conn, "SELECT typeof(CAST(1.5 AS money))") == "MONEY");
+	// The base type's width and scale still apply.
+	REQUIRE(QueryText(fx.conn, "SELECT CAST(1.005 AS money)::VARCHAR") == "1.01");
+	REQUIRE(TypeQueryFails(fx.conn, "SELECT CAST(1000 AS money)"));
+}
+
+TEST_CASE("V2 custom type: registration refusals", "[capi_v2][custom_type]") {
+	EnvFixture fx;
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	auto any = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_ANY);
+
+	// No name.
+	{
+		duckdb_v2_custom_type_handle type = nullptr;
+		REQUIRE(duckdb_v2_custom_type_create_with_connection(fx.conn, &type, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_custom_type_set_base_type(type, integer, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_custom_type_register(type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_custom_type_destroy(&type);
+	}
+
+	// No base type.
+	{
+		duckdb_v2_custom_type_handle type = nullptr;
+		REQUIRE(duckdb_v2_custom_type_create_with_connection(fx.conn, &type, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_custom_type_set_name(type, TypeIdent("no_base"), nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_custom_type_register(type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_custom_type_destroy(&type);
+	}
+
+	// ANY is a signature wildcard, not something a registered type can be built on.
+	{
+		auto type = MakeCustomType(fx.conn, "any_base", any);
+		REQUIRE(duckdb_v2_custom_type_register(type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_custom_type_destroy(&type);
+	}
+
+	duckdb_v2_logical_type_destroy(&integer);
+	duckdb_v2_logical_type_destroy(&any);
+}
+
+TEST_CASE("V2 custom type: null arguments and destroy null-safety", "[capi_v2][custom_type]") {
+	EnvFixture fx;
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+
+	duckdb_v2_custom_type_handle type = nullptr;
+	REQUIRE(duckdb_v2_custom_type_create_with_connection(nullptr, &type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(type == nullptr);
+	REQUIRE(duckdb_v2_custom_type_create_with_connection(fx.conn, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_custom_type_create_with_extension(nullptr, &type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	REQUIRE(duckdb_v2_custom_type_create_with_connection(fx.conn, &type, nullptr) == DUCKDB_V2_ERROR_NONE);
+	// A view with a null pointer but a non-zero length is rejected; the empty view is a legitimate (empty) name,
+	// which registration then refuses.
+	REQUIRE(duckdb_v2_custom_type_set_name(type, duckdb_v2_identifier_t {nullptr, 4}, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_custom_type_set_name(type, TypeIdent(nullptr), nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_custom_type_set_name(nullptr, TypeIdent("x"), nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_custom_type_set_base_type(type, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_custom_type_set_base_type(nullptr, integer, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_custom_type_register(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_custom_type_destroy(&type) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(type == nullptr);
+
+	// Destroy is null-safe on both the pointer and the handle behind it.
+	REQUIRE(duckdb_v2_custom_type_destroy(&type) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_custom_type_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	duckdb_v2_logical_type_destroy(&integer);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_data_chunk.cpp
+++ b/test/api/capi/v2/test_capi_v2_data_chunk.cpp
@@ -1015,6 +1015,7 @@ TEST_CASE("V2: vector_flatten CONSTANT → FLAT", "[capi_v2][data_chunk]") {
 //     on a fixture that has different valid/invalid rows under sel.
 // ===========================================================================
 
+#if (STANDARD_VECTOR_SIZE > 3)
 TEST_CASE("V2: DICTIONARY vector view", "[capi_v2][data_chunk]") {
 	// Build a FLAT INTEGER vector backing the dictionary. Mark row 1
 	// invalid so validity-follows-sel has something to expose.
@@ -1068,6 +1069,7 @@ TEST_CASE("V2: DICTIONARY vector view", "[capi_v2][data_chunk]") {
 		REQUIRE(RowValid(view, SelAt(view.sel, i)));
 	}
 }
+#endif
 
 // ===========================================================================
 // vector_get_view rejects OTHER (FSST / SEQUENCE / SHREDDED) vectors

--- a/test/api/capi/v2/test_capi_v2_expression.cpp
+++ b/test/api/capi/v2/test_capi_v2_expression.cpp
@@ -299,7 +299,7 @@ void ProbePushdownCb(duckdb_v2_table_function_filter_pushdown_info_handle info, 
 constexpr int64_t PROBE_ROWS = 4;
 
 struct ProbeGlobal {
-	bool done = false;
+	int64_t position = 0;
 };
 
 void DeleteProbeGlobal(void *ptr) {
@@ -351,11 +351,15 @@ void ProbeExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_conte
 			return;
 		}
 	}
-	if (global.done) {
+	// Batches are capped by the vector size so the probe also serves builds with a tiny STANDARD_VECTOR_SIZE.
+	auto produced = PROBE_ROWS - global.position;
+	if (produced > static_cast<int64_t>(STANDARD_VECTOR_SIZE)) {
+		produced = static_cast<int64_t>(STANDARD_VECTOR_SIZE);
+	}
+	if (produced <= 0) {
 		duckdb_v2_vector_set_size(vectors[0], 0, err);
 		return;
 	}
-	global.done = true;
 
 	void *a_raw = nullptr;
 	void *c_raw = nullptr;
@@ -363,16 +367,18 @@ void ProbeExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_conte
 	    duckdb_v2_vector_get_data_mutable(vectors[2], &c_raw, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	for (int64_t i = 0; i < PROBE_ROWS; i++) {
-		static_cast<int32_t *>(a_raw)[i] = static_cast<int32_t>(i);
-		static_cast<int64_t *>(c_raw)[i] = i * 10;
-		auto text = std::to_string(i);
+	for (int64_t i = 0; i < produced; i++) {
+		const auto row = global.position + i;
+		static_cast<int32_t *>(a_raw)[i] = static_cast<int32_t>(row);
+		static_cast<int64_t *>(c_raw)[i] = row * 10;
+		auto text = std::to_string(row);
 		if (V2VectorAssignString(vectors[1], static_cast<idx_t>(i), text.data(), text.size(), err) !=
 		    DUCKDB_V2_ERROR_NONE) {
 			return;
 		}
 	}
-	duckdb_v2_vector_set_size(vectors[0], static_cast<idx_t>(PROBE_ROWS), err);
+	global.position += produced;
+	duckdb_v2_vector_set_size(vectors[0], static_cast<idx_t>(produced), err);
 }
 
 void RegisterProbe(duckdb_v2_connection_handle conn) {

--- a/test/api/capi/v2/test_capi_v2_expression.cpp
+++ b/test/api/capi/v2/test_capi_v2_expression.cpp
@@ -1,0 +1,512 @@
+#include "test_capi_v2.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// V2 expression tests. Expressions only ever reach a caller through the filter
+// pushdown callback of a table function, so every test registers expr_probe(),
+// a table function whose pushdown callback renders each offered predicate into
+// a string without claiming it, then queries it with a WHERE clause and checks
+// what the callback saw.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+// What the pushdown callback recorded for the last query.
+struct ExpressionProbe {
+	std::vector<std::string> filters;
+	std::string root_type;
+	std::string failure;
+	idx_t misuse_failures = 0;
+	bool check_misuse = false;
+
+	void Reset() {
+		filters.clear();
+		root_type.clear();
+		failure.clear();
+		misuse_failures = 0;
+		check_misuse = false;
+	}
+};
+
+ExpressionProbe expression_probe;
+
+void ProbeFail(const char *what, duckdb_v2_error_info_handle *err) {
+	if (expression_probe.failure.empty()) {
+		expression_probe.failure = what;
+		if (err && *err) {
+			duckdb_v2_str text = {nullptr, 0};
+			duckdb_v2_error_info_get_text(*err, &text);
+			expression_probe.failure += ": " + Convert(text);
+		}
+	}
+}
+
+// The two-call text protocol, without REQUIRE so it is safe inside a callback.
+template <class CALL>
+std::string ProbeText(CALL call, bool &ok) {
+	idx_t len = 0;
+	if (call(nullptr, 0, &len) != DUCKDB_V2_ERROR_NONE) {
+		ok = false;
+		return std::string();
+	}
+	std::vector<char> buf(len + 1, '\0');
+	if (call(buf.data(), buf.size(), &len) != DUCKDB_V2_ERROR_NONE) {
+		ok = false;
+		return std::string();
+	}
+	return std::string(buf.data(), len);
+}
+
+std::string ProbeValue(duckdb_v2_value_handle value, bool &ok) {
+	return ProbeText(
+	    [&](char *buf, idx_t cap, idx_t *len) { return duckdb_v2_value_to_string(value, buf, cap, len, nullptr); }, ok);
+}
+
+std::string ProbeType(duckdb_v2_logical_type_handle type, bool &ok) {
+	return ProbeText(
+	    [&](char *buf, idx_t cap, idx_t *len) { return duckdb_v2_logical_type_to_text(type, buf, cap, len, nullptr); },
+	    ok);
+}
+
+// A tag for the node types that are not function calls.
+const char *ProbeTag(DUCKDB_V2_EXPRESSION_TYPE type) {
+	switch (type) {
+	case DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_NOT:
+		return "not";
+	case DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_IS_NULL:
+		return "is_null";
+	case DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_IS_NOT_NULL:
+		return "is_not_null";
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_IN:
+		return "in";
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_NOT_IN:
+		return "not_in";
+	case DUCKDB_V2_EXPRESSION_TYPE_CONJUNCTION_AND:
+		return "and";
+	case DUCKDB_V2_EXPRESSION_TYPE_CONJUNCTION_OR:
+		return "or";
+	case DUCKDB_V2_EXPRESSION_TYPE_VALUE_PARAMETER:
+		return "param";
+	case DUCKDB_V2_EXPRESSION_TYPE_CASE_EXPR:
+		return "case";
+	case DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_COALESCE:
+		return "coalesce";
+	case DUCKDB_V2_EXPRESSION_TYPE_INVALID:
+		return "invalid";
+	default:
+		return "?";
+	}
+}
+
+bool ProbeIsFunction(DUCKDB_V2_EXPRESSION_TYPE type) {
+	switch (type) {
+	case DUCKDB_V2_EXPRESSION_TYPE_BOUND_FUNCTION:
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_EQUAL:
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_NOTEQUAL:
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_LESSTHAN:
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_GREATERTHAN:
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO:
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO:
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_DISTINCT_FROM:
+	case DUCKDB_V2_EXPRESSION_TYPE_COMPARE_NOT_DISTINCT_FROM:
+		return true;
+	default:
+		return false;
+	}
+}
+
+// Renders a predicate: constants as their text, column references as "col<declared index>", plain function calls
+// as "qualified.name(children)", comparisons as "op(children)", casts as "cast(child)::TYPE", and everything else
+// as "tag(children)".
+std::string ProbeRender(duckdb_v2_table_function_filter_pushdown_info_handle info, duckdb_v2_expression_handle expr,
+                        duckdb_v2_error_info_handle *err, bool &ok) {
+	DUCKDB_V2_EXPRESSION_TYPE type = DUCKDB_V2_EXPRESSION_TYPE_INVALID;
+	if (duckdb_v2_expression_get_type(expr, &type, err) != DUCKDB_V2_ERROR_NONE) {
+		ok = false;
+		return "";
+	}
+
+	if (type == DUCKDB_V2_EXPRESSION_TYPE_VALUE_CONSTANT) {
+		duckdb_v2_value_handle value = nullptr;
+		if (duckdb_v2_expression_constant_get_value(expr, &value, err) != DUCKDB_V2_ERROR_NONE) {
+			ok = false;
+			return "";
+		}
+		auto text = ProbeValue(value, ok);
+		duckdb_v2_value_destroy(&value);
+		return text;
+	}
+	if (type == DUCKDB_V2_EXPRESSION_TYPE_BOUND_COLUMN_REF) {
+		idx_t index = 0;
+		idx_t declared = 0;
+		if (duckdb_v2_expression_column_ref_get_index(expr, &index, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_table_function_filter_pushdown_get_column_index(info, index, &declared, err) !=
+		        DUCKDB_V2_ERROR_NONE) {
+			ok = false;
+			return "";
+		}
+		return "col" + std::to_string(declared);
+	}
+
+	idx_t child_count = 0;
+	if (duckdb_v2_expression_get_child_count(expr, &child_count, err) != DUCKDB_V2_ERROR_NONE) {
+		ok = false;
+		return "";
+	}
+	std::string children;
+	for (idx_t i = 0; i < child_count; i++) {
+		duckdb_v2_expression_handle child = nullptr;
+		if (duckdb_v2_expression_get_child(expr, i, &child, err) != DUCKDB_V2_ERROR_NONE) {
+			ok = false;
+			return "";
+		}
+		if (i > 0) {
+			children += ", ";
+		}
+		children += ProbeRender(info, child, err, ok);
+	}
+
+	if (type == DUCKDB_V2_EXPRESSION_TYPE_OPERATOR_CAST) {
+		DUCKDB_V2_CAST_MODE mode = DUCKDB_V2_CAST_MODE_NORMAL;
+		duckdb_v2_logical_type_handle target = nullptr;
+		if (duckdb_v2_expression_cast_get_mode(expr, &mode, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_expression_get_return_type(expr, &target, err) != DUCKDB_V2_ERROR_NONE) {
+			ok = false;
+			return "";
+		}
+		auto target_text = ProbeType(target, ok);
+		duckdb_v2_logical_type_destroy(&target);
+		return std::string(mode == DUCKDB_V2_CAST_MODE_TRY ? "try_cast" : "cast") + "(" + children +
+		       ")::" + target_text;
+	}
+	if (type == DUCKDB_V2_EXPRESSION_TYPE_COMPARE_BETWEEN) {
+		return "between(" + children + ")";
+	}
+	if (type == DUCKDB_V2_EXPRESSION_TYPE_BOUND_FUNCTION) {
+		duckdb_v2_qname_handle qname = nullptr;
+		if (duckdb_v2_expression_function_get_qname(expr, &qname, err) != DUCKDB_V2_ERROR_NONE) {
+			ok = false;
+			return "";
+		}
+		auto text = ProbeText(
+		    [&](char *buf, idx_t cap, idx_t *len) { return duckdb_v2_qname_render(qname, buf, cap, len, nullptr); },
+		    ok);
+		duckdb_v2_qname_destroy(&qname);
+		return text + "(" + children + ")";
+	}
+	if (ProbeIsFunction(type)) {
+		duckdb_v2_identifier_t name = {nullptr, 0};
+		if (duckdb_v2_expression_function_get_name(expr, &name, err) != DUCKDB_V2_ERROR_NONE) {
+			ok = false;
+			return "";
+		}
+		return Convert(name) + "(" + children + ")";
+	}
+	std::string rendered = ProbeTag(type);
+	if (child_count > 0) {
+		rendered += "(" + children + ")";
+	}
+	return rendered;
+}
+
+// Counts how many of the type-specific accessors refuse a node they do not apply to. Runs on a "a < 5" predicate:
+// the root is a comparison, its first child a column reference, its second a constant.
+void ProbeMisuse(duckdb_v2_table_function_filter_pushdown_info_handle info, duckdb_v2_expression_handle root) {
+	duckdb_v2_expression_handle column = nullptr;
+	duckdb_v2_expression_handle constant = nullptr;
+	if (duckdb_v2_expression_get_child(root, 0, &column, nullptr) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_expression_get_child(root, 1, &constant, nullptr) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	auto count_failure = [&](DUCKDB_V2_ERROR rc, duckdb_v2_error_info_handle *err) {
+		if (rc != DUCKDB_V2_ERROR_NONE && *err) {
+			expression_probe.misuse_failures++;
+		}
+		duckdb_v2_error_info_destroy(err);
+	};
+	duckdb_v2_error_info_handle err = nullptr;
+
+	duckdb_v2_value_handle value = nullptr;
+	count_failure(duckdb_v2_expression_constant_get_value(root, &value, &err), &err);
+	idx_t index = 0;
+	count_failure(duckdb_v2_expression_column_ref_get_index(root, &index, &err), &err);
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	count_failure(duckdb_v2_expression_function_get_name(constant, &name, &err), &err);
+	duckdb_v2_qname_handle qname = nullptr;
+	count_failure(duckdb_v2_expression_function_get_qname(constant, &qname, &err), &err);
+	DUCKDB_V2_CAST_MODE mode = DUCKDB_V2_CAST_MODE_NORMAL;
+	count_failure(duckdb_v2_expression_cast_get_mode(root, &mode, &err), &err);
+	duckdb_v2_expression_handle child = nullptr;
+	count_failure(duckdb_v2_expression_get_child(root, 2, &child, &err), &err);
+	count_failure(duckdb_v2_expression_get_child(column, 0, &child, &err), &err);
+
+	duckdb_v2_expression_handle filter = nullptr;
+	count_failure(duckdb_v2_table_function_filter_pushdown_get_filter(info, 99, &filter, &err), &err);
+	count_failure(duckdb_v2_table_function_filter_pushdown_get_column_index(info, 99, &index, &err), &err);
+	count_failure(duckdb_v2_table_function_filter_pushdown_accept(info, 99, &err), &err);
+}
+
+void ProbePushdownCb(duckdb_v2_table_function_filter_pushdown_info_handle info, duckdb_v2_context_handle,
+                     duckdb_v2_error_info_handle *err) {
+	// The optimizer may offer the (unclaimed) predicates more than once per query: keep the last round.
+	expression_probe.filters.clear();
+	idx_t count = 0;
+	if (duckdb_v2_table_function_filter_pushdown_get_filter_count(info, &count, err) != DUCKDB_V2_ERROR_NONE) {
+		ProbeFail("get_filter_count", err);
+		return;
+	}
+	for (idx_t i = 0; i < count; i++) {
+		duckdb_v2_expression_handle filter = nullptr;
+		if (duckdb_v2_table_function_filter_pushdown_get_filter(info, i, &filter, err) != DUCKDB_V2_ERROR_NONE) {
+			ProbeFail("get_filter", err);
+			return;
+		}
+		bool ok = true;
+		auto rendered = ProbeRender(info, filter, err, ok);
+		if (!ok) {
+			ProbeFail("render", err);
+			return;
+		}
+		expression_probe.filters.push_back(rendered);
+
+		if (i == 0) {
+			duckdb_v2_logical_type_handle type = nullptr;
+			if (duckdb_v2_expression_get_return_type(filter, &type, err) != DUCKDB_V2_ERROR_NONE) {
+				ProbeFail("get_return_type", err);
+				return;
+			}
+			expression_probe.root_type = ProbeType(type, ok);
+			duckdb_v2_logical_type_destroy(&type);
+			if (expression_probe.check_misuse) {
+				ProbeMisuse(info, filter);
+			}
+		}
+	}
+	std::sort(expression_probe.filters.begin(), expression_probe.filters.end());
+}
+
+// ---------------------------------------------------------------------------
+// expr_probe(): columns a INTEGER, b VARCHAR, c BIGINT with rows (i, str(i), i*10) for i in 0..3.
+// ---------------------------------------------------------------------------
+
+constexpr int64_t PROBE_ROWS = 4;
+
+struct ProbeGlobal {
+	bool done = false;
+};
+
+void DeleteProbeGlobal(void *ptr) {
+	delete static_cast<ProbeGlobal *>(ptr);
+}
+
+void ProbeBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                 duckdb_v2_error_info_handle *err) {
+	struct {
+		const char *name;
+		DUCKDB_V2_LOGICAL_TYPE_ID id;
+	} columns[] = {{"a", DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER},
+	               {"b", DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR},
+	               {"c", DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT}};
+	for (auto &column : columns) {
+		duckdb_v2_logical_type_handle type = nullptr;
+		if (duckdb_v2_context_create_type_from_id(context, column.id, nullptr, nullptr, 0, &type, err) !=
+		    DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		auto rc = duckdb_v2_table_function_bind_add_result_column(
+		    info, duckdb_v2_identifier_t {column.name, std::strlen(column.name)}, type, err);
+		duckdb_v2_logical_type_destroy(&type);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+}
+
+void ProbeInitGlobalCb(duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_context_handle,
+                       duckdb_v2_error_info_handle *err) {
+	duckdb_v2_opaque state = {new ProbeGlobal {}, DeleteProbeGlobal, nullptr};
+	duckdb_v2_table_function_init_global_set_global_state(info, &state, err);
+}
+
+void ProbeExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle,
+                 duckdb_v2_error_info_handle *err) {
+	void *global_ptr = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	if (duckdb_v2_table_function_exec_get_global_state(info, &global_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_output_chunk(info, &chunk, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &global = *static_cast<ProbeGlobal *>(global_ptr);
+
+	duckdb_v2_vector_handle vectors[3] = {nullptr, nullptr, nullptr};
+	for (idx_t i = 0; i < 3; i++) {
+		if (duckdb_v2_data_chunk_get_vector(chunk, i, &vectors[i], err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+	if (global.done) {
+		duckdb_v2_vector_set_size(vectors[0], 0, err);
+		return;
+	}
+	global.done = true;
+
+	void *a_raw = nullptr;
+	void *c_raw = nullptr;
+	if (duckdb_v2_vector_get_data_mutable(vectors[0], &a_raw, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(vectors[2], &c_raw, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (int64_t i = 0; i < PROBE_ROWS; i++) {
+		static_cast<int32_t *>(a_raw)[i] = static_cast<int32_t>(i);
+		static_cast<int64_t *>(c_raw)[i] = i * 10;
+		auto text = std::to_string(i);
+		if (V2VectorAssignString(vectors[1], static_cast<idx_t>(i), text.data(), text.size(), err) !=
+		    DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+	duckdb_v2_vector_set_size(vectors[0], static_cast<idx_t>(PROBE_ROWS), err);
+}
+
+void RegisterProbe(duckdb_v2_connection_handle conn) {
+	duckdb_v2_table_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_table_function_create_with_connection(conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto name = Convert("expr_probe");
+	REQUIRE(duckdb_v2_table_function_set_name(function, &name, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, ProbeBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, ProbeInitGlobalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, ProbeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_filter_pushdown_callback(function, ProbePushdownCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+}
+
+// Runs a single-BIGINT-cell query against the probe and returns the rendered predicates it saw.
+std::vector<std::string> Probe(duckdb_v2_connection_handle conn, const char *sql, int64_t expected) {
+	expression_probe.Reset();
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql, &result) == DUCKDB_V2_ERROR_NONE);
+	auto chunk = StepChunk(result);
+	REQUIRE(chunk != nullptr);
+	duckdb_v2_vector_handle vec = nullptr;
+	duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr);
+	duckdb_v2_vector_view view {};
+	duckdb_v2_vector_get_view(vec, &view, nullptr);
+	auto cell = static_cast<const int64_t *>(view.data)[SelAt(view.sel, 0)];
+	duckdb_v2_data_chunk_destroy(&chunk);
+	duckdb_v2_result_destroy(&result);
+	REQUIRE(cell == expected);
+	REQUIRE(expression_probe.failure.empty());
+	return expression_probe.filters;
+}
+
+using Filters = std::vector<std::string>;
+
+} // namespace
+
+TEST_CASE("V2 expression: comparison, column and constant nodes", "[capi_v2][expression]") {
+	EnvFixture fx;
+	RegisterProbe(fx.conn);
+
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE a < 3", 3) == Filters {"<(col0, 3)"});
+	REQUIRE(expression_probe.root_type == "BOOLEAN");
+	// A query without predicates offers nothing.
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe()", 4).empty());
+}
+
+TEST_CASE("V2 expression: type-specific accessors refuse other node types", "[capi_v2][expression]") {
+	EnvFixture fx;
+	RegisterProbe(fx.conn);
+
+	expression_probe.Reset();
+	expression_probe.check_misuse = true;
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT count(*) FROM expr_probe() WHERE a < 3", &result) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(DrainRowCount(result) == 1);
+	duckdb_v2_result_destroy(&result);
+	REQUIRE(expression_probe.failure.empty());
+	REQUIRE(expression_probe.filters == Filters {"<(col0, 3)"});
+	// Seven accessor misuses on the expression plus three out-of-bounds indices on the pushdown info, counted on
+	// every round the optimizer offered the predicate.
+	REQUIRE(expression_probe.misuse_failures % 10 == 0);
+	REQUIRE(expression_probe.misuse_failures > 0);
+}
+
+TEST_CASE("V2 expression: conjunctions, operators and functions", "[capi_v2][expression]") {
+	EnvFixture fx;
+	RegisterProbe(fx.conn);
+
+	// A top-level AND arrives as separate predicates.
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE a > 1 AND b = '3'", 1) ==
+	        Filters {"=(col1, 3)", ">(col0, 1)"});
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE a = 1 OR c IS NULL", 1) ==
+	        Filters {"or(=(col0, 1), is_null(col2))"});
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE c IS NOT NULL", 4) ==
+	        Filters {"is_not_null(col2)"});
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE lower(b) = '2'", 1) ==
+	        Filters {"=(\"system\".main.lower(col1), 2)"});
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE a IN (1, 2)", 2) == Filters {"in(col0, 1, 2)"});
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE a BETWEEN 1 AND 2", 2) ==
+	        Filters {"between(col0, 1, 2)"});
+}
+
+TEST_CASE("V2 expression: casts report their mode and target", "[capi_v2][expression]") {
+	EnvFixture fx;
+	RegisterProbe(fx.conn);
+
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE CAST(b AS INTEGER) = 3", 1) ==
+	        Filters {"=(cast(col1)::INTEGER, 3)"});
+	REQUIRE(Probe(fx.conn, "SELECT count(*) FROM expr_probe() WHERE TRY_CAST(b AS INTEGER) = 3", 1) ==
+	        Filters {"=(try_cast(col1)::INTEGER, 3)"});
+}
+
+TEST_CASE("V2 expression: column references resolve to declared columns", "[capi_v2][expression]") {
+	EnvFixture fx;
+	RegisterProbe(fx.conn);
+
+	// Only c is read, so the predicate's column reference is the first (and only) scanned column, which the
+	// pushdown info resolves back to the third declared column.
+	REQUIRE(Probe(fx.conn, "SELECT sum(c) FROM expr_probe() WHERE c > 10", 50) == Filters {">(col2, 10)"});
+}
+
+TEST_CASE("V2 expression: null arguments", "[capi_v2][expression]") {
+	DUCKDB_V2_EXPRESSION_TYPE type = DUCKDB_V2_EXPRESSION_TYPE_INVALID;
+	duckdb_v2_logical_type_handle logical_type = nullptr;
+	idx_t count = 0;
+	duckdb_v2_expression_handle child = nullptr;
+	duckdb_v2_value_handle value = nullptr;
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	DUCKDB_V2_CAST_MODE mode = DUCKDB_V2_CAST_MODE_NORMAL;
+
+	REQUIRE(duckdb_v2_expression_get_type(nullptr, &type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_expression_get_return_type(nullptr, &logical_type, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_expression_get_child_count(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_expression_get_child(nullptr, 0, &child, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_expression_constant_get_value(nullptr, &value, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_expression_column_ref_get_index(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_expression_function_get_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	duckdb_v2_qname_handle qname = nullptr;
+	REQUIRE(duckdb_v2_expression_function_get_qname(nullptr, &qname, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_expression_cast_get_mode(nullptr, &mode, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	REQUIRE(duckdb_v2_table_function_filter_pushdown_get_filter_count(nullptr, &count, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_filter_pushdown_get_filter(nullptr, 0, &child, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_filter_pushdown_accept(nullptr, 0, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_filter_pushdown_get_column_count(nullptr, &count, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_filter_pushdown_get_column_index(nullptr, 0, &count, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_file_system.cpp
+++ b/test/api/capi/v2/test_capi_v2_file_system.cpp
@@ -180,7 +180,7 @@ TEST_CASE("V2 file system: EXCLUSIVE_CREATE refuses an existing file", "[capi_v2
 	duckdb_v2_error_info_handle err = nullptr;
 	(void)err;
 	REQUIRE(FsTryOpen(fs, path,
-	                  {DUCKDB_V2_FILE_FLAG_WRITE, {DUCKDB_V2_FILE_FLAG_CREATE}, DUCKDB_V2_FILE_FLAG_EXCLUSIVE_CREATE},
+	                  {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE, DUCKDB_V2_FILE_FLAG_EXCLUSIVE_CREATE},
 	                  &handle) != DUCKDB_V2_ERROR_NONE);
 	REQUIRE(handle == nullptr);
 

--- a/test/api/capi/v2/test_capi_v2_file_system.cpp
+++ b/test/api/capi/v2/test_capi_v2_file_system.cpp
@@ -1,0 +1,422 @@
+#include "test_capi_v2.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// V2 file system tests: borrow the engine's file system, open files through
+// it, and read/write/seek them.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+duckdb_v2_file_system_handle FsOf(duckdb_v2_connection_handle conn) {
+	duckdb_v2_file_system_handle fs = nullptr;
+	REQUIRE(duckdb_v2_file_system_get_from_connection(conn, &fs, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(fs != nullptr);
+	return fs;
+}
+
+// Builds a set of options with the given flags applied one at a time.
+duckdb_v2_file_open_options_handle FsOptions(duckdb_v2_file_system_handle fs,
+                                             const std::vector<DUCKDB_V2_FILE_FLAG> &flags) {
+	duckdb_v2_file_open_options_handle options = nullptr;
+	REQUIRE(duckdb_v2_file_open_options_create(fs, &options, nullptr) == DUCKDB_V2_ERROR_NONE);
+	for (auto flag : flags) {
+		REQUIRE(duckdb_v2_file_open_options_set_flag(options, flag, nullptr) == DUCKDB_V2_ERROR_NONE);
+	}
+	return options;
+}
+
+// Opens with nothing but flags, which is what most of these cases need.
+duckdb_v2_file_handle FsOpen(duckdb_v2_file_system_handle fs, const std::string &path,
+                             const std::vector<DUCKDB_V2_FILE_FLAG> &flags) {
+	auto options = FsOptions(fs, flags);
+	duckdb_v2_file_handle handle = nullptr;
+	auto rc = duckdb_v2_file_system_open(fs, Convert(path), options, &handle, nullptr);
+	duckdb_v2_file_open_options_destroy(&options);
+	REQUIRE(rc == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(handle != nullptr);
+	return handle;
+}
+
+// The same, reporting the code rather than asserting success.
+DUCKDB_V2_ERROR FsTryOpen(duckdb_v2_file_system_handle fs, const std::string &path,
+                          const std::vector<DUCKDB_V2_FILE_FLAG> &flags, duckdb_v2_file_handle *out) {
+	auto options = FsOptions(fs, flags);
+	auto rc = duckdb_v2_file_system_open(fs, Convert(path), options, out, nullptr);
+	duckdb_v2_file_open_options_destroy(&options);
+	return rc;
+}
+
+void FsWrite(duckdb_v2_file_handle handle, const std::string &data) {
+	idx_t written = 0;
+	REQUIRE(duckdb_v2_file_write(handle, data.data(), data.size(), &written, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(written == data.size());
+}
+
+// Reads the whole file from the current position.
+std::string FsReadAll(duckdb_v2_file_handle handle, idx_t capacity) {
+	std::vector<char> buffer(capacity, '\0');
+	idx_t read = 0;
+	REQUIRE(duckdb_v2_file_read(handle, buffer.data(), capacity, &read, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return std::string(buffer.data(), read);
+}
+
+idx_t FsSize(duckdb_v2_file_handle handle) {
+	idx_t size = 0;
+	REQUIRE(duckdb_v2_file_size(handle, &size, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return size;
+}
+
+idx_t FsTell(duckdb_v2_file_handle handle) {
+	idx_t position = 0;
+	REQUIRE(duckdb_v2_file_tell(handle, &position, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return position;
+}
+
+} // namespace
+
+TEST_CASE("V2 file system: write, read back, and seek", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_roundtrip.bin");
+
+	{
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE_NEW});
+		FsWrite(handle, "hello world");
+		REQUIRE(FsTell(handle) == 11);
+		REQUIRE(FsSize(handle) == 11);
+		REQUIRE(duckdb_v2_file_sync(handle, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_file_destroy(&handle) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(handle == nullptr);
+	}
+
+	auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_READ});
+	REQUIRE(FsSize(handle) == 11);
+	REQUIRE(FsReadAll(handle, 32) == "hello world");
+	// Reading again at the end yields nothing, which is not an error.
+	REQUIRE(FsReadAll(handle, 32).empty());
+
+	// Seeking moves the position; a partial read stops where asked.
+	REQUIRE(duckdb_v2_file_seek(handle, 6, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(FsTell(handle) == 6);
+	REQUIRE(FsReadAll(handle, 5) == "world");
+
+	REQUIRE(duckdb_v2_file_seek(handle, 0, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(FsReadAll(handle, 5) == "hello");
+
+	duckdb_v2_file_destroy(&handle);
+}
+
+TEST_CASE("V2 file system: borrowed from a context or a connection", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	duckdb_v2_file_system_handle from_conn = nullptr;
+	REQUIRE(duckdb_v2_file_system_get_from_connection(fx.conn, &from_conn, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(from_conn != nullptr);
+	// Borrowed: there is no destroy, and asking twice gives the same file system.
+	duckdb_v2_file_system_handle again = nullptr;
+	REQUIRE(duckdb_v2_file_system_get_from_connection(fx.conn, &again, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(again == from_conn);
+}
+
+TEST_CASE("V2 file system: CREATE opens an existing file as it is", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_create.bin");
+
+	{
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE_NEW});
+		FsWrite(handle, "original");
+		duckdb_v2_file_destroy(&handle);
+	}
+	{
+		// CREATE on an existing file leaves the contents alone.
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE});
+		REQUIRE(FsSize(handle) == 8);
+		duckdb_v2_file_destroy(&handle);
+	}
+}
+
+TEST_CASE("V2 file system: CREATE_NEW truncates an existing file", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_create_new.bin");
+
+	{
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE});
+		FsWrite(handle, "hello");
+		duckdb_v2_file_destroy(&handle);
+	}
+	{
+		// CREATE_NEW truncates rather than failing: the earlier contents are gone.
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE_NEW});
+		REQUIRE(FsSize(handle) == 0);
+		FsWrite(handle, "hi");
+		duckdb_v2_file_destroy(&handle);
+	}
+	{
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_READ});
+		REQUIRE(FsReadAll(handle, 32) == "hi");
+		duckdb_v2_file_destroy(&handle);
+	}
+}
+
+TEST_CASE("V2 file system: EXCLUSIVE_CREATE refuses an existing file", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_exclusive.bin");
+
+	{
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE});
+		FsWrite(handle, "taken");
+		duckdb_v2_file_destroy(&handle);
+	}
+
+	// The file is there, so the exclusive create fails rather than opening or truncating it.
+	duckdb_v2_file_handle handle = nullptr;
+	duckdb_v2_error_info_handle err = nullptr;
+	(void)err;
+	REQUIRE(FsTryOpen(fs, path,
+	                  {DUCKDB_V2_FILE_FLAG_WRITE, {DUCKDB_V2_FILE_FLAG_CREATE}, DUCKDB_V2_FILE_FLAG_EXCLUSIVE_CREATE},
+	                  &handle) != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(handle == nullptr);
+
+	// The contents survived.
+	auto reader = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_READ});
+	REQUIRE(FsReadAll(reader, 32) == "taken");
+	duckdb_v2_file_destroy(&reader);
+}
+
+TEST_CASE("V2 file system: APPEND writes at the end", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_append.bin");
+
+	{
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE_NEW});
+		FsWrite(handle, "one");
+		duckdb_v2_file_destroy(&handle);
+	}
+	{
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_APPEND});
+		FsWrite(handle, "two");
+		duckdb_v2_file_destroy(&handle);
+	}
+	{
+		auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_READ});
+		REQUIRE(FsReadAll(handle, 32) == "onetwo");
+		duckdb_v2_file_destroy(&handle);
+	}
+}
+
+TEST_CASE("V2 file system: open refusals", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	duckdb_v2_file_handle handle = nullptr;
+
+	// A missing file without CREATE.
+	auto missing = duckdb::TestCreatePath("v2_fs_missing.bin");
+	REQUIRE(FsTryOpen(fs, missing, {DUCKDB_V2_FILE_FLAG_READ}, &handle) != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(handle == nullptr);
+
+	// Options that were never given flags cannot say whether the file is being read or written.
+	auto path = duckdb::TestCreatePath("v2_fs_flags.bin");
+	duckdb_v2_file_open_options_handle empty = nullptr;
+	REQUIRE(duckdb_v2_file_open_options_create(fs, &empty, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_file_system_open(fs, Convert(path), empty, &handle, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(handle == nullptr);
+	duckdb_v2_file_open_options_destroy(&empty);
+}
+
+TEST_CASE("V2 file system: close leaves the handle destroyable", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_close.bin");
+
+	auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE_NEW});
+	FsWrite(handle, "data");
+	REQUIRE(duckdb_v2_file_close(handle, nullptr) == DUCKDB_V2_ERROR_NONE);
+	// The handle itself is still alive and must still be destroyed.
+	REQUIRE(duckdb_v2_file_destroy(&handle) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(handle == nullptr);
+}
+
+TEST_CASE("V2 file system: null arguments and destroy null-safety", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_nulls.bin");
+	auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE_NEW});
+
+	duckdb_v2_file_system_handle out_fs = nullptr;
+	duckdb_v2_file_handle out_handle = nullptr;
+	idx_t count = 0;
+	char buffer[4] = {0};
+
+	REQUIRE(duckdb_v2_file_system_get_from_connection(nullptr, &out_fs, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_system_get_from_connection(fx.conn, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_system_get_from_context(nullptr, &out_fs, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	duckdb_v2_file_open_options_handle options = nullptr;
+	REQUIRE(duckdb_v2_file_open_options_create(fs, &options, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_file_open_options_set_flag(options, DUCKDB_V2_FILE_FLAG_READ, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_file_system_open(nullptr, Convert(path), options, &out_handle, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_system_open(fs, Convert(path), nullptr, &out_handle, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_system_open(fs, Convert(path), options, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	duckdb_v2_file_open_options_destroy(&options);
+
+	REQUIRE(duckdb_v2_file_read(nullptr, buffer, 4, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_read(handle, nullptr, 4, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_read(handle, buffer, 4, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_write(nullptr, buffer, 4, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_write(handle, nullptr, 4, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_tell(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_tell(handle, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_size(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_size(handle, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_seek(nullptr, 0, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_sync(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_close(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	REQUIRE(duckdb_v2_file_destroy(&handle) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(handle == nullptr);
+	REQUIRE(duckdb_v2_file_destroy(&handle) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_file_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+}
+
+TEST_CASE("V2 file system: positional read and write", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_positional.bin");
+	const auto flags = {DUCKDB_V2_FILE_FLAG_READ, DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE_NEW,
+	                    DUCKDB_V2_FILE_FLAG_PARALLEL_ACCESS};
+
+	auto handle = FsOpen(fs, path, flags);
+	const std::string data = "abcdefghij";
+	FsWrite(handle, data);
+	REQUIRE(FsTell(handle) == 10);
+
+	// A positional read does not move the position.
+	char buffer[4] = {0};
+	REQUIRE(duckdb_v2_file_read_at(handle, buffer, 4, 2, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(std::string(buffer, 4) == "cdef");
+	REQUIRE(FsTell(handle) == 10);
+
+	// Neither does a positional write.
+	REQUIRE(duckdb_v2_file_write_at(handle, "XY", 2, 4, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(FsTell(handle) == 10);
+	REQUIRE(duckdb_v2_file_read_at(handle, buffer, 4, 2, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(std::string(buffer, 4) == "cdXY");
+
+	// Reading past the end is an error rather than a short read, since there is no count to report.
+	REQUIRE(duckdb_v2_file_read_at(handle, buffer, 4, 8, nullptr) != DUCKDB_V2_ERROR_NONE);
+
+	// A positional write past the end extends the file.
+	REQUIRE(duckdb_v2_file_write_at(handle, "Z", 1, 15, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(FsSize(handle) == 16);
+
+	duckdb_v2_file_destroy(&handle);
+
+	// The sequential view of the file agrees with what the positional writes did.
+	auto reader = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_READ});
+	REQUIRE(FsReadAll(reader, 32).substr(0, 10) == "abcdXYghij");
+	duckdb_v2_file_destroy(&reader);
+}
+
+TEST_CASE("V2 file system: positional read and write null arguments", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_positional_nulls.bin");
+	auto handle = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_WRITE, DUCKDB_V2_FILE_FLAG_CREATE_NEW});
+	char buffer[4] = {0};
+
+	REQUIRE(duckdb_v2_file_read_at(nullptr, buffer, 4, 0, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_read_at(handle, nullptr, 4, 0, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_write_at(nullptr, buffer, 4, 0, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_write_at(handle, nullptr, 4, 0, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	duckdb_v2_file_destroy(&handle);
+}
+
+TEST_CASE("V2 file system: open options carry flags and values", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	auto path = duckdb::TestCreatePath("v2_fs_options.bin");
+
+	duckdb_v2_file_open_options_handle options = nullptr;
+	REQUIRE(duckdb_v2_file_open_options_create(fs, &options, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(options != nullptr);
+	REQUIRE(duckdb_v2_file_open_options_set_flag(options, DUCKDB_V2_FILE_FLAG_WRITE, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_file_open_options_set_flag(options, DUCKDB_V2_FILE_FLAG_CREATE_NEW, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	// Applying the same flag twice is harmless.
+	REQUIRE(duckdb_v2_file_open_options_set_flag(options, DUCKDB_V2_FILE_FLAG_WRITE, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	// Values a file system does not recognise are carried and ignored rather than rejected.
+	auto size = MakeInt64Value(fx.conn, 4);
+	REQUIRE(duckdb_v2_file_open_options_set_value(options, Convert("file_size"), size, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	// Copied at the call, so the value can go immediately.
+	duckdb_v2_value_destroy(&size);
+	auto unknown = MakeVarcharValue(fx.conn, "nobody-reads-this");
+	REQUIRE(duckdb_v2_file_open_options_set_value(options, Convert("made_up_option"), unknown, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_value_destroy(&unknown);
+
+	duckdb_v2_file_handle handle = nullptr;
+	REQUIRE(duckdb_v2_file_system_open(fs, Convert(path), options, &handle, nullptr) == DUCKDB_V2_ERROR_NONE);
+	FsWrite(handle, "data");
+	duckdb_v2_file_destroy(&handle);
+
+	// One options object opens as many files as you like, and setting a name again replaces it.
+	auto again = MakeInt64Value(fx.conn, 8);
+	REQUIRE(duckdb_v2_file_open_options_set_value(options, Convert("file_size"), again, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_value_destroy(&again);
+	auto second = duckdb::TestCreatePath("v2_fs_options_second.bin");
+	REQUIRE(duckdb_v2_file_system_open(fs, Convert(second), options, &handle, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_file_destroy(&handle);
+
+	// Destroying the options does not affect files already opened with them.
+	REQUIRE(duckdb_v2_file_open_options_destroy(&options) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(options == nullptr);
+	REQUIRE(duckdb_v2_file_open_options_destroy(&options) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_file_open_options_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	auto reader = FsOpen(fs, path, {DUCKDB_V2_FILE_FLAG_READ});
+	REQUIRE(FsReadAll(reader, 32) == "data");
+	duckdb_v2_file_destroy(&reader);
+}
+
+TEST_CASE("V2 file system: open options null arguments", "[capi_v2][file_system]") {
+	EnvFixture fx;
+	auto fs = FsOf(fx.conn);
+	duckdb_v2_file_open_options_handle options = nullptr;
+	REQUIRE(duckdb_v2_file_open_options_create(fs, &options, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto value = MakeInt64Value(fx.conn, 1);
+
+	REQUIRE(duckdb_v2_file_open_options_create(nullptr, &options, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_open_options_create(fs, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_open_options_set_flag(nullptr, DUCKDB_V2_FILE_FLAG_READ, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	// INVALID names no behaviour, and neither does a value outside the enum.
+	REQUIRE(duckdb_v2_file_open_options_set_flag(options, DUCKDB_V2_FILE_FLAG_INVALID, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_open_options_set_flag(options, static_cast<DUCKDB_V2_FILE_FLAG>(99), nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_open_options_set_value(nullptr, Convert("k"), value, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_file_open_options_set_value(options, Convert("k"), nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	// An empty name is not a usable key.
+	REQUIRE(duckdb_v2_file_open_options_set_value(options, Convert(""), value, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	duckdb_v2_value_destroy(&value);
+	duckdb_v2_file_open_options_destroy(&options);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_identifier.cpp
+++ b/test/api/capi/v2/test_capi_v2_identifier.cpp
@@ -1,0 +1,84 @@
+#include "test_capi_v2.hpp"
+
+#include <string>
+
+// ---------------------------------------------------------------------------
+// V2 identifier tests: rendering names into SQL through the engine's own
+// quoting rules.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+// Renders a name through the two-call text protocol.
+std::string RenderQuoted(const char *name, DUCKDB_V2_ERROR &rc) {
+	auto view = Convert(name);
+	return RenderText([&](char *buf, idx_t cap,
+	                      idx_t *len) { return duckdb_v2_identifier_render_quoted(view, buf, cap, len, nullptr); },
+	                  rc);
+}
+
+std::string RenderQuoted(const char *name) {
+	auto rc = DUCKDB_V2_ERROR_NONE;
+	auto out = RenderQuoted(name, rc);
+	REQUIRE(rc == DUCKDB_V2_ERROR_NONE);
+	return out;
+}
+
+} // namespace
+
+TEST_CASE("V2 identifier: render quotes only when required", "[capi_v2][identifier]") {
+	// Legal bare identifiers pass through, casing preserved.
+	REQUIRE(RenderQuoted("col") == "col");
+	REQUIRE(RenderQuoted("MyCol") == "MyCol");
+	REQUIRE(RenderQuoted("a_1") == "a_1");
+
+	// Keywords, spaces, leading digits and embedded quotes are quoted and escaped.
+	REQUIRE(RenderQuoted("select") == "\"select\"");
+	REQUIRE(RenderQuoted("my col") == "\"my col\"");
+	REQUIRE(RenderQuoted("1abc") == "\"1abc\"");
+	REQUIRE(RenderQuoted("a\"b") == "\"a\"\"b\"");
+}
+
+TEST_CASE("V2 identifier: rendered names round-trip through the parser", "[capi_v2][identifier]") {
+	EnvFixture fx;
+
+	// A quoted name is usable verbatim in SQL and comes back as the original name.
+	const char *names[] = {"plain", "Mixed Case", "select", "we\"ird", "1abc"};
+	for (auto name : names) {
+		ExecSQL(fx.conn, ("CREATE TABLE " + RenderQuoted(name) + " (i INTEGER)").c_str());
+		duckdb_v2_result_handle result = nullptr;
+		REQUIRE(Query(fx.conn, ("SELECT * FROM " + RenderQuoted(name)).c_str(), &result) == DUCKDB_V2_ERROR_NONE);
+		duckdb_v2_result_destroy(&result);
+	}
+}
+
+TEST_CASE("V2 identifier: buffer protocol and null arguments", "[capi_v2][identifier]") {
+	auto view = Convert("my col");
+	idx_t length = 0;
+
+	// A null buffer reports the length only.
+	REQUIRE(duckdb_v2_identifier_render_quoted(view, nullptr, 0, &length, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(length == 8);
+
+	// A buffer without room for the terminator is refused, reporting the required length.
+	char small[8];
+	length = 0;
+	REQUIRE(duckdb_v2_identifier_render_quoted(view, small, sizeof(small), &length, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_OBJECT_SIZE);
+	REQUIRE(length == 8);
+
+	// A big enough buffer receives the text and a terminator.
+	char big[9];
+	REQUIRE(duckdb_v2_identifier_render_quoted(view, big, sizeof(big), &length, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(std::string(big) == "\"my col\"");
+
+	// A null name view with a non-zero length, or a null length slot, is an input error.
+	duckdb_v2_identifier_t malformed = {nullptr, 3};
+	REQUIRE(duckdb_v2_identifier_render_quoted(malformed, nullptr, 0, &length, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_identifier_render_quoted(view, nullptr, 0, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_logical_type.cpp
+++ b/test/api/capi/v2/test_capi_v2_logical_type.cpp
@@ -26,6 +26,25 @@
 
 namespace test_capi_v2 {
 
+// The type name is a qualified name; every case here names an unqualified type, so it is wrapped in a one-part name.
+inline DUCKDB_V2_ERROR LTCreateTypeFromName(duckdb_v2_connection_handle conn, duckdb_v2_identifier_t name,
+                                            const duckdb_v2_identifier_t *param_names,
+                                            const duckdb_v2_value_handle *param_values, idx_t param_count,
+                                            duckdb_v2_logical_type_handle *out_type, duckdb_v2_error_info_handle *err) {
+	duckdb_v2_identifier_t parts[1] = {name};
+	duckdb_v2_qname_handle qname = nullptr;
+	auto rc = duckdb_v2_qname_create(parts, 1, &qname, err);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		if (out_type) {
+			*out_type = nullptr;
+		}
+		return rc;
+	}
+	rc = duckdb_v2_connection_create_type_from_name(conn, qname, param_names, param_values, param_count, out_type, err);
+	duckdb_v2_qname_destroy(&qname);
+	return rc;
+}
+
 // ===========================================================================
 // Lifecycle: create_from_id / destroy
 // ===========================================================================
@@ -512,8 +531,8 @@ DUCKDB_V2_ERROR MakeTypeErr(duckdb_v2_connection_handle conn, const char *name, 
 	bool err_set = false;
 	auto t = reinterpret_cast<duckdb_v2_logical_type_handle>(0x1);
 	duckdb_v2_error_info_handle err = nullptr;
-	rc = duckdb_v2_connection_create_type_from_name(conn, Convert(name), names ? name_views.data() : nullptr,
-	                                                values.empty() ? nullptr : values.data(), values.size(), &t, &err);
+	rc = LTCreateTypeFromName(conn, Convert(name), names ? name_views.data() : nullptr,
+	                          values.empty() ? nullptr : values.data(), values.size(), &t, &err);
 	out_nulled = (t == nullptr);
 	err_set = (err != nullptr);
 	duckdb_v2_error_info_destroy(&err);
@@ -565,9 +584,8 @@ void RequireParamRoundTrip(duckdb_v2_connection_handle conn, duckdb_v2_logical_t
 	auto kind_name = V2KindName(t);
 	duckdb_v2_logical_type_handle rebuilt = nullptr;
 	DUCKDB_V2_ERROR rc = DUCKDB_V2_ERROR_NONE;
-	rc = duckdb_v2_connection_create_type_from_name(conn, Convert(kind_name), any_named ? names.data() : nullptr,
-	                                                values.empty() ? nullptr : values.data(), values.size(), &rebuilt,
-	                                                nullptr);
+	rc = LTCreateTypeFromName(conn, Convert(kind_name), any_named ? names.data() : nullptr,
+	                          values.empty() ? nullptr : values.data(), values.size(), &rebuilt, nullptr);
 	for (auto &v : values) {
 		duckdb_v2_value_destroy(&v);
 	}
@@ -977,7 +995,7 @@ TEST_CASE("V2: type construction does not disturb a live streaming result",
 	duckdb_v2_value_handle elem = MakeTypeValue(f.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
 	const duckdb_v2_value_handle params[1] = {elem};
 	duckdb_v2_logical_type_handle built = nullptr;
-	auto rc = duckdb_v2_connection_create_type_from_name(f.conn, Convert("list"), nullptr, params, 1, &built, nullptr);
+	auto rc = LTCreateTypeFromName(f.conn, Convert("list"), nullptr, params, 1, &built, nullptr);
 	duckdb_v2_value_destroy(&elem);
 	REQUIRE(rc == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(V2TypeIdOf(built) == DUCKDB_V2_LOGICAL_TYPE_ID_LIST);
@@ -1295,31 +1313,31 @@ TEST_CASE("V2: logical_type_create null-arg refusals", "[capi_v2][logical_type][
 	duckdb_v2_logical_type_handle t = nullptr;
 
 	// A null connection is refused.
-	REQUIRE(duckdb_v2_connection_create_type_from_name(nullptr, Convert("integer"), nullptr, nullptr, 0, &t, nullptr) ==
+	REQUIRE(LTCreateTypeFromName(nullptr, Convert("integer"), nullptr, nullptr, 0, &t, nullptr) ==
 	        DUCKDB_V2_ERROR_INPUT_INVALID);
 
 	duckdb_v2_value_handle value = MakeInt32Value(f.conn, 1);
 	const duckdb_v2_value_handle values[1] = {value};
 	duckdb_v2_logical_type_handle out = nullptr;
 	// Null out_type.
-	REQUIRE(duckdb_v2_connection_create_type_from_name(f.conn, Convert("integer"), nullptr, nullptr, 0, nullptr,
-	                                                   nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	// Malformed name view.
-	REQUIRE(duckdb_v2_connection_create_type_from_name(f.conn, duckdb_v2_str {nullptr, 3}, nullptr, nullptr, 0, &out,
-	                                                   nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(LTCreateTypeFromName(f.conn, Convert("integer"), nullptr, nullptr, 0, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	// A null name handle.
+	REQUIRE(duckdb_v2_connection_create_type_from_name(f.conn, nullptr, nullptr, nullptr, 0, &out, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(out == nullptr);
 	// param_count > 0 with a null values array.
-	REQUIRE(duckdb_v2_connection_create_type_from_name(f.conn, Convert("list"), nullptr, nullptr, 1, &out, nullptr) ==
+	REQUIRE(LTCreateTypeFromName(f.conn, Convert("list"), nullptr, nullptr, 1, &out, nullptr) ==
 	        DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(out == nullptr);
 	// A null value handle inside the array.
 	const duckdb_v2_value_handle holed[1] = {nullptr};
-	REQUIRE(duckdb_v2_connection_create_type_from_name(f.conn, Convert("list"), nullptr, holed, 1, &out, nullptr) ==
+	REQUIRE(LTCreateTypeFromName(f.conn, Convert("list"), nullptr, holed, 1, &out, nullptr) ==
 	        DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(out == nullptr);
 	// A malformed name view inside the names array.
 	const duckdb_v2_str bad_names[1] = {{nullptr, 3}};
-	REQUIRE(duckdb_v2_connection_create_type_from_name(f.conn, Convert("list"), bad_names, values, 1, &out, nullptr) ==
+	REQUIRE(LTCreateTypeFromName(f.conn, Convert("list"), bad_names, values, 1, &out, nullptr) ==
 	        DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(out == nullptr);
 	duckdb_v2_value_destroy(&value);
@@ -1349,8 +1367,7 @@ TEST_CASE("V2: logical_type get_from_text / get_from_args", "[capi_v2][logical_t
 	        DUCKDB_V2_ERROR_NONE);
 	const duckdb_v2_value_handle params[1] = {child_type_value};
 	duckdb_v2_logical_type_handle list = nullptr;
-	REQUIRE(duckdb_v2_connection_create_type_from_name(f.conn, Convert("list"), nullptr, params, 1, &list, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(LTCreateTypeFromName(f.conn, Convert("list"), nullptr, params, 1, &list, nullptr) == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(list != nullptr);
 	DUCKDB_V2_LOGICAL_TYPE_ID list_id = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
 	REQUIRE(duckdb_v2_logical_type_get_id(list, &list_id, nullptr) == DUCKDB_V2_ERROR_NONE);
@@ -1363,8 +1380,8 @@ TEST_CASE("V2: logical_type get_from_text / get_from_args", "[capi_v2][logical_t
 	duckdb_v2_logical_type_handle out = nullptr;
 	REQUIRE(duckdb_v2_connection_create_type_from_text(nullptr, Convert("INTEGER"), &out, nullptr) ==
 	        DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_connection_create_type_from_name(nullptr, Convert("integer"), nullptr, nullptr, 0, &out,
-	                                                   nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(LTCreateTypeFromName(nullptr, Convert("integer"), nullptr, nullptr, 0, &out, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
 }
 
 TEST_CASE("V2: GEOMETRY with a coordinate system constructs and inspects",
@@ -1624,6 +1641,46 @@ TEST_CASE("V2 bench: 100k-entry enum inspection cost", "[.][capi_v2_bench]") {
 	                                                         << " ns/entry); borrowed engine floor " << borrowed_us
 	                                                         << " us");
 	duckdb_v2_logical_type_destroy(&t);
+}
+
+TEST_CASE("V2: create_type_from_name resolves a qualified name", "[capi_v2][logical_type]") {
+	EnvFixture f;
+	ExecSQL(f.conn, "CREATE SCHEMA s");
+	ExecSQL(f.conn, "CREATE TYPE s.scoped AS INTEGER");
+
+	auto resolve = [&](const std::vector<const char *> &parts, duckdb_v2_logical_type_handle *out) {
+		std::vector<duckdb_v2_identifier_t> views;
+		for (auto *part : parts) {
+			views.push_back(Convert(part));
+		}
+		duckdb_v2_qname_handle qname = nullptr;
+		REQUIRE(duckdb_v2_qname_create(views.data(), views.size(), &qname, nullptr) == DUCKDB_V2_ERROR_NONE);
+		auto rc = duckdb_v2_connection_create_type_from_name(f.conn, qname, nullptr, nullptr, 0, out, nullptr);
+		duckdb_v2_qname_destroy(&qname);
+		return rc;
+	};
+
+	// The qualified name reaches a type the search path does not cover.
+	duckdb_v2_logical_type_handle scoped = nullptr;
+	REQUIRE(resolve({"s", "scoped"}, &scoped) == DUCKDB_V2_ERROR_NONE);
+	DUCKDB_V2_LOGICAL_TYPE_ID id = DUCKDB_V2_LOGICAL_TYPE_ID_INVALID;
+	REQUIRE(duckdb_v2_logical_type_get_id(scoped, &id, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(id == DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	duckdb_v2_logical_type_destroy(&scoped);
+
+	// Unqualified, the same name is not on the search path.
+	duckdb_v2_logical_type_handle missing = nullptr;
+	REQUIRE(resolve({"scoped"}, &missing) != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(missing == nullptr);
+
+	// A qualified name is resolved exactly: naming the wrong schema fails rather than falling back.
+	REQUIRE(resolve({"main", "scoped"}, &missing) != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(missing == nullptr);
+
+	// Built-in kinds still resolve unqualified, through the system catalog.
+	duckdb_v2_logical_type_handle builtin = nullptr;
+	REQUIRE(resolve({"integer"}, &builtin) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_logical_type_destroy(&builtin);
 }
 
 } // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_prepared_statement.cpp
+++ b/test/api/capi/v2/test_capi_v2_prepared_statement.cpp
@@ -1,0 +1,600 @@
+#include "test_capi_v2.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// V2 prepared_statement tests: the opt-in cached-execution path. Prepare once,
+// execute repeatedly, and ask whether the plan is actually reused. The result
+// handle is the same one statement_execute returns and behaves identically, so
+// a block of these tests is parity against that path.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+namespace {
+
+// Parse exactly one statement from sql (raw, unbound). Unique name to avoid a
+// unity-build clash with the same-shaped helper in other test files.
+duckdb_v2_sql_statement_handle PsParseOne(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_statement_iterator_handle iter = nullptr;
+	REQUIRE(duckdb_v2_parse_sql(conn, sql, &iter, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_sql_statement_handle stmt = nullptr;
+	REQUIRE(duckdb_v2_statement_iterator_next(iter, &stmt, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(stmt != nullptr);
+	duckdb_v2_statement_iterator_destroy(&iter);
+	return stmt;
+}
+
+// Prepares one statement from sql, destroying the parsed statement afterwards (it is
+// borrowed, never consumed). Returns nullptr when the prepare fails; `out_rc` takes the
+// code so the caller can assert on it.
+duckdb_v2_prepared_statement_handle PsPrepare(duckdb_v2_connection_handle conn, const char *sql,
+                                              bool require_cacheable = false, DUCKDB_V2_ERROR *out_rc = nullptr) {
+	auto stmt = PsParseOne(conn, sql);
+	duckdb_v2_prepared_statement_handle prepared = nullptr;
+	auto rc = duckdb_v2_prepared_statement_create(conn, stmt, require_cacheable, &prepared, nullptr);
+	if (out_rc) {
+		*out_rc = rc;
+	}
+	REQUIRE(stmt != nullptr); // borrowed, not consumed
+	duckdb_v2_sql_statement_destroy(&stmt);
+	return prepared;
+}
+
+bool PsReusesPlan(duckdb_v2_connection_handle conn, const char *sql) {
+	auto prepared = PsPrepare(conn, sql);
+	REQUIRE(prepared != nullptr);
+	bool reuses = false;
+	REQUIRE(duckdb_v2_prepared_statement_reuses_plan(prepared, &reuses, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_prepared_statement_destroy(&prepared);
+	return reuses;
+}
+
+// Drains every chunk of a single-column BIGINT result into a vector. STANDARD_VECTOR_SIZE
+// can be as low as 2 in the assertion build, so this must not assume one chunk.
+std::vector<int64_t> PsDrainBigints(duckdb_v2_result_handle r) {
+	std::vector<int64_t> out;
+	while (auto chunk = StepChunk(r)) {
+		idx_t size = 0;
+		REQUIRE(duckdb_v2_data_chunk_get_size(chunk, &size, nullptr) == DUCKDB_V2_ERROR_NONE);
+		duckdb_v2_vector_handle vec = nullptr;
+		REQUIRE(duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr) == DUCKDB_V2_ERROR_NONE);
+		duckdb_v2_vector_view view {};
+		REQUIRE(duckdb_v2_vector_get_view(vec, &view, nullptr) == DUCKDB_V2_ERROR_NONE);
+		for (idx_t i = 0; i < size; i++) {
+			out.push_back(reinterpret_cast<const int64_t *>(view.data)[SelAt(view.sel, i)]);
+		}
+		duckdb_v2_data_chunk_destroy(&chunk);
+	}
+	return out;
+}
+
+// The single BIGINT of a one-row, one-column result; pins end-of-stream.
+int64_t PsScalarI64(duckdb_v2_result_handle r) {
+	auto rows = PsDrainBigints(r);
+	REQUIRE(rows.size() == 1);
+	return rows[0];
+}
+
+// Executes a prepared statement with positional BIGINT parameters and returns its rows.
+std::vector<int64_t> PsExecuteWith(duckdb_v2_connection_handle conn, duckdb_v2_prepared_statement_handle prepared,
+                                   const std::vector<int64_t> &params) {
+	std::vector<duckdb_v2_value_handle> values;
+	for (auto param : params) {
+		values.push_back(MakeInt64Value(conn, param));
+	}
+	duckdb_v2_result_handle r = nullptr;
+	auto rc = duckdb_v2_prepared_statement_execute(prepared, nullptr, values.empty() ? nullptr : values.data(),
+	                                               static_cast<idx_t>(values.size()), &r, nullptr);
+	for (auto &value : values) {
+		duckdb_v2_value_destroy(&value);
+	}
+	REQUIRE(rc == DUCKDB_V2_ERROR_NONE);
+	auto rows = PsDrainBigints(r);
+	duckdb_v2_result_destroy(&r);
+	return rows;
+}
+
+// Seeds t(x BIGINT) with 1..4.
+void PsSeedTable(duckdb_v2_connection_handle conn) {
+	ExecSQL(conn, "CREATE TABLE t(x BIGINT)");
+	ExecSQL(conn, "INSERT INTO t VALUES (1), (2), (3), (4)");
+}
+
+} // namespace
+
+// ===========================================================================
+// Prepare once, execute many. The handle is non-consuming in both directions:
+// the parsed statement survives the prepare, and the prepared statement
+// survives every execution.
+// ===========================================================================
+
+TEST_CASE("V2: a prepared statement executes repeatedly", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	PsSeedTable(fx.conn);
+
+	auto prepared = PsPrepare(fx.conn, "SELECT x FROM t WHERE x > $1 ORDER BY x");
+	REQUIRE(prepared != nullptr);
+
+	// Three executions from one handle, each with its own values; nothing carries over.
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {0}) == std::vector<int64_t> {1, 2, 3, 4});
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {2}) == std::vector<int64_t> {3, 4});
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {9}).empty());
+	// And again with the first value, to pin that no state accumulated.
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {0}) == std::vector<int64_t> {1, 2, 3, 4});
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+	REQUIRE(prepared == nullptr);
+}
+
+TEST_CASE("V2: prepared_statement_create borrows the statement", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto stmt = PsParseOne(fx.conn, "SELECT 42::BIGINT");
+
+	// The same statement prepares twice and still executes directly: only copies are ever
+	// consumed.
+	duckdb_v2_prepared_statement_handle first = nullptr;
+	duckdb_v2_prepared_statement_handle second = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, &first, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, &second, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(first != nullptr);
+	REQUIRE(second != nullptr);
+	REQUIRE(first != second);
+
+	REQUIRE(PsExecuteWith(fx.conn, first, {}) == std::vector<int64_t> {42});
+	REQUIRE(PsExecuteWith(fx.conn, second, {}) == std::vector<int64_t> {42});
+
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_statement_execute(fx.conn, stmt, nullptr, nullptr, 0, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(PsScalarI64(r) == 42);
+	duckdb_v2_result_destroy(&r);
+
+	duckdb_v2_prepared_statement_destroy(&first);
+	duckdb_v2_prepared_statement_destroy(&second);
+	duckdb_v2_sql_statement_destroy(&stmt);
+}
+
+// ===========================================================================
+// Plan reuse, reported rather than assumed.
+// ===========================================================================
+
+TEST_CASE("V2: prepared_statement_reuses_plan reports reuse honestly", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	PsSeedTable(fx.conn);
+
+	// Nothing unresolved and nothing to invalidate: the plan is reused.
+	REQUIRE(PsReusesPlan(fx.conn, "SELECT 42"));
+	// A parameter whose type the cast anchors at prepare time: still reused.
+	REQUIRE(PsReusesPlan(fx.conn, "SELECT $1::INTEGER + 1"));
+	// A table scan re-binds every execution so a catalog change is picked up.
+	REQUIRE_FALSE(PsReusesPlan(fx.conn, "SELECT x FROM t WHERE x = $1"));
+	// Unanchored parameters: the types are unknown until values arrive.
+	REQUIRE_FALSE(PsReusesPlan(fx.conn, "SELECT $1 + $2"));
+}
+
+TEST_CASE("V2: require_cacheable accepts a reused plan", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto rc = DUCKDB_V2_ERROR_NONE;
+	auto prepared = PsPrepare(fx.conn, "SELECT $1::BIGINT + 1", true, &rc);
+	REQUIRE(rc == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(prepared != nullptr);
+
+	bool reuses = false;
+	REQUIRE(duckdb_v2_prepared_statement_reuses_plan(prepared, &reuses, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(reuses);
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {41}) == std::vector<int64_t> {42});
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+TEST_CASE("V2: require_cacheable rejects a re-bound plan", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	PsSeedTable(fx.conn);
+
+	auto rc = DUCKDB_V2_ERROR_NONE;
+	auto prepared = PsPrepare(fx.conn, "SELECT x FROM t WHERE x = $1", true, &rc);
+	REQUIRE(rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(prepared == nullptr);
+
+	// The same statement prepares fine without the flag; the caller then knows what it got.
+	REQUIRE_FALSE(PsReusesPlan(fx.conn, "SELECT x FROM t WHERE x = $1"));
+}
+
+// ===========================================================================
+// Parameters. Same arrays, same rules, same error codes as statement_execute.
+// ===========================================================================
+
+TEST_CASE("V2: prepared_statement_execute binds positional parameters", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto prepared = PsPrepare(fx.conn, "SELECT $1 - $2");
+	REQUIRE(prepared != nullptr);
+
+	// Positional binding is order-sensitive: $1 is element 0.
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {10, 4}) == std::vector<int64_t> {6});
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {4, 10}) == std::vector<int64_t> {-6});
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+TEST_CASE("V2: prepared_statement_execute binds named parameters", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto prepared = PsPrepare(fx.conn, "SELECT $a - $b");
+	REQUIRE(prepared != nullptr);
+
+	duckdb_v2_value_handle va = MakeInt64Value(fx.conn, 10);
+	duckdb_v2_value_handle vb = MakeInt64Value(fx.conn, 4);
+
+	// Keyed by name, so the array order is irrelevant: the same pairing both ways.
+	duckdb_v2_str names[2] = {Convert("a"), Convert("b")};
+	duckdb_v2_value_handle values[2] = {va, vb};
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, names, values, 2, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(PsScalarI64(r) == 6);
+	duckdb_v2_result_destroy(&r);
+
+	duckdb_v2_str reversed[2] = {Convert("b"), Convert("a")};
+	duckdb_v2_value_handle reversed_values[2] = {vb, va};
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, reversed, reversed_values, 2, &r, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(PsScalarI64(r) == 6);
+	duckdb_v2_result_destroy(&r);
+
+	// Case-insensitive, like every other identifier key.
+	duckdb_v2_str upper[2] = {Convert("A"), Convert("B")};
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, upper, values, 2, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(PsScalarI64(r) == 6);
+	duckdb_v2_result_destroy(&r);
+
+	// A key set the statement does not have is a bind error, and the values are not consumed.
+	duckdb_v2_str wrong[2] = {Convert("a"), Convert("c")};
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, wrong, values, 2, &r, nullptr) != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(r == nullptr);
+
+	duckdb_v2_value_destroy(&va);
+	duckdb_v2_value_destroy(&vb);
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+TEST_CASE("V2: prepared_statement_execute copies its parameter values", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto prepared = PsPrepare(fx.conn, "SELECT $1::BIGINT");
+	REQUIRE(prepared != nullptr);
+
+	// Destroy the value before a single row is read: it was copied in, so the still-lazy
+	// result is unaffected.
+	duckdb_v2_value_handle v = MakeInt64Value(fx.conn, 7);
+	duckdb_v2_value_handle values[1] = {v};
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, values, 1, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_value_destroy(&v);
+	REQUIRE(PsScalarI64(r) == 7);
+	duckdb_v2_result_destroy(&r);
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+// ===========================================================================
+// Parity: the result handle is the one statement_execute returns.
+// ===========================================================================
+
+TEST_CASE("V2: a prepared result carries the same rows and schema", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	PsSeedTable(fx.conn);
+
+	const char *sql = "SELECT x, x * 2 AS doubled FROM t ORDER BY x";
+	auto prepared = PsPrepare(fx.conn, sql);
+	REQUIRE(prepared != nullptr);
+
+	duckdb_v2_result_handle prepared_result = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 0, &prepared_result, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	// Metadata is available before the first step, as on the stateless path.
+	REQUIRE(ColumnCount(prepared_result) == 2);
+	RequireColumn(prepared_result, 0, "x", DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	RequireColumn(prepared_result, 1, "doubled", DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+
+	DUCKDB_V2_RESULT_TYPE result_type = DUCKDB_V2_RESULT_TYPE_NOTHING;
+	REQUIRE(duckdb_v2_result_get_result_type(prepared_result, &result_type, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(result_type == DUCKDB_V2_RESULT_TYPE_QUERY_RESULT);
+	DUCKDB_V2_STATEMENT_TYPE statement_type = DUCKDB_V2_STATEMENT_TYPE_INVALID;
+	REQUIRE(duckdb_v2_result_get_statement_type(prepared_result, &statement_type, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(statement_type == DUCKDB_V2_STATEMENT_TYPE_SELECT);
+
+	REQUIRE(PsDrainBigints(prepared_result) == std::vector<int64_t> {1, 2, 3, 4});
+	duckdb_v2_result_destroy(&prepared_result);
+
+	// The stateless path agrees, column for column.
+	duckdb_v2_result_handle direct = nullptr;
+	REQUIRE(Query(fx.conn, sql, &direct) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(ColumnCount(direct) == 2);
+	RequireColumn(direct, 0, "x", DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	RequireColumn(direct, 1, "doubled", DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	REQUIRE(PsDrainBigints(direct) == std::vector<int64_t> {1, 2, 3, 4});
+	duckdb_v2_result_destroy(&direct);
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+TEST_CASE("V2: a prepared DML reports its changed-row count", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	PsSeedTable(fx.conn);
+
+	auto prepared = PsPrepare(fx.conn, "INSERT INTO t VALUES ($1)");
+	REQUIRE(prepared != nullptr);
+
+	for (int64_t value : {10, 20, 30}) {
+		duckdb_v2_value_handle v = MakeInt64Value(fx.conn, value);
+		duckdb_v2_value_handle values[1] = {v};
+		duckdb_v2_result_handle r = nullptr;
+		REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, values, 1, &r, nullptr) ==
+		        DUCKDB_V2_ERROR_NONE);
+		DUCKDB_V2_RESULT_TYPE result_type = DUCKDB_V2_RESULT_TYPE_NOTHING;
+		REQUIRE(duckdb_v2_result_get_result_type(r, &result_type, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(result_type == DUCKDB_V2_RESULT_TYPE_CHANGED_ROWS);
+		REQUIRE(DrainChangedRows(r) == 1);
+		duckdb_v2_result_destroy(&r);
+		duckdb_v2_value_destroy(&v);
+	}
+
+	// The inserts landed, so the side effects of a prepared execution are real.
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT count(*) FROM t", &r) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(PsScalarI64(r) == 7);
+	duckdb_v2_result_destroy(&r);
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+TEST_CASE("V2: a prepared statement re-binds after a catalog change", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	PsSeedTable(fx.conn);
+
+	auto prepared = PsPrepare(fx.conn, "SELECT * FROM t ORDER BY x");
+	REQUIRE(prepared != nullptr);
+
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 0, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(ColumnCount(r) == 1);
+	REQUIRE(DrainRowCount(r) == 4);
+	duckdb_v2_result_destroy(&r);
+
+	// A table scan is re-bound every execution, which is exactly what makes the new
+	// column visible without re-preparing.
+	ExecSQL(fx.conn, "ALTER TABLE t ADD COLUMN y BIGINT DEFAULT 9");
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 0, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(ColumnCount(r) == 2);
+	RequireColumn(r, 1, "y", DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	REQUIRE(DrainRowCount(r) == 4);
+	duckdb_v2_result_destroy(&r);
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+// ===========================================================================
+// Lifetimes. Both directions of "the other handle keeps working".
+// ===========================================================================
+
+TEST_CASE("V2: a result outlives its prepared statement", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	PsSeedTable(fx.conn);
+
+	auto prepared = PsPrepare(fx.conn, "SELECT x FROM t ORDER BY x");
+	REQUIRE(prepared != nullptr);
+
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 0, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	// Destroy the prepared statement mid-stream: the result owns its session independently.
+	duckdb_v2_prepared_statement_destroy(&prepared);
+	REQUIRE(PsDrainBigints(r) == std::vector<int64_t> {1, 2, 3, 4});
+	duckdb_v2_result_destroy(&r);
+}
+
+TEST_CASE("V2: a prepared statement outlives its connection", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	PsSeedTable(fx.conn);
+
+	duckdb_v2_connection_handle other = nullptr;
+	REQUIRE(duckdb_v2_connect(fx.db, &other, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto prepared = PsPrepare(other, "SELECT x FROM t ORDER BY x");
+	REQUIRE(prepared != nullptr);
+
+	// The handle keeps the session alive, the same guarantee an undrained result carries.
+	duckdb_v2_disconnect(&other);
+	REQUIRE(other == nullptr);
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {}) == std::vector<int64_t> {1, 2, 3, 4});
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+TEST_CASE("V2: prepared_statement_destroy is null-safe and idempotent", "[capi_v2][prepared_statement]") {
+	REQUIRE(duckdb_v2_prepared_statement_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_prepared_statement_handle prepared = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_destroy(&prepared) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(prepared == nullptr);
+
+	EnvFixture fx;
+	prepared = PsPrepare(fx.conn, "SELECT 1");
+	REQUIRE(prepared != nullptr);
+	REQUIRE(duckdb_v2_prepared_statement_destroy(&prepared) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(prepared == nullptr);
+	REQUIRE(duckdb_v2_prepared_statement_destroy(&prepared) == DUCKDB_V2_ERROR_NONE);
+}
+
+// ===========================================================================
+// One live result per connection, in both directions, and the error path that
+// has to hand the connection back.
+// ===========================================================================
+
+TEST_CASE("V2: prepared_statement_create refuses while a result is live", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+
+	duckdb_v2_result_handle live = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT i FROM range(100000) t(i)", &live) == DUCKDB_V2_ERROR_NONE);
+
+	auto stmt = PsParseOne(fx.conn, "SELECT 1");
+	duckdb_v2_prepared_statement_handle prepared = nullptr;
+	// Preparing would run the engine's cleanup and cancel the live stream, so it refuses
+	// before reaching the engine, leaving the statement intact.
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, &prepared, nullptr) ==
+	        DUCKDB_V2_ERROR_RESOURCE_IN_USE);
+	REQUIRE(prepared == nullptr);
+	REQUIRE(stmt != nullptr);
+
+	// The live result is untouched by the refusal, and preparing works once it is gone.
+	REQUIRE(DrainRowCount(live) == 100000);
+	duckdb_v2_result_destroy(&live);
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, &prepared, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(prepared != nullptr);
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+	duckdb_v2_sql_statement_destroy(&stmt);
+}
+
+TEST_CASE("V2: prepared_statement_execute refuses while a result is live", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto prepared = PsPrepare(fx.conn, "SELECT 1::BIGINT");
+	REQUIRE(prepared != nullptr);
+
+	duckdb_v2_result_handle live = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT i FROM range(100000) t(i)", &live) == DUCKDB_V2_ERROR_NONE);
+
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 0, &r, nullptr) ==
+	        DUCKDB_V2_ERROR_RESOURCE_IN_USE);
+	REQUIRE(r == nullptr);
+
+	REQUIRE(DrainRowCount(live) == 100000);
+	duckdb_v2_result_destroy(&live);
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {}) == std::vector<int64_t> {1});
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+TEST_CASE("V2: a live prepared result blocks statement_execute", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto prepared = PsPrepare(fx.conn, "SELECT i FROM range(100000) t(i)");
+	REQUIRE(prepared != nullptr);
+
+	duckdb_v2_result_handle live = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 0, &live, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+
+	// The slot the prepared path claims is the one the stateless path checks.
+	auto stmt = PsParseOne(fx.conn, "SELECT 1");
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_statement_execute(fx.conn, stmt, nullptr, nullptr, 0, &r, nullptr) ==
+	        DUCKDB_V2_ERROR_RESOURCE_IN_USE);
+	REQUIRE(r == nullptr);
+
+	// Destroying the prepared result frees the connection even undrained.
+	duckdb_v2_result_destroy(&live);
+	REQUIRE(duckdb_v2_statement_execute(fx.conn, stmt, nullptr, nullptr, 0, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(DrainRowCount(r) == 1);
+	duckdb_v2_result_destroy(&r);
+
+	duckdb_v2_sql_statement_destroy(&stmt);
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+TEST_CASE("V2: a failed prepared execution frees the connection", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto prepared = PsPrepare(fx.conn, "SELECT $a");
+	REQUIRE(prepared != nullptr);
+
+	// Positional values for a named parameter: a bind error, raised after the slot was
+	// claimed, so this pins that the failure path releases it.
+	duckdb_v2_value_handle v = MakeInt64Value(fx.conn, 1);
+	duckdb_v2_value_handle values[1] = {v};
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, values, 1, &r, nullptr) != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(r == nullptr);
+	duckdb_v2_value_destroy(&v);
+
+	// The connection is usable again.
+	REQUIRE(Query(fx.conn, "SELECT 1", &r) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(DrainRowCount(r) == 1);
+	duckdb_v2_result_destroy(&r);
+
+	// And so is the prepared statement: a failed execution does not consume it.
+	duckdb_v2_value_handle named = MakeInt64Value(fx.conn, 7);
+	duckdb_v2_value_handle named_values[1] = {named};
+	duckdb_v2_str names[1] = {Convert("a")};
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, names, named_values, 1, &r, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(PsScalarI64(r) == 7);
+	duckdb_v2_result_destroy(&r);
+	duckdb_v2_value_destroy(&named);
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+// ===========================================================================
+// Prepare-time errors and argument rejection.
+// ===========================================================================
+
+TEST_CASE("V2: prepared_statement_create surfaces a catalog error", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto stmt = PsParseOne(fx.conn, "SELECT * FROM no_such_table");
+
+	duckdb_v2_prepared_statement_handle prepared = nullptr;
+	duckdb_v2_error_info_handle err = nullptr;
+	// The typed error survives the prepare, so the code is the catalog one rather than a
+	// generic failure.
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, &prepared, &err) ==
+	        DUCKDB_V2_ERROR_DATABASE_CATALOG);
+	REQUIRE(prepared == nullptr);
+	REQUIRE(err != nullptr);
+	duckdb_v2_str msg = {nullptr, 0};
+	REQUIRE(duckdb_v2_error_info_get_text(err, &msg) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(std::string(msg.ptr, msg.len).find("no_such_table") != std::string::npos);
+	duckdb_v2_error_info_destroy(&err);
+
+	// The connection is not left busy by the failure.
+	REQUIRE(stmt != nullptr);
+	ExecSQL(fx.conn, "CREATE TABLE no_such_table(i BIGINT)");
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, &prepared, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_prepared_statement_destroy(&prepared);
+	duckdb_v2_sql_statement_destroy(&stmt);
+}
+
+TEST_CASE("V2: prepared_statement functions guard null arguments", "[capi_v2][prepared_statement]") {
+	EnvFixture fx;
+	auto stmt = PsParseOne(fx.conn, "SELECT 1::BIGINT");
+	duckdb_v2_prepared_statement_handle prepared = nullptr;
+
+	REQUIRE(duckdb_v2_prepared_statement_create(nullptr, stmt, false, &prepared, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, nullptr, false, &prepared, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(prepared == nullptr);
+
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, &prepared, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_sql_statement_destroy(&stmt);
+
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(nullptr, nullptr, nullptr, 0, &r, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(r == nullptr);
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 0, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	// A count without values, and a null value inside the array, are both rejected.
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 1, &r, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(r == nullptr);
+	duckdb_v2_value_handle null_values[1] = {nullptr};
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, null_values, 1, &r, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(r == nullptr);
+
+	bool reuses = false;
+	REQUIRE(duckdb_v2_prepared_statement_reuses_plan(nullptr, &reuses, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_prepared_statement_reuses_plan(prepared, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// Every rejection above left the prepared statement usable.
+	REQUIRE(PsExecuteWith(fx.conn, prepared, {}) == std::vector<int64_t> {1});
+	duckdb_v2_prepared_statement_destroy(&prepared);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_qname.cpp
+++ b/test/api/capi/v2/test_capi_v2_qname.cpp
@@ -1,0 +1,196 @@
+#include "test_capi_v2.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// V2 qualified name tests. A qualified name is a path of identifier parts
+// whose last element is the object; partial qualification is a shorter path,
+// never an empty placeholder part.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+duckdb_v2_qname_handle QNameParse(const char *text) {
+	duckdb_v2_qname_handle name = nullptr;
+	REQUIRE(duckdb_v2_qname_parse(Convert(text), &name, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(name != nullptr);
+	return name;
+}
+
+duckdb_v2_qname_handle QNameCreate(const std::vector<const char *> &parts) {
+	std::vector<duckdb_v2_identifier_t> views;
+	for (auto *part : parts) {
+		views.push_back(Convert(part));
+	}
+	duckdb_v2_qname_handle name = nullptr;
+	REQUIRE(duckdb_v2_qname_create(views.empty() ? nullptr : views.data(), views.size(), &name, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	return name;
+}
+
+std::vector<std::string> QNameParts(duckdb_v2_qname_handle name) {
+	idx_t count = 0;
+	REQUIRE(duckdb_v2_qname_get_part_count(name, &count, nullptr) == DUCKDB_V2_ERROR_NONE);
+	std::vector<std::string> out;
+	for (idx_t i = 0; i < count; i++) {
+		duckdb_v2_identifier_t part = {nullptr, 0};
+		REQUIRE(duckdb_v2_qname_get_part(name, i, &part, nullptr) == DUCKDB_V2_ERROR_NONE);
+		out.push_back(Convert(part));
+	}
+	return out;
+}
+
+std::string QNameRender(duckdb_v2_qname_handle name) {
+	auto rc = DUCKDB_V2_ERROR_NONE;
+	auto out = RenderText(
+	    [&](char *buf, idx_t cap, idx_t *len) { return duckdb_v2_qname_render(name, buf, cap, len, nullptr); }, rc);
+	REQUIRE(rc == DUCKDB_V2_ERROR_NONE);
+	return out;
+}
+
+bool QNameEquals(duckdb_v2_qname_handle left, duckdb_v2_qname_handle right) {
+	bool result = false;
+	REQUIRE(duckdb_v2_qname_equals(left, right, &result, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return result;
+}
+
+uint64_t QNameHash(duckdb_v2_qname_handle name) {
+	uint64_t hash = 0;
+	REQUIRE(duckdb_v2_qname_hash(name, &hash, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return hash;
+}
+
+} // namespace
+
+TEST_CASE("V2 qname: create and inspect", "[capi_v2][qname]") {
+	auto one = QNameCreate({"tbl"});
+	REQUIRE(QNameParts(one) == std::vector<std::string> {"tbl"});
+
+	auto two = QNameCreate({"sch", "tbl"});
+	REQUIRE(QNameParts(two) == std::vector<std::string> {"sch", "tbl"});
+
+	auto three = QNameCreate({"cat", "sch", "tbl"});
+	REQUIRE(QNameParts(three) == std::vector<std::string> {"cat", "sch", "tbl"});
+
+	// Reading past the end is refused rather than silently empty.
+	duckdb_v2_identifier_t part = {nullptr, 0};
+	REQUIRE(duckdb_v2_qname_get_part(one, 1, &part, nullptr) == DUCKDB_V2_ERROR_INPUT_OUT_OF_RANGE);
+
+	duckdb_v2_qname_destroy(&one);
+	duckdb_v2_qname_destroy(&two);
+	duckdb_v2_qname_destroy(&three);
+}
+
+TEST_CASE("V2 qname: parse", "[capi_v2][qname]") {
+	auto plain = QNameParse("tbl");
+	REQUIRE(QNameParts(plain) == std::vector<std::string> {"tbl"});
+
+	auto qualified = QNameParse("cat.sch.tbl");
+	REQUIRE(QNameParts(qualified) == std::vector<std::string> {"cat", "sch", "tbl"});
+
+	// A quoted part may contain dots, and doubled quotes are one quote.
+	auto quoted = QNameParse("\"we.ird\".tbl");
+	REQUIRE(QNameParts(quoted) == std::vector<std::string> {"we.ird", "tbl"});
+	auto escaped = QNameParse("\"a\"\"b\"");
+	REQUIRE(QNameParts(escaped) == std::vector<std::string> {"a\"b"});
+
+	duckdb_v2_qname_destroy(&plain);
+	duckdb_v2_qname_destroy(&qualified);
+	duckdb_v2_qname_destroy(&quoted);
+	duckdb_v2_qname_destroy(&escaped);
+}
+
+TEST_CASE("V2 qname: render round-trips through parse", "[capi_v2][qname]") {
+	// Quoting is applied only where the identifier requires it.
+	auto plain = QNameCreate({"cat", "sch", "tbl"});
+	REQUIRE(QNameRender(plain) == "cat.sch.tbl");
+
+	auto needs_quotes = QNameCreate({"we.ird", "tbl"});
+	auto rendered = QNameRender(needs_quotes);
+	REQUIRE(rendered == "\"we.ird\".tbl");
+
+	auto reparsed = QNameParse(rendered.c_str());
+	REQUIRE(QNameEquals(reparsed, needs_quotes));
+
+	duckdb_v2_qname_destroy(&plain);
+	duckdb_v2_qname_destroy(&needs_quotes);
+	duckdb_v2_qname_destroy(&reparsed);
+}
+
+TEST_CASE("V2 qname: equality is case-insensitive and agrees with hash", "[capi_v2][qname]") {
+	auto lower = QNameCreate({"cat", "sch", "tbl"});
+	auto upper = QNameCreate({"CAT", "Sch", "TBL"});
+	auto shorter = QNameCreate({"sch", "tbl"});
+	auto different = QNameCreate({"cat", "sch", "other"});
+
+	REQUIRE(QNameEquals(lower, upper));
+	REQUIRE(QNameHash(lower) == QNameHash(upper));
+	// Fewer parts is a different name, not a partial match.
+	REQUIRE_FALSE(QNameEquals(lower, shorter));
+	REQUIRE_FALSE(QNameEquals(lower, different));
+
+	duckdb_v2_qname_destroy(&lower);
+	duckdb_v2_qname_destroy(&upper);
+	duckdb_v2_qname_destroy(&shorter);
+	duckdb_v2_qname_destroy(&different);
+}
+
+TEST_CASE("V2 qname: construction refusals", "[capi_v2][qname]") {
+	duckdb_v2_qname_handle name = nullptr;
+
+	// Between one and three parts, none empty.
+	REQUIRE(duckdb_v2_qname_create(nullptr, 0, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(name == nullptr);
+
+	duckdb_v2_identifier_t four[4] = {Convert("a"), Convert("b"), Convert("c"), Convert("d")};
+	REQUIRE(duckdb_v2_qname_create(four, 4, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	duckdb_v2_identifier_t with_empty[2] = {Convert("a"), Convert("")};
+	REQUIRE(duckdb_v2_qname_create(with_empty, 2, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	duckdb_v2_identifier_t one[1] = {Convert("a")};
+	REQUIRE(duckdb_v2_qname_create(nullptr, 1, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_create(one, 1, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// Text without a usable part, and more parts than the engine qualifies.
+	REQUIRE(duckdb_v2_qname_parse(Convert(""), &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_parse(Convert("a.b.c.d"), &name, nullptr) != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_qname_parse(Convert("\"unterminated"), &name, nullptr) != DUCKDB_V2_ERROR_NONE);
+}
+
+TEST_CASE("V2 qname: null arguments and destroy null-safety", "[capi_v2][qname]") {
+	auto name = QNameCreate({"tbl"});
+
+	idx_t count = 0;
+	duckdb_v2_identifier_t part = {nullptr, 0};
+	idx_t length = 0;
+	bool result = false;
+	uint64_t hash = 0;
+	REQUIRE(duckdb_v2_qname_get_part_count(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_get_part_count(name, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_get_part(nullptr, 0, &part, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_get_part(name, 0, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_render(nullptr, nullptr, 0, &length, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_render(name, nullptr, 0, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_equals(nullptr, name, &result, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_equals(name, nullptr, &result, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_equals(name, name, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_hash(nullptr, &hash, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_qname_hash(name, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// A buffer that cannot hold the text plus its terminator is refused, with the required length reported.
+	char small[2] = {'\0', '\0'};
+	length = 0;
+	REQUIRE(duckdb_v2_qname_render(name, small, 1, &length, nullptr) == DUCKDB_V2_ERROR_INPUT_OBJECT_SIZE);
+	REQUIRE(length == 3);
+
+	REQUIRE(duckdb_v2_qname_destroy(&name) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(name == nullptr);
+	REQUIRE(duckdb_v2_qname_destroy(&name) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_qname_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_replacement_scan.cpp
+++ b/test/api/capi/v2/test_capi_v2_replacement_scan.cpp
@@ -1,0 +1,662 @@
+#include "test_capi_v2.hpp"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// V2 replacement scan tests: a callback the binder consults when a table name
+// cannot be resolved, which claims the name by naming a table function, a
+// column data collection, or a query to read instead.
+//
+// Callbacks avoid Catch assertions: a REQUIRE would throw through the C
+// callback boundary into the engine. They latch what they observe into
+// file-scope statics, which the test asserts on after the query.
+//
+// All file-scope names carry a Repl prefix: this directory is a unity build,
+// so they must be unique across test files.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+duckdb_v2_identifier_t ReplIdent(const char *s) {
+	return Convert(s);
+}
+
+// What the callback saw, for the test to assert on afterwards.
+struct ReplObserved {
+	std::string catalog;
+	std::string schema;
+	std::string table;
+	bool catalog_is_null_view = false;
+	bool schema_is_null_view = false;
+	int calls = 0;
+	// Return codes latched from calls the callback expects to fail.
+	DUCKDB_V2_ERROR mixed_form_rc = DUCKDB_V2_ERROR_NONE;
+	DUCKDB_V2_ERROR bare_argument_rc = DUCKDB_V2_ERROR_NONE;
+};
+ReplObserved repl_observed;
+
+void ReplReset() {
+	repl_observed = ReplObserved();
+}
+
+// Reads the unresolved name into the observation record.
+void ReplRecordName(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_error_info_handle *err) {
+	duckdb_v2_identifier_t catalog = {nullptr, 0};
+	duckdb_v2_identifier_t schema = {nullptr, 0};
+	duckdb_v2_identifier_t table = {nullptr, 0};
+	if (duckdb_v2_replacement_scan_get_catalog_name(info, &catalog, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_replacement_scan_get_schema_name(info, &schema, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_replacement_scan_get_table_name(info, &table, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	repl_observed.calls++;
+	repl_observed.catalog = Convert(catalog);
+	repl_observed.schema = Convert(schema);
+	repl_observed.table = Convert(table);
+	repl_observed.catalog_is_null_view = catalog.ptr == nullptr;
+	repl_observed.schema_is_null_view = schema.ptr == nullptr;
+}
+
+// Claims every name with range(2).
+void ReplClaimRange(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle context,
+                    duckdb_v2_error_info_handle *err) {
+	ReplRecordName(info, err);
+	if (duckdb_v2_replacement_scan_set_function_name(info, ReplIdent("range"), err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_value_handle value = nullptr;
+	if (duckdb_v2_value_create_bigint_with_context(context, 2, &value, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto rc = duckdb_v2_replacement_scan_add_argument(info, value, err);
+	// Destroyed immediately: the argument is copied at the call.
+	duckdb_v2_value_destroy(&value);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_replacement_scan_set_alias(info, ReplIdent("claimed"), err);
+}
+
+// Records the name and declines.
+void ReplDecline(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle,
+                 duckdb_v2_error_info_handle *err) {
+	ReplRecordName(info, err);
+}
+
+// Claims only names ending in ".csv", so it can be shown to outrank the built-in CSV scan.
+void ReplClaimCsv(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle context,
+                  duckdb_v2_error_info_handle *err) {
+	duckdb_v2_identifier_t table = {nullptr, 0};
+	if (duckdb_v2_replacement_scan_get_table_name(info, &table, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	const auto name = Convert(table);
+	if (name.size() < 4 || name.compare(name.size() - 4, 4, ".csv") != 0) {
+		return;
+	}
+	ReplClaimRange(info, context, err);
+}
+
+// Fails with a specific code.
+void ReplFail(duckdb_v2_replacement_scan_info_handle, duckdb_v2_context_handle, duckdb_v2_error_info_handle *err) {
+	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_IO_GENERAL);
+	duckdb_v2_error_info_set_text(*err, Convert("the replacement scan refused"));
+}
+
+// Claims a function that does not exist.
+void ReplClaimUnknown(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle,
+                      duckdb_v2_error_info_handle *err) {
+	duckdb_v2_replacement_scan_set_function_name(info, ReplIdent("no_such_table_function"), err);
+}
+
+// Exercises the claim-form rules, then claims by function.
+void ReplClaimRules(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle context,
+                    duckdb_v2_error_info_handle *err) {
+	// An argument before a function name is refused. The error slot is not touched by a failing call, so these
+	// probes pass nullptr and read the return code instead.
+	duckdb_v2_value_handle value = nullptr;
+	if (duckdb_v2_value_create_bigint_with_context(context, 1, &value, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	repl_observed.bare_argument_rc = duckdb_v2_replacement_scan_add_argument(info, value, nullptr);
+	duckdb_v2_value_destroy(&value);
+
+	// A first claim, then the same form again (allowed, last wins), then a different form (refused).
+	if (duckdb_v2_replacement_scan_set_function_name(info, ReplIdent("not_this_one"), err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_replacement_scan_set_function_name(info, ReplIdent("range"), err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	repl_observed.mixed_form_rc = duckdb_v2_replacement_scan_set_subquery(info, Convert("SELECT 1"), nullptr);
+
+	duckdb_v2_value_handle two = nullptr;
+	if (duckdb_v2_value_create_bigint_with_context(context, 2, &two, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_replacement_scan_add_argument(info, two, err);
+	duckdb_v2_value_destroy(&two);
+}
+
+// Claims with a subquery.
+void ReplClaimSubquery(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle,
+                       duckdb_v2_error_info_handle *err) {
+	duckdb_v2_replacement_scan_set_subquery(info, Convert("SELECT 41 + 1 AS v"), err);
+}
+
+// Latches the rejections the subquery form makes.
+DUCKDB_V2_ERROR repl_multi_statement_rc = DUCKDB_V2_ERROR_NONE;
+DUCKDB_V2_ERROR repl_non_select_rc = DUCKDB_V2_ERROR_NONE;
+DUCKDB_V2_ERROR repl_bad_syntax_rc = DUCKDB_V2_ERROR_NONE;
+
+void ReplClaimBadSubqueries(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle,
+                            duckdb_v2_error_info_handle *err) {
+	repl_multi_statement_rc = duckdb_v2_replacement_scan_set_subquery(info, Convert("SELECT 1; SELECT 2"), nullptr);
+	repl_non_select_rc = duckdb_v2_replacement_scan_set_subquery(info, Convert("CREATE TABLE x (i INTEGER)"), nullptr);
+	repl_bad_syntax_rc = duckdb_v2_replacement_scan_set_subquery(info, Convert("SELECT FROM WHERE"), nullptr);
+	// Still claim something valid, so the query itself succeeds.
+	duckdb_v2_replacement_scan_set_subquery(info, Convert("SELECT 7 AS v"), err);
+}
+
+// Counts how many times a user data destructor ran.
+int repl_destroy_calls = 0;
+void ReplDestroyUserData(void *data) {
+	repl_destroy_calls++;
+	delete static_cast<std::string *>(data);
+}
+
+// Reads the user data and claims range(2) when it is what was planted.
+void ReplClaimWithUserData(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle context,
+                           duckdb_v2_error_info_handle *err) {
+	void *user_data = nullptr;
+	if (duckdb_v2_replacement_scan_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto *tag = static_cast<std::string *>(user_data);
+	if (!tag || *tag != "planted") {
+		duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_error_info_set_text(*err, Convert("user data did not reach the replacement scan"));
+		return;
+	}
+	ReplClaimRange(info, context, err);
+}
+
+// Creates a scan on the connection with the given callback, registers it, and destroys the handle.
+void ReplRegisterOnConnection(duckdb_v2_connection_handle conn, duckdb_v2_replacement_scan_callback_fn callback) {
+	duckdb_v2_replacement_scan_handle scan = nullptr;
+	REQUIRE(duckdb_v2_replacement_scan_create_with_connection(conn, &scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_set_callback(scan, callback, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_register(scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_destroy(&scan) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(scan == nullptr);
+}
+
+// Collects a single BIGINT column.
+std::vector<int64_t> ReplQueryI64(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql, &result) == DUCKDB_V2_ERROR_NONE);
+	std::vector<int64_t> out;
+	while (auto chunk = StepChunk(result)) {
+		idx_t size = 0;
+		duckdb_v2_data_chunk_get_size(chunk, &size, nullptr);
+		duckdb_v2_vector_handle vec = nullptr;
+		duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr);
+		duckdb_v2_vector_view view {};
+		duckdb_v2_vector_get_view(vec, &view, nullptr);
+		for (idx_t i = 0; i < size; i++) {
+			out.push_back(static_cast<const int64_t *>(view.data)[SelAt(view.sel, i)]);
+		}
+		duckdb_v2_data_chunk_destroy(&chunk);
+	}
+	duckdb_v2_result_destroy(&result);
+	return out;
+}
+
+// Runs a query to exhaustion, returning the code the failure surfaced with.
+DUCKDB_V2_ERROR ReplQueryError(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	auto rc = Query(conn, sql, &result);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_result_destroy(&result);
+		return rc;
+	}
+	auto status = DUCKDB_V2_RESULT_STEP_STATUS_WAITING;
+	while (rc == DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_data_chunk_handle chunk = nullptr;
+		rc = duckdb_v2_result_step(result, &chunk, &status, nullptr);
+		if (chunk) {
+			duckdb_v2_data_chunk_destroy(&chunk);
+		}
+		if (rc != DUCKDB_V2_ERROR_NONE || status == DUCKDB_V2_RESULT_STEP_STATUS_FINISHED ||
+		    status == DUCKDB_V2_RESULT_STEP_STATUS_CANCELLED) {
+			break;
+		}
+		if (status == DUCKDB_V2_RESULT_STEP_STATUS_WAITING) {
+			rc = duckdb_v2_result_wait(result, nullptr);
+		}
+	}
+	duckdb_v2_result_destroy(&result);
+	return rc;
+}
+
+// ---------------------------------------------------------------------------
+// The collection claim. This is how a caller makes its own buffered data
+// queryable: the scan's user data holds a name -> collection registry, and the
+// callback hands back whichever collection matches the unresolved name.
+// ---------------------------------------------------------------------------
+
+// A single-column BIGINT collection holding the given values.
+duckdb_v2_column_data_collection_handle ReplMakeCollection(duckdb_v2_connection_handle conn,
+                                                           const std::vector<int64_t> &values) {
+	auto bigint = MakeType(conn, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	duckdb_v2_logical_type_handle types[1] = {bigint};
+
+	duckdb_v2_column_data_collection_handle cdc = nullptr;
+	REQUIRE(duckdb_v2_column_data_collection_create_with_connection(conn, types, 1, &cdc, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	auto chunk_rc = duckdb_v2_data_chunk_create_with_connection(conn, types, 1, &chunk, nullptr);
+	duckdb_v2_logical_type_destroy(&bigint);
+	REQUIRE(chunk_rc == DUCKDB_V2_ERROR_NONE);
+
+	duckdb_v2_vector_handle vec = nullptr;
+	REQUIRE(duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_vector_set_size(vec, values.size(), nullptr) == DUCKDB_V2_ERROR_NONE);
+	if (!values.empty()) {
+		void *raw = nullptr;
+		REQUIRE(duckdb_v2_vector_get_data_mutable(vec, &raw, nullptr) == DUCKDB_V2_ERROR_NONE);
+		std::memcpy(raw, values.data(), values.size() * sizeof(int64_t));
+	}
+
+	duckdb_v2_column_data_collection_append_state_handle state = nullptr;
+	REQUIRE(duckdb_v2_column_data_collection_append_state_create(cdc, &state, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto append_rc = duckdb_v2_column_data_collection_append(cdc, state, chunk, nullptr);
+	duckdb_v2_column_data_collection_append_state_destroy(&state);
+	duckdb_v2_data_chunk_destroy(&chunk);
+	REQUIRE(append_rc == DUCKDB_V2_ERROR_NONE);
+	return cdc;
+}
+
+// What a caller would keep to make its collections queryable by name.
+struct ReplRegistry {
+	std::string name;
+	duckdb_v2_column_data_collection_handle collection = nullptr;
+	std::vector<std::string> column_names;
+	// Latched from the calls the test expects the setter to refuse.
+	DUCKDB_V2_ERROR wrong_count_rc = DUCKDB_V2_ERROR_NONE;
+	DUCKDB_V2_ERROR empty_name_rc = DUCKDB_V2_ERROR_NONE;
+	DUCKDB_V2_ERROR null_names_rc = DUCKDB_V2_ERROR_NONE;
+	bool probe_refusals = false;
+};
+
+void ReplClaimCollection(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle,
+                         duckdb_v2_error_info_handle *err) {
+	void *user_data = nullptr;
+	duckdb_v2_identifier_t table = {nullptr, 0};
+	if (duckdb_v2_replacement_scan_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_replacement_scan_get_table_name(info, &table, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &registry = *static_cast<ReplRegistry *>(user_data);
+	if (Convert(table) != registry.name) {
+		return; // not ours: decline
+	}
+
+	std::vector<duckdb_v2_identifier_t> names;
+	for (auto &name : registry.column_names) {
+		names.push_back(Convert(name));
+	}
+
+	if (registry.probe_refusals) {
+		duckdb_v2_identifier_t too_many[3] = {Convert("a"), Convert("b"), Convert("c")};
+		registry.wrong_count_rc =
+		    duckdb_v2_replacement_scan_set_collection(info, registry.collection, too_many, 3, nullptr);
+		duckdb_v2_identifier_t empty[1] = {Convert("")};
+		registry.empty_name_rc =
+		    duckdb_v2_replacement_scan_set_collection(info, registry.collection, empty, 1, nullptr);
+		registry.null_names_rc =
+		    duckdb_v2_replacement_scan_set_collection(info, registry.collection, nullptr, 1, nullptr);
+	}
+
+	duckdb_v2_replacement_scan_set_collection(info, registry.collection, names.empty() ? nullptr : names.data(),
+	                                          names.size(), err);
+}
+
+// Registers a collection-serving scan whose user data is the caller-owned registry.
+void ReplRegisterRegistry(duckdb_v2_connection_handle conn, ReplRegistry &registry) {
+	duckdb_v2_replacement_scan_handle scan = nullptr;
+	REQUIRE(duckdb_v2_replacement_scan_create_with_connection(conn, &scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_set_callback(scan, ReplClaimCollection, nullptr) == DUCKDB_V2_ERROR_NONE);
+	// The registry outlives the database, so nothing to destroy.
+	duckdb_v2_opaque user_data = {&registry, nullptr, nullptr};
+	REQUIRE(duckdb_v2_replacement_scan_set_user_data(scan, &user_data, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_register(scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_replacement_scan_destroy(&scan);
+}
+
+} // namespace
+
+TEST_CASE("V2 replacement scan: claims a table function", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	ReplReset();
+	ReplRegisterOnConnection(fx.conn, ReplClaimRange);
+
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT * FROM not_a_table") == std::vector<int64_t> {0, 1});
+	REQUIRE(repl_observed.calls == 1);
+	REQUIRE(repl_observed.table == "not_a_table");
+	// The scan's alias names the binding, so a qualified reference resolves.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT claimed.range FROM not_a_table") == std::vector<int64_t> {0, 1});
+	// A query-written alias wins over the scan's.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT t.range FROM not_a_table AS t") == std::vector<int64_t> {0, 1});
+}
+
+TEST_CASE("V2 replacement scan: reports the unresolved name and can decline", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	ReplReset();
+	ReplRegisterOnConnection(fx.conn, ReplDecline);
+
+	// Declining leaves the reference unresolved, so the normal catalog error surfaces.
+	REQUIRE(ReplQueryError(fx.conn, "SELECT * FROM missing_table") != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(repl_observed.calls == 1);
+	REQUIRE(repl_observed.table == "missing_table");
+	// An unqualified reference reports the canonical empty view for the qualifiers, not a pointer to "".
+	REQUIRE(repl_observed.catalog.empty());
+	REQUIRE(repl_observed.schema.empty());
+	REQUIRE(repl_observed.catalog_is_null_view);
+	REQUIRE(repl_observed.schema_is_null_view);
+
+	ReplReset();
+	REQUIRE(ReplQueryError(fx.conn, "SELECT * FROM memory.main.missing_table") != DUCKDB_V2_ERROR_NONE);
+	REQUIRE(repl_observed.calls == 1);
+	REQUIRE(repl_observed.catalog == "memory");
+	REQUIRE(repl_observed.schema == "main");
+	REQUIRE(repl_observed.table == "missing_table");
+	REQUIRE_FALSE(repl_observed.catalog_is_null_view);
+	REQUIRE_FALSE(repl_observed.schema_is_null_view);
+}
+
+TEST_CASE("V2 replacement scan: not consulted for names the catalog resolves", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	ReplReset();
+	ReplRegisterOnConnection(fx.conn, ReplClaimRange);
+
+	ExecSQL(fx.conn, "CREATE TABLE real_table (i BIGINT)");
+	ExecSQL(fx.conn, "INSERT INTO real_table VALUES (7), (8)");
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT i FROM real_table ORDER BY i") == std::vector<int64_t> {7, 8});
+	REQUIRE(repl_observed.calls == 0);
+}
+
+TEST_CASE("V2 replacement scan: connection scope and precedence", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	duckdb_v2_connection_handle other = nullptr;
+	REQUIRE(duckdb_v2_connect(fx.db, &other, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	ReplReset();
+	ReplRegisterOnConnection(fx.conn, ReplClaimRange);
+
+	// Visible on the registering connection only.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT * FROM anything") == std::vector<int64_t> {0, 1});
+	REQUIRE(ReplQueryError(other, "SELECT * FROM anything") != DUCKDB_V2_ERROR_NONE);
+
+	// A database-scoped scan reaches every connection, including ones opened afterwards.
+	duckdb_v2_replacement_scan_handle db_scan = nullptr;
+	REQUIRE(duckdb_v2_replacement_scan_create_with_database(fx.db, &db_scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_set_callback(db_scan, ReplClaimRange, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_register(db_scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_replacement_scan_destroy(&db_scan);
+
+	REQUIRE(ReplQueryI64(other, "SELECT * FROM anything") == std::vector<int64_t> {0, 1});
+	duckdb_v2_connection_handle later = nullptr;
+	REQUIRE(duckdb_v2_connect(fx.db, &later, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(ReplQueryI64(later, "SELECT * FROM anything") == std::vector<int64_t> {0, 1});
+	duckdb_v2_disconnect(&later);
+
+	duckdb_v2_disconnect(&other);
+}
+
+TEST_CASE("V2 replacement scan: outranks the built-in file scans", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	duckdb_v2_connection_handle other = nullptr;
+	REQUIRE(duckdb_v2_connect(fx.db, &other, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	ReplReset();
+	ReplRegisterOnConnection(fx.conn, ReplClaimCsv);
+
+	// Without the scan the CSV replacement takes the name and fails on the missing file.
+	REQUIRE(ReplQueryError(other, "SELECT * FROM 'no_such_file.csv'") != DUCKDB_V2_ERROR_NONE);
+	// With it, the connection-scoped scan claims the name first.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT * FROM 'no_such_file.csv'") == std::vector<int64_t> {0, 1});
+	// Names it declines still reach the built-ins.
+	REQUIRE(ReplQueryError(fx.conn, "SELECT * FROM 'no_such_file.parquet'") != DUCKDB_V2_ERROR_NONE);
+
+	duckdb_v2_disconnect(&other);
+}
+
+TEST_CASE("V2 replacement scan: registration order, first claim wins", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	ReplReset();
+	// The claiming scan is registered first, so the recording one is never consulted.
+	ReplRegisterOnConnection(fx.conn, ReplClaimRange);
+	ReplRegisterOnConnection(fx.conn, ReplDecline);
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT * FROM anything") == std::vector<int64_t> {0, 1});
+	REQUIRE(repl_observed.calls == 1); // only the claiming scan recorded a call
+}
+
+TEST_CASE("V2 replacement scan: callback errors and unknown functions", "[capi_v2][replacement_scan]") {
+	SECTION("an error reported by the callback surfaces with its code") {
+		EnvFixture fx;
+		ReplRegisterOnConnection(fx.conn, ReplFail);
+		REQUIRE(ReplQueryError(fx.conn, "SELECT * FROM anything") == DUCKDB_V2_ERROR_IO_GENERAL);
+	}
+	SECTION("claiming a function that does not exist surfaces a catalog error") {
+		EnvFixture fx;
+		ReplRegisterOnConnection(fx.conn, ReplClaimUnknown);
+		REQUIRE(ReplQueryError(fx.conn, "SELECT * FROM anything") == DUCKDB_V2_ERROR_DATABASE_CATALOG);
+	}
+}
+
+TEST_CASE("V2 replacement scan: claim form rules", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	ReplReset();
+	ReplRegisterOnConnection(fx.conn, ReplClaimRules);
+
+	// The last set_function_name wins, so the query still resolves to range(2).
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT * FROM anything") == std::vector<int64_t> {0, 1});
+	// An argument before a function name, and a second claim form, are both refused.
+	REQUIRE(repl_observed.bare_argument_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(repl_observed.mixed_form_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
+TEST_CASE("V2 replacement scan: claims a subquery", "[capi_v2][replacement_scan]") {
+	SECTION("a single SELECT is read instead") {
+		EnvFixture fx;
+		ReplRegisterOnConnection(fx.conn, ReplClaimSubquery);
+		REQUIRE(ReplQueryI64(fx.conn, "SELECT v::BIGINT FROM anything") == std::vector<int64_t> {42});
+	}
+	SECTION("anything else is rejected by the setter") {
+		EnvFixture fx;
+		repl_multi_statement_rc = DUCKDB_V2_ERROR_NONE;
+		repl_non_select_rc = DUCKDB_V2_ERROR_NONE;
+		repl_bad_syntax_rc = DUCKDB_V2_ERROR_NONE;
+		ReplRegisterOnConnection(fx.conn, ReplClaimBadSubqueries);
+
+		REQUIRE(ReplQueryI64(fx.conn, "SELECT v::BIGINT FROM anything") == std::vector<int64_t> {7});
+		REQUIRE(repl_multi_statement_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+		REQUIRE(repl_non_select_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+		REQUIRE(repl_bad_syntax_rc == DUCKDB_V2_ERROR_QUERY_PARSER);
+	}
+}
+
+TEST_CASE("V2 replacement scan: user data flows and is destroyed once", "[capi_v2][replacement_scan]") {
+	repl_destroy_calls = 0;
+	{
+		EnvFixture fx;
+		duckdb_v2_replacement_scan_handle scan = nullptr;
+		REQUIRE(duckdb_v2_replacement_scan_create_with_connection(fx.conn, &scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_replacement_scan_set_callback(scan, ReplClaimWithUserData, nullptr) == DUCKDB_V2_ERROR_NONE);
+		duckdb_v2_opaque user_data = {new std::string("planted"), ReplDestroyUserData, nullptr};
+		REQUIRE(duckdb_v2_replacement_scan_set_user_data(scan, &user_data, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_replacement_scan_register(scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+		// Destroying the builder does not affect the registered scan or free the user data.
+		REQUIRE(duckdb_v2_replacement_scan_destroy(&scan) == DUCKDB_V2_ERROR_NONE);
+
+		REQUIRE(ReplQueryI64(fx.conn, "SELECT * FROM anything") == std::vector<int64_t> {0, 1});
+		REQUIRE(repl_destroy_calls == 0);
+	}
+	// A connection-scoped scan is released with its connection.
+	REQUIRE(repl_destroy_calls == 1);
+}
+
+TEST_CASE("V2 replacement scan: registration refusals", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+
+	// No callback.
+	{
+		duckdb_v2_replacement_scan_handle scan = nullptr;
+		REQUIRE(duckdb_v2_replacement_scan_create_with_connection(fx.conn, &scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_replacement_scan_register(scan, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_replacement_scan_destroy(&scan);
+	}
+	// Registering twice from one handle.
+	{
+		duckdb_v2_replacement_scan_handle scan = nullptr;
+		REQUIRE(duckdb_v2_replacement_scan_create_with_connection(fx.conn, &scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_replacement_scan_set_callback(scan, ReplDecline, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_replacement_scan_register(scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_replacement_scan_register(scan, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_replacement_scan_destroy(&scan);
+	}
+}
+
+TEST_CASE("V2 replacement scan: null arguments and destroy null-safety", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+
+	duckdb_v2_replacement_scan_handle scan = nullptr;
+	REQUIRE(duckdb_v2_replacement_scan_create_with_connection(nullptr, &scan, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(scan == nullptr);
+	REQUIRE(duckdb_v2_replacement_scan_create_with_connection(fx.conn, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_create_with_database(nullptr, &scan, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_create_with_extension(nullptr, &scan, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	REQUIRE(duckdb_v2_replacement_scan_create_with_connection(fx.conn, &scan, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_set_callback(nullptr, ReplDecline, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_set_user_data(scan, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_register(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// The info accessors reject a null handle and a null out-parameter alike.
+	void *data = nullptr;
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	REQUIRE(duckdb_v2_replacement_scan_get_user_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_get_catalog_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_get_schema_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_get_table_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_set_function_name(nullptr, ReplIdent("x"), nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_add_argument(nullptr, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_set_subquery(nullptr, Convert("SELECT 1"), nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_set_alias(nullptr, ReplIdent("x"), nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	// A view with a null pointer but a non-zero length is malformed.
+	REQUIRE(duckdb_v2_replacement_scan_set_function_name(nullptr, duckdb_v2_identifier_t {nullptr, 4}, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	REQUIRE(duckdb_v2_replacement_scan_destroy(&scan) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(scan == nullptr);
+	REQUIRE(duckdb_v2_replacement_scan_destroy(&scan) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_replacement_scan_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+}
+
+// ===========================================================================
+// The collection claim carries the load of the "register my data under a name"
+// workflow: no dedicated API, just a scan over a registry the caller owns.
+// ===========================================================================
+
+TEST_CASE("V2 replacement scan: claims a column data collection", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	auto cdc = ReplMakeCollection(fx.conn, {10, 20});
+
+	ReplRegistry registry;
+	registry.name = "my_batch";
+	registry.collection = cdc;
+	ReplRegisterRegistry(fx.conn, registry);
+
+	// Readable like a table, with the default col1..colN naming.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT col1 FROM my_batch ORDER BY col1") == std::vector<int64_t> {10, 20});
+
+	// The motivating case: a client-side buffer as the source of an INSERT.
+	ExecSQL(fx.conn, "CREATE TABLE sink (v BIGINT)");
+	ExecSQL(fx.conn, "INSERT INTO sink SELECT * FROM my_batch");
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT v FROM sink ORDER BY v") == std::vector<int64_t> {10, 20});
+
+	// Joined against a real table, and re-read after the collection changed underneath.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT s.v FROM sink s JOIN my_batch b ON s.v = b.col1 ORDER BY s.v") ==
+	        std::vector<int64_t> {10, 20});
+
+	// Names it does not recognise are declined, so the normal catalog error surfaces.
+	REQUIRE(ReplQueryError(fx.conn, "SELECT * FROM some_other_name") != DUCKDB_V2_ERROR_NONE);
+
+	duckdb_v2_column_data_collection_destroy(&cdc);
+}
+
+TEST_CASE("V2 replacement scan: collection column names", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	auto cdc = ReplMakeCollection(fx.conn, {5, 6});
+
+	ReplRegistry registry;
+	registry.name = "named_batch";
+	registry.collection = cdc;
+	registry.column_names = {"amount"};
+	ReplRegisterRegistry(fx.conn, registry);
+
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT amount FROM named_batch ORDER BY amount") == std::vector<int64_t> {5, 6});
+	// The alias defaults to the reference's own name, so a qualified read resolves too.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT named_batch.amount FROM named_batch ORDER BY 1") ==
+	        std::vector<int64_t> {5, 6});
+	// And a query-written column alias still applies.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT renamed FROM named_batch t(renamed) ORDER BY renamed") ==
+	        std::vector<int64_t> {5, 6});
+
+	duckdb_v2_column_data_collection_destroy(&cdc);
+}
+
+TEST_CASE("V2 replacement scan: empty collection binds and yields no rows", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	auto cdc = ReplMakeCollection(fx.conn, {});
+
+	ReplRegistry registry;
+	registry.name = "empty_batch";
+	registry.collection = cdc;
+	ReplRegisterRegistry(fx.conn, registry);
+
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT col1 FROM empty_batch").empty());
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT count(*)::BIGINT FROM empty_batch") == std::vector<int64_t> {0});
+
+	duckdb_v2_column_data_collection_destroy(&cdc);
+}
+
+TEST_CASE("V2 replacement scan: collection column name validation", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	auto cdc = ReplMakeCollection(fx.conn, {1, 2});
+
+	ReplRegistry registry;
+	registry.name = "probe_batch";
+	registry.collection = cdc;
+	registry.probe_refusals = true;
+	ReplRegisterRegistry(fx.conn, registry);
+
+	// The valid claim at the end still lands, so the query itself succeeds.
+	REQUIRE(ReplQueryI64(fx.conn, "SELECT col1 FROM probe_batch ORDER BY col1") == std::vector<int64_t> {1, 2});
+	// More names than columns, an empty name, and a null array with a non-zero count are all refused.
+	REQUIRE(registry.wrong_count_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(registry.empty_name_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(registry.null_names_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	duckdb_v2_column_data_collection_destroy(&cdc);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_replacement_scan.cpp
+++ b/test/api/capi/v2/test_capi_v2_replacement_scan.cpp
@@ -644,6 +644,42 @@ TEST_CASE("V2 replacement scan: collection column names", "[capi_v2][replacement
 	duckdb_v2_column_data_collection_destroy(&cdc);
 }
 
+TEST_CASE("V2 replacement scan: a prepared collection claim caches its borrow", "[capi_v2][replacement_scan]") {
+	EnvFixture fx;
+	auto cdc = ReplMakeCollection(fx.conn, {10, 20});
+
+	ReplRegistry registry;
+	registry.name = "cached_batch";
+	registry.collection = cdc;
+	ReplRegisterRegistry(fx.conn, registry);
+
+	duckdb_v2_statement_iterator_handle iter = nullptr;
+	REQUIRE(duckdb_v2_parse_sql(fx.conn, "SELECT col1 FROM cached_batch ORDER BY col1", &iter, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_sql_statement_handle stmt = nullptr;
+	REQUIRE(duckdb_v2_statement_iterator_next(iter, &stmt, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_statement_iterator_destroy(&iter);
+
+	duckdb_v2_prepared_statement_handle prepared = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_create(fx.conn, stmt, false, &prepared, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_sql_statement_destroy(&stmt);
+
+	// A collection claim reads no database, so nothing invalidates the plan: it is reused,
+	// which means the scan callback is NOT consulted again and the plan keeps the borrow it
+	// took at prepare time.
+	bool reuses = false;
+	REQUIRE(duckdb_v2_prepared_statement_reuses_plan(prepared, &reuses, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(reuses);
+
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(duckdb_v2_prepared_statement_execute(prepared, nullptr, nullptr, 0, &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(DrainRowCount(r) == 2);
+	duckdb_v2_result_destroy(&r);
+
+	duckdb_v2_prepared_statement_destroy(&prepared);
+	duckdb_v2_column_data_collection_destroy(&cdc);
+}
+
 TEST_CASE("V2 replacement scan: empty collection binds and yields no rows", "[capi_v2][replacement_scan]") {
 	EnvFixture fx;
 	auto cdc = ReplMakeCollection(fx.conn, {});

--- a/test/api/capi/v2/test_capi_v2_replacement_scan.cpp
+++ b/test/api/capi/v2/test_capi_v2_replacement_scan.cpp
@@ -27,11 +27,8 @@ duckdb_v2_identifier_t ReplIdent(const char *s) {
 
 // What the callback saw, for the test to assert on afterwards.
 struct ReplObserved {
-	std::string catalog;
-	std::string schema;
-	std::string table;
-	bool catalog_is_null_view = false;
-	bool schema_is_null_view = false;
+	std::vector<std::string> parts;
+	std::string rendered;
 	int calls = 0;
 	// Return codes latched from calls the callback expects to fail.
 	DUCKDB_V2_ERROR mixed_form_rc = DUCKDB_V2_ERROR_NONE;
@@ -43,29 +40,54 @@ void ReplReset() {
 	repl_observed = ReplObserved();
 }
 
-// Reads the unresolved name into the observation record.
+// Reads the unresolved name into the observation record. The name is owned, so it is destroyed here.
 void ReplRecordName(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_error_info_handle *err) {
-	duckdb_v2_identifier_t catalog = {nullptr, 0};
-	duckdb_v2_identifier_t schema = {nullptr, 0};
-	duckdb_v2_identifier_t table = {nullptr, 0};
-	if (duckdb_v2_replacement_scan_get_catalog_name(info, &catalog, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_replacement_scan_get_schema_name(info, &schema, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_replacement_scan_get_table_name(info, &table, err) != DUCKDB_V2_ERROR_NONE) {
+	duckdb_v2_qname_handle name = nullptr;
+	if (duckdb_v2_replacement_scan_get_name(info, &name, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
 	repl_observed.calls++;
-	repl_observed.catalog = Convert(catalog);
-	repl_observed.schema = Convert(schema);
-	repl_observed.table = Convert(table);
-	repl_observed.catalog_is_null_view = catalog.ptr == nullptr;
-	repl_observed.schema_is_null_view = schema.ptr == nullptr;
+	repl_observed.parts.clear();
+
+	idx_t count = 0;
+	if (duckdb_v2_qname_get_part_count(name, &count, err) == DUCKDB_V2_ERROR_NONE) {
+		for (idx_t i = 0; i < count; i++) {
+			duckdb_v2_identifier_t part = {nullptr, 0};
+			if (duckdb_v2_qname_get_part(name, i, &part, err) != DUCKDB_V2_ERROR_NONE) {
+				break;
+			}
+			repl_observed.parts.push_back(Convert(part));
+		}
+	}
+	idx_t length = 0;
+	if (duckdb_v2_qname_render(name, nullptr, 0, &length, err) == DUCKDB_V2_ERROR_NONE) {
+		std::vector<char> buffer(length + 1, '\0');
+		if (duckdb_v2_qname_render(name, buffer.data(), buffer.size(), &length, err) == DUCKDB_V2_ERROR_NONE) {
+			repl_observed.rendered = std::string(buffer.data(), length);
+		}
+	}
+	duckdb_v2_qname_destroy(&name);
+}
+
+// Claims by an unqualified function name, which now means building a one-part qualified name.
+DUCKDB_V2_ERROR ReplClaimFunction(duckdb_v2_replacement_scan_info_handle info, const char *function_name,
+                                  duckdb_v2_error_info_handle *err) {
+	duckdb_v2_identifier_t parts[1] = {Convert(function_name)};
+	duckdb_v2_qname_handle name = nullptr;
+	auto rc = duckdb_v2_qname_create(parts, 1, &name, err);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return rc;
+	}
+	rc = duckdb_v2_replacement_scan_set_function_name(info, name, err);
+	duckdb_v2_qname_destroy(&name);
+	return rc;
 }
 
 // Claims every name with range(2).
 void ReplClaimRange(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle context,
                     duckdb_v2_error_info_handle *err) {
 	ReplRecordName(info, err);
-	if (duckdb_v2_replacement_scan_set_function_name(info, ReplIdent("range"), err) != DUCKDB_V2_ERROR_NONE) {
+	if (ReplClaimFunction(info, "range", err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
 	duckdb_v2_value_handle value = nullptr;
@@ -90,11 +112,14 @@ void ReplDecline(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_
 // Claims only names ending in ".csv", so it can be shown to outrank the built-in CSV scan.
 void ReplClaimCsv(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle context,
                   duckdb_v2_error_info_handle *err) {
-	duckdb_v2_identifier_t table = {nullptr, 0};
-	if (duckdb_v2_replacement_scan_get_table_name(info, &table, err) != DUCKDB_V2_ERROR_NONE) {
+	duckdb_v2_qname_handle qname = nullptr;
+	if (duckdb_v2_replacement_scan_get_name(info, &qname, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
-	const auto name = Convert(table);
+	duckdb_v2_identifier_t part = {nullptr, 0};
+	auto rc = duckdb_v2_qname_get_part(qname, 0, &part, err);
+	const auto name = rc == DUCKDB_V2_ERROR_NONE ? Convert(part) : std::string();
+	duckdb_v2_qname_destroy(&qname);
 	if (name.size() < 4 || name.compare(name.size() - 4, 4, ".csv") != 0) {
 		return;
 	}
@@ -110,7 +135,7 @@ void ReplFail(duckdb_v2_replacement_scan_info_handle, duckdb_v2_context_handle, 
 // Claims a function that does not exist.
 void ReplClaimUnknown(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle,
                       duckdb_v2_error_info_handle *err) {
-	duckdb_v2_replacement_scan_set_function_name(info, ReplIdent("no_such_table_function"), err);
+	ReplClaimFunction(info, "no_such_table_function", err);
 }
 
 // Exercises the claim-form rules, then claims by function.
@@ -126,8 +151,8 @@ void ReplClaimRules(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_conte
 	duckdb_v2_value_destroy(&value);
 
 	// A first claim, then the same form again (allowed, last wins), then a different form (refused).
-	if (duckdb_v2_replacement_scan_set_function_name(info, ReplIdent("not_this_one"), err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_replacement_scan_set_function_name(info, ReplIdent("range"), err) != DUCKDB_V2_ERROR_NONE) {
+	if (ReplClaimFunction(info, "not_this_one", err) != DUCKDB_V2_ERROR_NONE ||
+	    ReplClaimFunction(info, "range", err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
 	repl_observed.mixed_form_rc = duckdb_v2_replacement_scan_set_subquery(info, Convert("SELECT 1"), nullptr);
@@ -295,13 +320,20 @@ struct ReplRegistry {
 void ReplClaimCollection(duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle,
                          duckdb_v2_error_info_handle *err) {
 	void *user_data = nullptr;
-	duckdb_v2_identifier_t table = {nullptr, 0};
+	duckdb_v2_qname_handle qname = nullptr;
 	if (duckdb_v2_replacement_scan_get_user_data(info, &user_data, err) != DUCKDB_V2_ERROR_NONE ||
-	    duckdb_v2_replacement_scan_get_table_name(info, &table, err) != DUCKDB_V2_ERROR_NONE) {
+	    duckdb_v2_replacement_scan_get_name(info, &qname, err) != DUCKDB_V2_ERROR_NONE) {
 		return;
 	}
+	duckdb_v2_identifier_t part = {nullptr, 0};
+	idx_t part_count = 0;
+	duckdb_v2_qname_get_part_count(qname, &part_count, err);
+	auto part_rc = duckdb_v2_qname_get_part(qname, 0, &part, err);
+	const auto table_name = part_rc == DUCKDB_V2_ERROR_NONE ? Convert(part) : std::string();
+	duckdb_v2_qname_destroy(&qname);
+
 	auto &registry = *static_cast<ReplRegistry *>(user_data);
-	if (Convert(table) != registry.name) {
+	if (part_count != 1 || table_name != registry.name) {
 		return; // not ours: decline
 	}
 
@@ -346,7 +378,7 @@ TEST_CASE("V2 replacement scan: claims a table function", "[capi_v2][replacement
 
 	REQUIRE(ReplQueryI64(fx.conn, "SELECT * FROM not_a_table") == std::vector<int64_t> {0, 1});
 	REQUIRE(repl_observed.calls == 1);
-	REQUIRE(repl_observed.table == "not_a_table");
+	REQUIRE(repl_observed.parts == std::vector<std::string> {"not_a_table"});
 	// The scan's alias names the binding, so a qualified reference resolves.
 	REQUIRE(ReplQueryI64(fx.conn, "SELECT claimed.range FROM not_a_table") == std::vector<int64_t> {0, 1});
 	// A query-written alias wins over the scan's.
@@ -361,21 +393,15 @@ TEST_CASE("V2 replacement scan: reports the unresolved name and can decline", "[
 	// Declining leaves the reference unresolved, so the normal catalog error surfaces.
 	REQUIRE(ReplQueryError(fx.conn, "SELECT * FROM missing_table") != DUCKDB_V2_ERROR_NONE);
 	REQUIRE(repl_observed.calls == 1);
-	REQUIRE(repl_observed.table == "missing_table");
-	// An unqualified reference reports the canonical empty view for the qualifiers, not a pointer to "".
-	REQUIRE(repl_observed.catalog.empty());
-	REQUIRE(repl_observed.schema.empty());
-	REQUIRE(repl_observed.catalog_is_null_view);
-	REQUIRE(repl_observed.schema_is_null_view);
+	// An unqualified reference is a single part: absence is a shorter path, never an empty placeholder.
+	REQUIRE(repl_observed.parts == std::vector<std::string> {"missing_table"});
+	REQUIRE(repl_observed.rendered == "missing_table");
 
 	ReplReset();
 	REQUIRE(ReplQueryError(fx.conn, "SELECT * FROM memory.main.missing_table") != DUCKDB_V2_ERROR_NONE);
 	REQUIRE(repl_observed.calls == 1);
-	REQUIRE(repl_observed.catalog == "memory");
-	REQUIRE(repl_observed.schema == "main");
-	REQUIRE(repl_observed.table == "missing_table");
-	REQUIRE_FALSE(repl_observed.catalog_is_null_view);
-	REQUIRE_FALSE(repl_observed.schema_is_null_view);
+	REQUIRE(repl_observed.parts == std::vector<std::string> {"memory", "main", "missing_table"});
+	REQUIRE(repl_observed.rendered == "memory.main.missing_table");
 }
 
 TEST_CASE("V2 replacement scan: not consulted for names the catalog resolves", "[capi_v2][replacement_scan]") {
@@ -550,20 +576,14 @@ TEST_CASE("V2 replacement scan: null arguments and destroy null-safety", "[capi_
 
 	// The info accessors reject a null handle and a null out-parameter alike.
 	void *data = nullptr;
-	duckdb_v2_identifier_t name = {nullptr, 0};
+	duckdb_v2_qname_handle name = nullptr;
 	REQUIRE(duckdb_v2_replacement_scan_get_user_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_replacement_scan_get_catalog_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_replacement_scan_get_schema_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_replacement_scan_get_table_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	REQUIRE(duckdb_v2_replacement_scan_set_function_name(nullptr, ReplIdent("x"), nullptr) ==
-	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_get_name(nullptr, &name, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_replacement_scan_set_function_name(nullptr, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(duckdb_v2_replacement_scan_add_argument(nullptr, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(duckdb_v2_replacement_scan_set_subquery(nullptr, Convert("SELECT 1"), nullptr) ==
 	        DUCKDB_V2_ERROR_INPUT_INVALID);
 	REQUIRE(duckdb_v2_replacement_scan_set_alias(nullptr, ReplIdent("x"), nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
-	// A view with a null pointer but a non-zero length is malformed.
-	REQUIRE(duckdb_v2_replacement_scan_set_function_name(nullptr, duckdb_v2_identifier_t {nullptr, 4}, nullptr) ==
-	        DUCKDB_V2_ERROR_INPUT_INVALID);
 
 	REQUIRE(duckdb_v2_replacement_scan_destroy(&scan) == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(scan == nullptr);

--- a/test/api/capi/v2/test_capi_v2_table_function.cpp
+++ b/test/api/capi/v2/test_capi_v2_table_function.cpp
@@ -528,28 +528,14 @@ void AnyColumnBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_c
 }
 
 // ---------------------------------------------------------------------------
-// Cardinality and progress
+// Progress
 // ---------------------------------------------------------------------------
 
 struct HookProbe {
-	idx_t cardinality_calls = 0;
 	idx_t progress_calls = 0;
-	bool cardinality_saw_bind_data = false;
 	bool progress_saw_global_state = false;
 };
 HookProbe hook_probe;
-
-void CardinalityCb(duckdb_v2_table_function_cardinality_info_handle info, duckdb_v2_context_handle,
-                   duckdb_v2_error_info_handle *err) {
-	hook_probe.cardinality_calls++;
-	void *bind_ptr = nullptr;
-	if (duckdb_v2_table_function_cardinality_get_bind_data(info, &bind_ptr, err) != DUCKDB_V2_ERROR_NONE) {
-		return;
-	}
-	hook_probe.cardinality_saw_bind_data = bind_ptr != nullptr;
-	auto count = bind_ptr ? static_cast<RangeBind *>(bind_ptr)->count : 0;
-	duckdb_v2_table_function_cardinality_set_cardinality(info, static_cast<idx_t>(count), true, err);
-}
 
 // Only the progress test uses this, and that test needs a full-size vector to stay quick.
 #if (STANDARD_VECTOR_SIZE == DEFAULT_STANDARD_VECTOR_SIZE)
@@ -806,31 +792,6 @@ TEST_CASE("V2 table: registration refusals", "[capi_v2][table_function]") {
 	}
 
 	duckdb_v2_logical_type_destroy(&bigint);
-}
-
-// ===========================================================================
-// Cardinality.
-// ===========================================================================
-
-TEST_CASE("V2 table: cardinality callback runs during planning", "[capi_v2][table_function]") {
-	EnvFixture fx;
-	hook_probe = HookProbe {};
-
-	auto function = MakeTable(fx.conn, "my_counted");
-	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, StateBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, StateInitGlobalCb, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_table_function_set_init_local_callback(function, StateInitLocalCb, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, StateExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_table_function_set_cardinality_callback(function, CardinalityCb, nullptr) ==
-	        DUCKDB_V2_ERROR_NONE);
-	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
-	duckdb_v2_table_function_destroy(&function);
-
-	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM my_counted()") == 3);
-	REQUIRE(hook_probe.cardinality_calls >= 1);
-	REQUIRE(hook_probe.cardinality_saw_bind_data);
 }
 
 // ===========================================================================

--- a/test/api/capi/v2/test_capi_v2_table_function.cpp
+++ b/test/api/capi/v2/test_capi_v2_table_function.cpp
@@ -893,4 +893,397 @@ TEST_CASE("V2 table: null arguments and destroy null-safety", "[capi_v2][table_f
 	REQUIRE(live == nullptr);
 }
 
+// ---------------------------------------------------------------------------
+// proj_probe(): three BIGINT columns x, y, z, three rows, cell = declared column * 100 + row. The exec callback
+// fills whatever the scan asks for through the column mapping, so it serves with and without projection pushdown.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct ProjGlobal {
+	bool done = false;
+};
+
+void DeleteProjGlobal(void *ptr) {
+	delete static_cast<ProjGlobal *>(ptr);
+}
+
+// The column mapping each init callback observed for the last scan.
+std::vector<idx_t> proj_global_columns;
+std::vector<idx_t> proj_local_columns;
+
+void ProjBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                duckdb_v2_error_info_handle *err) {
+	auto bigint = MakeTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, err);
+	if (!bigint) {
+		return;
+	}
+	for (auto name : {"x", "y", "z"}) {
+		if (duckdb_v2_table_function_bind_add_result_column(info, TableIdent(name), bigint, err) !=
+		    DUCKDB_V2_ERROR_NONE) {
+			break;
+		}
+	}
+	duckdb_v2_logical_type_destroy(&bigint);
+}
+
+void ProjInitGlobalCb(duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_context_handle,
+                      duckdb_v2_error_info_handle *err) {
+	proj_global_columns.clear();
+	idx_t count = 0;
+	if (duckdb_v2_table_function_init_global_get_column_count(info, &count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (idx_t i = 0; i < count; i++) {
+		idx_t column = 0;
+		if (duckdb_v2_table_function_init_global_get_column_index(info, i, &column, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		proj_global_columns.push_back(column);
+	}
+	duckdb_v2_opaque state = {new ProjGlobal {}, DeleteProjGlobal, nullptr};
+	duckdb_v2_table_function_init_global_set_global_state(info, &state, err);
+}
+
+void ProjInitLocalCb(duckdb_v2_table_function_init_local_info_handle info, duckdb_v2_context_handle,
+                     duckdb_v2_error_info_handle *err) {
+	proj_local_columns.clear();
+	idx_t count = 0;
+	if (duckdb_v2_table_function_init_local_get_column_count(info, &count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (idx_t i = 0; i < count; i++) {
+		idx_t column = 0;
+		if (duckdb_v2_table_function_init_local_get_column_index(info, i, &column, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		proj_local_columns.push_back(column);
+	}
+}
+
+void ProjExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle,
+                duckdb_v2_error_info_handle *err) {
+	void *global_ptr = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	idx_t count = 0;
+	if (duckdb_v2_table_function_exec_get_global_state(info, &global_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_output_chunk(info, &chunk, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_column_count(info, &count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &global = *static_cast<ProjGlobal *>(global_ptr);
+	const idx_t rows = global.done ? 0 : 3;
+	global.done = true;
+
+	for (idx_t i = 0; i < count; i++) {
+		idx_t column = 0;
+		duckdb_v2_vector_handle vec = nullptr;
+		void *raw = nullptr;
+		if (duckdb_v2_table_function_exec_get_column_index(info, i, &column, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_data_chunk_get_vector(chunk, i, &vec, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_vector_get_data_mutable(vec, &raw, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		for (idx_t row = 0; row < rows; row++) {
+			static_cast<int64_t *>(raw)[row] = static_cast<int64_t>(column * 100 + row);
+		}
+		if (i == 0) {
+			duckdb_v2_vector_set_size(vec, rows, err);
+		}
+	}
+}
+
+void RegisterProj(duckdb_v2_connection_handle conn, const char *name, bool projection_pushdown) {
+	auto function = MakeTable(conn, name);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, ProjBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, ProjInitGlobalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_local_callback(function, ProjInitLocalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, ProjExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_projection_pushdown(function, projection_pushdown, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+}
+
+// Runs a query and collects its BIGINT columns row-major.
+std::vector<int64_t> QueryCells(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql, &result) == DUCKDB_V2_ERROR_NONE);
+	std::vector<int64_t> cells;
+	while (auto chunk = StepChunk(result)) {
+		idx_t columns = 0;
+		idx_t rows = 0;
+		duckdb_v2_data_chunk_get_vector_count(chunk, &columns, nullptr);
+		duckdb_v2_data_chunk_get_size(chunk, &rows, nullptr);
+		for (idx_t row = 0; row < rows; row++) {
+			for (idx_t col = 0; col < columns; col++) {
+				duckdb_v2_vector_handle vec = nullptr;
+				duckdb_v2_data_chunk_get_vector(chunk, col, &vec, nullptr);
+				duckdb_v2_vector_view view {};
+				duckdb_v2_vector_get_view(vec, &view, nullptr);
+				cells.push_back(static_cast<const int64_t *>(view.data)[SelAt(view.sel, row)]);
+			}
+		}
+		duckdb_v2_data_chunk_destroy(&chunk);
+	}
+	duckdb_v2_result_destroy(&result);
+	return cells;
+}
+
+// ---------------------------------------------------------------------------
+// claim_probe(n): column i BIGINT with 0..n-1. Its pushdown callback claims every "i < constant" predicate by
+// recording the bound in the bind data; the scan then deliberately produces two rows past the bound, which only
+// reach the result if the engine really stopped applying the claimed predicate.
+// ---------------------------------------------------------------------------
+
+struct ClaimBind {
+	int64_t count = 0;
+	int64_t bound = -1;
+};
+struct ClaimGlobal {
+	int64_t position = 0;
+};
+
+void DeleteClaimBind(void *ptr) {
+	delete static_cast<ClaimBind *>(ptr);
+}
+void DeleteClaimGlobal(void *ptr) {
+	delete static_cast<ClaimGlobal *>(ptr);
+}
+
+// Whether the pushdown callback saw the user data it was registered with.
+bool claim_saw_user_data = false;
+int claim_user_data_marker = 0;
+
+void ClaimBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                 duckdb_v2_error_info_handle *err) {
+	duckdb_v2_value_handle value = nullptr;
+	if (duckdb_v2_table_function_bind_get_arg_value(info, 0, &value, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	int64_t count = 0;
+	auto rc = duckdb_v2_value_get_bigint(value, &count, err);
+	duckdb_v2_value_destroy(&value);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto bigint = MakeTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, err);
+	if (!bigint) {
+		return;
+	}
+	rc = duckdb_v2_table_function_bind_add_result_column(info, TableIdent("i"), bigint, err);
+	duckdb_v2_logical_type_destroy(&bigint);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_opaque bind_data = {new ClaimBind {count, -1}, DeleteClaimBind, nullptr};
+	duckdb_v2_table_function_bind_set_bind_data(info, &bind_data, err);
+}
+
+void ClaimPushdownCb(duckdb_v2_table_function_filter_pushdown_info_handle info, duckdb_v2_context_handle,
+                     duckdb_v2_error_info_handle *err) {
+	void *user_ptr = nullptr;
+	void *bind_ptr = nullptr;
+	idx_t count = 0;
+	if (duckdb_v2_table_function_filter_pushdown_get_user_data(info, &user_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_filter_pushdown_get_bind_data(info, &bind_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_filter_pushdown_get_filter_count(info, &count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	claim_saw_user_data = user_ptr == &claim_user_data_marker;
+	auto &bind = *static_cast<ClaimBind *>(bind_ptr);
+
+	for (idx_t i = 0; i < count; i++) {
+		duckdb_v2_expression_handle filter = nullptr;
+		DUCKDB_V2_EXPRESSION_TYPE type = DUCKDB_V2_EXPRESSION_TYPE_INVALID;
+		if (duckdb_v2_table_function_filter_pushdown_get_filter(info, i, &filter, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_expression_get_type(filter, &type, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		if (type != DUCKDB_V2_EXPRESSION_TYPE_COMPARE_LESSTHAN) {
+			continue;
+		}
+		duckdb_v2_expression_handle left = nullptr;
+		duckdb_v2_expression_handle right = nullptr;
+		DUCKDB_V2_EXPRESSION_TYPE left_type = DUCKDB_V2_EXPRESSION_TYPE_INVALID;
+		DUCKDB_V2_EXPRESSION_TYPE right_type = DUCKDB_V2_EXPRESSION_TYPE_INVALID;
+		if (duckdb_v2_expression_get_child(filter, 0, &left, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_expression_get_child(filter, 1, &right, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_expression_get_type(left, &left_type, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_expression_get_type(right, &right_type, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		if (left_type != DUCKDB_V2_EXPRESSION_TYPE_BOUND_COLUMN_REF ||
+		    right_type != DUCKDB_V2_EXPRESSION_TYPE_VALUE_CONSTANT) {
+			continue;
+		}
+		idx_t column = 0;
+		idx_t declared = 0;
+		duckdb_v2_value_handle value = nullptr;
+		if (duckdb_v2_expression_column_ref_get_index(left, &column, err) != DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_table_function_filter_pushdown_get_column_index(info, column, &declared, err) !=
+		        DUCKDB_V2_ERROR_NONE ||
+		    duckdb_v2_expression_constant_get_value(right, &value, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		int64_t bound = 0;
+		auto rc = duckdb_v2_value_get_bigint(value, &bound, err);
+		duckdb_v2_value_destroy(&value);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		if (declared != 0) {
+			continue;
+		}
+		bind.bound = bound;
+		if (duckdb_v2_table_function_filter_pushdown_accept(info, i, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+}
+
+void ClaimInitGlobalCb(duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_context_handle,
+                       duckdb_v2_error_info_handle *err) {
+	duckdb_v2_opaque state = {new ClaimGlobal {0}, DeleteClaimGlobal, nullptr};
+	duckdb_v2_table_function_init_global_set_global_state(info, &state, err);
+}
+
+void ClaimExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle,
+                 duckdb_v2_error_info_handle *err) {
+	void *bind_ptr = nullptr;
+	void *global_ptr = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	if (duckdb_v2_table_function_exec_get_bind_data(info, &bind_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_global_state(info, &global_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_output_chunk(info, &chunk, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &bind = *static_cast<ClaimBind *>(bind_ptr);
+	auto &global = *static_cast<ClaimGlobal *>(global_ptr);
+
+	duckdb_v2_vector_handle vec = nullptr;
+	void *raw = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(vec, &raw, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	// Two rows past a claimed bound: they surface only if the engine dropped the predicate.
+	auto limit = bind.bound < 0 ? bind.count : bind.bound + 2;
+	if (limit > bind.count) {
+		limit = bind.count;
+	}
+	auto remaining = limit - global.position;
+	auto produced =
+	    remaining < static_cast<int64_t>(STANDARD_VECTOR_SIZE) ? remaining : static_cast<int64_t>(STANDARD_VECTOR_SIZE);
+	if (produced < 0) {
+		produced = 0;
+	}
+	auto *out = static_cast<int64_t *>(raw);
+	for (int64_t i = 0; i < produced; i++) {
+		out[i] = global.position + i;
+	}
+	global.position += produced;
+	duckdb_v2_vector_set_size(vec, static_cast<idx_t>(produced), err);
+}
+
+void FailingPushdownCb(duckdb_v2_table_function_filter_pushdown_info_handle, duckdb_v2_context_handle,
+                       duckdb_v2_error_info_handle *err) {
+	SetErrorInfo(err, DUCKDB_V2_ERROR_INPUT_INVALID, "pushdown refused");
+}
+
+void RegisterClaim(duckdb_v2_connection_handle conn, const char *name,
+                   duckdb_v2_table_function_filter_pushdown_callback_fn pushdown) {
+	auto bigint = MakeType(conn, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	auto function = MakeTable(conn, name);
+	TableSigParam(SigOf(function), "n", bigint);
+	duckdb_v2_opaque user_data = {&claim_user_data_marker, nullptr, nullptr};
+	REQUIRE(duckdb_v2_table_function_set_user_data(function, &user_data, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, ClaimBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, ClaimInitGlobalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, ClaimExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_filter_pushdown_callback(function, pushdown, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&bigint);
+}
+
+} // namespace
+
+TEST_CASE("V2 table: projection pushdown narrows the output chunk", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	RegisterProj(fx.conn, "proj_probe", true);
+	RegisterProj(fx.conn, "proj_plain", false);
+
+	using Cells = std::vector<int64_t>;
+	using Columns = std::vector<idx_t>;
+
+	// Two of three columns, in query order: the chunk holds exactly those, and the values prove the mapping.
+	REQUIRE(QueryCells(fx.conn, "SELECT z, x FROM proj_probe()") == Cells {200, 0, 201, 1, 202, 2});
+	REQUIRE(proj_global_columns == Columns {2, 0});
+	REQUIRE(proj_local_columns == Columns {2, 0});
+
+	// A query that needs no column at all still scans one.
+	REQUIRE(QueryCells(fx.conn, "SELECT count(*) FROM proj_probe()") == Cells {3});
+	REQUIRE(proj_global_columns.size() == 1);
+
+	// Without projection pushdown the chunk always holds every declared column, in declaration order.
+	REQUIRE(QueryCells(fx.conn, "SELECT z, x FROM proj_plain()") == Cells {200, 0, 201, 1, 202, 2});
+	REQUIRE(proj_global_columns == Columns {0, 1, 2});
+	REQUIRE(proj_local_columns == Columns {0, 1, 2});
+}
+
+TEST_CASE("V2 table: claimed filters are no longer applied by the engine", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	RegisterClaim(fx.conn, "claim_probe", ClaimPushdownCb);
+
+	// Nothing to claim: every row comes through.
+	claim_saw_user_data = false;
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM claim_probe(100) WHERE i % 2 = 0") == 50);
+	REQUIRE(claim_saw_user_data);
+
+	// The claimed bound plus the two rows the scan sneaks past it: the engine no longer filters them out.
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM claim_probe(100) WHERE i < 10") == 12);
+	// The unclaimed half of the conjunction is still applied above the scan.
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM claim_probe(100) WHERE i < 10 AND i % 2 = 0") == 6);
+	// A comparison the callback does not recognize stays with the engine.
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM claim_probe(100) WHERE i > 90") == 9);
+}
+
+TEST_CASE("V2 table: filter pushdown errors fail the query", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	RegisterClaim(fx.conn, "claim_fail", FailingPushdownCb);
+
+	// Without a predicate there is nothing to offer, so the callback never runs.
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM claim_fail(5)") == 5);
+	auto message = QueryError(fx.conn, "SELECT count(*) FROM claim_fail(5) WHERE i < 3");
+	REQUIRE(message.find("pushdown refused") != std::string::npos);
+}
+
+TEST_CASE("V2 table: pushdown null arguments", "[capi_v2][table_function]") {
+	idx_t count = 0;
+	void *data = nullptr;
+	REQUIRE(duckdb_v2_table_function_set_projection_pushdown(nullptr, true, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_set_filter_pushdown_callback(nullptr, ClaimPushdownCb, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_init_global_get_column_count(nullptr, &count, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_init_global_get_column_index(nullptr, 0, &count, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_init_local_get_column_count(nullptr, &count, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_init_local_get_column_index(nullptr, 0, &count, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_exec_get_column_count(nullptr, &count, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_exec_get_column_index(nullptr, 0, &count, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_filter_pushdown_get_user_data(nullptr, &data, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_filter_pushdown_get_bind_data(nullptr, &data, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
 } // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_table_function.cpp
+++ b/test/api/capi/v2/test_capi_v2_table_function.cpp
@@ -1,0 +1,935 @@
+#include "test_capi_v2.hpp"
+
+#include <cstring>
+
+// ---------------------------------------------------------------------------
+// V2 table function tests: build a function on a connection, configure its
+// signature, register it, and scan it through SQL.
+//
+// Callbacks avoid Catch assertions: a REQUIRE would throw through the C
+// callback boundary into the engine. On failure they populate the provided
+// error slot and return; the failure then surfaces as a query error that the
+// test asserts on. Cross-callback observations are latched into file-scope
+// statics and asserted after the query.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+
+namespace {
+
+duckdb_v2_identifier_t TableIdent(const char *s) {
+	return duckdb_v2_identifier_t {s, std::strlen(s)};
+}
+
+// Create a table function on the connection with the given name.
+duckdb_v2_table_function_handle MakeTable(duckdb_v2_connection_handle conn, const char *name) {
+	duckdb_v2_table_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_table_function_create_with_connection(conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	auto str = Convert(name);
+	REQUIRE(duckdb_v2_table_function_set_name(function, &str, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return function;
+}
+
+// The function's borrowed signature.
+duckdb_v2_function_signature_handle SigOf(duckdb_v2_table_function_handle function) {
+	duckdb_v2_function_signature_handle sig = nullptr;
+	REQUIRE(duckdb_v2_table_function_get_signature(function, &sig, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(sig != nullptr);
+	return sig;
+}
+
+void TableSigParam(duckdb_v2_function_signature_handle sig, const char *name, duckdb_v2_logical_type_handle type,
+                   duckdb_v2_value_handle default_value = nullptr) {
+	REQUIRE(duckdb_v2_function_signature_add_parameter(sig, TableIdent(name), type, default_value, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+}
+
+// Run a query producing a single BIGINT cell.
+int64_t QueryI64(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(conn, sql, &result) == DUCKDB_V2_ERROR_NONE);
+	auto chunk = StepChunk(result);
+	REQUIRE(chunk != nullptr);
+	duckdb_v2_vector_handle vec = nullptr;
+	duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr);
+	duckdb_v2_vector_view view {};
+	duckdb_v2_vector_get_view(vec, &view, nullptr);
+	auto out = static_cast<const int64_t *>(view.data)[SelAt(view.sel, 0)];
+	duckdb_v2_data_chunk_destroy(&chunk);
+	duckdb_v2_result_destroy(&result);
+	return out;
+}
+
+// Builds a type from inside a callback, where a context rather than a connection is in hand.
+// Returns null after populating the error slot, so the caller can bail out.
+duckdb_v2_logical_type_handle MakeTypeInCallback(duckdb_v2_context_handle context, DUCKDB_V2_LOGICAL_TYPE_ID id,
+                                                 duckdb_v2_error_info_handle *err) {
+	duckdb_v2_logical_type_handle type = nullptr;
+	if (duckdb_v2_context_create_type_from_id(context, id, nullptr, nullptr, 0, &type, err) != DUCKDB_V2_ERROR_NONE) {
+		return nullptr;
+	}
+	return type;
+}
+
+// The message of a failing query, or the empty string when it succeeded.
+std::string QueryError(duckdb_v2_connection_handle conn, const char *sql) {
+	duckdb_v2_result_handle result = nullptr;
+	duckdb_v2_error_info_handle err = nullptr;
+	auto rc = Query(conn, sql, &result, &err);
+	// Streaming execution is lazy: the failure only surfaces once stepping reaches it, which may
+	// take several rounds. Drain until something fails or the stream ends.
+	while (rc == DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_data_chunk_handle chunk = nullptr;
+		DUCKDB_V2_RESULT_STEP_STATUS status = DUCKDB_V2_RESULT_STEP_STATUS_WAITING;
+		rc = duckdb_v2_result_step(result, &chunk, &status, &err);
+		duckdb_v2_data_chunk_destroy(&chunk);
+		if (rc != DUCKDB_V2_ERROR_NONE || status == DUCKDB_V2_RESULT_STEP_STATUS_FINISHED ||
+		    status == DUCKDB_V2_RESULT_STEP_STATUS_CANCELLED) {
+			break;
+		}
+		if (status == DUCKDB_V2_RESULT_STEP_STATUS_WAITING) {
+			rc = duckdb_v2_result_wait(result, &err);
+		}
+	}
+	duckdb_v2_result_destroy(&result);
+	std::string message;
+	if (rc != DUCKDB_V2_ERROR_NONE && err) {
+		duckdb_v2_str text = {nullptr, 0};
+		duckdb_v2_error_info_get_text(err, &text);
+		message = Convert(text);
+	}
+	duckdb_v2_error_info_destroy(&err);
+	REQUIRE(rc != DUCKDB_V2_ERROR_NONE);
+	return message;
+}
+
+// ---------------------------------------------------------------------------
+// my_range(n): one BIGINT column "i" carrying 0..n-1.
+// ---------------------------------------------------------------------------
+
+struct RangeBind {
+	int64_t count = 0;
+};
+struct RangeGlobal {
+	int64_t position = 0;
+};
+
+void DeleteRangeBind(void *ptr) {
+	delete static_cast<RangeBind *>(ptr);
+}
+void DeleteRangeGlobal(void *ptr) {
+	delete static_cast<RangeGlobal *>(ptr);
+}
+
+void RangeBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                 duckdb_v2_error_info_handle *err) {
+	duckdb_v2_value_handle value = nullptr;
+	if (duckdb_v2_table_function_bind_get_arg_value(info, 0, &value, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	int64_t count = 0;
+	auto rc = duckdb_v2_value_get_bigint(value, &count, err);
+	duckdb_v2_value_destroy(&value);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	duckdb_v2_logical_type_handle bigint = nullptr;
+	if (duckdb_v2_context_create_type_from_id(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, nullptr, nullptr, 0, &bigint,
+	                                          err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	rc = duckdb_v2_table_function_bind_add_result_column(info, TableIdent("i"), bigint, err);
+	duckdb_v2_logical_type_destroy(&bigint);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	// An exact row count is known here, so hand it to the optimizer directly.
+	if (duckdb_v2_table_function_bind_set_cardinality(info, static_cast<idx_t>(count), true, err) !=
+	    DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	duckdb_v2_opaque bind_data = {new RangeBind {count}, DeleteRangeBind, nullptr};
+	duckdb_v2_table_function_bind_set_bind_data(info, &bind_data, err);
+}
+
+void RangeInitGlobalCb(duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_context_handle,
+                       duckdb_v2_error_info_handle *err) {
+	duckdb_v2_opaque state = {new RangeGlobal {0}, DeleteRangeGlobal, nullptr};
+	duckdb_v2_table_function_init_global_set_global_state(info, &state, err);
+}
+
+void RangeExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle,
+                 duckdb_v2_error_info_handle *err) {
+	void *bind_ptr = nullptr;
+	void *global_ptr = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	if (duckdb_v2_table_function_exec_get_bind_data(info, &bind_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_global_state(info, &global_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_output_chunk(info, &chunk, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &bind = *static_cast<RangeBind *>(bind_ptr);
+	auto &global = *static_cast<RangeGlobal *>(global_ptr);
+
+	duckdb_v2_vector_handle vec = nullptr;
+	void *raw = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(vec, &raw, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	auto remaining = bind.count - global.position;
+	auto produced =
+	    remaining < static_cast<int64_t>(STANDARD_VECTOR_SIZE) ? remaining : static_cast<int64_t>(STANDARD_VECTOR_SIZE);
+	if (produced < 0) {
+		produced = 0;
+	}
+	auto *out = static_cast<int64_t *>(raw);
+	for (int64_t i = 0; i < produced; i++) {
+		out[i] = global.position + i;
+	}
+	global.position += produced;
+
+	// The first vector's size is the batch's row count; 0 ends the scan.
+	duckdb_v2_vector_set_size(vec, static_cast<idx_t>(produced), err);
+}
+
+// Registers my_range on the connection.
+void RegisterRange(duckdb_v2_connection_handle conn, const char *name = "my_range") {
+	auto bigint = MakeType(conn, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	auto function = MakeTable(conn, name);
+	TableSigParam(SigOf(function), "n", bigint);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, RangeBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, RangeInitGlobalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&bigint);
+}
+
+// ---------------------------------------------------------------------------
+// my_pairs(n): two columns, "a" INTEGER and "b" VARCHAR, produced in one batch.
+// Pins that the row count taken from the first vector reaches the others.
+// ---------------------------------------------------------------------------
+
+#if (STANDARD_VECTOR_SIZE > 2)
+struct PairsBind {
+	int32_t count = 0;
+};
+
+void DeletePairsBind(void *ptr) {
+	delete static_cast<PairsBind *>(ptr);
+}
+
+void PairsBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                 duckdb_v2_error_info_handle *err) {
+	duckdb_v2_value_handle value = nullptr;
+	if (duckdb_v2_table_function_bind_get_arg_value(info, 0, &value, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	int32_t count = 0;
+	auto rc = duckdb_v2_value_get_int(value, &count, err);
+	duckdb_v2_value_destroy(&value);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	auto integer = MakeTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER, err);
+	if (!integer) {
+		return;
+	}
+	rc = duckdb_v2_table_function_bind_add_result_column(info, TableIdent("a"), integer, err);
+	duckdb_v2_logical_type_destroy(&integer);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto varchar = MakeTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR, err);
+	if (!varchar) {
+		return;
+	}
+	rc = duckdb_v2_table_function_bind_add_result_column(info, TableIdent("b"), varchar, err);
+	duckdb_v2_logical_type_destroy(&varchar);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+
+	duckdb_v2_opaque bind_data = {new PairsBind {count}, DeletePairsBind, nullptr};
+	duckdb_v2_table_function_bind_set_bind_data(info, &bind_data, err);
+}
+
+void PairsExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle,
+                 duckdb_v2_error_info_handle *err) {
+	void *bind_ptr = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	if (duckdb_v2_table_function_exec_get_bind_data(info, &bind_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_output_chunk(info, &chunk, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &bind = *static_cast<PairsBind *>(bind_ptr);
+
+	// Everything is produced in the first batch; the next call ends the scan.
+	auto produced = bind.count;
+	bind.count = 0;
+
+	duckdb_v2_vector_handle a = nullptr;
+	duckdb_v2_vector_handle b = nullptr;
+	void *raw = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(chunk, 0, &a, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_data_chunk_get_vector(chunk, 1, &b, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(a, &raw, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto *values = static_cast<int32_t *>(raw);
+	for (int32_t i = 0; i < produced; i++) {
+		values[i] = i;
+		char text[16] = {};
+		auto len = std::snprintf(text, sizeof(text), "row%d", i);
+		if (V2VectorAssignString(b, static_cast<idx_t>(i), text, static_cast<idx_t>(len), err) !=
+		    DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+	// Only the first vector is sized; the engine propagates the count to "b".
+	duckdb_v2_vector_set_size(a, static_cast<idx_t>(produced), err);
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// my_args(a, b := 7, ...): latches the argument slots the bind callback sees.
+// ---------------------------------------------------------------------------
+
+struct TableArgProbe {
+	idx_t arg_count = 0;
+	int64_t values[8] = {};
+	DUCKDB_V2_LOGICAL_TYPE_ID types[8] = {};
+	DUCKDB_V2_ERROR oob_type_rc = DUCKDB_V2_ERROR_NONE;
+	DUCKDB_V2_ERROR oob_value_rc = DUCKDB_V2_ERROR_NONE;
+	bool oob_type_cleared = false;
+	bool oob_value_cleared = false;
+};
+TableArgProbe table_arg_probe;
+
+void ArgsBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                duckdb_v2_error_info_handle *err) {
+	table_arg_probe = TableArgProbe {};
+	if (duckdb_v2_table_function_bind_get_arg_count(info, &table_arg_probe.arg_count, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	for (idx_t i = 0; i < table_arg_probe.arg_count && i < 8; i++) {
+		duckdb_v2_logical_type_handle type = nullptr;
+		if (duckdb_v2_table_function_bind_get_arg_type(info, i, &type, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		auto rc = duckdb_v2_logical_type_get_id(type, &table_arg_probe.types[i], err);
+		duckdb_v2_logical_type_destroy(&type);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		duckdb_v2_value_handle value = nullptr;
+		if (duckdb_v2_table_function_bind_get_arg_value(info, i, &value, err) != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+		rc = duckdb_v2_value_get_bigint(value, &table_arg_probe.values[i], err);
+		duckdb_v2_value_destroy(&value);
+		if (rc != DUCKDB_V2_ERROR_NONE) {
+			return;
+		}
+	}
+
+	// An index past the last argument is an input error, and leaves the out-parameter cleared.
+	duckdb_v2_logical_type_handle oob_type = nullptr;
+	duckdb_v2_value_handle oob_value = nullptr;
+	table_arg_probe.oob_type_rc = duckdb_v2_table_function_bind_get_arg_type(info, 99, &oob_type, nullptr);
+	table_arg_probe.oob_value_rc = duckdb_v2_table_function_bind_get_arg_value(info, 99, &oob_value, nullptr);
+	table_arg_probe.oob_type_cleared = oob_type == nullptr;
+	table_arg_probe.oob_value_cleared = oob_value == nullptr;
+
+	auto bigint = MakeTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, err);
+	if (!bigint) {
+		return;
+	}
+	auto rc = duckdb_v2_table_function_bind_add_result_column(info, TableIdent("n"), bigint, err);
+	duckdb_v2_logical_type_destroy(&bigint);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_opaque bind_data = {new RangeBind {static_cast<int64_t>(table_arg_probe.arg_count)}, DeleteRangeBind,
+	                              nullptr};
+	duckdb_v2_table_function_bind_set_bind_data(info, &bind_data, err);
+}
+
+// Emits a single row carrying the argument count, then ends the scan.
+void ArgsExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle,
+                duckdb_v2_error_info_handle *err) {
+	void *bind_ptr = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	if (duckdb_v2_table_function_exec_get_bind_data(info, &bind_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_output_chunk(info, &chunk, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &bind = *static_cast<RangeBind *>(bind_ptr);
+
+	duckdb_v2_vector_handle vec = nullptr;
+	void *raw = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(vec, &raw, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	idx_t produced = 0;
+	if (bind.count >= 0) {
+		static_cast<int64_t *>(raw)[0] = bind.count;
+		produced = 1;
+		bind.count = -1;
+	}
+	duckdb_v2_vector_set_size(vec, produced, err);
+}
+
+// ---------------------------------------------------------------------------
+// State plumbing: a global counter and a per-thread local state, both read back
+// in exec.
+// ---------------------------------------------------------------------------
+
+struct StateProbe {
+	idx_t init_global_calls = 0;
+	idx_t init_local_calls = 0;
+	bool local_saw_global = false;
+	bool exec_saw_global = false;
+	bool exec_saw_local = false;
+	bool exec_saw_user_data = false;
+};
+StateProbe state_probe;
+
+struct GlobalState {
+	int64_t remaining = 0;
+};
+struct LocalState {
+	int64_t tag = 0;
+};
+
+void DeleteGlobalState(void *ptr) {
+	delete static_cast<GlobalState *>(ptr);
+}
+void DeleteLocalState(void *ptr) {
+	delete static_cast<LocalState *>(ptr);
+}
+
+void StateBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                 duckdb_v2_error_info_handle *err) {
+	state_probe = StateProbe {};
+	auto bigint = MakeTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT, err);
+	if (!bigint) {
+		return;
+	}
+	auto rc = duckdb_v2_table_function_bind_add_result_column(info, TableIdent("v"), bigint, err);
+	duckdb_v2_logical_type_destroy(&bigint);
+	if (rc != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_opaque bind_data = {new RangeBind {3}, DeleteRangeBind, nullptr};
+	duckdb_v2_table_function_bind_set_bind_data(info, &bind_data, err);
+}
+
+void StateInitGlobalCb(duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_context_handle,
+                       duckdb_v2_error_info_handle *err) {
+	state_probe.init_global_calls++;
+	void *bind_ptr = nullptr;
+	if (duckdb_v2_table_function_init_global_get_bind_data(info, &bind_ptr, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	auto &bind = *static_cast<RangeBind *>(bind_ptr);
+	duckdb_v2_opaque state = {new GlobalState {bind.count}, DeleteGlobalState, nullptr};
+	if (duckdb_v2_table_function_init_global_set_global_state(info, &state, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	duckdb_v2_table_function_init_global_set_max_threads(info, 1, err);
+}
+
+void StateInitLocalCb(duckdb_v2_table_function_init_local_info_handle info, duckdb_v2_context_handle,
+                      duckdb_v2_error_info_handle *err) {
+	state_probe.init_local_calls++;
+	void *global_ptr = nullptr;
+	if (duckdb_v2_table_function_init_local_get_global_state(info, &global_ptr, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	state_probe.local_saw_global = global_ptr != nullptr;
+	duckdb_v2_opaque state = {new LocalState {42}, DeleteLocalState, nullptr};
+	duckdb_v2_table_function_init_local_set_local_state(info, &state, err);
+}
+
+void StateExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle,
+                 duckdb_v2_error_info_handle *err) {
+	void *global_ptr = nullptr;
+	void *local_ptr = nullptr;
+	void *user_ptr = nullptr;
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	if (duckdb_v2_table_function_exec_get_global_state(info, &global_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_local_state(info, &local_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_user_data(info, &user_ptr, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_table_function_exec_get_output_chunk(info, &chunk, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	state_probe.exec_saw_global = global_ptr != nullptr;
+	state_probe.exec_saw_local = local_ptr != nullptr;
+	state_probe.exec_saw_user_data = user_ptr != nullptr;
+
+	auto &global = *static_cast<GlobalState *>(global_ptr);
+	auto &local = *static_cast<LocalState *>(local_ptr);
+
+	duckdb_v2_vector_handle vec = nullptr;
+	void *raw = nullptr;
+	if (duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, err) != DUCKDB_V2_ERROR_NONE ||
+	    duckdb_v2_vector_get_data_mutable(vec, &raw, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	idx_t produced = 0;
+	if (global.remaining > 0) {
+		global.remaining--;
+		static_cast<int64_t *>(raw)[0] = local.tag;
+		produced = 1;
+	}
+	duckdb_v2_vector_set_size(vec, produced, err);
+}
+
+// ---------------------------------------------------------------------------
+// Failure callbacks
+// ---------------------------------------------------------------------------
+
+void FailingBindCb(duckdb_v2_table_function_bind_info_handle, duckdb_v2_context_handle,
+                   duckdb_v2_error_info_handle *err) {
+	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_INPUT_INVALID);
+	duckdb_v2_error_info_set_text(*err, Convert("bind refused"));
+}
+
+void FailingExecCb(duckdb_v2_table_function_exec_info_handle, duckdb_v2_context_handle,
+                   duckdb_v2_error_info_handle *err) {
+	duckdb_v2_error_info_set_code(*err, DUCKDB_V2_ERROR_INPUT_OUT_OF_RANGE);
+	duckdb_v2_error_info_set_text(*err, Convert("exec refused"));
+}
+
+// A bind callback that declares nothing: registration cannot catch this, the scan must.
+void NoColumnsBindCb(duckdb_v2_table_function_bind_info_handle, duckdb_v2_context_handle,
+                     duckdb_v2_error_info_handle *) {
+}
+
+// A bind callback that tries to declare an ANY column.
+void AnyColumnBindCb(duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+                     duckdb_v2_error_info_handle *err) {
+	auto any = MakeTypeInCallback(context, DUCKDB_V2_LOGICAL_TYPE_ID_ANY, err);
+	if (!any) {
+		return;
+	}
+	auto rc = duckdb_v2_table_function_bind_add_result_column(info, TableIdent("x"), any, err);
+	duckdb_v2_logical_type_destroy(&any);
+	(void)rc;
+}
+
+// ---------------------------------------------------------------------------
+// Cardinality and progress
+// ---------------------------------------------------------------------------
+
+struct HookProbe {
+	idx_t cardinality_calls = 0;
+	idx_t progress_calls = 0;
+	bool cardinality_saw_bind_data = false;
+	bool progress_saw_global_state = false;
+};
+HookProbe hook_probe;
+
+void CardinalityCb(duckdb_v2_table_function_cardinality_info_handle info, duckdb_v2_context_handle,
+                   duckdb_v2_error_info_handle *err) {
+	hook_probe.cardinality_calls++;
+	void *bind_ptr = nullptr;
+	if (duckdb_v2_table_function_cardinality_get_bind_data(info, &bind_ptr, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	hook_probe.cardinality_saw_bind_data = bind_ptr != nullptr;
+	auto count = bind_ptr ? static_cast<RangeBind *>(bind_ptr)->count : 0;
+	duckdb_v2_table_function_cardinality_set_cardinality(info, static_cast<idx_t>(count), true, err);
+}
+
+// Only the progress test uses this, and that test needs a full-size vector to stay quick.
+#if (STANDARD_VECTOR_SIZE == DEFAULT_STANDARD_VECTOR_SIZE)
+void ProgressCb(duckdb_v2_table_function_progress_info_handle info, duckdb_v2_context_handle,
+                duckdb_v2_error_info_handle *err) {
+	hook_probe.progress_calls++;
+	void *global_ptr = nullptr;
+	if (duckdb_v2_table_function_progress_get_global_state(info, &global_ptr, err) != DUCKDB_V2_ERROR_NONE) {
+		return;
+	}
+	hook_probe.progress_saw_global_state = global_ptr != nullptr;
+	duckdb_v2_table_function_progress_set_progress(info, 0.5, err);
+}
+#endif
+
+} // namespace
+
+// ===========================================================================
+// Register on a connection and scan through SQL.
+// ===========================================================================
+
+TEST_CASE("V2 table: register on connection and scan", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	RegisterRange(fx.conn);
+
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM my_range(10)") == 10);
+	REQUIRE(QueryI64(fx.conn, "SELECT sum(i) FROM my_range(10)") == 45);
+	// A scan spanning several batches, and one producing nothing at all.
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM my_range(5000)") == 5000);
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM my_range(0)") == 0);
+
+	// The bind callback's column declaration is the function's schema.
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT * FROM my_range(3)", &result) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(ColumnCount(result) == 1);
+	RequireColumn(result, 0, "i", DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	REQUIRE(DrainRowCount(result) == 3);
+	duckdb_v2_result_destroy(&result);
+}
+
+// my_pairs writes its whole result in one batch, so it needs a vector that holds more than two rows.
+#if (STANDARD_VECTOR_SIZE > 2)
+TEST_CASE("V2 table: multiple result columns share the batch row count", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	auto integer = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+
+	auto function = MakeTable(fx.conn, "my_pairs");
+	TableSigParam(SigOf(function), "n", integer);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, PairsBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, PairsExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&integer);
+
+	duckdb_v2_result_handle result = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT * FROM my_pairs(4)", &result) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(ColumnCount(result) == 2);
+	RequireColumn(result, 0, "a", DUCKDB_V2_LOGICAL_TYPE_ID_INTEGER);
+	RequireColumn(result, 1, "b", DUCKDB_V2_LOGICAL_TYPE_ID_VARCHAR);
+	REQUIRE(DrainRowCount(result) == 4);
+	duckdb_v2_result_destroy(&result);
+
+	// Both columns carry all four rows: the count set on "a" reached "b".
+	REQUIRE(QueryI64(fx.conn, "SELECT count(b) FROM my_pairs(4)") == 4);
+	REQUIRE(QueryI64(fx.conn, "SELECT sum(a) FROM my_pairs(4)") == 6);
+
+	duckdb_v2_result_handle text = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT string_agg(b, ',' ORDER BY a) FROM my_pairs(3)", &text) == DUCKDB_V2_ERROR_NONE);
+	auto chunk = StepChunk(text);
+	REQUIRE(chunk != nullptr);
+	duckdb_v2_vector_handle vec = nullptr;
+	duckdb_v2_data_chunk_get_vector(chunk, 0, &vec, nullptr);
+	duckdb_v2_vector_view view {};
+	duckdb_v2_vector_get_view(vec, &view, nullptr);
+	auto bytes = static_cast<const duckdb_v2_bytes *>(view.data)[SelAt(view.sel, 0)];
+	REQUIRE(Convert(Convert(bytes)) == "row0,row1,row2");
+	duckdb_v2_data_chunk_destroy(&chunk);
+	duckdb_v2_result_destroy(&text);
+}
+#endif
+
+// ===========================================================================
+// Argument routing: required parameters are positional, defaulted ones named.
+// ===========================================================================
+
+TEST_CASE("V2 table: parameter defaults, named arguments and varargs", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	auto bigint = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	auto seven = MakeInt64Value(fx.conn, 7);
+
+	auto function = MakeTable(fx.conn, "my_args");
+	auto sig = SigOf(function);
+	TableSigParam(sig, "a", bigint);
+	TableSigParam(sig, "b", bigint, seven);
+	REQUIRE(duckdb_v2_function_signature_set_varargs(sig, bigint, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, ArgsBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, ArgsExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+	duckdb_v2_value_destroy(&seven);
+	duckdb_v2_logical_type_destroy(&bigint);
+
+	// Only the required parameter: the defaulted one is still present, carrying its default.
+	REQUIRE(QueryI64(fx.conn, "SELECT * FROM my_args(1)") == 2);
+	REQUIRE(table_arg_probe.arg_count == 2);
+	REQUIRE(table_arg_probe.values[0] == 1);
+	REQUIRE(table_arg_probe.values[1] == 7);
+	REQUIRE(table_arg_probe.types[0] == DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	// An out-of-range index fails and leaves the out-parameter cleared.
+	REQUIRE(table_arg_probe.oob_type_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(table_arg_probe.oob_value_rc == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(table_arg_probe.oob_type_cleared);
+	REQUIRE(table_arg_probe.oob_value_cleared);
+
+	// A defaulted parameter is passed by name.
+	REQUIRE(QueryI64(fx.conn, "SELECT * FROM my_args(1, b => 5)") == 2);
+	REQUIRE(table_arg_probe.values[0] == 1);
+	REQUIRE(table_arg_probe.values[1] == 5);
+
+	// The variadic tail follows the fixed slots, in call order.
+	REQUIRE(QueryI64(fx.conn, "SELECT * FROM my_args(1, 30, 40)") == 4);
+	REQUIRE(table_arg_probe.arg_count == 4);
+	REQUIRE(table_arg_probe.values[0] == 1);
+	REQUIRE(table_arg_probe.values[1] == 7);
+	REQUIRE(table_arg_probe.values[2] == 30);
+	REQUIRE(table_arg_probe.values[3] == 40);
+}
+
+// ===========================================================================
+// Global and local state.
+// ===========================================================================
+
+TEST_CASE("V2 table: user data, global state and local state reach exec", "[capi_v2][table_function]") {
+	EnvFixture fx;
+
+	auto function = MakeTable(fx.conn, "my_state");
+	int payload = 99;
+	duckdb_v2_opaque user_data = {&payload, nullptr, nullptr};
+	REQUIRE(duckdb_v2_table_function_set_user_data(function, &user_data, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, StateBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, StateInitGlobalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_local_callback(function, StateInitLocalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, StateExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+
+	// The bind data seeded the global counter with 3 rows, each carrying the local state's tag.
+	REQUIRE(QueryI64(fx.conn, "SELECT sum(v) FROM my_state()") == 126);
+	REQUIRE(state_probe.init_global_calls == 1);
+	REQUIRE(state_probe.init_local_calls >= 1);
+	REQUIRE(state_probe.local_saw_global);
+	REQUIRE(state_probe.exec_saw_global);
+	REQUIRE(state_probe.exec_saw_local);
+	REQUIRE(state_probe.exec_saw_user_data);
+}
+
+// ===========================================================================
+// Errors reported from the callbacks.
+// ===========================================================================
+
+TEST_CASE("V2 table: bind and exec errors propagate to the result", "[capi_v2][table_function]") {
+	EnvFixture fx;
+
+	auto failing_bind = MakeTable(fx.conn, "bad_bind");
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(failing_bind, FailingBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(failing_bind, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(failing_bind, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&failing_bind);
+
+	auto failing_exec = MakeTable(fx.conn, "bad_exec");
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(failing_exec, StateBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(failing_exec, FailingExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(failing_exec, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&failing_exec);
+
+	auto no_columns = MakeTable(fx.conn, "no_columns");
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(no_columns, NoColumnsBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(no_columns, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(no_columns, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&no_columns);
+
+	auto any_column = MakeTable(fx.conn, "any_column");
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(any_column, AnyColumnBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(any_column, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(any_column, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&any_column);
+
+	REQUIRE(QueryError(fx.conn, "SELECT * FROM bad_bind()").find("bind refused") != std::string::npos);
+	REQUIRE(QueryError(fx.conn, "SELECT * FROM bad_exec()").find("exec refused") != std::string::npos);
+	REQUIRE(QueryError(fx.conn, "SELECT * FROM no_columns()").find("result columns") != std::string::npos);
+	// The ANY column is rejected where it is declared, and the bind callback ignores the failure,
+	// so the scan fails for having declared nothing.
+	REQUIRE_FALSE(QueryError(fx.conn, "SELECT * FROM any_column()").empty());
+}
+
+// ===========================================================================
+// Registration refusals.
+// ===========================================================================
+
+TEST_CASE("V2 table: registration refusals", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	auto bigint = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+
+	// No name.
+	{
+		duckdb_v2_table_function_handle function = nullptr;
+		REQUIRE(duckdb_v2_table_function_create_with_connection(fx.conn, &function, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_set_bind_callback(function, StateBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_set_exec_callback(function, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_table_function_destroy(&function);
+	}
+
+	// No bind callback: a table function has no other way to declare its columns.
+	{
+		auto function = MakeTable(fx.conn, "no_bind");
+		REQUIRE(duckdb_v2_table_function_set_exec_callback(function, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_table_function_destroy(&function);
+	}
+
+	// No exec callback.
+	{
+		auto function = MakeTable(fx.conn, "no_exec");
+		REQUIRE(duckdb_v2_table_function_set_bind_callback(function, StateBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_table_function_destroy(&function);
+	}
+
+	// A return type on the signature: the columns come from bind instead.
+	{
+		auto function = MakeTable(fx.conn, "has_return_type");
+		REQUIRE(duckdb_v2_function_signature_set_return_type(SigOf(function), bigint, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_set_bind_callback(function, StateBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_set_exec_callback(function, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_table_function_destroy(&function);
+	}
+
+	// A parameter without a default following one with a default.
+	{
+		auto function = MakeTable(fx.conn, "bad_defaults");
+		auto sig = SigOf(function);
+		auto seven = MakeInt64Value(fx.conn, 7);
+		TableSigParam(sig, "a", bigint, seven);
+		TableSigParam(sig, "b", bigint);
+		duckdb_v2_value_destroy(&seven);
+		REQUIRE(duckdb_v2_table_function_set_bind_callback(function, StateBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_set_exec_callback(function, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+		REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+		duckdb_v2_table_function_destroy(&function);
+	}
+
+	duckdb_v2_logical_type_destroy(&bigint);
+}
+
+// ===========================================================================
+// Cardinality.
+// ===========================================================================
+
+TEST_CASE("V2 table: cardinality callback runs during planning", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	hook_probe = HookProbe {};
+
+	auto function = MakeTable(fx.conn, "my_counted");
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, StateBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, StateInitGlobalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_local_callback(function, StateInitLocalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, StateExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_cardinality_callback(function, CardinalityCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+
+	REQUIRE(QueryI64(fx.conn, "SELECT count(*) FROM my_counted()") == 3);
+	REQUIRE(hook_probe.cardinality_calls >= 1);
+	REQUIRE(hook_probe.cardinality_saw_bind_data);
+}
+
+// ===========================================================================
+// Progress.
+// ===========================================================================
+
+#if (STANDARD_VECTOR_SIZE == DEFAULT_STANDARD_VECTOR_SIZE)
+TEST_CASE("V2 table: progress callback reports scan progress", "[capi_v2][table_function]") {
+	EnvFixture fx;
+	hook_probe = HookProbe {};
+
+	// Single-threaded so all execution happens in our steps, and the progress
+	// bar enabled so the engine polls the scan for progress at all.
+	for (const char *setup_sql :
+	     {"SET threads=1", "SET enable_progress_bar=true", "SET enable_progress_bar_print=false"}) {
+		ExecSQL(fx.conn, setup_sql);
+	}
+
+	auto bigint = MakeType(fx.conn, DUCKDB_V2_LOGICAL_TYPE_ID_BIGINT);
+	auto function = MakeTable(fx.conn, "my_progress");
+	TableSigParam(SigOf(function), "n", bigint);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(function, RangeBindCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_init_global_callback(function, RangeInitGlobalCb, nullptr) ==
+	        DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(function, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_set_progress_callback(function, ProgressCb, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_table_function_register(function, nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_destroy(&function);
+	duckdb_v2_logical_type_destroy(&bigint);
+
+	duckdb_v2_result_handle r = nullptr;
+	REQUIRE(Query(fx.conn, "SELECT * FROM my_progress(1000000)", &r, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	// The round count is timing-dependent, so the loop latches instead of asserting.
+	auto step_rc = DUCKDB_V2_ERROR_NONE;
+	idx_t rows = 0;
+	while (true) {
+		duckdb_v2_data_chunk_handle chunk = nullptr;
+		DUCKDB_V2_RESULT_STEP_STATUS status = DUCKDB_V2_RESULT_STEP_STATUS_WAITING;
+		step_rc = duckdb_v2_result_step(r, &chunk, &status, nullptr);
+		if (step_rc != DUCKDB_V2_ERROR_NONE) {
+			break;
+		}
+		if (chunk) {
+			idx_t size = 0;
+			duckdb_v2_data_chunk_get_size(chunk, &size, nullptr);
+			rows += size;
+			duckdb_v2_data_chunk_destroy(&chunk);
+		}
+		if (status == DUCKDB_V2_RESULT_STEP_STATUS_FINISHED) {
+			break;
+		}
+	}
+	REQUIRE(step_rc == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(rows == 1000000);
+	REQUIRE(hook_probe.progress_calls >= 1);
+	REQUIRE(hook_probe.progress_saw_global_state);
+
+	duckdb_v2_result_destroy(&r);
+}
+#endif
+
+// ===========================================================================
+// Null argument handling and destroy null-safety.
+// ===========================================================================
+
+TEST_CASE("V2 table: null arguments and destroy null-safety", "[capi_v2][table_function]") {
+	EnvFixture fx;
+
+	duckdb_v2_table_function_handle function = nullptr;
+	REQUIRE(duckdb_v2_table_function_create_with_connection(nullptr, &function, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_create_with_connection(fx.conn, nullptr, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_create_with_extension(nullptr, &function, nullptr) ==
+	        DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	auto str = Convert("x");
+	REQUIRE(duckdb_v2_table_function_set_name(nullptr, &str, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_set_bind_callback(nullptr, StateBindCb, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_set_exec_callback(nullptr, RangeExecCb, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_get_signature(nullptr, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_register(nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	void *data = nullptr;
+	REQUIRE(duckdb_v2_table_function_bind_get_user_data(nullptr, &data, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_exec_get_output_chunk(nullptr, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_table_function_progress_set_progress(nullptr, 0.5, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// A thread count of zero would starve the scan.
+	REQUIRE(duckdb_v2_table_function_init_global_set_max_threads(nullptr, 0, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// Destroy is null-safe and clears the slot.
+	REQUIRE(duckdb_v2_table_function_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_table_function_handle already_null = nullptr;
+	REQUIRE(duckdb_v2_table_function_destroy(&already_null) == DUCKDB_V2_ERROR_NONE);
+	auto live = MakeTable(fx.conn, "unused");
+	REQUIRE(duckdb_v2_table_function_destroy(&live) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(live == nullptr);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_table_function.cpp
+++ b/test/api/capi/v2/test_capi_v2_table_function.cpp
@@ -901,8 +901,10 @@ TEST_CASE("V2 table: null arguments and destroy null-safety", "[capi_v2][table_f
 namespace {
 
 struct ProjGlobal {
-	bool done = false;
+	idx_t position = 0;
 };
+
+constexpr idx_t PROJ_ROWS = 3;
 
 void DeleteProjGlobal(void *ptr) {
 	delete static_cast<ProjGlobal *>(ptr);
@@ -972,8 +974,11 @@ void ProjExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_contex
 		return;
 	}
 	auto &global = *static_cast<ProjGlobal *>(global_ptr);
-	const idx_t rows = global.done ? 0 : 3;
-	global.done = true;
+	// Batches are capped by the vector size so the probe also serves builds with a tiny STANDARD_VECTOR_SIZE.
+	idx_t rows = PROJ_ROWS - global.position;
+	if (rows > STANDARD_VECTOR_SIZE) {
+		rows = STANDARD_VECTOR_SIZE;
+	}
 
 	for (idx_t i = 0; i < count; i++) {
 		idx_t column = 0;
@@ -985,12 +990,13 @@ void ProjExecCb(duckdb_v2_table_function_exec_info_handle info, duckdb_v2_contex
 			return;
 		}
 		for (idx_t row = 0; row < rows; row++) {
-			static_cast<int64_t *>(raw)[row] = static_cast<int64_t>(column * 100 + row);
+			static_cast<int64_t *>(raw)[row] = static_cast<int64_t>(column * 100 + global.position + row);
 		}
 		if (i == 0) {
 			duckdb_v2_vector_set_size(vec, rows, err);
 		}
 	}
+	global.position += rows;
 }
 
 void RegisterProj(duckdb_v2_connection_handle conn, const char *name, bool projection_pushdown) {

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
   test_cpp_api OBJECT
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_aggregate_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_appender.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_arrow.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_cast_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_core.cpp

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_core.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_file_system.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_prepared_statement.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_query.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_replacement_scan.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_scalar_function.cpp

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_appender.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_arrow.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_cast_function.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_catalog.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_copy_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_core.cpp

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(${CMAKE_SOURCE_DIR}/tools/cpp
 add_library(
   test_cpp_api OBJECT
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_aggregate_function.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_cast_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_core.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_query.cpp

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_cast_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_core.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_file_system.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_query.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_replacement_scan.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_scalar_function.cpp

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_core.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_query.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_scalar_function.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_table_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_types_values.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_vector.cpp)
 

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_arrow.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_cast_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_copy_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_core.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_file_system.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_prepared_statement.cpp

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -10,10 +10,12 @@ include_directories(${CMAKE_SOURCE_DIR}/tools/cpp
 add_library(
   test_cpp_api OBJECT
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_aggregate_function.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_appender.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_cast_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_core.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_query.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_replacement_scan.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_scalar_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_table_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_types_values.cpp

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -138,6 +138,10 @@ template <>
 struct HandleTraits<ReplacementScan> {
 	using handle = duckdb_v2_replacement_scan_handle;
 };
+template <>
+struct HandleTraits<QualifiedName> {
+	using handle = duckdb_v2_qname_handle;
+};
 
 } // namespace detail
 
@@ -508,9 +512,13 @@ auto Connection::CreateType(std::string_view name) -> LogicalType {
 }
 
 auto Connection::CreateType(std::string_view name, const std::vector<TypeParam> &params) -> LogicalType {
+	return CreateType(QualifiedName::Create({std::string(name)}), params);
+}
+
+auto Connection::CreateType(const QualifiedName &name, const std::vector<TypeParam> &params) -> LogicalType {
 	TypeParamArrays split(params);
 	duckdb_v2_logical_type_handle type = nullptr;
-	CheckedAPICall(duckdb_v2_connection_create_type_from_name, handle(), ToStr(name), split.names(), split.values(),
+	CheckedAPICall(duckdb_v2_connection_create_type_from_name, handle(), name.handle(), split.names(), split.values(),
 	               static_cast<idx_t>(params.size()), &type);
 	return detail::Factory::Make<LogicalType>(type);
 }
@@ -678,9 +686,13 @@ auto Context::CreateType(std::string_view name) const -> LogicalType {
 }
 
 auto Context::CreateType(std::string_view name, const std::vector<TypeParam> &params) const -> LogicalType {
+	return CreateType(QualifiedName::Create({std::string(name)}), params);
+}
+
+auto Context::CreateType(const QualifiedName &name, const std::vector<TypeParam> &params) const -> LogicalType {
 	TypeParamArrays split(params);
 	duckdb_v2_logical_type_handle type = nullptr;
-	CheckedAPICall(duckdb_v2_context_create_type_from_name, handle(), ToStr(name), split.names(), split.values(),
+	CheckedAPICall(duckdb_v2_context_create_type_from_name, handle(), name.handle(), split.names(), split.values(),
 	               static_cast<idx_t>(params.size()), &type);
 	return detail::Factory::Make<LogicalType>(type);
 }
@@ -3871,6 +3883,71 @@ auto CastFunction::ExecInput::GetContext() const -> Context {
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+// Qualified Name
+//----------------------------------------------------------------------------------------------------------------------
+
+QualifiedName::QualifiedName(void *impl) : detail::Handle<QualifiedName>(impl) {
+}
+
+QualifiedName::~QualifiedName() {
+	auto _h = handle();
+	duckdb_v2_qname_destroy(&_h);
+}
+
+auto QualifiedName::Parse(std::string_view text) -> QualifiedName {
+	duckdb_v2_qname_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_qname_parse, ToStr(text), &_h);
+	return detail::Factory::Make<QualifiedName>(_h);
+}
+
+auto QualifiedName::Create(const std::vector<std::string> &parts) -> QualifiedName {
+	std::vector<duckdb_v2_identifier_t> views;
+	views.reserve(parts.size());
+	for (auto &part : parts) {
+		views.push_back(ToStr(part));
+	}
+	duckdb_v2_qname_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_qname_create, views.empty() ? nullptr : views.data(), views.size(), &_h);
+	return detail::Factory::Make<QualifiedName>(_h);
+}
+
+auto QualifiedName::GetPartCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_qname_get_part_count, handle(), &count);
+	return count;
+}
+
+auto QualifiedName::GetPart(idx_t index) const -> std::string_view {
+	duckdb_v2_identifier_t part = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_qname_get_part, handle(), index, &part);
+	return FromStr(part);
+}
+
+auto QualifiedName::GetName() const -> std::string_view {
+	return GetPart(GetPartCount() - 1);
+}
+
+auto QualifiedName::Render() const -> std::string {
+	idx_t length = 0;
+	CheckedAPICall(duckdb_v2_qname_render, handle(), nullptr, 0, &length);
+	std::string out(length, '\0');
+	CheckedAPICall(duckdb_v2_qname_render, handle(), &out[0], length + 1, &length);
+	return out;
+}
+
+auto QualifiedName::Equals(const QualifiedName &other) const -> bool {
+	bool result = false;
+	CheckedAPICall(duckdb_v2_qname_equals, handle(), other.handle(), &result);
+	return result;
+}
+
+auto QualifiedName::Hash() const -> uint64_t {
+	uint64_t hash = 0;
+	CheckedAPICall(duckdb_v2_qname_hash, handle(), &hash);
+	return hash;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 // Replacement Scan
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -3980,30 +4057,20 @@ void *ReplacementScan::Input::GetUserDataInternal() const {
 	return RequireReplacementUserData(scan.user_data);
 }
 
-auto ReplacementScan::Input::GetCatalogName() const -> std::string_view {
-	duckdb_v2_identifier_t name = {nullptr, 0};
-	CheckedAPICall(duckdb_v2_replacement_scan_get_catalog_name,
-	               static_cast<duckdb_v2_replacement_scan_info_handle>(args), &name);
-	return FromStr(name);
-}
-
-auto ReplacementScan::Input::GetSchemaName() const -> std::string_view {
-	duckdb_v2_identifier_t name = {nullptr, 0};
-	CheckedAPICall(duckdb_v2_replacement_scan_get_schema_name,
-	               static_cast<duckdb_v2_replacement_scan_info_handle>(args), &name);
-	return FromStr(name);
-}
-
-auto ReplacementScan::Input::GetTableName() const -> std::string_view {
-	duckdb_v2_identifier_t name = {nullptr, 0};
-	CheckedAPICall(duckdb_v2_replacement_scan_get_table_name, static_cast<duckdb_v2_replacement_scan_info_handle>(args),
+auto ReplacementScan::Input::GetName() const -> QualifiedName {
+	duckdb_v2_qname_handle name = nullptr;
+	CheckedAPICall(duckdb_v2_replacement_scan_get_name, static_cast<duckdb_v2_replacement_scan_info_handle>(args),
 	               &name);
-	return FromStr(name);
+	return detail::Factory::Make<QualifiedName>(name);
+}
+
+auto ReplacementScan::Input::SetFunctionName(const QualifiedName &name) -> void {
+	CheckedAPICall(duckdb_v2_replacement_scan_set_function_name,
+	               static_cast<duckdb_v2_replacement_scan_info_handle>(args), name.handle());
 }
 
 auto ReplacementScan::Input::SetFunctionName(std::string_view name) -> void {
-	CheckedAPICall(duckdb_v2_replacement_scan_set_function_name,
-	               static_cast<duckdb_v2_replacement_scan_info_handle>(args), ToStr(name));
+	SetFunctionName(QualifiedName::Create({std::string(name)}));
 }
 
 auto ReplacementScan::Input::AddArgument(const Value &value) -> void {
@@ -4115,8 +4182,13 @@ void Appender::Initialize(Connection &conn, const std::string &query, std::vecto
 	auto scan = ReplacementScan::Create(conn);
 	scan.SetCallback([](ReplacementScan::Input &input) {
 		auto &shared = input.GetUserData<std::shared_ptr<Buffer>>();
-		if (!shared->collection || !EqualsIgnoreCase(input.GetTableName(), shared->name)) {
-			return; // not ours, or the appender is gone: decline
+		if (!shared->collection) {
+			return; // the appender is gone: decline
+		}
+		// Only an unqualified reference can be the buffer; anything catalog- or schema-qualified is a real object.
+		auto name = input.GetName();
+		if (name.GetPartCount() != 1 || !EqualsIgnoreCase(name.GetName(), shared->name)) {
+			return; // not ours: decline
 		}
 		input.SetCollection(*shared->collection, shared->column_names);
 	});

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -115,6 +115,10 @@ struct HandleTraits<QueryResult> {
 	using handle = duckdb_v2_result_handle;
 };
 template <>
+struct HandleTraits<ArrowConverter> {
+	using handle = duckdb_v2_arrow_converter_handle;
+};
+template <>
 struct HandleTraits<FunctionSignature> {
 	using handle = duckdb_v2_function_signature_handle;
 };
@@ -1026,6 +1030,18 @@ auto Schema::GetFieldType(idx_t index) const -> LogicalType {
 	duckdb_v2_logical_type_handle owned = nullptr;
 	CheckedAPICall(duckdb_v2_logical_type_copy, borrowed, &owned);
 	return detail::Factory::Make<LogicalType>(owned);
+}
+
+auto Schema::ToArrowSchema(const Context &context, ArrowSchema &out) const -> void {
+	// The C converter takes parallel name/type arrays. get_field borrows both, and they stay
+	// valid for the whole of this call, so nothing needs copying.
+	const auto count = GetFieldCount();
+	std::vector<duckdb_v2_logical_type_handle> types(count, nullptr);
+	std::vector<duckdb_v2_str> names(count, duckdb_v2_str {nullptr, 0});
+	for (idx_t i = 0; i < count; i++) {
+		CheckedAPICall(duckdb_v2_schema_get_field, handle(), i, &names[i], &types[i]);
+	}
+	CheckedAPICall(duckdb_v2_logical_types_to_arrow_schema, context.handle(), types.data(), names.data(), count, &out);
 }
 
 auto Connection::Bind(const SqlStatement &statement) const -> Signature {
@@ -2028,6 +2044,10 @@ auto DataChunk::Copy(const Context &ctx) const -> DataChunk {
 	return detail::Factory::Make<DataChunk>(copy, true);
 }
 
+auto DataChunk::ToArrowArray(const Context &context, ArrowArray &out) const -> void {
+	CheckedAPICall(duckdb_v2_data_chunk_to_arrow_array, context.handle(), handle(), &out);
+}
+
 auto DataChunk::GetRowCount() const -> idx_t {
 	idx_t count = 0;
 	CheckedAPICall(duckdb_v2_data_chunk_get_size, handle(), &count);
@@ -2281,6 +2301,86 @@ auto QueryResult::RenderBox(idx_t max_rows, idx_t max_width, idx_t max_col_width
 	CheckedAPICall(duckdb_v2_result_render_box, &raw, max_rows, max_width, max_col_width, ToStr(null_value),
 	               render_mode, limit, sink, &out);
 	return out;
+}
+
+auto QueryResult::ToArrowStream(idx_t batch_size) -> ArrowStream {
+	// Allocate before detaching: if this throws, the result is still ours and ~QueryResult
+	// frees it.
+	auto *stream = new ArrowArrayStream {};
+	auto raw = handle();
+	// The C call takes the result by transfer, consuming it on success and failure alike, so
+	// detach now and ~QueryResult will not double-free it.
+	this->release();
+	try {
+		CheckedAPICall(duckdb_v2_result_to_arrow_stream, &raw, batch_size, stream);
+	} catch (...) {
+		delete stream;
+		throw;
+	}
+	return detail::Factory::Make<ArrowStream>(stream);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Arrow
+//----------------------------------------------------------------------------------------------------------------------
+
+ArrowConverter::ArrowConverter(void *impl) : detail::Handle<ArrowConverter>(impl) {
+}
+
+ArrowConverter::ArrowConverter(const Context &context, ArrowSchema &schema) : detail::Handle<ArrowConverter>(nullptr) {
+	duckdb_v2_arrow_converter_handle converter = nullptr;
+	CheckedAPICall(duckdb_v2_arrow_converter_create, context.handle(), &schema, &converter);
+	impl = converter;
+}
+
+ArrowConverter::~ArrowConverter() {
+	auto _h = handle();
+	duckdb_v2_arrow_converter_destroy(&_h);
+}
+
+auto ArrowConverter::ArrayToChunk(const Context &context, ArrowArray &array) const -> DataChunk {
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	CheckedAPICall(duckdb_v2_arrow_converter_array_to_chunk, context.handle(), &array, handle(), &chunk);
+	return detail::Factory::Make<DataChunk>(chunk, true);
+}
+
+auto ArrowConverter::GetSchema() const -> Schema {
+	duckdb_v2_schema_handle schema = nullptr;
+	CheckedAPICall(duckdb_v2_arrow_converter_get_schema, handle(), &schema);
+	return detail::Factory::Make<Schema>(schema);
+}
+
+ArrowStream::~ArrowStream() {
+	if (stream) {
+		if (stream->release) {
+			stream->release(stream);
+		}
+		delete stream;
+	}
+}
+
+// The Arrow C stream interface reports failure only as an errno-style int with no error code, so both calls below
+// surface a generic INVALID_INPUT; the detail comes from get_last_error and is carried in the message.
+void ArrowStream::GetSchema(ArrowSchema &out) const {
+	if (!stream || !stream->release) {
+		throw InvalidInputException("ArrowStream::GetSchema on an empty stream");
+	}
+	if (stream->get_schema(stream, &out) != 0) {
+		const char *msg = stream->get_last_error ? stream->get_last_error(stream) : nullptr;
+		throw InvalidInputException(msg ? msg : "Arrow stream get_schema failed");
+	}
+}
+
+bool ArrowStream::Next(ArrowArray &out) const {
+	out.release = nullptr;
+	if (!stream || !stream->release) {
+		throw InvalidInputException("ArrowStream::Next on an empty stream");
+	}
+	if (stream->get_next(stream, &out) != 0) {
+		const char *msg = stream->get_last_error ? stream->get_last_error(stream) : nullptr;
+		throw InvalidInputException(msg ? msg : "Arrow stream get_next failed");
+	}
+	return out.release != nullptr;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -3470,25 +3470,21 @@ struct TableFunctionInfo {
 	TableFunction::InitGlobalCallback init_global_callback = nullptr;
 	TableFunction::InitLocalCallback init_local_callback = nullptr;
 	TableFunction::ExecCallback exec_callback = nullptr;
-	TableFunction::CardinalityCallback cardinality_callback = nullptr;
 	TableFunction::ProgressCallback progress_callback = nullptr;
 	detail::UserData user_data;
 
 	TableFunctionInfo(TableFunction::BindCallback bind_callback, TableFunction::InitGlobalCallback init_global_callback,
 	                  TableFunction::InitLocalCallback init_local_callback, TableFunction::ExecCallback exec_callback,
-	                  TableFunction::CardinalityCallback cardinality_callback,
 	                  TableFunction::ProgressCallback progress_callback, detail::UserData user_data)
 	    : bind_callback(bind_callback), init_global_callback(init_global_callback),
-	      init_local_callback(init_local_callback), exec_callback(exec_callback),
-	      cardinality_callback(cardinality_callback), progress_callback(progress_callback),
+	      init_local_callback(init_local_callback), exec_callback(exec_callback), progress_callback(progress_callback),
 	      user_data(std::move(user_data)) {
 	}
 
 	bool operator==(const TableFunctionInfo &other) const {
 		return bind_callback == other.bind_callback && init_global_callback == other.init_global_callback &&
 		       init_local_callback == other.init_local_callback && exec_callback == other.exec_callback &&
-		       cardinality_callback == other.cardinality_callback && progress_callback == other.progress_callback &&
-		       user_data.get() == other.user_data.get();
+		       progress_callback == other.progress_callback && user_data.get() == other.user_data.get();
 	}
 };
 
@@ -3664,31 +3660,6 @@ auto TableFunction::SetExecCallback(ExecCallback callback) & -> TableFunction & 
 	return *this;
 }
 
-auto TableFunction::SetCardinalityCallback(CardinalityCallback callback) & -> TableFunction & {
-	if (!callback) {
-		CheckedAPICall(duckdb_v2_table_function_set_cardinality_callback, handle(), nullptr);
-		cardinality_callback = nullptr;
-		return *this;
-	}
-
-	static auto trampoline = [](duckdb_v2_table_function_cardinality_info_handle info, duckdb_v2_context_handle context,
-	                            duckdb_v2_error_info_handle *err) {
-		WithExceptionGuard(err, [&]() {
-			void *user_data = nullptr;
-			CheckedAPICall(duckdb_v2_table_function_cardinality_get_user_data, info, &user_data);
-			const auto &function = *static_cast<TableFunctionInfo *>(user_data);
-
-			auto input =
-			    detail::Factory::Make<CardinalityInput>(static_cast<void *>(info), static_cast<void *>(context));
-			function.cardinality_callback(input);
-		});
-	};
-
-	CheckedAPICall(duckdb_v2_table_function_set_cardinality_callback, handle(), trampoline);
-	cardinality_callback = callback;
-	return *this;
-}
-
 auto TableFunction::SetProgressCallback(ProgressCallback callback) & -> TableFunction & {
 	if (!callback) {
 		CheckedAPICall(duckdb_v2_table_function_set_progress_callback, handle(), nullptr);
@@ -3716,9 +3687,9 @@ auto TableFunction::SetProgressCallback(ProgressCallback callback) & -> TableFun
 auto TableFunction::Register() -> void {
 	// The callback table rides the C user_data slot so the trampolines can find
 	// it; the user's own data (SetUserData, moved out here) rides inside it.
-	auto info = std::unique_ptr<TableFunctionInfo>(
-	    new TableFunctionInfo(bind_callback, init_global_callback, init_local_callback, exec_callback,
-	                          cardinality_callback, progress_callback, std::move(user_data)));
+	auto info = std::unique_ptr<TableFunctionInfo>(new TableFunctionInfo(bind_callback, init_global_callback,
+	                                                                     init_local_callback, exec_callback,
+	                                                                     progress_callback, std::move(user_data)));
 	duckdb_v2_opaque opaque {info.get(), detail::TypedDelete<TableFunctionInfo>,
 	                         detail::TypedEquals<TableFunctionInfo>};
 	CheckedAPICall(duckdb_v2_table_function_set_user_data, handle(), &opaque);
@@ -3882,30 +3853,6 @@ auto TableFunction::ExecInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
 }
 
-void *TableFunction::CardinalityInput::GetBindDataInternal() const {
-	void *bind_data = nullptr;
-	CheckedAPICall(duckdb_v2_table_function_cardinality_get_bind_data,
-	               static_cast<duckdb_v2_table_function_cardinality_info_handle>(args), &bind_data);
-	return RequireTableBindData(bind_data);
-}
-
-void *TableFunction::CardinalityInput::GetUserDataInternal() const {
-	void *user_data = nullptr;
-	CheckedAPICall(duckdb_v2_table_function_cardinality_get_user_data,
-	               static_cast<duckdb_v2_table_function_cardinality_info_handle>(args), &user_data);
-	const auto &function = *static_cast<const TableFunctionInfo *>(user_data);
-	return RequireTableUserData(function.user_data);
-}
-
-auto TableFunction::CardinalityInput::SetCardinality(idx_t cardinality, bool is_exact) -> void {
-	CheckedAPICall(duckdb_v2_table_function_cardinality_set_cardinality,
-	               static_cast<duckdb_v2_table_function_cardinality_info_handle>(args), cardinality, is_exact);
-}
-
-auto TableFunction::CardinalityInput::GetContext() const -> Context {
-	return detail::Factory::Make<Context>(context);
-}
-
 void *TableFunction::ProgressInput::GetBindDataInternal() const {
 	void *bind_data = nullptr;
 	CheckedAPICall(duckdb_v2_table_function_progress_get_bind_data,
@@ -3985,27 +3932,52 @@ namespace {
 // slot so the trampolines can find it; the user's own slot (SetUserData) rides
 // inside it. Owned by the registered function, freed at engine teardown.
 struct CopyFunctionInfo {
-	CopyFunction::BindCallback bind_callback = nullptr;
-	CopyFunction::BatchSizeCallback batch_size_callback = nullptr;
-	CopyFunction::InitCallback init_callback = nullptr;
-	CopyFunction::BatchCallback batch_callback = nullptr;
-	CopyFunction::FlushCallback flush_callback = nullptr;
-	CopyFunction::FinalizeCallback finalize_callback = nullptr;
+	CopyFunction::CopyToBindCallback copy_to_bind_callback = nullptr;
+	CopyFunction::CopyToBatchSizeCallback copy_to_batch_size_callback = nullptr;
+	CopyFunction::CopyToInitCallback copy_to_init_callback = nullptr;
+	CopyFunction::CopyToBatchCallback copy_to_batch_callback = nullptr;
+	CopyFunction::CopyToFlushCallback copy_to_flush_callback = nullptr;
+	CopyFunction::CopyToFinalizeCallback copy_to_finalize_callback = nullptr;
+	CopyFunction::CopyFromBindCallback copy_from_bind_callback = nullptr;
+	CopyFunction::CopyFromInitGlobalCallback copy_from_init_global_callback = nullptr;
+	CopyFunction::CopyFromInitLocalCallback copy_from_init_local_callback = nullptr;
+	CopyFunction::CopyFromExecCallback copy_from_exec_callback = nullptr;
+	CopyFunction::CopyFromProgressCallback copy_from_progress_callback = nullptr;
 	detail::UserData user_data;
 
-	CopyFunctionInfo(CopyFunction::BindCallback bind_callback, CopyFunction::BatchSizeCallback batch_size_callback,
-	                 CopyFunction::InitCallback init_callback, CopyFunction::BatchCallback batch_callback,
-	                 CopyFunction::FlushCallback flush_callback, CopyFunction::FinalizeCallback finalize_callback,
-	                 detail::UserData user_data)
-	    : bind_callback(bind_callback), batch_size_callback(batch_size_callback), init_callback(init_callback),
-	      batch_callback(batch_callback), flush_callback(flush_callback), finalize_callback(finalize_callback),
+	CopyFunctionInfo(CopyFunction::CopyToBindCallback copy_to_bind_callback,
+	                 CopyFunction::CopyToBatchSizeCallback copy_to_batch_size_callback,
+	                 CopyFunction::CopyToInitCallback copy_to_init_callback,
+	                 CopyFunction::CopyToBatchCallback copy_to_batch_callback,
+	                 CopyFunction::CopyToFlushCallback copy_to_flush_callback,
+	                 CopyFunction::CopyToFinalizeCallback copy_to_finalize_callback,
+	                 CopyFunction::CopyFromBindCallback copy_from_bind_callback,
+	                 CopyFunction::CopyFromInitGlobalCallback copy_from_init_global_callback,
+	                 CopyFunction::CopyFromInitLocalCallback copy_from_init_local_callback,
+	                 CopyFunction::CopyFromExecCallback copy_from_exec_callback,
+	                 CopyFunction::CopyFromProgressCallback copy_from_progress_callback, detail::UserData user_data)
+	    : copy_to_bind_callback(copy_to_bind_callback), copy_to_batch_size_callback(copy_to_batch_size_callback),
+	      copy_to_init_callback(copy_to_init_callback), copy_to_batch_callback(copy_to_batch_callback),
+	      copy_to_flush_callback(copy_to_flush_callback), copy_to_finalize_callback(copy_to_finalize_callback),
+	      copy_from_bind_callback(copy_from_bind_callback),
+	      copy_from_init_global_callback(copy_from_init_global_callback),
+	      copy_from_init_local_callback(copy_from_init_local_callback),
+	      copy_from_exec_callback(copy_from_exec_callback), copy_from_progress_callback(copy_from_progress_callback),
 	      user_data(std::move(user_data)) {
 	}
 
 	bool operator==(const CopyFunctionInfo &other) const {
-		return bind_callback == other.bind_callback && batch_size_callback == other.batch_size_callback &&
-		       init_callback == other.init_callback && batch_callback == other.batch_callback &&
-		       flush_callback == other.flush_callback && finalize_callback == other.finalize_callback &&
+		return copy_to_bind_callback == other.copy_to_bind_callback &&
+		       copy_to_batch_size_callback == other.copy_to_batch_size_callback &&
+		       copy_to_init_callback == other.copy_to_init_callback &&
+		       copy_to_batch_callback == other.copy_to_batch_callback &&
+		       copy_to_flush_callback == other.copy_to_flush_callback &&
+		       copy_to_finalize_callback == other.copy_to_finalize_callback &&
+		       copy_from_bind_callback == other.copy_from_bind_callback &&
+		       copy_from_init_global_callback == other.copy_from_init_global_callback &&
+		       copy_from_init_local_callback == other.copy_from_init_local_callback &&
+		       copy_from_exec_callback == other.copy_from_exec_callback &&
+		       copy_from_progress_callback == other.copy_from_progress_callback &&
 		       user_data.get() == other.user_data.get();
 	}
 };
@@ -4022,7 +3994,7 @@ void *RequireCopyUserData(const detail::UserData &user_data) {
 // Guard for the inputs' GetBindData: a clear error instead of a null deref.
 void *RequireCopyBindData(void *ptr) {
 	if (!ptr) {
-		throw InvalidInputException("no bind data was set; call BindInput::SetBindData in the bind callback");
+		throw InvalidInputException("no bind data was set; call the bind input's SetBindData in the bind callback");
 	}
 	return ptr;
 }
@@ -4030,7 +4002,7 @@ void *RequireCopyBindData(void *ptr) {
 // Guard for the inputs' GetInitData: a clear error instead of a null deref.
 void *RequireCopyInitData(void *ptr) {
 	if (!ptr) {
-		throw InvalidInputException("no init data was set; call InitInput::SetInitData in the init callback");
+		throw InvalidInputException("no init data was set; call CopyToInitInput::SetInitData in the init callback");
 	}
 	return ptr;
 }
@@ -4038,7 +4010,25 @@ void *RequireCopyInitData(void *ptr) {
 // Guard for the inputs' GetBatchData: a clear error instead of a null deref.
 void *RequireCopyBatchData(void *ptr) {
 	if (!ptr) {
-		throw InvalidInputException("no batch data was set; call BatchInput::SetBatchData in the batch callback");
+		throw InvalidInputException("no batch data was set; call CopyToBatchInput::SetBatchData in the batch callback");
+	}
+	return ptr;
+}
+
+// Guard for the inputs' GetGlobalState: a clear error instead of a null deref.
+void *RequireCopyGlobalState(void *ptr) {
+	if (!ptr) {
+		throw InvalidInputException(
+		    "no global state was set; call CopyFromInitGlobalInput::SetGlobalState in the global init callback");
+	}
+	return ptr;
+}
+
+// Guard for the inputs' GetLocalState: a clear error instead of a null deref.
+void *RequireCopyLocalState(void *ptr) {
+	if (!ptr) {
+		throw InvalidInputException(
+		    "no local state was set; call CopyFromInitLocalInput::SetLocalState in the local init callback");
 	}
 	return ptr;
 }
@@ -4075,158 +4065,290 @@ auto CopyFunction::SetUserDataInternal(void *data, void (*destructor)(void *)) -
 	user_data = detail::UserData(data, destructor);
 }
 
-auto CopyFunction::SetBindCallback(BindCallback callback) & -> CopyFunction & {
+auto CopyFunction::SetCopyToBindCallback(CopyToBindCallback callback) & -> CopyFunction & {
 	if (!callback) {
-		CheckedAPICall(duckdb_v2_copy_function_set_bind_callback, handle(), nullptr);
-		bind_callback = nullptr;
+		CheckedAPICall(duckdb_v2_copy_to_set_bind_callback, handle(), nullptr);
+		copy_to_bind_callback = nullptr;
 		return *this;
 	}
 
 	// The C-side callback is one shared trampoline; the user's callback is looked
 	// up through the info table riding the user_data slot (set by Register).
-	static auto trampoline = [](duckdb_v2_copy_function_bind_info_handle info, duckdb_v2_context_handle context,
+	static auto trampoline = [](duckdb_v2_copy_to_bind_info_handle info, duckdb_v2_context_handle context,
 	                            duckdb_v2_error_info_handle *err) {
 		WithExceptionGuard(err, [&]() {
 			void *user_data = nullptr;
-			CheckedAPICall(duckdb_v2_copy_function_bind_get_user_data, info, &user_data);
+			CheckedAPICall(duckdb_v2_copy_to_bind_get_user_data, info, &user_data);
 			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
 
-			auto input = detail::Factory::Make<BindInput>(static_cast<void *>(info), static_cast<void *>(context));
-			function.bind_callback(input);
+			auto input =
+			    detail::Factory::Make<CopyToBindInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_to_bind_callback(input);
 		});
 	};
 
-	CheckedAPICall(duckdb_v2_copy_function_set_bind_callback, handle(), trampoline);
-	bind_callback = callback;
+	CheckedAPICall(duckdb_v2_copy_to_set_bind_callback, handle(), trampoline);
+	copy_to_bind_callback = callback;
 	return *this;
 }
 
-auto CopyFunction::SetBatchSizeCallback(BatchSizeCallback callback) & -> CopyFunction & {
+auto CopyFunction::SetCopyToBatchSizeCallback(CopyToBatchSizeCallback callback) & -> CopyFunction & {
 	if (!callback) {
-		CheckedAPICall(duckdb_v2_copy_function_set_batch_size_callback, handle(), nullptr);
-		batch_size_callback = nullptr;
+		CheckedAPICall(duckdb_v2_copy_to_set_batch_size_callback, handle(), nullptr);
+		copy_to_batch_size_callback = nullptr;
 		return *this;
 	}
 
-	static auto trampoline = [](duckdb_v2_copy_function_batch_size_info_handle info, duckdb_v2_context_handle context,
+	static auto trampoline = [](duckdb_v2_copy_to_batch_size_info_handle info, duckdb_v2_context_handle context,
 	                            duckdb_v2_error_info_handle *err) {
 		WithExceptionGuard(err, [&]() {
 			void *user_data = nullptr;
-			CheckedAPICall(duckdb_v2_copy_function_batch_size_get_user_data, info, &user_data);
+			CheckedAPICall(duckdb_v2_copy_to_batch_size_get_user_data, info, &user_data);
 			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
 
-			auto input = detail::Factory::Make<BatchSizeInput>(static_cast<void *>(info), static_cast<void *>(context));
-			function.batch_size_callback(input);
+			auto input =
+			    detail::Factory::Make<CopyToBatchSizeInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_to_batch_size_callback(input);
 		});
 	};
 
-	CheckedAPICall(duckdb_v2_copy_function_set_batch_size_callback, handle(), trampoline);
-	batch_size_callback = callback;
+	CheckedAPICall(duckdb_v2_copy_to_set_batch_size_callback, handle(), trampoline);
+	copy_to_batch_size_callback = callback;
 	return *this;
 }
 
-auto CopyFunction::SetInitCallback(InitCallback callback) & -> CopyFunction & {
+auto CopyFunction::SetCopyToInitCallback(CopyToInitCallback callback) & -> CopyFunction & {
 	if (!callback) {
-		CheckedAPICall(duckdb_v2_copy_function_set_init_callback, handle(), nullptr);
-		init_callback = nullptr;
+		CheckedAPICall(duckdb_v2_copy_to_set_init_callback, handle(), nullptr);
+		copy_to_init_callback = nullptr;
 		return *this;
 	}
 
-	static auto trampoline = [](duckdb_v2_copy_function_init_info_handle info, duckdb_v2_context_handle context,
+	static auto trampoline = [](duckdb_v2_copy_to_init_info_handle info, duckdb_v2_context_handle context,
 	                            duckdb_v2_error_info_handle *err) {
 		WithExceptionGuard(err, [&]() {
 			void *user_data = nullptr;
-			CheckedAPICall(duckdb_v2_copy_function_init_get_user_data, info, &user_data);
+			CheckedAPICall(duckdb_v2_copy_to_init_get_user_data, info, &user_data);
 			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
 
-			auto input = detail::Factory::Make<InitInput>(static_cast<void *>(info), static_cast<void *>(context));
-			function.init_callback(input);
+			auto input =
+			    detail::Factory::Make<CopyToInitInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_to_init_callback(input);
 		});
 	};
 
-	CheckedAPICall(duckdb_v2_copy_function_set_init_callback, handle(), trampoline);
-	init_callback = callback;
+	CheckedAPICall(duckdb_v2_copy_to_set_init_callback, handle(), trampoline);
+	copy_to_init_callback = callback;
 	return *this;
 }
 
-auto CopyFunction::SetBatchCallback(BatchCallback callback) & -> CopyFunction & {
+auto CopyFunction::SetCopyToBatchCallback(CopyToBatchCallback callback) & -> CopyFunction & {
 	if (!callback) {
-		CheckedAPICall(duckdb_v2_copy_function_set_batch_callback, handle(), nullptr);
-		batch_callback = nullptr;
+		CheckedAPICall(duckdb_v2_copy_to_set_batch_callback, handle(), nullptr);
+		copy_to_batch_callback = nullptr;
 		return *this;
 	}
 
-	static auto trampoline = [](duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_context_handle context,
+	static auto trampoline = [](duckdb_v2_copy_to_batch_info_handle info, duckdb_v2_context_handle context,
 	                            duckdb_v2_error_info_handle *err) {
 		WithExceptionGuard(err, [&]() {
 			void *user_data = nullptr;
-			CheckedAPICall(duckdb_v2_copy_function_batch_get_user_data, info, &user_data);
+			CheckedAPICall(duckdb_v2_copy_to_batch_get_user_data, info, &user_data);
 			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
 
-			auto input = detail::Factory::Make<BatchInput>(static_cast<void *>(info), static_cast<void *>(context));
-			function.batch_callback(input);
+			auto input =
+			    detail::Factory::Make<CopyToBatchInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_to_batch_callback(input);
 		});
 	};
 
-	CheckedAPICall(duckdb_v2_copy_function_set_batch_callback, handle(), trampoline);
-	batch_callback = callback;
+	CheckedAPICall(duckdb_v2_copy_to_set_batch_callback, handle(), trampoline);
+	copy_to_batch_callback = callback;
 	return *this;
 }
 
-auto CopyFunction::SetFlushCallback(FlushCallback callback) & -> CopyFunction & {
+auto CopyFunction::SetCopyToFlushCallback(CopyToFlushCallback callback) & -> CopyFunction & {
 	if (!callback) {
-		CheckedAPICall(duckdb_v2_copy_function_set_flush_callback, handle(), nullptr);
-		flush_callback = nullptr;
+		CheckedAPICall(duckdb_v2_copy_to_set_flush_callback, handle(), nullptr);
+		copy_to_flush_callback = nullptr;
 		return *this;
 	}
 
-	static auto trampoline = [](duckdb_v2_copy_function_flush_info_handle info, duckdb_v2_context_handle context,
+	static auto trampoline = [](duckdb_v2_copy_to_flush_info_handle info, duckdb_v2_context_handle context,
 	                            duckdb_v2_error_info_handle *err) {
 		WithExceptionGuard(err, [&]() {
 			void *user_data = nullptr;
-			CheckedAPICall(duckdb_v2_copy_function_flush_get_user_data, info, &user_data);
+			CheckedAPICall(duckdb_v2_copy_to_flush_get_user_data, info, &user_data);
 			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
 
-			auto input = detail::Factory::Make<FlushInput>(static_cast<void *>(info), static_cast<void *>(context));
-			function.flush_callback(input);
+			auto input =
+			    detail::Factory::Make<CopyToFlushInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_to_flush_callback(input);
 		});
 	};
 
-	CheckedAPICall(duckdb_v2_copy_function_set_flush_callback, handle(), trampoline);
-	flush_callback = callback;
+	CheckedAPICall(duckdb_v2_copy_to_set_flush_callback, handle(), trampoline);
+	copy_to_flush_callback = callback;
 	return *this;
 }
 
-auto CopyFunction::SetFinalizeCallback(FinalizeCallback callback) & -> CopyFunction & {
+auto CopyFunction::SetCopyToFinalizeCallback(CopyToFinalizeCallback callback) & -> CopyFunction & {
 	if (!callback) {
-		CheckedAPICall(duckdb_v2_copy_function_set_finalize_callback, handle(), nullptr);
-		finalize_callback = nullptr;
+		CheckedAPICall(duckdb_v2_copy_to_set_finalize_callback, handle(), nullptr);
+		copy_to_finalize_callback = nullptr;
 		return *this;
 	}
 
-	static auto trampoline = [](duckdb_v2_copy_function_finalize_info_handle info, duckdb_v2_context_handle context,
+	static auto trampoline = [](duckdb_v2_copy_to_finalize_info_handle info, duckdb_v2_context_handle context,
 	                            duckdb_v2_error_info_handle *err) {
 		WithExceptionGuard(err, [&]() {
 			void *user_data = nullptr;
-			CheckedAPICall(duckdb_v2_copy_function_finalize_get_user_data, info, &user_data);
+			CheckedAPICall(duckdb_v2_copy_to_finalize_get_user_data, info, &user_data);
 			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
 
-			auto input = detail::Factory::Make<FinalizeInput>(static_cast<void *>(info), static_cast<void *>(context));
-			function.finalize_callback(input);
+			auto input =
+			    detail::Factory::Make<CopyToFinalizeInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_to_finalize_callback(input);
 		});
 	};
 
-	CheckedAPICall(duckdb_v2_copy_function_set_finalize_callback, handle(), trampoline);
-	finalize_callback = callback;
+	CheckedAPICall(duckdb_v2_copy_to_set_finalize_callback, handle(), trampoline);
+	copy_to_finalize_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetCopyFromBindCallback(CopyFromBindCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_from_set_bind_callback, handle(), nullptr);
+		copy_from_bind_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_from_bind_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_from_bind_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input =
+			    detail::Factory::Make<CopyFromBindInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_from_bind_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_from_set_bind_callback, handle(), trampoline);
+	copy_from_bind_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetCopyFromInitGlobalCallback(CopyFromInitGlobalCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_from_set_init_global_callback, handle(), nullptr);
+		copy_from_init_global_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_from_init_global_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_from_init_global_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input =
+			    detail::Factory::Make<CopyFromInitGlobalInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_from_init_global_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_from_set_init_global_callback, handle(), trampoline);
+	copy_from_init_global_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetCopyFromInitLocalCallback(CopyFromInitLocalCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_from_set_init_local_callback, handle(), nullptr);
+		copy_from_init_local_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_from_init_local_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_from_init_local_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input =
+			    detail::Factory::Make<CopyFromInitLocalInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_from_init_local_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_from_set_init_local_callback, handle(), trampoline);
+	copy_from_init_local_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetCopyFromExecCallback(CopyFromExecCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_from_set_exec_callback, handle(), nullptr);
+		copy_from_exec_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_from_exec_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_from_exec_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input =
+			    detail::Factory::Make<CopyFromExecInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_from_exec_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_from_set_exec_callback, handle(), trampoline);
+	copy_from_exec_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetCopyFromProgressCallback(CopyFromProgressCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_from_set_progress_callback, handle(), nullptr);
+		copy_from_progress_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_from_progress_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_from_progress_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input =
+			    detail::Factory::Make<CopyFromProgressInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.copy_from_progress_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_from_set_progress_callback, handle(), trampoline);
+	copy_from_progress_callback = callback;
 	return *this;
 }
 
 auto CopyFunction::Register() -> void {
 	// The callback table rides the C user_data slot so the trampolines can find
 	// it; the user's own data (SetUserData, moved out here) rides inside it.
-	auto info = std::unique_ptr<CopyFunctionInfo>(new CopyFunctionInfo(bind_callback, batch_size_callback,
-	                                                                   init_callback, batch_callback, flush_callback,
-	                                                                   finalize_callback, std::move(user_data)));
+	auto info = std::unique_ptr<CopyFunctionInfo>(new CopyFunctionInfo(
+	    copy_to_bind_callback, copy_to_batch_size_callback, copy_to_init_callback, copy_to_batch_callback,
+	    copy_to_flush_callback, copy_to_finalize_callback, copy_from_bind_callback, copy_from_init_global_callback,
+	    copy_from_init_local_callback, copy_from_exec_callback, copy_from_progress_callback, std::move(user_data)));
 	duckdb_v2_opaque opaque {info.get(), detail::TypedDelete<CopyFunctionInfo>, detail::TypedEquals<CopyFunctionInfo>};
 	CheckedAPICall(duckdb_v2_copy_function_set_user_data, handle(), &opaque);
 	// The function owns the table now.
@@ -4235,197 +4357,429 @@ auto CopyFunction::Register() -> void {
 	CheckedAPICall(duckdb_v2_copy_function_register, handle());
 }
 
-void *CopyFunction::BindInput::GetUserDataInternal() const {
+void *CopyFunction::CopyToBindInput::GetUserDataInternal() const {
 	void *user_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_bind_get_user_data,
-	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), &user_data);
+	CheckedAPICall(duckdb_v2_copy_to_bind_get_user_data, static_cast<duckdb_v2_copy_to_bind_info_handle>(args),
+	               &user_data);
 	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
 	return RequireCopyUserData(function.user_data);
 }
 
-void CopyFunction::BindInput::SetBindDataInternal(void *data, bool (*equals)(void *a, void *b),
-                                                  void (*destructor)(void *)) {
+void CopyFunction::CopyToBindInput::SetBindDataInternal(void *data, bool (*equals)(void *a, void *b),
+                                                        void (*destructor)(void *)) {
 	duckdb_v2_opaque opaque {data, destructor, equals};
-	CheckedAPICall(duckdb_v2_copy_function_bind_set_bind_data,
-	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), &opaque);
+	CheckedAPICall(duckdb_v2_copy_to_bind_set_bind_data, static_cast<duckdb_v2_copy_to_bind_info_handle>(args),
+	               &opaque);
 }
 
-auto CopyFunction::BindInput::GetColumnCount() const -> idx_t {
-	idx_t count = 0;
-	CheckedAPICall(duckdb_v2_copy_function_bind_get_column_count,
-	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), &count);
-	return count;
-}
-
-auto CopyFunction::BindInput::GetColumnName(idx_t index) const -> std::string {
-	duckdb_v2_identifier_t name = {nullptr, 0};
-	CheckedAPICall(duckdb_v2_copy_function_bind_get_column_name,
-	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), index, &name);
-	return std::string(FromStr(name));
-}
-
-auto CopyFunction::BindInput::GetColumnType(idx_t index) const -> LogicalType {
-	duckdb_v2_logical_type_handle type = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_bind_get_column_type,
-	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), index, &type);
-	return detail::Factory::Make<LogicalType>(type);
-}
-
-auto CopyFunction::BindInput::GetContext() const -> Context {
-	return detail::Factory::Make<Context>(context);
-}
-
-void *CopyFunction::BatchSizeInput::GetBindDataInternal() const {
-	void *bind_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_batch_size_get_bind_data,
-	               static_cast<duckdb_v2_copy_function_batch_size_info_handle>(args), &bind_data);
-	return RequireCopyBindData(bind_data);
-}
-
-void *CopyFunction::BatchSizeInput::GetUserDataInternal() const {
-	void *user_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_batch_size_get_user_data,
-	               static_cast<duckdb_v2_copy_function_batch_size_info_handle>(args), &user_data);
-	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
-	return RequireCopyUserData(function.user_data);
-}
-
-auto CopyFunction::BatchSizeInput::SetTarget(idx_t rows) -> void {
-	CheckedAPICall(duckdb_v2_copy_function_batch_size_set_target,
-	               static_cast<duckdb_v2_copy_function_batch_size_info_handle>(args), rows);
-}
-
-auto CopyFunction::BatchSizeInput::GetContext() const -> Context {
-	return detail::Factory::Make<Context>(context);
-}
-
-void CopyFunction::InitInput::SetInitDataInternal(void *data, void (*destructor)(void *)) {
-	duckdb_v2_opaque opaque {data, destructor, nullptr};
-	CheckedAPICall(duckdb_v2_copy_function_init_set_init_data,
-	               static_cast<duckdb_v2_copy_function_init_info_handle>(args), &opaque);
-}
-
-void *CopyFunction::InitInput::GetBindDataInternal() const {
-	void *bind_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_init_get_bind_data,
-	               static_cast<duckdb_v2_copy_function_init_info_handle>(args), &bind_data);
-	return RequireCopyBindData(bind_data);
-}
-
-void *CopyFunction::InitInput::GetUserDataInternal() const {
-	void *user_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_init_get_user_data,
-	               static_cast<duckdb_v2_copy_function_init_info_handle>(args), &user_data);
-	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
-	return RequireCopyUserData(function.user_data);
-}
-
-auto CopyFunction::InitInput::GetFilePath() const -> std::string {
+auto CopyFunction::CopyToBindInput::GetFilePath() const -> std::string {
 	duckdb_v2_str path = {nullptr, 0};
-	CheckedAPICall(duckdb_v2_copy_function_init_get_file_path,
-	               static_cast<duckdb_v2_copy_function_init_info_handle>(args), &path);
+	CheckedAPICall(duckdb_v2_copy_to_bind_get_file_path, static_cast<duckdb_v2_copy_to_bind_info_handle>(args), &path);
 	return std::string(FromStr(path));
 }
 
-auto CopyFunction::InitInput::GetContext() const -> Context {
+auto CopyFunction::CopyToBindInput::GetColumnCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_copy_to_bind_get_column_count, static_cast<duckdb_v2_copy_to_bind_info_handle>(args),
+	               &count);
+	return count;
+}
+
+auto CopyFunction::CopyToBindInput::GetColumnName(idx_t index) const -> std::string {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_copy_to_bind_get_column_name, static_cast<duckdb_v2_copy_to_bind_info_handle>(args), index,
+	               &name);
+	return std::string(FromStr(name));
+}
+
+auto CopyFunction::CopyToBindInput::GetColumnType(idx_t index) const -> LogicalType {
+	duckdb_v2_logical_type_handle type = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_bind_get_column_type, static_cast<duckdb_v2_copy_to_bind_info_handle>(args), index,
+	               &type);
+	return detail::Factory::Make<LogicalType>(type);
+}
+
+auto CopyFunction::CopyToBindInput::GetOptionCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_copy_to_bind_get_option_count, static_cast<duckdb_v2_copy_to_bind_info_handle>(args),
+	               &count);
+	return count;
+}
+
+auto CopyFunction::CopyToBindInput::GetOptionName(idx_t index) const -> std::string {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_copy_to_bind_get_option_name, static_cast<duckdb_v2_copy_to_bind_info_handle>(args), index,
+	               &name);
+	return std::string(FromStr(name));
+}
+
+auto CopyFunction::CopyToBindInput::GetOptionValue(idx_t index) const -> Value {
+	duckdb_v2_value_handle value = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_bind_get_option_value, static_cast<duckdb_v2_copy_to_bind_info_handle>(args),
+	               index, &value);
+	return detail::Factory::Make<Value>(value);
+}
+
+auto CopyFunction::CopyToBindInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
 }
 
-void CopyFunction::BatchInput::SetBatchDataInternal(void *data, void (*destructor)(void *)) {
-	duckdb_v2_opaque opaque {data, destructor, nullptr};
-	CheckedAPICall(duckdb_v2_copy_function_batch_set_batch_data,
-	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &opaque);
+void *CopyFunction::CopyToBatchSizeInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_batch_size_get_bind_data,
+	               static_cast<duckdb_v2_copy_to_batch_size_info_handle>(args), &data);
+	return RequireCopyBindData(data);
 }
 
-void *CopyFunction::BatchInput::GetBindDataInternal() const {
-	void *bind_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_batch_get_bind_data,
-	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &bind_data);
-	return RequireCopyBindData(bind_data);
-}
-
-void *CopyFunction::BatchInput::GetInitDataInternal() const {
-	void *init_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_batch_get_init_data,
-	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &init_data);
-	return RequireCopyInitData(init_data);
-}
-
-void *CopyFunction::BatchInput::GetUserDataInternal() const {
+void *CopyFunction::CopyToBatchSizeInput::GetUserDataInternal() const {
 	void *user_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_batch_get_user_data,
-	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &user_data);
+	CheckedAPICall(duckdb_v2_copy_to_batch_size_get_user_data,
+	               static_cast<duckdb_v2_copy_to_batch_size_info_handle>(args), &user_data);
 	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
 	return RequireCopyUserData(function.user_data);
 }
 
-auto CopyFunction::BatchInput::TakeBatch() -> ColumnDataCollection {
+auto CopyFunction::CopyToBatchSizeInput::SetTarget(idx_t rows) -> void {
+	CheckedAPICall(duckdb_v2_copy_to_batch_size_set_target, static_cast<duckdb_v2_copy_to_batch_size_info_handle>(args),
+	               rows);
+}
+
+auto CopyFunction::CopyToBatchSizeInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void CopyFunction::CopyToInitInput::SetInitDataInternal(void *data, void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, nullptr};
+	CheckedAPICall(duckdb_v2_copy_to_init_set_init_data, static_cast<duckdb_v2_copy_to_init_info_handle>(args),
+	               &opaque);
+}
+
+void *CopyFunction::CopyToInitInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_init_get_bind_data, static_cast<duckdb_v2_copy_to_init_info_handle>(args), &data);
+	return RequireCopyBindData(data);
+}
+
+void *CopyFunction::CopyToInitInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_init_get_user_data, static_cast<duckdb_v2_copy_to_init_info_handle>(args),
+	               &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::CopyToInitInput::GetFilePath() const -> std::string {
+	duckdb_v2_str path = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_copy_to_init_get_file_path, static_cast<duckdb_v2_copy_to_init_info_handle>(args), &path);
+	return std::string(FromStr(path));
+}
+
+auto CopyFunction::CopyToInitInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void CopyFunction::CopyToBatchInput::SetBatchDataInternal(void *data, void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, nullptr};
+	CheckedAPICall(duckdb_v2_copy_to_batch_set_batch_data, static_cast<duckdb_v2_copy_to_batch_info_handle>(args),
+	               &opaque);
+}
+
+void *CopyFunction::CopyToBatchInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_batch_get_bind_data, static_cast<duckdb_v2_copy_to_batch_info_handle>(args),
+	               &data);
+	return RequireCopyBindData(data);
+}
+
+void *CopyFunction::CopyToBatchInput::GetInitDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_batch_get_init_data, static_cast<duckdb_v2_copy_to_batch_info_handle>(args),
+	               &data);
+	return RequireCopyInitData(data);
+}
+
+void *CopyFunction::CopyToBatchInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_batch_get_user_data, static_cast<duckdb_v2_copy_to_batch_info_handle>(args),
+	               &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::CopyToBatchInput::TakeBatch() -> ColumnDataCollection {
 	duckdb_v2_column_data_collection_handle collection = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_batch_take_input,
-	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &collection);
+	CheckedAPICall(duckdb_v2_copy_to_batch_take_input, static_cast<duckdb_v2_copy_to_batch_info_handle>(args),
+	               &collection);
 	return detail::Factory::Make<ColumnDataCollection>(collection);
 }
 
-auto CopyFunction::BatchInput::GetContext() const -> Context {
+auto CopyFunction::CopyToBatchInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
 }
 
-void *CopyFunction::FlushInput::GetBindDataInternal() const {
-	void *bind_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_flush_get_bind_data,
-	               static_cast<duckdb_v2_copy_function_flush_info_handle>(args), &bind_data);
-	return RequireCopyBindData(bind_data);
+void *CopyFunction::CopyToFlushInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_flush_get_bind_data, static_cast<duckdb_v2_copy_to_flush_info_handle>(args),
+	               &data);
+	return RequireCopyBindData(data);
 }
 
-void *CopyFunction::FlushInput::GetInitDataInternal() const {
-	void *init_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_flush_get_init_data,
-	               static_cast<duckdb_v2_copy_function_flush_info_handle>(args), &init_data);
-	return RequireCopyInitData(init_data);
+void *CopyFunction::CopyToFlushInput::GetInitDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_flush_get_init_data, static_cast<duckdb_v2_copy_to_flush_info_handle>(args),
+	               &data);
+	return RequireCopyInitData(data);
 }
 
-void *CopyFunction::FlushInput::GetBatchDataInternal() const {
-	void *batch_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_flush_get_batch_data,
-	               static_cast<duckdb_v2_copy_function_flush_info_handle>(args), &batch_data);
-	return RequireCopyBatchData(batch_data);
+void *CopyFunction::CopyToFlushInput::GetBatchDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_flush_get_batch_data, static_cast<duckdb_v2_copy_to_flush_info_handle>(args),
+	               &data);
+	return RequireCopyBatchData(data);
 }
 
-void *CopyFunction::FlushInput::GetUserDataInternal() const {
+void *CopyFunction::CopyToFlushInput::GetUserDataInternal() const {
 	void *user_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_flush_get_user_data,
-	               static_cast<duckdb_v2_copy_function_flush_info_handle>(args), &user_data);
+	CheckedAPICall(duckdb_v2_copy_to_flush_get_user_data, static_cast<duckdb_v2_copy_to_flush_info_handle>(args),
+	               &user_data);
 	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
 	return RequireCopyUserData(function.user_data);
 }
 
-auto CopyFunction::FlushInput::GetContext() const -> Context {
+auto CopyFunction::CopyToFlushInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
 }
 
-void *CopyFunction::FinalizeInput::GetBindDataInternal() const {
-	void *bind_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_finalize_get_bind_data,
-	               static_cast<duckdb_v2_copy_function_finalize_info_handle>(args), &bind_data);
-	return RequireCopyBindData(bind_data);
+void *CopyFunction::CopyToFinalizeInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_finalize_get_bind_data, static_cast<duckdb_v2_copy_to_finalize_info_handle>(args),
+	               &data);
+	return RequireCopyBindData(data);
 }
 
-void *CopyFunction::FinalizeInput::GetInitDataInternal() const {
-	void *init_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_finalize_get_init_data,
-	               static_cast<duckdb_v2_copy_function_finalize_info_handle>(args), &init_data);
-	return RequireCopyInitData(init_data);
+void *CopyFunction::CopyToFinalizeInput::GetInitDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_to_finalize_get_init_data, static_cast<duckdb_v2_copy_to_finalize_info_handle>(args),
+	               &data);
+	return RequireCopyInitData(data);
 }
 
-void *CopyFunction::FinalizeInput::GetUserDataInternal() const {
+void *CopyFunction::CopyToFinalizeInput::GetUserDataInternal() const {
 	void *user_data = nullptr;
-	CheckedAPICall(duckdb_v2_copy_function_finalize_get_user_data,
-	               static_cast<duckdb_v2_copy_function_finalize_info_handle>(args), &user_data);
+	CheckedAPICall(duckdb_v2_copy_to_finalize_get_user_data, static_cast<duckdb_v2_copy_to_finalize_info_handle>(args),
+	               &user_data);
 	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
 	return RequireCopyUserData(function.user_data);
 }
 
-auto CopyFunction::FinalizeInput::GetContext() const -> Context {
+auto CopyFunction::CopyToFinalizeInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *CopyFunction::CopyFromBindInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_bind_get_user_data, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+void CopyFunction::CopyFromBindInput::SetBindDataInternal(void *data, bool (*equals)(void *a, void *b),
+                                                          void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, equals};
+	CheckedAPICall(duckdb_v2_copy_from_bind_set_bind_data, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               &opaque);
+}
+
+auto CopyFunction::CopyFromBindInput::GetFilePath() const -> std::string {
+	duckdb_v2_str path = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_copy_from_bind_get_file_path, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               &path);
+	return std::string(FromStr(path));
+}
+
+auto CopyFunction::CopyFromBindInput::GetColumnCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_copy_from_bind_get_column_count, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               &count);
+	return count;
+}
+
+auto CopyFunction::CopyFromBindInput::GetColumnName(idx_t index) const -> std::string {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_copy_from_bind_get_column_name, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               index, &name);
+	return std::string(FromStr(name));
+}
+
+auto CopyFunction::CopyFromBindInput::GetColumnType(idx_t index) const -> LogicalType {
+	duckdb_v2_logical_type_handle type = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_bind_get_column_type, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               index, &type);
+	return detail::Factory::Make<LogicalType>(type);
+}
+
+auto CopyFunction::CopyFromBindInput::GetOptionCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_copy_from_bind_get_option_count, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               &count);
+	return count;
+}
+
+auto CopyFunction::CopyFromBindInput::GetOptionName(idx_t index) const -> std::string {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_copy_from_bind_get_option_name, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               index, &name);
+	return std::string(FromStr(name));
+}
+
+auto CopyFunction::CopyFromBindInput::GetOptionValue(idx_t index) const -> Value {
+	duckdb_v2_value_handle value = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_bind_get_option_value, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               index, &value);
+	return detail::Factory::Make<Value>(value);
+}
+
+auto CopyFunction::CopyFromBindInput::SetCardinality(idx_t cardinality, bool is_exact) -> void {
+	CheckedAPICall(duckdb_v2_copy_from_bind_set_cardinality, static_cast<duckdb_v2_copy_from_bind_info_handle>(args),
+	               cardinality, is_exact);
+}
+
+auto CopyFunction::CopyFromBindInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void CopyFunction::CopyFromInitGlobalInput::SetGlobalStateInternal(void *data, void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, nullptr};
+	CheckedAPICall(duckdb_v2_copy_from_init_global_set_global_state,
+	               static_cast<duckdb_v2_copy_from_init_global_info_handle>(args), &opaque);
+}
+
+void *CopyFunction::CopyFromInitGlobalInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_init_global_get_bind_data,
+	               static_cast<duckdb_v2_copy_from_init_global_info_handle>(args), &data);
+	return RequireCopyBindData(data);
+}
+
+void *CopyFunction::CopyFromInitGlobalInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_init_global_get_user_data,
+	               static_cast<duckdb_v2_copy_from_init_global_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::CopyFromInitGlobalInput::SetMaxThreads(idx_t max_threads) -> void {
+	CheckedAPICall(duckdb_v2_copy_from_init_global_set_max_threads,
+	               static_cast<duckdb_v2_copy_from_init_global_info_handle>(args), max_threads);
+}
+
+auto CopyFunction::CopyFromInitGlobalInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void CopyFunction::CopyFromInitLocalInput::SetLocalStateInternal(void *data, void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, nullptr};
+	CheckedAPICall(duckdb_v2_copy_from_init_local_set_local_state,
+	               static_cast<duckdb_v2_copy_from_init_local_info_handle>(args), &opaque);
+}
+
+void *CopyFunction::CopyFromInitLocalInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_init_local_get_bind_data,
+	               static_cast<duckdb_v2_copy_from_init_local_info_handle>(args), &data);
+	return RequireCopyBindData(data);
+}
+
+void *CopyFunction::CopyFromInitLocalInput::GetGlobalStateInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_init_local_get_global_state,
+	               static_cast<duckdb_v2_copy_from_init_local_info_handle>(args), &data);
+	return RequireCopyGlobalState(data);
+}
+
+void *CopyFunction::CopyFromInitLocalInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_init_local_get_user_data,
+	               static_cast<duckdb_v2_copy_from_init_local_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::CopyFromInitLocalInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *CopyFunction::CopyFromExecInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_exec_get_bind_data, static_cast<duckdb_v2_copy_from_exec_info_handle>(args),
+	               &data);
+	return RequireCopyBindData(data);
+}
+
+void *CopyFunction::CopyFromExecInput::GetGlobalStateInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_exec_get_global_state, static_cast<duckdb_v2_copy_from_exec_info_handle>(args),
+	               &data);
+	return RequireCopyGlobalState(data);
+}
+
+void *CopyFunction::CopyFromExecInput::GetLocalStateInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_exec_get_local_state, static_cast<duckdb_v2_copy_from_exec_info_handle>(args),
+	               &data);
+	return RequireCopyLocalState(data);
+}
+
+void *CopyFunction::CopyFromExecInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_exec_get_user_data, static_cast<duckdb_v2_copy_from_exec_info_handle>(args),
+	               &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::CopyFromExecInput::GetOutputChunk() const -> DataChunk {
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_exec_get_output_chunk, static_cast<duckdb_v2_copy_from_exec_info_handle>(args),
+	               &chunk);
+	// Borrowed: the engine owns the chunk and reuses it across invocations.
+	return detail::Factory::Make<DataChunk>(chunk, false);
+}
+
+auto CopyFunction::CopyFromExecInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *CopyFunction::CopyFromProgressInput::GetBindDataInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_progress_get_bind_data,
+	               static_cast<duckdb_v2_copy_from_progress_info_handle>(args), &data);
+	return RequireCopyBindData(data);
+}
+
+void *CopyFunction::CopyFromProgressInput::GetGlobalStateInternal() const {
+	void *data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_progress_get_global_state,
+	               static_cast<duckdb_v2_copy_from_progress_info_handle>(args), &data);
+	return RequireCopyGlobalState(data);
+}
+
+void *CopyFunction::CopyFromProgressInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_from_progress_get_user_data,
+	               static_cast<duckdb_v2_copy_from_progress_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::CopyFromProgressInput::SetProgress(double progress) -> void {
+	CheckedAPICall(duckdb_v2_copy_from_progress_set_progress,
+	               static_cast<duckdb_v2_copy_from_progress_info_handle>(args), progress);
+}
+
+auto CopyFunction::CopyFromProgressInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
 }
 

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -331,6 +331,10 @@ auto LibraryVersion() -> std::string {
 	return std::string(version.ptr, version.len);
 }
 
+auto RenderQuotedIdentifier(std::string_view name) -> std::string {
+	return RenderText(duckdb_v2_identifier_render_quoted, duckdb_v2_identifier_t {name.data(), name.size()});
+}
+
 //---------------------------------------------------------------------------
 // Environment
 //---------------------------------------------------------------------------
@@ -5270,19 +5274,6 @@ auto ReplacementScan::Input::GetContext() const -> Context {
 
 namespace {
 
-// Renders an identifier as SQL, doubling any embedded quotes.
-std::string QuoteIdentifier(std::string_view name) {
-	std::string out = "\"";
-	for (auto c : name) {
-		if (c == '"') {
-			out += '"';
-		}
-		out += c;
-	}
-	out += '"';
-	return out;
-}
-
 bool EqualsIgnoreCase(std::string_view a, std::string_view b) {
 	if (a.size() != b.size()) {
 		return false;
@@ -5383,7 +5374,7 @@ AppenderTablePlan PlanTableAppender(Connection &conn, std::string_view table) {
 		if (i > 0) {
 			columns += ", ";
 		}
-		columns += QuoteIdentifier(schema.GetFieldName(i));
+		columns += RenderQuotedIdentifier(schema.GetFieldName(i));
 		plan.column_names.emplace_back(schema.GetFieldName(i));
 		plan.types.push_back(schema.GetFieldType(i));
 	}

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -124,6 +124,14 @@ template <>
 struct HandleTraits<TableFunction> {
 	using handle = duckdb_v2_table_function_handle;
 };
+template <>
+struct HandleTraits<CustomType> {
+	using handle = duckdb_v2_custom_type_handle;
+};
+template <>
+struct HandleTraits<CastFunction> {
+	using handle = duckdb_v2_cast_function_handle;
+};
 
 } // namespace detail
 
@@ -3661,6 +3669,194 @@ auto TableFunction::ProgressInput::SetProgress(double progress) -> void {
 }
 
 auto TableFunction::ProgressInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Custom Type
+//----------------------------------------------------------------------------------------------------------------------
+
+CustomType::CustomType(void *impl) : detail::Handle<CustomType>(impl) {
+}
+
+CustomType::~CustomType() {
+	auto _h = handle();
+	duckdb_v2_custom_type_destroy(&_h);
+}
+
+auto CustomType::Create(const Connection &conn) -> CustomType {
+	duckdb_v2_custom_type_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_custom_type_create_with_connection, conn.handle(), &_h);
+	return detail::Factory::Make<CustomType>(_h);
+}
+
+auto CustomType::Create(const Extension &extension) -> CustomType {
+	duckdb_v2_custom_type_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_custom_type_create_with_extension, extension.handle(), &_h);
+	return detail::Factory::Make<CustomType>(_h);
+}
+
+auto CustomType::SetName(const std::string &name) & -> CustomType & {
+	CheckedAPICall(duckdb_v2_custom_type_set_name, handle(), ToStr(name));
+	return *this;
+}
+
+auto CustomType::SetBaseType(const LogicalType &type) & -> CustomType & {
+	CheckedAPICall(duckdb_v2_custom_type_set_base_type, handle(), type.handle());
+	return *this;
+}
+
+auto CustomType::Register() -> void {
+	CheckedAPICall(duckdb_v2_custom_type_register, handle());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Cast Function
+//----------------------------------------------------------------------------------------------------------------------
+
+namespace {
+
+// The callback table for one registered cast: rides the C user_data slot so
+// the trampoline can find it; the user's own slot (SetUserData) rides inside
+// it. Owned by the registered cast, freed at engine teardown.
+struct CastFunctionInfo {
+	CastFunction::ExecCallback exec_callback = nullptr;
+	detail::UserData user_data;
+
+	CastFunctionInfo(CastFunction::ExecCallback exec_callback, detail::UserData user_data)
+	    : exec_callback(exec_callback), user_data(std::move(user_data)) {
+	}
+
+	bool operator==(const CastFunctionInfo &other) const {
+		return exec_callback == other.exec_callback && user_data.get() == other.user_data.get();
+	}
+};
+
+// Guard for ExecInput::GetUserData: a clear error instead of a null deref.
+void *RequireCastUserData(const detail::UserData &user_data) {
+	auto ptr = user_data.get();
+	if (!ptr) {
+		throw InvalidInputException("no user data was set; call CastFunction::SetUserData before Register");
+	}
+	return ptr;
+}
+
+} // namespace
+
+CastFunction::CastFunction(void *impl) : detail::Handle<CastFunction>(impl) {
+}
+
+CastFunction::~CastFunction() {
+	auto _h = handle();
+	duckdb_v2_cast_function_destroy(&_h);
+}
+
+auto CastFunction::Create(const Connection &conn) -> CastFunction {
+	duckdb_v2_cast_function_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_cast_function_create_with_connection, conn.handle(), &_h);
+	return detail::Factory::Make<CastFunction>(_h);
+}
+
+auto CastFunction::Create(const Extension &extension) -> CastFunction {
+	duckdb_v2_cast_function_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_cast_function_create_with_extension, extension.handle(), &_h);
+	return detail::Factory::Make<CastFunction>(_h);
+}
+
+auto CastFunction::SetSourceType(const LogicalType &type) & -> CastFunction & {
+	CheckedAPICall(duckdb_v2_cast_function_set_source_type, handle(), type.handle());
+	return *this;
+}
+
+auto CastFunction::SetTargetType(const LogicalType &type) & -> CastFunction & {
+	CheckedAPICall(duckdb_v2_cast_function_set_target_type, handle(), type.handle());
+	return *this;
+}
+
+auto CastFunction::SetImplicitCastCost(int64_t cost) & -> CastFunction & {
+	CheckedAPICall(duckdb_v2_cast_function_set_implicit_cast_cost, handle(), cost);
+	return *this;
+}
+
+auto CastFunction::SetUserDataInternal(void *data, void (*destructor)(void *)) -> void {
+	user_data = detail::UserData(data, destructor);
+}
+
+auto CastFunction::SetExecCallback(ExecCallback callback) & -> CastFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_cast_function_set_exec_callback, handle(), nullptr);
+		exec_callback = nullptr;
+		return *this;
+	}
+
+	// The C-side callback is one shared trampoline; the user's callback is looked
+	// up through the info table riding the user_data slot (set by Register).
+	static auto trampoline = [](duckdb_v2_cast_function_exec_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_cast_function_exec_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CastFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<ExecInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.exec_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_cast_function_set_exec_callback, handle(), trampoline);
+	exec_callback = callback;
+	return *this;
+}
+
+auto CastFunction::Register() -> void {
+	// The callback table rides the C user_data slot so the trampoline can find
+	// it; the user's own data (SetUserData, moved out here) rides inside it.
+	auto info = std::unique_ptr<CastFunctionInfo>(new CastFunctionInfo(exec_callback, std::move(user_data)));
+	duckdb_v2_opaque opaque {info.get(), detail::TypedDelete<CastFunctionInfo>, detail::TypedEquals<CastFunctionInfo>};
+	CheckedAPICall(duckdb_v2_cast_function_set_user_data, handle(), &opaque);
+	// The cast owns the table now.
+	info.release();
+
+	CheckedAPICall(duckdb_v2_cast_function_register, handle());
+}
+
+void *CastFunction::ExecInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_cast_function_exec_get_user_data,
+	               static_cast<duckdb_v2_cast_function_exec_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CastFunctionInfo *>(user_data);
+	return RequireCastUserData(function.user_data);
+}
+
+auto CastFunction::ExecInput::GetRowCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_cast_function_exec_get_row_count,
+	               static_cast<duckdb_v2_cast_function_exec_info_handle>(args), &count);
+	return count;
+}
+
+auto CastFunction::ExecInput::GetInput() const -> Vector {
+	duckdb_v2_vector_handle vector = nullptr;
+	CheckedAPICall(duckdb_v2_cast_function_exec_get_input, static_cast<duckdb_v2_cast_function_exec_info_handle>(args),
+	               &vector);
+	return detail::Factory::Make<Vector>(vector);
+}
+
+auto CastFunction::ExecInput::GetOutput() const -> Vector {
+	duckdb_v2_vector_handle vector = nullptr;
+	CheckedAPICall(duckdb_v2_cast_function_exec_get_output, static_cast<duckdb_v2_cast_function_exec_info_handle>(args),
+	               &vector);
+	return detail::Factory::Make<Vector>(vector);
+}
+
+auto CastFunction::ExecInput::GetMode() const -> CastMode {
+	auto mode = DUCKDB_V2_CAST_MODE_NORMAL;
+	CheckedAPICall(duckdb_v2_cast_function_exec_get_mode, static_cast<duckdb_v2_cast_function_exec_info_handle>(args),
+	               &mode);
+	return static_cast<CastMode>(mode);
+}
+
+auto CastFunction::ExecInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
 }
 

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -1,6 +1,8 @@
 // Include the C++ API header (which includes the C API header)
 #include "duckdb_cpp.hpp"
 
+#include <atomic>
+#include <cctype>
 #include <cstring>
 #include <memory>
 
@@ -131,6 +133,10 @@ struct HandleTraits<CustomType> {
 template <>
 struct HandleTraits<CastFunction> {
 	using handle = duckdb_v2_cast_function_handle;
+};
+template <>
+struct HandleTraits<ReplacementScan> {
+	using handle = duckdb_v2_replacement_scan_handle;
 };
 
 } // namespace detail
@@ -2003,6 +2009,10 @@ auto ColumnDataCollection::Reset() -> void {
 	CheckedAPICall(duckdb_v2_column_data_collection_reset, handle());
 }
 
+auto ColumnDataCollection::Clear() -> void {
+	CheckedAPICall(duckdb_v2_column_data_collection_clear, handle());
+}
+
 auto ColumnDataCollection::Combine(ColumnDataCollection &&source) -> void {
 	auto source_handle = source.handle();
 	CheckedAPICall(duckdb_v2_column_data_collection_combine, handle(), &source_handle);
@@ -3858,6 +3868,374 @@ auto CastFunction::ExecInput::GetMode() const -> CastMode {
 
 auto CastFunction::ExecInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Replacement Scan
+//----------------------------------------------------------------------------------------------------------------------
+
+namespace {
+
+// The callback table for one registered scan: rides the C user_data slot so
+// the trampoline can find it; the user's own slot (SetUserData) rides inside
+// it. Owned by the registered scan, freed when its scope ends.
+struct ReplacementScanInfo {
+	ReplacementScan::Callback callback = nullptr;
+	detail::UserData user_data;
+
+	ReplacementScanInfo(ReplacementScan::Callback callback, detail::UserData user_data)
+	    : callback(callback), user_data(std::move(user_data)) {
+	}
+
+	bool operator==(const ReplacementScanInfo &other) const {
+		return callback == other.callback && user_data.get() == other.user_data.get();
+	}
+};
+
+// Guard for Input::GetUserData: a clear error instead of a null deref.
+void *RequireReplacementUserData(const detail::UserData &user_data) {
+	auto ptr = user_data.get();
+	if (!ptr) {
+		throw InvalidInputException("no user data was set; call ReplacementScan::SetUserData before Register");
+	}
+	return ptr;
+}
+
+} // namespace
+
+ReplacementScan::ReplacementScan(void *impl) : detail::Handle<ReplacementScan>(impl) {
+}
+
+ReplacementScan::~ReplacementScan() {
+	auto _h = handle();
+	duckdb_v2_replacement_scan_destroy(&_h);
+}
+
+auto ReplacementScan::Create(const Connection &conn) -> ReplacementScan {
+	duckdb_v2_replacement_scan_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_replacement_scan_create_with_connection, conn.handle(), &_h);
+	return detail::Factory::Make<ReplacementScan>(_h);
+}
+
+auto ReplacementScan::Create(const Database &db) -> ReplacementScan {
+	duckdb_v2_replacement_scan_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_replacement_scan_create_with_database, db.handle(), &_h);
+	return detail::Factory::Make<ReplacementScan>(_h);
+}
+
+auto ReplacementScan::Create(const Extension &extension) -> ReplacementScan {
+	duckdb_v2_replacement_scan_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_replacement_scan_create_with_extension, extension.handle(), &_h);
+	return detail::Factory::Make<ReplacementScan>(_h);
+}
+
+auto ReplacementScan::SetUserDataInternal(void *data, void (*destructor)(void *)) -> void {
+	user_data = detail::UserData(data, destructor);
+}
+
+auto ReplacementScan::SetCallback(Callback callback_p) & -> ReplacementScan & {
+	if (!callback_p) {
+		CheckedAPICall(duckdb_v2_replacement_scan_set_callback, handle(), nullptr);
+		callback = nullptr;
+		return *this;
+	}
+
+	// The C-side callback is one shared trampoline; the user's callback is looked
+	// up through the info table riding the user_data slot (set by Register).
+	static auto trampoline = [](duckdb_v2_replacement_scan_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_replacement_scan_get_user_data, info, &user_data);
+			const auto &scan = *static_cast<ReplacementScanInfo *>(user_data);
+
+			auto input = detail::Factory::Make<Input>(static_cast<void *>(info), static_cast<void *>(context));
+			scan.callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_replacement_scan_set_callback, handle(), trampoline);
+	callback = callback_p;
+	return *this;
+}
+
+auto ReplacementScan::Register() -> void {
+	// The callback table rides the C user_data slot so the trampoline can find
+	// it; the user's own data (SetUserData, moved out here) rides inside it.
+	auto info = std::unique_ptr<ReplacementScanInfo>(new ReplacementScanInfo(callback, std::move(user_data)));
+	duckdb_v2_opaque opaque {info.get(), detail::TypedDelete<ReplacementScanInfo>,
+	                         detail::TypedEquals<ReplacementScanInfo>};
+	CheckedAPICall(duckdb_v2_replacement_scan_set_user_data, handle(), &opaque);
+	// The scan owns the table now.
+	info.release();
+
+	CheckedAPICall(duckdb_v2_replacement_scan_register, handle());
+}
+
+void *ReplacementScan::Input::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_replacement_scan_get_user_data, static_cast<duckdb_v2_replacement_scan_info_handle>(args),
+	               &user_data);
+	const auto &scan = *static_cast<const ReplacementScanInfo *>(user_data);
+	return RequireReplacementUserData(scan.user_data);
+}
+
+auto ReplacementScan::Input::GetCatalogName() const -> std::string_view {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_replacement_scan_get_catalog_name,
+	               static_cast<duckdb_v2_replacement_scan_info_handle>(args), &name);
+	return FromStr(name);
+}
+
+auto ReplacementScan::Input::GetSchemaName() const -> std::string_view {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_replacement_scan_get_schema_name,
+	               static_cast<duckdb_v2_replacement_scan_info_handle>(args), &name);
+	return FromStr(name);
+}
+
+auto ReplacementScan::Input::GetTableName() const -> std::string_view {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_replacement_scan_get_table_name, static_cast<duckdb_v2_replacement_scan_info_handle>(args),
+	               &name);
+	return FromStr(name);
+}
+
+auto ReplacementScan::Input::SetFunctionName(std::string_view name) -> void {
+	CheckedAPICall(duckdb_v2_replacement_scan_set_function_name,
+	               static_cast<duckdb_v2_replacement_scan_info_handle>(args), ToStr(name));
+}
+
+auto ReplacementScan::Input::AddArgument(const Value &value) -> void {
+	CheckedAPICall(duckdb_v2_replacement_scan_add_argument, static_cast<duckdb_v2_replacement_scan_info_handle>(args),
+	               value.handle());
+}
+
+auto ReplacementScan::Input::AddNamedArgument(std::string_view name, const Value &value) -> void {
+	CheckedAPICall(duckdb_v2_replacement_scan_add_named_argument,
+	               static_cast<duckdb_v2_replacement_scan_info_handle>(args), ToStr(name), value.handle());
+}
+
+auto ReplacementScan::Input::SetCollection(const ColumnDataCollection &collection,
+                                           const std::vector<std::string> &column_names) -> void {
+	std::vector<duckdb_v2_identifier_t> names;
+	names.reserve(column_names.size());
+	for (auto &name : column_names) {
+		names.push_back(ToStr(name));
+	}
+	CheckedAPICall(duckdb_v2_replacement_scan_set_collection, static_cast<duckdb_v2_replacement_scan_info_handle>(args),
+	               collection.handle(), names.empty() ? nullptr : names.data(), names.size());
+}
+
+auto ReplacementScan::Input::SetSubquery(std::string_view sql) -> void {
+	CheckedAPICall(duckdb_v2_replacement_scan_set_subquery, static_cast<duckdb_v2_replacement_scan_info_handle>(args),
+	               ToStr(sql));
+}
+
+auto ReplacementScan::Input::SetAlias(std::string_view alias) -> void {
+	CheckedAPICall(duckdb_v2_replacement_scan_set_alias, static_cast<duckdb_v2_replacement_scan_info_handle>(args),
+	               ToStr(alias));
+}
+
+auto ReplacementScan::Input::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Appender
+//----------------------------------------------------------------------------------------------------------------------
+
+namespace {
+
+// Renders an identifier as SQL, doubling any embedded quotes.
+std::string QuoteIdentifier(std::string_view name) {
+	std::string out = "\"";
+	for (auto c : name) {
+		if (c == '"') {
+			out += '"';
+		}
+		out += c;
+	}
+	out += '"';
+	return out;
+}
+
+bool EqualsIgnoreCase(std::string_view a, std::string_view b) {
+	if (a.size() != b.size()) {
+		return false;
+	}
+	for (size_t i = 0; i < a.size(); i++) {
+		auto lhs = static_cast<unsigned char>(a[i]);
+		auto rhs = static_cast<unsigned char>(b[i]);
+		if (std::tolower(lhs) != std::tolower(rhs)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Parses exactly one statement out of `sql`.
+auto ParseSingleStatement(Connection &conn, const std::string &sql) -> SqlStatement {
+	auto statements = conn.ParseSQL(sql);
+	auto first = statements.Next();
+	if (!first) {
+		throw InvalidInputException("the appender's query contains no statement");
+	}
+	if (statements.Next()) {
+		throw InvalidInputException("the appender's query must contain exactly one statement");
+	}
+	return first;
+}
+
+// Names the buffers the table constructor generates, so two appenders on one connection never collide.
+std::atomic<uint64_t> appender_buffer_counter {0};
+
+} // namespace
+
+Appender::Appender(Connection &conn, std::string_view query, std::vector<LogicalType> column_types,
+                   std::string_view buffer_name, const std::vector<std::string> &column_names) {
+	Initialize(conn, std::string(query), std::move(column_types), std::string(buffer_name), column_names);
+}
+
+void Appender::Initialize(Connection &conn, const std::string &query, std::vector<LogicalType> column_types,
+                          const std::string &buffer_name, const std::vector<std::string> &column_names) {
+	connection = &conn;
+	types = std::move(column_types);
+	if (types.empty()) {
+		throw InvalidInputException("an appender needs at least one column type");
+	}
+
+	buffer = std::make_shared<Buffer>();
+	buffer->name = buffer_name;
+	buffer->column_names = column_names;
+	buffer->collection = std::make_unique<ColumnDataCollection>(conn, types);
+
+	// The scan makes the buffer visible to the statement under its name. It is connection-scoped, so it is invisible
+	// to every other connection, and it holds the buffer by shared_ptr because it outlives this object.
+	auto scan = ReplacementScan::Create(conn);
+	scan.SetCallback([](ReplacementScan::Input &input) {
+		auto &shared = input.GetUserData<std::shared_ptr<Buffer>>();
+		if (!shared->collection || !EqualsIgnoreCase(input.GetTableName(), shared->name)) {
+			return; // not ours, or the appender is gone: decline
+		}
+		input.SetCollection(*shared->collection, shared->column_names);
+	});
+	scan.SetUserData<std::shared_ptr<Buffer>>(buffer);
+	scan.Register();
+
+	// Parsed once and re-executed per flush.
+	statement = std::make_unique<SqlStatement>(ParseSingleStatement(conn, query));
+	append_state = std::make_unique<ColumnDataCollection::AppendState>(buffer->collection->CreateAppendState());
+}
+
+namespace {
+
+// The table constructor's two derived pieces: the buffer's columns, and the INSERT that drains it.
+struct AppenderTablePlan {
+	std::vector<LogicalType> types;
+	std::vector<std::string> column_names;
+	std::string query;
+	std::string buffer_name;
+};
+
+AppenderTablePlan PlanTableAppender(Connection &conn, std::string_view table) {
+	AppenderTablePlan plan;
+	plan.buffer_name = "__appender_buffer_" + std::to_string(appender_buffer_counter++);
+
+	// Bind rather than execute: it resolves the table and reports its columns without reading a row.
+	auto probe = ParseSingleStatement(conn, "SELECT * FROM " + std::string(table));
+	auto signature = conn.Bind(probe);
+	auto &schema = signature.output;
+	if (schema.GetFieldCount() == 0) {
+		throw InvalidInputException("table " + std::string(table) + " has no columns to append to");
+	}
+
+	std::string columns;
+	for (idx_t i = 0; i < schema.GetFieldCount(); i++) {
+		if (i > 0) {
+			columns += ", ";
+		}
+		columns += QuoteIdentifier(schema.GetFieldName(i));
+		plan.column_names.emplace_back(schema.GetFieldName(i));
+		plan.types.push_back(schema.GetFieldType(i));
+	}
+	plan.query = "INSERT INTO " + std::string(table) + " (" + columns + ") SELECT * FROM " + plan.buffer_name;
+	return plan;
+}
+
+} // namespace
+
+Appender::Appender(Connection &conn, std::string_view table) {
+	auto plan = PlanTableAppender(conn, table);
+	Initialize(conn, plan.query, std::move(plan.types), plan.buffer_name, plan.column_names);
+}
+
+Appender::~Appender() {
+	// Frees the buffer without flushing. The replacement scan outlives this object and stays registered on the
+	// connection, so the shared block survives; nulling the collection makes the scan decline from here on.
+	if (buffer) {
+		append_state.reset();
+		buffer->collection.reset();
+	}
+}
+
+void Appender::ResetBuffer() {
+	// Drop the append state first: it references the segments the clear releases.
+	append_state.reset();
+	buffer->collection->Clear();
+	try {
+		append_state = std::make_unique<ColumnDataCollection::AppendState>(buffer->collection->CreateAppendState());
+	} catch (...) {
+		broken = true;
+		throw;
+	}
+}
+
+void Appender::AppendChunk(DataChunk &chunk) {
+	if (broken) {
+		throw InvalidInputException("the appender is broken after a failed buffer operation; Clear or destroy it");
+	}
+	try {
+		// The append validates the chunk's columns against the buffer and refuses a mismatch before copying.
+		buffer->collection->Append(*append_state, chunk);
+	} catch (const Exception &ex) {
+		// A validation refusal leaves the buffer untouched; anything else may have copied part of the chunk.
+		if (ex.GetCode() != DUCKDB_V2_ERROR_INPUT_INVALID) {
+			broken = true;
+		}
+		throw;
+	} catch (...) {
+		broken = true;
+		throw;
+	}
+}
+
+void Appender::Flush() {
+	if (broken) {
+		throw InvalidInputException("the appender is broken after a failed buffer operation; Clear or destroy it");
+	}
+	if (buffer->collection->GetRowCount() == 0) {
+		return;
+	}
+	try {
+		connection->Execute(*statement).Drain();
+	} catch (const Exception &ex) {
+		// A busy connection or an interrupted run keeps the rows so the flush can be retried; any other failure drops
+		// them, so a retry does not re-run the same failing statement over the same rows.
+		if (ex.GetCode() != DUCKDB_V2_ERROR_RESOURCE_IN_USE && ex.GetCode() != DUCKDB_V2_ERROR_RUNTIME_INTERRUPT) {
+			ResetBuffer();
+		}
+		throw;
+	} catch (...) {
+		ResetBuffer();
+		throw;
+	}
+	ResetBuffer();
+}
+
+void Appender::Clear() {
+	ResetBuffer();
+	broken = false;
 }
 
 } // namespace cxx

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -115,8 +115,12 @@ struct HandleTraits<QueryResult> {
 	using handle = duckdb_v2_result_handle;
 };
 template <>
-struct HandleTraits<ArrowConverter> {
-	using handle = duckdb_v2_arrow_converter_handle;
+struct HandleTraits<ArrowImporter> {
+	using handle = duckdb_v2_arrow_importer_handle;
+};
+template <>
+struct HandleTraits<ArrowExporter> {
+	using handle = duckdb_v2_arrow_exporter_handle;
 };
 template <>
 struct HandleTraits<FunctionSignature> {
@@ -1030,18 +1034,6 @@ auto Schema::GetFieldType(idx_t index) const -> LogicalType {
 	duckdb_v2_logical_type_handle owned = nullptr;
 	CheckedAPICall(duckdb_v2_logical_type_copy, borrowed, &owned);
 	return detail::Factory::Make<LogicalType>(owned);
-}
-
-auto Schema::ToArrowSchema(const Context &context, ArrowSchema &out) const -> void {
-	// The C converter takes parallel name/type arrays. get_field borrows both, and they stay
-	// valid for the whole of this call, so nothing needs copying.
-	const auto count = GetFieldCount();
-	std::vector<duckdb_v2_logical_type_handle> types(count, nullptr);
-	std::vector<duckdb_v2_str> names(count, duckdb_v2_str {nullptr, 0});
-	for (idx_t i = 0; i < count; i++) {
-		CheckedAPICall(duckdb_v2_schema_get_field, handle(), i, &names[i], &types[i]);
-	}
-	CheckedAPICall(duckdb_v2_logical_types_to_arrow_schema, context.handle(), types.data(), names.data(), count, &out);
 }
 
 auto Connection::Bind(const SqlStatement &statement) const -> Signature {
@@ -2044,10 +2036,6 @@ auto DataChunk::Copy(const Context &ctx) const -> DataChunk {
 	return detail::Factory::Make<DataChunk>(copy, true);
 }
 
-auto DataChunk::ToArrowArray(const Context &context, ArrowArray &out) const -> void {
-	CheckedAPICall(duckdb_v2_data_chunk_to_arrow_array, context.handle(), handle(), &out);
-}
-
 auto DataChunk::GetRowCount() const -> idx_t {
 	idx_t count = 0;
 	CheckedAPICall(duckdb_v2_data_chunk_get_size, handle(), &count);
@@ -2324,30 +2312,94 @@ auto QueryResult::ToArrowStream(idx_t batch_size) -> ArrowStream {
 // Arrow
 //----------------------------------------------------------------------------------------------------------------------
 
-ArrowConverter::ArrowConverter(void *impl) : detail::Handle<ArrowConverter>(impl) {
+ArrowImporter::ArrowImporter(void *impl) : detail::Handle<ArrowImporter>(impl) {
 }
 
-ArrowConverter::ArrowConverter(const Context &context, ArrowSchema &schema) : detail::Handle<ArrowConverter>(nullptr) {
-	duckdb_v2_arrow_converter_handle converter = nullptr;
-	CheckedAPICall(duckdb_v2_arrow_converter_create, context.handle(), &schema, &converter);
-	impl = converter;
+ArrowImporter::ArrowImporter(const Context &context, ArrowSchema &schema, idx_t batch_size)
+    : detail::Handle<ArrowImporter>(nullptr) {
+	duckdb_v2_arrow_importer_handle importer = nullptr;
+	CheckedAPICall(duckdb_v2_arrow_importer_create, context.handle(), &schema, batch_size, &importer);
+	impl = importer;
 }
 
-ArrowConverter::~ArrowConverter() {
+ArrowImporter::~ArrowImporter() {
 	auto _h = handle();
-	duckdb_v2_arrow_converter_destroy(&_h);
+	duckdb_v2_arrow_importer_destroy(&_h);
 }
 
-auto ArrowConverter::ArrayToChunk(const Context &context, ArrowArray &array) const -> DataChunk {
+auto ArrowImporter::GetSchema() const -> Schema {
+	duckdb_v2_schema_handle schema = nullptr;
+	CheckedAPICall(duckdb_v2_arrow_importer_get_schema, handle(), &schema);
+	return detail::Factory::Make<Schema>(schema);
+}
+
+auto ArrowImporter::Append(ArrowArray &array, bool consume, bool flush) -> void {
+	CheckedAPICall(duckdb_v2_arrow_importer_append, handle(), &array, consume, flush);
+}
+
+auto ArrowImporter::Flush() -> void {
+	CheckedAPICall(duckdb_v2_arrow_importer_append, handle(), static_cast<ArrowArray *>(nullptr), false, true);
+}
+
+auto ArrowImporter::NextChunk() -> DataChunk {
 	duckdb_v2_data_chunk_handle chunk = nullptr;
-	CheckedAPICall(duckdb_v2_arrow_converter_array_to_chunk, context.handle(), &array, handle(), &chunk);
+	CheckedAPICall(duckdb_v2_arrow_importer_next_chunk, handle(), &chunk);
+	// A null handle, meaning the array is drained, becomes an empty DataChunk.
 	return detail::Factory::Make<DataChunk>(chunk, true);
 }
 
-auto ArrowConverter::GetSchema() const -> Schema {
-	duckdb_v2_schema_handle schema = nullptr;
-	CheckedAPICall(duckdb_v2_arrow_converter_get_schema, handle(), &schema);
-	return detail::Factory::Make<Schema>(schema);
+ArrowExporter::ArrowExporter(void *impl) : detail::Handle<ArrowExporter>(impl) {
+}
+
+ArrowExporter::ArrowExporter(const Context &context, const std::vector<LogicalType> &types,
+                             const std::vector<std::string> &names, idx_t batch_size)
+    : detail::Handle<ArrowExporter>(nullptr) {
+	// LogicalType is a Handle with a vtable, so its storage is not layout-compatible with a raw
+	// handle array; extract into contiguous buffers.
+	std::vector<duckdb_v2_logical_type_handle> type_handles;
+	std::vector<duckdb_v2_str> name_views;
+	type_handles.reserve(types.size());
+	name_views.reserve(names.size());
+	for (const auto &type : types) {
+		type_handles.push_back(type.handle());
+	}
+	for (const auto &name : names) {
+		name_views.push_back(ToStr(name));
+	}
+	if (type_handles.size() != name_views.size()) {
+		throw InvalidInputException("ArrowExporter: one name is required per column type");
+	}
+	duckdb_v2_arrow_exporter_handle exporter = nullptr;
+	CheckedAPICall(duckdb_v2_arrow_exporter_create, context.handle(),
+	               type_handles.empty() ? nullptr : type_handles.data(),
+	               name_views.empty() ? nullptr : name_views.data(), static_cast<idx_t>(type_handles.size()),
+	               batch_size, &exporter);
+	impl = exporter;
+}
+
+ArrowExporter::~ArrowExporter() {
+	auto _h = handle();
+	duckdb_v2_arrow_exporter_destroy(&_h);
+}
+
+auto ArrowExporter::GetSchema(ArrowSchema &out) const -> void {
+	CheckedAPICall(duckdb_v2_arrow_exporter_get_schema, handle(), &out);
+}
+
+auto ArrowExporter::Append(const DataChunk &chunk, bool flush) -> void {
+	// consume is false, so the C call leaves the chunk alone; the copy of the handle only gives it a slot to read.
+	auto raw = chunk.handle();
+	CheckedAPICall(duckdb_v2_arrow_exporter_append, handle(), &raw, false, flush);
+}
+
+auto ArrowExporter::Flush() -> void {
+	CheckedAPICall(duckdb_v2_arrow_exporter_append, handle(), static_cast<duckdb_v2_data_chunk_handle *>(nullptr),
+	               false, true);
+}
+
+auto ArrowExporter::NextArray(ArrowArray &out) -> bool {
+	CheckedAPICall(duckdb_v2_arrow_exporter_next_array, handle(), &out);
+	return out.release != nullptr;
 }
 
 ArrowStream::~ArrowStream() {

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -95,6 +95,10 @@ struct HandleTraits<DataChunk> {
 	using handle = duckdb_v2_data_chunk_handle;
 };
 template <>
+struct HandleTraits<Expression> {
+	using handle = duckdb_v2_expression_handle;
+};
+template <>
 struct HandleTraits<ColumnDataCollection> {
 	using handle = duckdb_v2_column_data_collection_handle;
 };
@@ -3489,20 +3493,23 @@ struct TableFunctionInfo {
 	TableFunction::InitLocalCallback init_local_callback = nullptr;
 	TableFunction::ExecCallback exec_callback = nullptr;
 	TableFunction::ProgressCallback progress_callback = nullptr;
+	TableFunction::FilterPushdownCallback filter_pushdown_callback = nullptr;
 	detail::UserData user_data;
 
 	TableFunctionInfo(TableFunction::BindCallback bind_callback, TableFunction::InitGlobalCallback init_global_callback,
 	                  TableFunction::InitLocalCallback init_local_callback, TableFunction::ExecCallback exec_callback,
-	                  TableFunction::ProgressCallback progress_callback, detail::UserData user_data)
+	                  TableFunction::ProgressCallback progress_callback,
+	                  TableFunction::FilterPushdownCallback filter_pushdown_callback, detail::UserData user_data)
 	    : bind_callback(bind_callback), init_global_callback(init_global_callback),
 	      init_local_callback(init_local_callback), exec_callback(exec_callback), progress_callback(progress_callback),
-	      user_data(std::move(user_data)) {
+	      filter_pushdown_callback(filter_pushdown_callback), user_data(std::move(user_data)) {
 	}
 
 	bool operator==(const TableFunctionInfo &other) const {
 		return bind_callback == other.bind_callback && init_global_callback == other.init_global_callback &&
 		       init_local_callback == other.init_local_callback && exec_callback == other.exec_callback &&
-		       progress_callback == other.progress_callback && user_data.get() == other.user_data.get();
+		       progress_callback == other.progress_callback &&
+		       filter_pushdown_callback == other.filter_pushdown_callback && user_data.get() == other.user_data.get();
 	}
 };
 
@@ -3702,12 +3709,42 @@ auto TableFunction::SetProgressCallback(ProgressCallback callback) & -> TableFun
 	return *this;
 }
 
+auto TableFunction::SetFilterPushdownCallback(FilterPushdownCallback callback) & -> TableFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_table_function_set_filter_pushdown_callback, handle(), nullptr);
+		filter_pushdown_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_table_function_filter_pushdown_info_handle info,
+	                            duckdb_v2_context_handle context, duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_table_function_filter_pushdown_get_user_data, info, &user_data);
+			const auto &function = *static_cast<TableFunctionInfo *>(user_data);
+
+			auto input =
+			    detail::Factory::Make<FilterPushdownInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.filter_pushdown_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_table_function_set_filter_pushdown_callback, handle(), trampoline);
+	filter_pushdown_callback = callback;
+	return *this;
+}
+
+auto TableFunction::SetProjectionPushdown(bool enable) & -> TableFunction & {
+	CheckedAPICall(duckdb_v2_table_function_set_projection_pushdown, handle(), enable);
+	return *this;
+}
+
 auto TableFunction::Register() -> void {
 	// The callback table rides the C user_data slot so the trampolines can find
 	// it; the user's own data (SetUserData, moved out here) rides inside it.
-	auto info = std::unique_ptr<TableFunctionInfo>(new TableFunctionInfo(bind_callback, init_global_callback,
-	                                                                     init_local_callback, exec_callback,
-	                                                                     progress_callback, std::move(user_data)));
+	auto info = std::unique_ptr<TableFunctionInfo>(
+	    new TableFunctionInfo(bind_callback, init_global_callback, init_local_callback, exec_callback,
+	                          progress_callback, filter_pushdown_callback, std::move(user_data)));
 	duckdb_v2_opaque opaque {info.get(), detail::TypedDelete<TableFunctionInfo>,
 	                         detail::TypedEquals<TableFunctionInfo>};
 	CheckedAPICall(duckdb_v2_table_function_set_user_data, handle(), &opaque);
@@ -3798,6 +3835,20 @@ auto TableFunction::InitGlobalInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
 }
 
+auto TableFunction::InitGlobalInput::GetColumnCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_table_function_init_global_get_column_count,
+	               static_cast<duckdb_v2_table_function_init_global_info_handle>(args), &count);
+	return count;
+}
+
+auto TableFunction::InitGlobalInput::GetColumnIndex(idx_t index) const -> idx_t {
+	idx_t column_index = 0;
+	CheckedAPICall(duckdb_v2_table_function_init_global_get_column_index,
+	               static_cast<duckdb_v2_table_function_init_global_info_handle>(args), index, &column_index);
+	return column_index;
+}
+
 void TableFunction::InitLocalInput::SetLocalStateInternal(void *data, void (*destructor)(void *)) {
 	duckdb_v2_opaque opaque {data, destructor, nullptr};
 	CheckedAPICall(duckdb_v2_table_function_init_local_set_local_state,
@@ -3828,6 +3879,20 @@ void *TableFunction::InitLocalInput::GetUserDataInternal() const {
 
 auto TableFunction::InitLocalInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
+}
+
+auto TableFunction::InitLocalInput::GetColumnCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_table_function_init_local_get_column_count,
+	               static_cast<duckdb_v2_table_function_init_local_info_handle>(args), &count);
+	return count;
+}
+
+auto TableFunction::InitLocalInput::GetColumnIndex(idx_t index) const -> idx_t {
+	idx_t column_index = 0;
+	CheckedAPICall(duckdb_v2_table_function_init_local_get_column_index,
+	               static_cast<duckdb_v2_table_function_init_local_info_handle>(args), index, &column_index);
+	return column_index;
 }
 
 void *TableFunction::ExecInput::GetBindDataInternal() const {
@@ -3871,6 +3936,20 @@ auto TableFunction::ExecInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
 }
 
+auto TableFunction::ExecInput::GetColumnCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_table_function_exec_get_column_count,
+	               static_cast<duckdb_v2_table_function_exec_info_handle>(args), &count);
+	return count;
+}
+
+auto TableFunction::ExecInput::GetColumnIndex(idx_t index) const -> idx_t {
+	idx_t column_index = 0;
+	CheckedAPICall(duckdb_v2_table_function_exec_get_column_index,
+	               static_cast<duckdb_v2_table_function_exec_info_handle>(args), index, &column_index);
+	return column_index;
+}
+
 void *TableFunction::ProgressInput::GetBindDataInternal() const {
 	void *bind_data = nullptr;
 	CheckedAPICall(duckdb_v2_table_function_progress_get_bind_data,
@@ -3900,6 +3979,119 @@ auto TableFunction::ProgressInput::SetProgress(double progress) -> void {
 
 auto TableFunction::ProgressInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
+}
+
+void *TableFunction::FilterPushdownInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_filter_pushdown_get_bind_data,
+	               static_cast<duckdb_v2_table_function_filter_pushdown_info_handle>(args), &bind_data);
+	return RequireTableBindData(bind_data);
+}
+
+void *TableFunction::FilterPushdownInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_filter_pushdown_get_user_data,
+	               static_cast<duckdb_v2_table_function_filter_pushdown_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const TableFunctionInfo *>(user_data);
+	return RequireTableUserData(function.user_data);
+}
+
+auto TableFunction::FilterPushdownInput::GetFilterCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_table_function_filter_pushdown_get_filter_count,
+	               static_cast<duckdb_v2_table_function_filter_pushdown_info_handle>(args), &count);
+	return count;
+}
+
+auto TableFunction::FilterPushdownInput::GetFilter(idx_t index) const -> Expression {
+	duckdb_v2_expression_handle filter = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_filter_pushdown_get_filter,
+	               static_cast<duckdb_v2_table_function_filter_pushdown_info_handle>(args), index, &filter);
+	return detail::Factory::Make<Expression>(static_cast<void *>(filter));
+}
+
+auto TableFunction::FilterPushdownInput::Accept(idx_t index) -> void {
+	CheckedAPICall(duckdb_v2_table_function_filter_pushdown_accept,
+	               static_cast<duckdb_v2_table_function_filter_pushdown_info_handle>(args), index);
+}
+
+auto TableFunction::FilterPushdownInput::GetColumnCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_table_function_filter_pushdown_get_column_count,
+	               static_cast<duckdb_v2_table_function_filter_pushdown_info_handle>(args), &count);
+	return count;
+}
+
+auto TableFunction::FilterPushdownInput::GetColumnIndex(idx_t index) const -> idx_t {
+	idx_t column_index = 0;
+	CheckedAPICall(duckdb_v2_table_function_filter_pushdown_get_column_index,
+	               static_cast<duckdb_v2_table_function_filter_pushdown_info_handle>(args), index, &column_index);
+	return column_index;
+}
+
+auto TableFunction::FilterPushdownInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Bound Expression
+//----------------------------------------------------------------------------------------------------------------------
+
+Expression::Expression(void *impl) : detail::Handle<Expression>(impl) {
+}
+
+auto Expression::GetType() const -> ExpressionType {
+	auto type = DUCKDB_V2_EXPRESSION_TYPE_INVALID;
+	CheckedAPICall(duckdb_v2_expression_get_type, handle(), &type);
+	return static_cast<ExpressionType>(type);
+}
+
+auto Expression::GetReturnType() const -> LogicalType {
+	duckdb_v2_logical_type_handle type = nullptr;
+	CheckedAPICall(duckdb_v2_expression_get_return_type, handle(), &type);
+	return detail::Factory::Make<LogicalType>(type);
+}
+
+auto Expression::GetChildCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_expression_get_child_count, handle(), &count);
+	return count;
+}
+
+auto Expression::GetChild(idx_t index) const -> Expression {
+	duckdb_v2_expression_handle child = nullptr;
+	CheckedAPICall(duckdb_v2_expression_get_child, handle(), index, &child);
+	return detail::Factory::Make<Expression>(static_cast<void *>(child));
+}
+
+auto Expression::GetConstantValue() const -> Value {
+	duckdb_v2_value_handle value = nullptr;
+	CheckedAPICall(duckdb_v2_expression_constant_get_value, handle(), &value);
+	return detail::Factory::Make<Value>(value);
+}
+
+auto Expression::GetColumnIndex() const -> idx_t {
+	idx_t index = 0;
+	CheckedAPICall(duckdb_v2_expression_column_ref_get_index, handle(), &index);
+	return index;
+}
+
+auto Expression::GetFunctionName() const -> std::string {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_expression_function_get_name, handle(), &name);
+	return std::string(FromStr(name));
+}
+
+auto Expression::GetFunctionQualifiedName() const -> QualifiedName {
+	duckdb_v2_qname_handle name = nullptr;
+	CheckedAPICall(duckdb_v2_expression_function_get_qname, handle(), &name);
+	return detail::Factory::Make<QualifiedName>(name);
+}
+
+auto Expression::GetCastMode() const -> CastMode {
+	auto mode = DUCKDB_V2_CAST_MODE_NORMAL;
+	CheckedAPICall(duckdb_v2_expression_cast_get_mode, handle(), &mode);
+	return static_cast<CastMode>(mode);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -139,6 +139,10 @@ struct HandleTraits<TableFunction> {
 	using handle = duckdb_v2_table_function_handle;
 };
 template <>
+struct HandleTraits<CopyFunction> {
+	using handle = duckdb_v2_copy_function_handle;
+};
+template <>
 struct HandleTraits<CustomType> {
 	using handle = duckdb_v2_custom_type_handle;
 };
@@ -3969,6 +3973,460 @@ auto CustomType::SetBaseType(const LogicalType &type) & -> CustomType & {
 
 auto CustomType::Register() -> void {
 	CheckedAPICall(duckdb_v2_custom_type_register, handle());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Copy Function
+//----------------------------------------------------------------------------------------------------------------------
+
+namespace {
+
+// The callback table for one registered copy function: rides the C user_data
+// slot so the trampolines can find it; the user's own slot (SetUserData) rides
+// inside it. Owned by the registered function, freed at engine teardown.
+struct CopyFunctionInfo {
+	CopyFunction::BindCallback bind_callback = nullptr;
+	CopyFunction::BatchSizeCallback batch_size_callback = nullptr;
+	CopyFunction::InitCallback init_callback = nullptr;
+	CopyFunction::BatchCallback batch_callback = nullptr;
+	CopyFunction::FlushCallback flush_callback = nullptr;
+	CopyFunction::FinalizeCallback finalize_callback = nullptr;
+	detail::UserData user_data;
+
+	CopyFunctionInfo(CopyFunction::BindCallback bind_callback, CopyFunction::BatchSizeCallback batch_size_callback,
+	                 CopyFunction::InitCallback init_callback, CopyFunction::BatchCallback batch_callback,
+	                 CopyFunction::FlushCallback flush_callback, CopyFunction::FinalizeCallback finalize_callback,
+	                 detail::UserData user_data)
+	    : bind_callback(bind_callback), batch_size_callback(batch_size_callback), init_callback(init_callback),
+	      batch_callback(batch_callback), flush_callback(flush_callback), finalize_callback(finalize_callback),
+	      user_data(std::move(user_data)) {
+	}
+
+	bool operator==(const CopyFunctionInfo &other) const {
+		return bind_callback == other.bind_callback && batch_size_callback == other.batch_size_callback &&
+		       init_callback == other.init_callback && batch_callback == other.batch_callback &&
+		       flush_callback == other.flush_callback && finalize_callback == other.finalize_callback &&
+		       user_data.get() == other.user_data.get();
+	}
+};
+
+// Guard for the inputs' GetUserData: a clear error instead of a null deref.
+void *RequireCopyUserData(const detail::UserData &user_data) {
+	auto ptr = user_data.get();
+	if (!ptr) {
+		throw InvalidInputException("no user data was set; call CopyFunction::SetUserData before Register");
+	}
+	return ptr;
+}
+
+// Guard for the inputs' GetBindData: a clear error instead of a null deref.
+void *RequireCopyBindData(void *ptr) {
+	if (!ptr) {
+		throw InvalidInputException("no bind data was set; call BindInput::SetBindData in the bind callback");
+	}
+	return ptr;
+}
+
+// Guard for the inputs' GetInitData: a clear error instead of a null deref.
+void *RequireCopyInitData(void *ptr) {
+	if (!ptr) {
+		throw InvalidInputException("no init data was set; call InitInput::SetInitData in the init callback");
+	}
+	return ptr;
+}
+
+// Guard for the inputs' GetBatchData: a clear error instead of a null deref.
+void *RequireCopyBatchData(void *ptr) {
+	if (!ptr) {
+		throw InvalidInputException("no batch data was set; call BatchInput::SetBatchData in the batch callback");
+	}
+	return ptr;
+}
+
+} // namespace
+
+CopyFunction::CopyFunction(void *impl) : detail::Handle<CopyFunction>(impl) {
+}
+
+CopyFunction::~CopyFunction() {
+	auto _h = handle();
+	duckdb_v2_copy_function_destroy(&_h);
+}
+
+auto CopyFunction::Create(const Connection &conn) -> CopyFunction {
+	duckdb_v2_copy_function_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_create_with_connection, conn.handle(), &_h);
+	return detail::Factory::Make<CopyFunction>(_h);
+}
+
+auto CopyFunction::Create(const Extension &extension) -> CopyFunction {
+	duckdb_v2_copy_function_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_create_with_extension, extension.handle(), &_h);
+	return detail::Factory::Make<CopyFunction>(_h);
+}
+
+auto CopyFunction::SetName(const std::string &name) & -> CopyFunction & {
+	auto view = ToStr(name);
+	CheckedAPICall(duckdb_v2_copy_function_set_name, handle(), &view);
+	return *this;
+}
+
+auto CopyFunction::SetUserDataInternal(void *data, void (*destructor)(void *)) -> void {
+	user_data = detail::UserData(data, destructor);
+}
+
+auto CopyFunction::SetBindCallback(BindCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_function_set_bind_callback, handle(), nullptr);
+		bind_callback = nullptr;
+		return *this;
+	}
+
+	// The C-side callback is one shared trampoline; the user's callback is looked
+	// up through the info table riding the user_data slot (set by Register).
+	static auto trampoline = [](duckdb_v2_copy_function_bind_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_function_bind_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<BindInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.bind_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_function_set_bind_callback, handle(), trampoline);
+	bind_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetBatchSizeCallback(BatchSizeCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_function_set_batch_size_callback, handle(), nullptr);
+		batch_size_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_function_batch_size_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_function_batch_size_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<BatchSizeInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.batch_size_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_function_set_batch_size_callback, handle(), trampoline);
+	batch_size_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetInitCallback(InitCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_function_set_init_callback, handle(), nullptr);
+		init_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_function_init_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_function_init_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<InitInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.init_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_function_set_init_callback, handle(), trampoline);
+	init_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetBatchCallback(BatchCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_function_set_batch_callback, handle(), nullptr);
+		batch_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_function_batch_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_function_batch_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<BatchInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.batch_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_function_set_batch_callback, handle(), trampoline);
+	batch_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetFlushCallback(FlushCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_function_set_flush_callback, handle(), nullptr);
+		flush_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_function_flush_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_function_flush_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<FlushInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.flush_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_function_set_flush_callback, handle(), trampoline);
+	flush_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::SetFinalizeCallback(FinalizeCallback callback) & -> CopyFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_copy_function_set_finalize_callback, handle(), nullptr);
+		finalize_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_copy_function_finalize_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_copy_function_finalize_get_user_data, info, &user_data);
+			const auto &function = *static_cast<CopyFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<FinalizeInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.finalize_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_copy_function_set_finalize_callback, handle(), trampoline);
+	finalize_callback = callback;
+	return *this;
+}
+
+auto CopyFunction::Register() -> void {
+	// The callback table rides the C user_data slot so the trampolines can find
+	// it; the user's own data (SetUserData, moved out here) rides inside it.
+	auto info = std::unique_ptr<CopyFunctionInfo>(new CopyFunctionInfo(bind_callback, batch_size_callback,
+	                                                                   init_callback, batch_callback, flush_callback,
+	                                                                   finalize_callback, std::move(user_data)));
+	duckdb_v2_opaque opaque {info.get(), detail::TypedDelete<CopyFunctionInfo>, detail::TypedEquals<CopyFunctionInfo>};
+	CheckedAPICall(duckdb_v2_copy_function_set_user_data, handle(), &opaque);
+	// The function owns the table now.
+	info.release();
+
+	CheckedAPICall(duckdb_v2_copy_function_register, handle());
+}
+
+void *CopyFunction::BindInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_bind_get_user_data,
+	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+void CopyFunction::BindInput::SetBindDataInternal(void *data, bool (*equals)(void *a, void *b),
+                                                  void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, equals};
+	CheckedAPICall(duckdb_v2_copy_function_bind_set_bind_data,
+	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), &opaque);
+}
+
+auto CopyFunction::BindInput::GetColumnCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_copy_function_bind_get_column_count,
+	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), &count);
+	return count;
+}
+
+auto CopyFunction::BindInput::GetColumnName(idx_t index) const -> std::string {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_copy_function_bind_get_column_name,
+	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), index, &name);
+	return std::string(FromStr(name));
+}
+
+auto CopyFunction::BindInput::GetColumnType(idx_t index) const -> LogicalType {
+	duckdb_v2_logical_type_handle type = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_bind_get_column_type,
+	               static_cast<duckdb_v2_copy_function_bind_info_handle>(args), index, &type);
+	return detail::Factory::Make<LogicalType>(type);
+}
+
+auto CopyFunction::BindInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *CopyFunction::BatchSizeInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_batch_size_get_bind_data,
+	               static_cast<duckdb_v2_copy_function_batch_size_info_handle>(args), &bind_data);
+	return RequireCopyBindData(bind_data);
+}
+
+void *CopyFunction::BatchSizeInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_batch_size_get_user_data,
+	               static_cast<duckdb_v2_copy_function_batch_size_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::BatchSizeInput::SetTarget(idx_t rows) -> void {
+	CheckedAPICall(duckdb_v2_copy_function_batch_size_set_target,
+	               static_cast<duckdb_v2_copy_function_batch_size_info_handle>(args), rows);
+}
+
+auto CopyFunction::BatchSizeInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void CopyFunction::InitInput::SetInitDataInternal(void *data, void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, nullptr};
+	CheckedAPICall(duckdb_v2_copy_function_init_set_init_data,
+	               static_cast<duckdb_v2_copy_function_init_info_handle>(args), &opaque);
+}
+
+void *CopyFunction::InitInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_init_get_bind_data,
+	               static_cast<duckdb_v2_copy_function_init_info_handle>(args), &bind_data);
+	return RequireCopyBindData(bind_data);
+}
+
+void *CopyFunction::InitInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_init_get_user_data,
+	               static_cast<duckdb_v2_copy_function_init_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::InitInput::GetFilePath() const -> std::string {
+	duckdb_v2_str path = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_copy_function_init_get_file_path,
+	               static_cast<duckdb_v2_copy_function_init_info_handle>(args), &path);
+	return std::string(FromStr(path));
+}
+
+auto CopyFunction::InitInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void CopyFunction::BatchInput::SetBatchDataInternal(void *data, void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, nullptr};
+	CheckedAPICall(duckdb_v2_copy_function_batch_set_batch_data,
+	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &opaque);
+}
+
+void *CopyFunction::BatchInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_batch_get_bind_data,
+	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &bind_data);
+	return RequireCopyBindData(bind_data);
+}
+
+void *CopyFunction::BatchInput::GetInitDataInternal() const {
+	void *init_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_batch_get_init_data,
+	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &init_data);
+	return RequireCopyInitData(init_data);
+}
+
+void *CopyFunction::BatchInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_batch_get_user_data,
+	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::BatchInput::TakeBatch() -> ColumnDataCollection {
+	duckdb_v2_column_data_collection_handle collection = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_batch_take_input,
+	               static_cast<duckdb_v2_copy_function_batch_info_handle>(args), &collection);
+	return detail::Factory::Make<ColumnDataCollection>(collection);
+}
+
+auto CopyFunction::BatchInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *CopyFunction::FlushInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_flush_get_bind_data,
+	               static_cast<duckdb_v2_copy_function_flush_info_handle>(args), &bind_data);
+	return RequireCopyBindData(bind_data);
+}
+
+void *CopyFunction::FlushInput::GetInitDataInternal() const {
+	void *init_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_flush_get_init_data,
+	               static_cast<duckdb_v2_copy_function_flush_info_handle>(args), &init_data);
+	return RequireCopyInitData(init_data);
+}
+
+void *CopyFunction::FlushInput::GetBatchDataInternal() const {
+	void *batch_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_flush_get_batch_data,
+	               static_cast<duckdb_v2_copy_function_flush_info_handle>(args), &batch_data);
+	return RequireCopyBatchData(batch_data);
+}
+
+void *CopyFunction::FlushInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_flush_get_user_data,
+	               static_cast<duckdb_v2_copy_function_flush_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::FlushInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *CopyFunction::FinalizeInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_finalize_get_bind_data,
+	               static_cast<duckdb_v2_copy_function_finalize_info_handle>(args), &bind_data);
+	return RequireCopyBindData(bind_data);
+}
+
+void *CopyFunction::FinalizeInput::GetInitDataInternal() const {
+	void *init_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_finalize_get_init_data,
+	               static_cast<duckdb_v2_copy_function_finalize_info_handle>(args), &init_data);
+	return RequireCopyInitData(init_data);
+}
+
+void *CopyFunction::FinalizeInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_copy_function_finalize_get_user_data,
+	               static_cast<duckdb_v2_copy_function_finalize_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const CopyFunctionInfo *>(user_data);
+	return RequireCopyUserData(function.user_data);
+}
+
+auto CopyFunction::FinalizeInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -120,6 +120,10 @@ template <>
 struct HandleTraits<AggregateFunction> {
 	using handle = duckdb_v2_aggregate_function_handle;
 };
+template <>
+struct HandleTraits<TableFunction> {
+	using handle = duckdb_v2_table_function_handle;
+};
 
 } // namespace detail
 
@@ -3177,6 +3181,487 @@ auto AggregateFunction::DestroyInput::GetStates() const -> void ** {
 	CheckedAPICall(duckdb_v2_aggregate_function_destroy_get_states,
 	               static_cast<duckdb_v2_aggregate_function_destroy_info_handle>(args), &states);
 	return states;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Table Function
+//----------------------------------------------------------------------------------------------------------------------
+
+namespace {
+
+// The callback table for one registered table function: rides the C user_data
+// slot so the trampolines can find it; the user's own slot (SetUserData) rides
+// inside it. Owned by the registered function, freed at engine teardown.
+struct TableFunctionInfo {
+	TableFunction::BindCallback bind_callback = nullptr;
+	TableFunction::InitGlobalCallback init_global_callback = nullptr;
+	TableFunction::InitLocalCallback init_local_callback = nullptr;
+	TableFunction::ExecCallback exec_callback = nullptr;
+	TableFunction::CardinalityCallback cardinality_callback = nullptr;
+	TableFunction::ProgressCallback progress_callback = nullptr;
+	detail::UserData user_data;
+
+	TableFunctionInfo(TableFunction::BindCallback bind_callback, TableFunction::InitGlobalCallback init_global_callback,
+	                  TableFunction::InitLocalCallback init_local_callback, TableFunction::ExecCallback exec_callback,
+	                  TableFunction::CardinalityCallback cardinality_callback,
+	                  TableFunction::ProgressCallback progress_callback, detail::UserData user_data)
+	    : bind_callback(bind_callback), init_global_callback(init_global_callback),
+	      init_local_callback(init_local_callback), exec_callback(exec_callback),
+	      cardinality_callback(cardinality_callback), progress_callback(progress_callback),
+	      user_data(std::move(user_data)) {
+	}
+
+	bool operator==(const TableFunctionInfo &other) const {
+		return bind_callback == other.bind_callback && init_global_callback == other.init_global_callback &&
+		       init_local_callback == other.init_local_callback && exec_callback == other.exec_callback &&
+		       cardinality_callback == other.cardinality_callback && progress_callback == other.progress_callback &&
+		       user_data.get() == other.user_data.get();
+	}
+};
+
+// Guard for the inputs' GetUserData: a clear error instead of a null deref.
+void *RequireTableUserData(const detail::UserData &user_data) {
+	auto ptr = user_data.get();
+	if (!ptr) {
+		throw InvalidInputException("no user data was set; call TableFunction::SetUserData before Register");
+	}
+	return ptr;
+}
+
+// Guard for the inputs' GetBindData: a clear error instead of a null deref.
+void *RequireTableBindData(void *ptr) {
+	if (!ptr) {
+		throw InvalidInputException("no bind data was set; call BindInput::SetBindData in the bind callback");
+	}
+	return ptr;
+}
+
+// Guard for the inputs' GetGlobalState: a clear error instead of a null deref.
+void *RequireGlobalState(void *ptr) {
+	if (!ptr) {
+		throw InvalidInputException(
+		    "no global state was set; call InitGlobalInput::SetGlobalState in the global init callback");
+	}
+	return ptr;
+}
+
+// Guard for ExecInput::GetLocalState: a clear error instead of a null deref.
+void *RequireLocalState(void *ptr) {
+	if (!ptr) {
+		throw InvalidInputException(
+		    "no local state was set; call InitLocalInput::SetLocalState in the local init callback");
+	}
+	return ptr;
+}
+
+} // namespace
+
+TableFunction::TableFunction(void *impl) : detail::Handle<TableFunction>(impl) {
+}
+
+TableFunction::~TableFunction() {
+	auto _h = handle();
+	duckdb_v2_table_function_destroy(&_h);
+}
+
+auto TableFunction::Create(const Connection &conn) -> TableFunction {
+	duckdb_v2_table_function_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_create_with_connection, conn.handle(), &_h);
+	return detail::Factory::Make<TableFunction>(_h);
+}
+
+auto TableFunction::Create(const Extension &extension) -> TableFunction {
+	duckdb_v2_table_function_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_create_with_extension, extension.handle(), &_h);
+	return detail::Factory::Make<TableFunction>(_h);
+}
+
+auto TableFunction::SetName(const std::string &name) & -> TableFunction & {
+	auto view = ToStr(name);
+	CheckedAPICall(duckdb_v2_table_function_set_name, handle(), &view);
+	return *this;
+}
+
+auto TableFunction::GetSignature() -> FunctionSignature {
+	duckdb_v2_function_signature_handle sig = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_get_signature, handle(), &sig);
+	return detail::Factory::Make<FunctionSignature>(sig);
+}
+
+auto TableFunction::SetUserDataInternal(void *data, void (*destructor)(void *)) -> void {
+	user_data = detail::UserData(data, destructor);
+}
+
+auto TableFunction::SetBindCallback(BindCallback callback) & -> TableFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_table_function_set_bind_callback, handle(), nullptr);
+		bind_callback = nullptr;
+		return *this;
+	}
+
+	// The C-side callback is one shared trampoline; the user's callback is looked
+	// up through the info table riding the user_data slot (set by Register).
+	static auto trampoline = [](duckdb_v2_table_function_bind_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_table_function_bind_get_user_data, info, &user_data);
+			const auto &function = *static_cast<TableFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<BindInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.bind_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_table_function_set_bind_callback, handle(), trampoline);
+	bind_callback = callback;
+	return *this;
+}
+
+auto TableFunction::SetInitGlobalCallback(InitGlobalCallback callback) & -> TableFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_table_function_set_init_global_callback, handle(), nullptr);
+		init_global_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_table_function_init_global_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_table_function_init_global_get_user_data, info, &user_data);
+			const auto &function = *static_cast<TableFunctionInfo *>(user_data);
+
+			auto input =
+			    detail::Factory::Make<InitGlobalInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.init_global_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_table_function_set_init_global_callback, handle(), trampoline);
+	init_global_callback = callback;
+	return *this;
+}
+
+auto TableFunction::SetInitLocalCallback(InitLocalCallback callback) & -> TableFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_table_function_set_init_local_callback, handle(), nullptr);
+		init_local_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_table_function_init_local_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_table_function_init_local_get_user_data, info, &user_data);
+			const auto &function = *static_cast<TableFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<InitLocalInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.init_local_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_table_function_set_init_local_callback, handle(), trampoline);
+	init_local_callback = callback;
+	return *this;
+}
+
+auto TableFunction::SetExecCallback(ExecCallback callback) & -> TableFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_table_function_set_exec_callback, handle(), nullptr);
+		exec_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_table_function_exec_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_table_function_exec_get_user_data, info, &user_data);
+			const auto &function = *static_cast<TableFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<ExecInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.exec_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_table_function_set_exec_callback, handle(), trampoline);
+	exec_callback = callback;
+	return *this;
+}
+
+auto TableFunction::SetCardinalityCallback(CardinalityCallback callback) & -> TableFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_table_function_set_cardinality_callback, handle(), nullptr);
+		cardinality_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_table_function_cardinality_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_table_function_cardinality_get_user_data, info, &user_data);
+			const auto &function = *static_cast<TableFunctionInfo *>(user_data);
+
+			auto input =
+			    detail::Factory::Make<CardinalityInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.cardinality_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_table_function_set_cardinality_callback, handle(), trampoline);
+	cardinality_callback = callback;
+	return *this;
+}
+
+auto TableFunction::SetProgressCallback(ProgressCallback callback) & -> TableFunction & {
+	if (!callback) {
+		CheckedAPICall(duckdb_v2_table_function_set_progress_callback, handle(), nullptr);
+		progress_callback = nullptr;
+		return *this;
+	}
+
+	static auto trampoline = [](duckdb_v2_table_function_progress_info_handle info, duckdb_v2_context_handle context,
+	                            duckdb_v2_error_info_handle *err) {
+		WithExceptionGuard(err, [&]() {
+			void *user_data = nullptr;
+			CheckedAPICall(duckdb_v2_table_function_progress_get_user_data, info, &user_data);
+			const auto &function = *static_cast<TableFunctionInfo *>(user_data);
+
+			auto input = detail::Factory::Make<ProgressInput>(static_cast<void *>(info), static_cast<void *>(context));
+			function.progress_callback(input);
+		});
+	};
+
+	CheckedAPICall(duckdb_v2_table_function_set_progress_callback, handle(), trampoline);
+	progress_callback = callback;
+	return *this;
+}
+
+auto TableFunction::Register() -> void {
+	// The callback table rides the C user_data slot so the trampolines can find
+	// it; the user's own data (SetUserData, moved out here) rides inside it.
+	auto info = std::unique_ptr<TableFunctionInfo>(
+	    new TableFunctionInfo(bind_callback, init_global_callback, init_local_callback, exec_callback,
+	                          cardinality_callback, progress_callback, std::move(user_data)));
+	duckdb_v2_opaque opaque {info.get(), detail::TypedDelete<TableFunctionInfo>,
+	                         detail::TypedEquals<TableFunctionInfo>};
+	CheckedAPICall(duckdb_v2_table_function_set_user_data, handle(), &opaque);
+	// The function owns the table now.
+	info.release();
+
+	CheckedAPICall(duckdb_v2_table_function_register, handle());
+}
+
+auto TableFunction::BindInput::AddResultColumn(const std::string &name, const LogicalType &type) -> void {
+	CheckedAPICall(duckdb_v2_table_function_bind_add_result_column,
+	               static_cast<duckdb_v2_table_function_bind_info_handle>(args),
+	               duckdb_v2_identifier_t {name.data(), name.size()}, type.handle());
+}
+
+void TableFunction::BindInput::SetBindDataInternal(void *data, bool (*equals)(void *a, void *b),
+                                                   void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, equals};
+	CheckedAPICall(duckdb_v2_table_function_bind_set_bind_data,
+	               static_cast<duckdb_v2_table_function_bind_info_handle>(args), &opaque);
+}
+
+void *TableFunction::BindInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_bind_get_user_data,
+	               static_cast<duckdb_v2_table_function_bind_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const TableFunctionInfo *>(user_data);
+	return RequireTableUserData(function.user_data);
+}
+
+auto TableFunction::BindInput::GetArgCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_table_function_bind_get_arg_count,
+	               static_cast<duckdb_v2_table_function_bind_info_handle>(args), &count);
+	return count;
+}
+
+auto TableFunction::BindInput::GetArgType(idx_t index) const -> LogicalType {
+	duckdb_v2_logical_type_handle type = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_bind_get_arg_type,
+	               static_cast<duckdb_v2_table_function_bind_info_handle>(args), index, &type);
+	return detail::Factory::Make<LogicalType>(type);
+}
+
+auto TableFunction::BindInput::GetArgument(idx_t index) const -> Value {
+	duckdb_v2_value_handle value = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_bind_get_arg_value,
+	               static_cast<duckdb_v2_table_function_bind_info_handle>(args), index, &value);
+	return detail::Factory::Make<Value>(value);
+}
+
+auto TableFunction::BindInput::SetCardinality(idx_t cardinality, bool is_exact) -> void {
+	CheckedAPICall(duckdb_v2_table_function_bind_set_cardinality,
+	               static_cast<duckdb_v2_table_function_bind_info_handle>(args), cardinality, is_exact);
+}
+
+auto TableFunction::BindInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void TableFunction::InitGlobalInput::SetGlobalStateInternal(void *data, void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, nullptr};
+	CheckedAPICall(duckdb_v2_table_function_init_global_set_global_state,
+	               static_cast<duckdb_v2_table_function_init_global_info_handle>(args), &opaque);
+}
+
+void *TableFunction::InitGlobalInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_init_global_get_bind_data,
+	               static_cast<duckdb_v2_table_function_init_global_info_handle>(args), &bind_data);
+	return RequireTableBindData(bind_data);
+}
+
+void *TableFunction::InitGlobalInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_init_global_get_user_data,
+	               static_cast<duckdb_v2_table_function_init_global_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const TableFunctionInfo *>(user_data);
+	return RequireTableUserData(function.user_data);
+}
+
+auto TableFunction::InitGlobalInput::SetMaxThreads(idx_t max_threads) -> void {
+	CheckedAPICall(duckdb_v2_table_function_init_global_set_max_threads,
+	               static_cast<duckdb_v2_table_function_init_global_info_handle>(args), max_threads);
+}
+
+auto TableFunction::InitGlobalInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void TableFunction::InitLocalInput::SetLocalStateInternal(void *data, void (*destructor)(void *)) {
+	duckdb_v2_opaque opaque {data, destructor, nullptr};
+	CheckedAPICall(duckdb_v2_table_function_init_local_set_local_state,
+	               static_cast<duckdb_v2_table_function_init_local_info_handle>(args), &opaque);
+}
+
+void *TableFunction::InitLocalInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_init_local_get_bind_data,
+	               static_cast<duckdb_v2_table_function_init_local_info_handle>(args), &bind_data);
+	return RequireTableBindData(bind_data);
+}
+
+void *TableFunction::InitLocalInput::GetGlobalStateInternal() const {
+	void *global_state = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_init_local_get_global_state,
+	               static_cast<duckdb_v2_table_function_init_local_info_handle>(args), &global_state);
+	return RequireGlobalState(global_state);
+}
+
+void *TableFunction::InitLocalInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_init_local_get_user_data,
+	               static_cast<duckdb_v2_table_function_init_local_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const TableFunctionInfo *>(user_data);
+	return RequireTableUserData(function.user_data);
+}
+
+auto TableFunction::InitLocalInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *TableFunction::ExecInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_exec_get_bind_data,
+	               static_cast<duckdb_v2_table_function_exec_info_handle>(args), &bind_data);
+	return RequireTableBindData(bind_data);
+}
+
+void *TableFunction::ExecInput::GetGlobalStateInternal() const {
+	void *global_state = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_exec_get_global_state,
+	               static_cast<duckdb_v2_table_function_exec_info_handle>(args), &global_state);
+	return RequireGlobalState(global_state);
+}
+
+void *TableFunction::ExecInput::GetLocalStateInternal() const {
+	void *local_state = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_exec_get_local_state,
+	               static_cast<duckdb_v2_table_function_exec_info_handle>(args), &local_state);
+	return RequireLocalState(local_state);
+}
+
+void *TableFunction::ExecInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_exec_get_user_data,
+	               static_cast<duckdb_v2_table_function_exec_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const TableFunctionInfo *>(user_data);
+	return RequireTableUserData(function.user_data);
+}
+
+auto TableFunction::ExecInput::GetOutputChunk() const -> DataChunk {
+	duckdb_v2_data_chunk_handle chunk = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_exec_get_output_chunk,
+	               static_cast<duckdb_v2_table_function_exec_info_handle>(args), &chunk);
+	// Borrowed: the engine owns the chunk and reuses it across invocations.
+	return detail::Factory::Make<DataChunk>(chunk, false);
+}
+
+auto TableFunction::ExecInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *TableFunction::CardinalityInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_cardinality_get_bind_data,
+	               static_cast<duckdb_v2_table_function_cardinality_info_handle>(args), &bind_data);
+	return RequireTableBindData(bind_data);
+}
+
+void *TableFunction::CardinalityInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_cardinality_get_user_data,
+	               static_cast<duckdb_v2_table_function_cardinality_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const TableFunctionInfo *>(user_data);
+	return RequireTableUserData(function.user_data);
+}
+
+auto TableFunction::CardinalityInput::SetCardinality(idx_t cardinality, bool is_exact) -> void {
+	CheckedAPICall(duckdb_v2_table_function_cardinality_set_cardinality,
+	               static_cast<duckdb_v2_table_function_cardinality_info_handle>(args), cardinality, is_exact);
+}
+
+auto TableFunction::CardinalityInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
+}
+
+void *TableFunction::ProgressInput::GetBindDataInternal() const {
+	void *bind_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_progress_get_bind_data,
+	               static_cast<duckdb_v2_table_function_progress_info_handle>(args), &bind_data);
+	return RequireTableBindData(bind_data);
+}
+
+void *TableFunction::ProgressInput::GetGlobalStateInternal() const {
+	void *global_state = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_progress_get_global_state,
+	               static_cast<duckdb_v2_table_function_progress_info_handle>(args), &global_state);
+	return RequireGlobalState(global_state);
+}
+
+void *TableFunction::ProgressInput::GetUserDataInternal() const {
+	void *user_data = nullptr;
+	CheckedAPICall(duckdb_v2_table_function_progress_get_user_data,
+	               static_cast<duckdb_v2_table_function_progress_info_handle>(args), &user_data);
+	const auto &function = *static_cast<const TableFunctionInfo *>(user_data);
+	return RequireTableUserData(function.user_data);
+}
+
+auto TableFunction::ProgressInput::SetProgress(double progress) -> void {
+	CheckedAPICall(duckdb_v2_table_function_progress_set_progress,
+	               static_cast<duckdb_v2_table_function_progress_info_handle>(args), progress);
+}
+
+auto TableFunction::ProgressInput::GetContext() const -> Context {
+	return detail::Factory::Make<Context>(context);
 }
 
 } // namespace cxx

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -59,6 +59,10 @@ struct HandleTraits<StatementIterator> {
 	using handle = duckdb_v2_statement_iterator_handle;
 };
 template <>
+struct HandleTraits<PreparedStatement> {
+	using handle = duckdb_v2_prepared_statement_handle;
+};
+template <>
 struct HandleTraits<Schema> {
 	using handle = duckdb_v2_schema_handle;
 };
@@ -628,6 +632,65 @@ auto Connection::Execute(const std::string &sql) -> QueryResult {
 		throw InvalidInputException("Execute expects exactly one statement; use ParseSQL for multi-statement input");
 	}
 	return Execute(statement);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Prepared statements
+//----------------------------------------------------------------------------------------------------------------------
+
+PreparedStatement::PreparedStatement(void *impl) : detail::Handle<PreparedStatement>(impl) {
+}
+
+PreparedStatement::~PreparedStatement() {
+	auto _h = handle();
+	duckdb_v2_prepared_statement_destroy(&_h);
+}
+
+auto Connection::Prepare(const SqlStatement &statement, bool require_cacheable) -> PreparedStatement {
+	// Borrowed, not consumed: the caller's SqlStatement keeps ownership and can be
+	// prepared or executed again.
+	duckdb_v2_prepared_statement_handle prepared = nullptr;
+	CheckedAPICall(duckdb_v2_prepared_statement_create, handle(), statement.handle(), require_cacheable, &prepared);
+	return detail::Factory::Make<PreparedStatement>(prepared);
+}
+
+auto PreparedStatement::Execute(const Value *parameters, idx_t parameter_count) -> QueryResult {
+	std::vector<duckdb_v2_value_handle> values;
+	values.reserve(parameter_count);
+	for (idx_t i = 0; i < parameter_count; i++) {
+		values.push_back(parameters[i].handle());
+	}
+	duckdb_v2_result_handle result = nullptr;
+	CheckedAPICall(duckdb_v2_prepared_statement_execute, handle(), nullptr, parameter_count ? values.data() : nullptr,
+	               parameter_count, &result);
+	return detail::Factory::Make<QueryResult>(result);
+}
+
+auto PreparedStatement::Execute(const std::vector<NamedParam> &parameters) -> QueryResult {
+	// Split into the C API's parallel arrays; an empty name crosses as the positional
+	// {NULL, 0} view (mirrors Connection::Execute).
+	std::vector<duckdb_v2_identifier_t> names;
+	std::vector<duckdb_v2_value_handle> values;
+	names.reserve(parameters.size());
+	values.reserve(parameters.size());
+	for (const auto &param : parameters) {
+		names.push_back(param.name.empty() ? duckdb_v2_identifier_t {nullptr, 0} : ToStr(param.name));
+		values.push_back(param.value.handle());
+	}
+	duckdb_v2_result_handle result = nullptr;
+	CheckedAPICall(duckdb_v2_prepared_statement_execute, handle(), names.empty() ? nullptr : names.data(),
+	               values.empty() ? nullptr : values.data(), static_cast<idx_t>(parameters.size()), &result);
+	return detail::Factory::Make<QueryResult>(result);
+}
+
+auto PreparedStatement::Execute() -> QueryResult {
+	return Execute(nullptr, 0);
+}
+
+auto PreparedStatement::ReusesPlan() const -> bool {
+	bool reuses = false;
+	CheckedAPICall(duckdb_v2_prepared_statement_reuses_plan, handle(), &reuses);
+	return reuses;
 }
 
 auto Connection::Interrupt() -> void {

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -142,6 +142,18 @@ template <>
 struct HandleTraits<QualifiedName> {
 	using handle = duckdb_v2_qname_handle;
 };
+template <>
+struct HandleTraits<FileSystem> {
+	using handle = duckdb_v2_file_system_handle;
+};
+template <>
+struct HandleTraits<FileHandle> {
+	using handle = duckdb_v2_file_handle;
+};
+template <>
+struct HandleTraits<FileOpenOptions> {
+	using handle = duckdb_v2_file_open_options_handle;
+};
 
 } // namespace detail
 
@@ -515,6 +527,12 @@ auto Connection::CreateType(std::string_view name, const std::vector<TypeParam> 
 	return CreateType(QualifiedName::Create({std::string(name)}), params);
 }
 
+auto Connection::GetFileSystem() const -> FileSystem {
+	duckdb_v2_file_system_handle fs = nullptr;
+	CheckedAPICall(duckdb_v2_file_system_get_from_connection, handle(), &fs);
+	return detail::Factory::Make<FileSystem>(fs);
+}
+
 auto Connection::CreateType(const QualifiedName &name, const std::vector<TypeParam> &params) -> LogicalType {
 	TypeParamArrays split(params);
 	duckdb_v2_logical_type_handle type = nullptr;
@@ -687,6 +705,12 @@ auto Context::CreateType(std::string_view name) const -> LogicalType {
 
 auto Context::CreateType(std::string_view name, const std::vector<TypeParam> &params) const -> LogicalType {
 	return CreateType(QualifiedName::Create({std::string(name)}), params);
+}
+
+auto Context::GetFileSystem() const -> FileSystem {
+	duckdb_v2_file_system_handle fs = nullptr;
+	CheckedAPICall(duckdb_v2_file_system_get_from_context, handle(), &fs);
+	return detail::Factory::Make<FileSystem>(fs);
 }
 
 auto Context::CreateType(const QualifiedName &name, const std::vector<TypeParam> &params) const -> LogicalType {
@@ -3880,6 +3904,111 @@ auto CastFunction::ExecInput::GetMode() const -> CastMode {
 
 auto CastFunction::ExecInput::GetContext() const -> Context {
 	return detail::Factory::Make<Context>(context);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// File System
+//----------------------------------------------------------------------------------------------------------------------
+
+FileSystem::FileSystem(void *impl) : detail::Handle<FileSystem>(impl) {
+}
+
+FileSystem::~FileSystem() {
+	// Borrowed: the context or connection owns the file system, so there is nothing to release here.
+}
+
+auto FileSystem::CreateOpenOptions() const -> FileOpenOptions {
+	return FileOpenOptions::Create(*this);
+}
+
+auto FileSystem::OpenFile(const std::string &path, std::initializer_list<FileFlags> flags) const -> FileHandle {
+	auto options = CreateOpenOptions();
+	for (auto flag : flags) {
+		options.SetFlag(flag);
+	}
+	return OpenFile(path, options);
+}
+
+auto FileSystem::OpenFile(const std::string &path, const FileOpenOptions &options) const -> FileHandle {
+	duckdb_v2_file_handle result = nullptr;
+	CheckedAPICall(duckdb_v2_file_system_open, handle(), ToStr(path), options.handle(), &result);
+	return detail::Factory::Make<FileHandle>(result);
+}
+
+FileOpenOptions::FileOpenOptions(void *impl) : detail::Handle<FileOpenOptions>(impl) {
+}
+
+FileOpenOptions::~FileOpenOptions() {
+	auto _h = handle();
+	duckdb_v2_file_open_options_destroy(&_h);
+}
+
+auto FileOpenOptions::Create(const FileSystem &fs) -> FileOpenOptions {
+	duckdb_v2_file_open_options_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_file_open_options_create, fs.handle(), &_h);
+	return detail::Factory::Make<FileOpenOptions>(_h);
+}
+
+auto FileOpenOptions::SetFlag(FileFlags flag) & -> FileOpenOptions & {
+	CheckedAPICall(duckdb_v2_file_open_options_set_flag, handle(), static_cast<DUCKDB_V2_FILE_FLAG>(flag));
+	return *this;
+}
+
+auto FileOpenOptions::SetValue(std::string_view name, const Value &value) & -> FileOpenOptions & {
+	CheckedAPICall(duckdb_v2_file_open_options_set_value, handle(), ToStr(name), value.handle());
+	return *this;
+}
+
+FileHandle::FileHandle(void *impl) : detail::Handle<FileHandle>(impl) {
+}
+
+FileHandle::~FileHandle() {
+	auto _h = handle();
+	duckdb_v2_file_destroy(&_h);
+}
+
+void FileHandle::Sync() {
+	CheckedAPICall(duckdb_v2_file_sync, handle());
+}
+
+void FileHandle::Close() {
+	CheckedAPICall(duckdb_v2_file_close, handle());
+}
+
+void FileHandle::Seek(idx_t position) {
+	CheckedAPICall(duckdb_v2_file_seek, handle(), position);
+}
+
+auto FileHandle::Tell() const -> idx_t {
+	idx_t position = 0;
+	CheckedAPICall(duckdb_v2_file_tell, handle(), &position);
+	return position;
+}
+
+auto FileHandle::Size() const -> idx_t {
+	idx_t size = 0;
+	CheckedAPICall(duckdb_v2_file_size, handle(), &size);
+	return size;
+}
+
+auto FileHandle::Read(void *buffer, idx_t size) -> idx_t {
+	idx_t bytes_read = 0;
+	CheckedAPICall(duckdb_v2_file_read, handle(), buffer, size, &bytes_read);
+	return bytes_read;
+}
+
+auto FileHandle::Write(const void *buffer, idx_t size) -> idx_t {
+	idx_t bytes_written = 0;
+	CheckedAPICall(duckdb_v2_file_write, handle(), buffer, size, &bytes_written);
+	return bytes_written;
+}
+
+void FileHandle::ReadAt(void *buffer, idx_t size, idx_t location) {
+	CheckedAPICall(duckdb_v2_file_read_at, handle(), buffer, size, location);
+}
+
+void FileHandle::WriteAt(const void *buffer, idx_t size, idx_t location) {
+	CheckedAPICall(duckdb_v2_file_write_at, handle(), buffer, size, location);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -159,6 +159,14 @@ struct HandleTraits<QualifiedName> {
 	using handle = duckdb_v2_qname_handle;
 };
 template <>
+struct HandleTraits<TableDescription> {
+	using handle = duckdb_v2_table_description_handle;
+};
+template <>
+struct HandleTraits<ColumnDescription> {
+	using handle = duckdb_v2_column_description_handle;
+};
+template <>
 struct HandleTraits<FileSystem> {
 	using handle = duckdb_v2_file_system_handle;
 };
@@ -1049,6 +1057,12 @@ auto Connection::Bind(const SqlStatement &statement) const -> Signature {
 	duckdb_v2_schema_handle out_parameters = nullptr;
 	CheckedAPICall(duckdb_v2_statement_bind, handle(), statement.handle(), &out_schema, &out_parameters);
 	return Signature {detail::Factory::Make<Schema>(out_schema), detail::Factory::Make<Schema>(out_parameters)};
+}
+
+auto Connection::DescribeTable(const QualifiedName &name) const -> TableDescription {
+	duckdb_v2_table_description_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_connection_describe_table, handle(), name.handle(), &_h);
+	return detail::Factory::Make<TableDescription>(_h);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -5108,6 +5122,42 @@ auto QualifiedName::Hash() const -> uint64_t {
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+// Table Description
+//----------------------------------------------------------------------------------------------------------------------
+
+TableDescription::TableDescription(void *impl) : detail::Handle<TableDescription>(impl) {
+}
+
+TableDescription::~TableDescription() {
+	auto _h = handle();
+	duckdb_v2_table_description_destroy(&_h);
+}
+
+auto TableDescription::GetQualifiedName() const -> QualifiedName {
+	duckdb_v2_qname_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_table_description_get_qname, handle(), &_h);
+	return detail::Factory::Make<QualifiedName>(_h);
+}
+
+auto TableDescription::GetColumnCount() const -> idx_t {
+	idx_t count = 0;
+	CheckedAPICall(duckdb_v2_table_description_get_column_count, handle(), &count);
+	return count;
+}
+
+auto TableDescription::GetColumn(idx_t index) const -> ColumnDescription {
+	duckdb_v2_column_description_handle _h = nullptr;
+	CheckedAPICall(duckdb_v2_table_description_get_column, handle(), index, &_h);
+	return detail::Factory::Make<ColumnDescription>(_h);
+}
+
+auto TableDescription::IsReadOnly() const -> bool {
+	bool result = false;
+	CheckedAPICall(duckdb_v2_table_description_is_readonly, handle(), &result);
+	return result;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 // Replacement Scan
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -5455,6 +5505,45 @@ void Appender::Flush() {
 void Appender::Clear() {
 	ResetBuffer();
 	broken = false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Column Description
+//----------------------------------------------------------------------------------------------------------------------
+
+ColumnDescription::ColumnDescription(void *impl) : detail::Handle<ColumnDescription>(impl) {
+}
+
+ColumnDescription::~ColumnDescription() {
+	auto _h = handle();
+	duckdb_v2_column_description_destroy(&_h);
+}
+
+auto ColumnDescription::GetName() const -> std::string_view {
+	duckdb_v2_identifier_t name = {nullptr, 0};
+	CheckedAPICall(duckdb_v2_column_description_get_name, handle(), &name);
+	return FromStr(name);
+}
+
+auto ColumnDescription::GetType() const -> LogicalType {
+	duckdb_v2_logical_type_handle borrowed = nullptr;
+	CheckedAPICall(duckdb_v2_column_description_get_type, handle(), &borrowed);
+	// get_type borrows the type; copy it into an owned handle the wrapper manages.
+	duckdb_v2_logical_type_handle owned = nullptr;
+	CheckedAPICall(duckdb_v2_logical_type_copy, borrowed, &owned);
+	return detail::Factory::Make<LogicalType>(owned);
+}
+
+auto ColumnDescription::HasDefault() const -> bool {
+	bool result = false;
+	CheckedAPICall(duckdb_v2_column_description_has_default, handle(), &result);
+	return result;
+}
+
+auto ColumnDescription::HasGenerated() const -> bool {
+	bool result = false;
+	CheckedAPICall(duckdb_v2_column_description_has_generated, handle(), &result);
+	return result;
 }
 
 } // namespace cxx

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -32,6 +32,7 @@
 #include <string_view>
 #include <type_traits>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <tuple>
 #include <vector>

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -815,6 +815,12 @@ public:
 /// "v1.5.0-dev123" on development builds.
 auto LibraryVersion() -> std::string;
 
+/// Renders a name as a SQL identifier, quoting and escaping only when required: the name itself when it is a legal
+/// bare identifier, or double-quoted with interior quotes doubled when it is a keyword or contains characters that
+/// require quoting. Use it for every name embedded in SQL text rather than quoting by hand.
+/// @param name The name to render.
+auto RenderQuotedIdentifier(std::string_view name) -> std::string;
+
 //----------------------------------------------------------------------------------------------------------------------
 // Logical Type
 //----------------------------------------------------------------------------------------------------------------------

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -76,6 +76,7 @@ template <class CTX>
 class TypeBuilder;
 class CustomType;
 class CastFunction;
+class ReplacementScan;
 
 //----------------------------------------------------------------------------------------------------------------------
 // Internal Implementation Details
@@ -2224,8 +2225,15 @@ public:
 	auto GetRowCount() const -> idx_t;
 
 	/// Drops all rows and releases their memory, keeping the column types; the collection is immediately appendable
-	/// again. Outstanding append and scan states are invalidated: create new ones.
+	/// again. Outstanding append and scan states are invalidated: create new ones. Prefer `Clear` when the collection
+	/// is about to be refilled.
 	auto Reset() -> void;
+
+	/// Drops all rows but keeps their memory, so the next appends write into buffers that are already allocated;
+	/// prefer it over `Reset` when the collection is refilled repeatedly. The column types are unchanged and the
+	/// collection is immediately appendable again. Outstanding append and scan states are invalidated: create new
+	/// ones.
+	auto Clear() -> void;
 
 	/// Moves another collection's rows to the end of this one, consuming it. The source must have the same column
 	/// types, and both collections must come from the same database -- the rows keep their original buffers rather
@@ -2271,6 +2279,103 @@ public:
 
 private:
 	explicit ColumnDataCollection(void *impl);
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+// Appender
+//----------------------------------------------------------------------------------------------------------------------
+
+/// Buffers rows on the client side and writes them to the database in bulk.
+/// An appender pairs a `ColumnDataCollection` with a statement that reads it: `AppendChunk` fills the buffer without
+/// touching the database, and `Flush` runs the statement over everything buffered so far and empties the buffer.
+/// Many small inserts thereby become one bulk insert.
+///
+/// The appender is built on the public API alone: a connection-scoped `ReplacementScan` exposes the buffer to the
+/// statement under a name. The same can be done by hand when a different shape is needed.
+///
+/// An appender is bound to the connection it was created on and can only be flushed there. It is not thread-safe:
+/// append from one thread at a time, or give each thread its own appender. It must not outlive its `Connection`.
+///
+/// Destroying an appender does not flush: rows buffered but not flushed are dropped. Since replacement scans cannot
+/// be unregistered, every appender leaves an inert scan registered on its connection; create appenders once and
+/// reuse them rather than creating one per batch.
+class Appender {
+public:
+	/// Creates an appender that inserts into `table`.
+	/// The buffer takes the table's columns, in order, with their types, resolved once at construction: the appender
+	/// keeps targeting that table even if the search path changes later.
+	/// @param conn The connection to buffer against and flush on.
+	/// @param table The table to append to, optionally qualified.
+	/// @throws Exception When the table cannot be resolved.
+	/// @note A table with generated columns needs the query constructor instead: this one lists every column, and
+	/// the engine refuses an INSERT that names a generated one.
+	Appender(Connection &conn, std::string_view table);
+
+	/// Creates an appender that flushes by running `query`, which reads the buffer as a table named `buffer_name`.
+	/// Use this when a plain INSERT of every column is not what is needed: a subset of columns, an UPDATE or MERGE
+	/// driven by the buffer, or an INSERT with an ON CONFLICT clause.
+	/// @param conn The connection to buffer against and flush on.
+	/// @param query Exactly one statement, referring to the buffer by `buffer_name`.
+	/// @param column_types One type per buffer column, at least one.
+	/// @param buffer_name The name `query` reads the buffer under. Must be unique among the appenders on this
+	/// connection: the first one registered claims the name.
+	/// @param column_names Names for the buffer's columns; empty names them col1..colN.
+	/// @throws InvalidInputException When `column_types` is empty, or `query` is not exactly one statement.
+	Appender(Connection &conn, std::string_view query, std::vector<LogicalType> column_types,
+	         std::string_view buffer_name, const std::vector<std::string> &column_names = {});
+
+	Appender(const Appender &) = delete;
+	Appender &operator=(const Appender &) = delete;
+	Appender(Appender &&) noexcept = default;
+	Appender &operator=(Appender &&) noexcept = default;
+
+	/// Drops whatever is still buffered. Does not flush.
+	~Appender();
+
+	/// The buffer's column types, in order. Build a chunk over these to fill and append, e.g.
+	/// `DataChunk chunk(appender.ColumnTypes())`. Valid for the appender's lifetime.
+	auto ColumnTypes() const -> const std::vector<LogicalType> & {
+		return types;
+	}
+
+	/// Buffers a whole chunk. Its column types must equal `ColumnTypes()` exactly; a mismatch is refused before
+	/// anything is copied.
+	/// @throws InvalidInputException When the chunk's columns do not match, or a previous buffer operation failed.
+	void AppendChunk(DataChunk &chunk);
+
+	/// Runs the statement over everything buffered and empties the buffer, keeping its memory for the next batch.
+	/// Does nothing when the buffer is empty.
+	/// @throws Exception When the statement fails. The rows are kept when the connection was busy or the run was
+	/// interrupted, so the flush can be retried; any other failure drops them.
+	void Flush();
+
+	/// Empties the buffer without running the statement, and recovers from a failed buffer operation.
+	void Clear();
+
+private:
+	// Shared with the replacement scan that exposes the buffer. The scan outlives the appender, since scans cannot be
+	// unregistered, so it holds this by shared_ptr; the appender's destructor nulls the collection to make it decline.
+	struct Buffer {
+		std::string name;
+		std::vector<std::string> column_names;
+		std::unique_ptr<ColumnDataCollection> collection;
+	};
+
+	// The shared body of both constructors.
+	void Initialize(Connection &conn, const std::string &query, std::vector<LogicalType> column_types,
+	                const std::string &buffer_name, const std::vector<std::string> &column_names);
+	void ResetBuffer();
+
+	// The connection the buffer's replacement scan is registered on, and the only one a flush can run on.
+	Connection *connection = nullptr;
+	std::vector<LogicalType> types;
+	std::shared_ptr<Buffer> buffer;
+	// The statement, parsed once and re-executed per flush, and the append state, recreated after every reset.
+	std::unique_ptr<SqlStatement> statement;
+	std::unique_ptr<ColumnDataCollection::AppendState> append_state;
+	// Set when a buffer operation failed mid-flight, leaving the buffered rows indeterminate: appends and flushes
+	// refuse until Clear recovers.
+	bool broken = false;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -3744,6 +3849,146 @@ public:
 
 	private:
 		ExecInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetUserDataInternal() const;
+	};
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+// Replacement Scan
+//----------------------------------------------------------------------------------------------------------------------
+
+/// A user-defined replacement scan, built up with the setters and made live with `Register`.
+/// Create one against the `Connection`, `Database` or `Extension` it will be registered on, set its callback and
+/// user data, then call `Register`. The scan object may be destroyed after registration; the registered scan lives
+/// on until its scope ends.
+///
+/// The binder consults replacement scans when a table name cannot be resolved in the catalog; this is what makes
+/// `SELECT * FROM 'file.parquet'` work. The callback inspects the unresolved name and either claims it, by naming a
+/// table function to call, a `ColumnDataCollection` to read or a query to run instead, or declines it by claiming
+/// nothing, which lets the next registered scan try. When no scan claims the name, the usual "table does not exist"
+/// error is raised. A callback reports failure by throwing; the exception surfaces as the query's error.
+///
+/// Scope follows the constructor. A scan created against a `Connection` is visible only to that connection, is
+/// released when it closes, and is consulted before every database-wide scan, including the built-in file scans. A
+/// scan created against a `Database` or `Extension` is visible to every connection to that database and lives until
+/// it closes; registering one is not thread-safe against queries binding on other connections, so do it during
+/// extension load or before issuing queries. A registered scan cannot be unregistered.
+class ReplacementScan final : public detail::Handle<ReplacementScan> {
+	friend detail::Factory;
+
+public:
+	class Input;
+
+	/// Called once per table reference the catalog could not resolve; claims it or declines it. Required.
+	using Callback = void (*)(Input &input);
+
+	ReplacementScan(ReplacementScan &&) noexcept = default;
+	ReplacementScan &operator=(ReplacementScan &&) noexcept = default;
+
+	~ReplacementScan() override;
+
+	/// Creates a scan that `Register` adds to the connection, visible only there.
+	static auto Create(const Connection &conn) -> ReplacementScan;
+	/// Creates a scan that `Register` adds to the database, visible to every connection.
+	static auto Create(const Database &db) -> ReplacementScan;
+	/// Creates a scan that `Register` adds through the loading extension, visible to every connection.
+	static auto Create(const Extension &extension) -> ReplacementScan;
+
+	auto SetCallback(Callback callback) & -> ReplacementScan &;
+
+	/// Constructs user data of type `T`, carried by the registered scan and freed when its scope ends; read it from
+	/// the callback via `Input::GetUserData<T>`. Consumed by `Register`.
+	template <class T, class... ARGS>
+	auto SetUserData(ARGS &&... args) & -> ReplacementScan & {
+		auto ptr = new T(std::forward<ARGS>(args)...);
+		SetUserDataInternal(ptr, detail::TypedDelete<T>);
+		return *this;
+	}
+
+	/// Registers the scan on the target it was created against. Scans are consulted in registration order within
+	/// their scope, connection-scoped ones before database-wide ones, and the first to claim a name wins. A scan can
+	/// be registered only once.
+	/// @throws InvalidInputException When the callback is missing, or the scan is already registered.
+	auto Register() -> void;
+
+private:
+	explicit ReplacementScan(void *impl);
+
+	auto SetUserDataInternal(void *data, void (*destructor)(void *)) -> void;
+
+	Callback callback = nullptr;
+	detail::UserData user_data;
+
+public:
+	/// What the callback works with. Borrowed, valid only for the callback duration, as are the name views it hands
+	/// out.
+	class Input {
+		friend detail::Factory;
+
+	public:
+		/// The user data set via `ReplacementScan::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The catalog qualifier of the unresolved reference, empty when it carries none.
+		auto GetCatalogName() const -> std::string_view;
+
+		/// The schema qualifier of the unresolved reference, empty when it carries none.
+		auto GetSchemaName() const -> std::string_view;
+
+		/// The table name of the unresolved reference, as written in the query; for a file-backed reference, the path.
+		auto GetTableName() const -> std::string_view;
+
+		/// Claims the reference by naming a table function to call instead; its arguments are then supplied with
+		/// `AddArgument` and `AddNamedArgument`. The name is unqualified and matched case-insensitively, and is not
+		/// resolved here: an unknown function fails later, when the replacement is bound. The three claim forms,
+		/// `SetFunctionName`, `SetCollection` and `SetSubquery`, are mutually exclusive.
+		/// @throws InvalidInputException When the name is empty, or a different claim form was already used.
+		auto SetFunctionName(std::string_view name) -> void;
+
+		/// Appends a positional argument to the claimed table function. Positional arguments are passed in the order
+		/// they are added, before any named ones.
+		/// @throws InvalidInputException Unless `SetFunctionName` was called first.
+		auto AddArgument(const Value &value) -> void;
+
+		/// Appends a named argument to the claimed table function, the equivalent of `name := value`.
+		/// @throws InvalidInputException Unless `SetFunctionName` was called first.
+		auto AddNamedArgument(std::string_view name, const Value &value) -> void;
+
+		/// Claims the reference by naming a collection to read instead. The collection is borrowed: it must stay
+		/// alive, and must not be cleared, reset or destroyed, for as long as any result reading it is live. The three
+		/// claim forms, `SetFunctionName`, `SetCollection` and `SetSubquery`, are mutually exclusive.
+		/// @param collection The collection to read.
+		/// @param column_names Names for its columns, in order; empty names them col1..colN.
+		/// @throws InvalidInputException When the names do not match the collection's columns, or a different claim
+		/// form was already used.
+		auto SetCollection(const ColumnDataCollection &collection, const std::vector<std::string> &column_names = {})
+		    -> void;
+
+		/// Claims the reference by naming a query to run instead. The text is parsed here and must contain exactly
+		/// one SELECT statement. The three claim forms, `SetFunctionName`, `SetCollection` and `SetSubquery`, are
+		/// mutually exclusive.
+		/// @throws Exception When the text does not parse, or is not a single SELECT.
+		/// @throws InvalidInputException When a different claim form was already used.
+		auto SetSubquery(std::string_view sql) -> void;
+
+		/// Sets the alias the claimed replacement is bound under. Optional: an alias written in the query takes
+		/// precedence, and without either the reference's own table name is used.
+		auto SetAlias(std::string_view alias) -> void;
+
+		/// The binding context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		Input(void *args, void *context) : args(args), context(context) {
 		}
 
 		void *args;

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -40,6 +40,13 @@
 #include <cstring>
 #include <limits>
 
+// Arrow C Data Interface structs, defined by `duckdb_v2.h` or by the consumer's own Arrow headers, whichever is
+// included first -- both use the same ARROW_C_DATA_INTERFACE / ARROW_C_STREAM_INTERFACE guards, and the layouts are
+// byte-identical by spec. Forward declared so this header carries no Arrow definition of its own.
+struct ArrowSchema;
+struct ArrowArray;
+struct ArrowArrayStream;
+
 namespace duckdb {
 namespace cxx {
 
@@ -67,6 +74,8 @@ class DataChunk;
 class ColumnDataCollection;
 class QueryResult;
 class PreparedStatement;
+class ArrowStream;
+class ArrowConverter;
 
 struct TypeParam;
 struct NamedParam;
@@ -1013,6 +1022,12 @@ public:
 	/// An owned copy of one field's type.
 	/// @param index Field index in [0, GetFieldCount()).
 	auto GetFieldType(idx_t index) const -> LogicalType;
+
+	/// Exports the fields as an Arrow schema into the caller-allocated `out`, which the caller then owns and
+	/// releases with `out.release(&out)`.
+	/// @param context A context with an active transaction: building the schema reads the catalog for extension
+	/// types and ENUM dictionaries.
+	auto ToArrowSchema(const Context &context, ArrowSchema &out) const -> void;
 
 private:
 	explicit Schema(void *impl);
@@ -2212,6 +2227,12 @@ public:
 	/// The `Context` flavor of `Copy`, inside a callback.
 	auto Copy(const Context &ctx) const -> DataChunk;
 
+	/// Exports this chunk as an Arrow array into the caller-allocated `out`, which the caller then owns and releases
+	/// with `out.release(&out)`. The chunk is borrowed and stays valid. Pair it with `Schema::ToArrowSchema` for the
+	/// schema; this produces data only.
+	/// @param context A context with an active transaction, whose Arrow options drive the conversion.
+	auto ToArrowArray(const Context &context, ArrowArray &out) const -> void;
+
 private:
 	explicit DataChunk(void *impl, bool owned);
 	bool owned = false; // TODO: This should be fixed C++ side
@@ -2447,6 +2468,100 @@ private:
 };
 
 //----------------------------------------------------------------------------------------------------------------------
+// Arrow
+//----------------------------------------------------------------------------------------------------------------------
+// Interop with the Arrow C Data Interface, in both directions. Exporting fills a caller-allocated Arrow struct, which
+// the caller then releases; importing hands an Arrow array's buffers to a `DataChunk` zero-copy. Reading Arrow needs
+// its schema resolved first, which `ArrowConversionPlan` does once for any number of arrays of the same shape.
+
+/// An owned, resolved interpretation of an `ArrowSchema`: every column's DuckDB type plus what importing an array
+/// needs. Build it once -- at a table function's bind time, say -- and reuse it for every array of that shape.
+/// The context is a per-call argument rather than something the converter captures, so one built under a bind-time
+/// context can be used at execution time under another.
+class ArrowConverter final : public detail::Handle<ArrowConverter> {
+	friend detail::Factory;
+
+public:
+	/// Resolves `schema` against `context`, extension types included.
+	/// @param context A context with an active transaction: resolving reads the catalog.
+	/// @param schema The schema to resolve. Read, not consumed; the caller keeps ownership.
+	ArrowConverter(const Context &context, ArrowSchema &schema);
+
+	ArrowConverter(ArrowConverter &&) noexcept = default;
+	ArrowConverter &operator=(ArrowConverter &&) noexcept = default;
+
+	~ArrowConverter() override;
+
+	/// Converts `array` into an owned chunk sized to the array's length, which may exceed the engine's vector size.
+	/// The chunk adopts the array's buffers zero-copy and `array.release` is set to NULL, so the caller must not
+	/// release `array` afterwards.
+	/// @throws InvalidInputException When the array's shape disagrees with what this converter resolved.
+	auto ArrayToChunk(const Context &context, ArrowArray &array) const -> DataChunk;
+
+	/// The resolved columns as an owned `Schema`: the DuckDB name and type of every column of the source
+	/// `ArrowSchema`, which is how a table function declares its result columns from an Arrow schema.
+	auto GetSchema() const -> Schema;
+
+private:
+	explicit ArrowConverter(void *impl);
+};
+
+/// An owning handle to an Arrow C Data Interface stream, produced by `QueryResult::ToArrowStream`. Destroying it
+/// releases the stream, which closes the query and frees the connection for its next one. Arrays handed out by
+/// `Next` are owned by the caller and released independently of this.
+///
+/// Unlike the other wrappers this does not derive from `detail::Handle`: it owns a raw `ArrowArrayStream` rather than
+/// an opaque DuckDB handle, so the handle machinery does not apply.
+class ArrowStream final {
+	friend detail::Factory;
+
+public:
+	ArrowStream(ArrowStream &&other) noexcept : stream(other.stream) {
+		other.stream = nullptr;
+	}
+	ArrowStream &operator=(ArrowStream &&other) noexcept {
+		std::swap(stream, other.stream);
+		return *this;
+	}
+	ArrowStream(const ArrowStream &) = delete;
+	ArrowStream &operator=(const ArrowStream &) = delete;
+
+	~ArrowStream();
+
+	/// True while this holds a live stream, false once it has been moved from or detached.
+	explicit operator bool() const noexcept {
+		return stream != nullptr;
+	}
+
+	/// Borrows the underlying stream, which this still owns. Hand its address to an Arrow consumer that does not
+	/// take ownership.
+	auto get() const noexcept -> ArrowArrayStream * {
+		return stream;
+	}
+
+	/// Detaches the underlying stream, handing the caller ownership and the duty to release it. Leaves this empty.
+	auto Detach() noexcept -> ArrowArrayStream * {
+		auto detached = stream;
+		stream = nullptr;
+		return detached;
+	}
+
+	/// Reads the stream's schema into `out`, which the caller then owns and releases.
+	/// @throws InvalidInputException On failure, or when this stream is empty.
+	void GetSchema(ArrowSchema &out) const;
+
+	/// Fetches the next array into `out`, which the caller then owns and releases.
+	/// @return False at end of stream, where `out` is left released.
+	/// @throws InvalidInputException On failure, or when this stream is empty.
+	bool Next(ArrowArray &out) const;
+
+private:
+	explicit ArrowStream(ArrowArrayStream *stream) : stream(stream) {
+	}
+	ArrowArrayStream *stream = nullptr;
+};
+
+//----------------------------------------------------------------------------------------------------------------------
 // Result
 //----------------------------------------------------------------------------------------------------------------------
 // A `QueryResult` is a lazily executed stream of chunks, produced by a query.
@@ -2576,6 +2691,12 @@ public:
 	/// "? rows", since there may have been more.
 	auto RenderBox(idx_t max_rows = 0, idx_t max_width = 0, idx_t max_col_width = 0, const std::string &null_value = "",
 	               idx_t render_mode = 0, idx_t limit = 0) -> std::string;
+
+	/// Exports the result as a lazy `ArrowStream`, consuming it. Nothing is executed here: the stream converts as its
+	/// consumer pulls. A result that has already yielded chunks produces a stream over what remains.
+	/// @param batch_size Target rows per Arrow array, 0 for the default of 131072.
+	/// @return The stream, which owns the query from now on and frees the connection when released.
+	auto ToArrowStream(idx_t batch_size = 0) -> ArrowStream;
 
 private:
 	explicit QueryResult(void *impl);

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -66,6 +66,7 @@ class Arena;
 class DataChunk;
 class ColumnDataCollection;
 class QueryResult;
+class PreparedStatement;
 
 struct TypeParam;
 struct NamedParam;
@@ -495,6 +496,47 @@ private:
 	explicit StatementIterator(void *impl);
 };
 
+/// A statement bound and planned once, executable repeatedly. Produced by `Connection::Prepare`.
+/// Where `Connection::Execute` re-binds on every call, this may run the plan it built at prepare time; ask
+/// `ReusesPlan` which one you got. Execution returns the same `QueryResult`, with identical behaviour.
+/// It keeps its connection's session alive, so it stays usable even after the `Connection` is gone.
+class PreparedStatement final : public detail::Handle<PreparedStatement> {
+	friend detail::Factory;
+
+public:
+	PreparedStatement(PreparedStatement &&) noexcept = default;
+	PreparedStatement &operator=(PreparedStatement &&) noexcept = default;
+
+	~PreparedStatement() override;
+
+	/// Executes with positional parameters ($1 = parameters[0]), returning a lazy streaming result.
+	/// Non-consuming: execute the same statement again, with the same values or different ones.
+	/// @param parameters Values for the statement's parameters, bound positionally.
+	/// @param parameter_count How many values `parameters` points at.
+	/// @return A streaming result. Execution is deferred until the result is read; binding errors throw here.
+	/// @throws Exception While an earlier result on the connection is still live. A failed execution leaves the
+	/// prepared statement usable.
+	auto Execute(const Value *parameters, idx_t parameter_count) -> QueryResult;
+
+	/// Executes a statement that takes no parameters.
+	auto Execute() -> QueryResult;
+
+	/// `std::vector` overload of the positional-parameter `Execute`.
+	auto Execute(const std::vector<Value> &parameters) -> QueryResult;
+
+	/// Executes with named parameters.
+	/// @param parameters One binding per parameter; each binds to $name, or positionally when its name is empty.
+	auto Execute(const std::vector<NamedParam> &parameters) -> QueryResult;
+
+	/// Whether executions reuse the plan built at prepare time, rather than re-binding each time and being no
+	/// faster than `Connection::Execute`. A static property of the built plan; see the C API's
+	/// `duckdb_v2_prepared_statement_reuses_plan` for what qualifies.
+	auto ReusesPlan() const -> bool;
+
+private:
+	explicit PreparedStatement(void *impl);
+};
+
 //----------------------------------------------------------------------------------------------------------------------
 // Connection
 //----------------------------------------------------------------------------------------------------------------------
@@ -596,6 +638,14 @@ public:
 	/// @param statement The statement to bind.
 	/// @return Its signature: the columns it will produce and the parameters it expects.
 	auto Bind(const SqlStatement &statement) const -> Signature;
+
+	/// Prepares a statement into a handle that can be executed repeatedly, borrowing it rather than consuming it.
+	/// @param statement The statement to prepare.
+	/// @param require_cacheable When true, fail rather than return a statement whose plan is re-bound on every
+	/// execution, so a caller who wants the handle only for the speedup finds out here.
+	/// @throws Exception On a bind or catalog error, while a result on this connection is still live, or when
+	/// `require_cacheable` is set and the plan would not be reused.
+	auto Prepare(const SqlStatement &statement, bool require_cacheable = false) -> PreparedStatement;
 
 	/// `Context::ParseType` outside a callback.
 	/// @param text A type as SQL spells it, e.g. "DECIMAL(18, 3)" or "STRUCT(a INTEGER, b VARCHAR)".
@@ -4181,8 +4231,11 @@ public:
 		auto AddNamedArgument(std::string_view name, const Value &value) -> void;
 
 		/// Claims the reference by naming a collection to read instead. The collection is borrowed: it must stay
-		/// alive, and must not be cleared, reset or destroyed, for as long as any result reading it is live. The three
-		/// claim forms, `SetFunctionName`, `SetCollection` and `SetSubquery`, are mutually exclusive.
+		/// alive, and must not be cleared, reset or destroyed, for as long as any result reading it is live. A
+		/// `PreparedStatement` over a claimed name extends that further: it captures the borrow in its plan and,
+		/// since a collection claim reads no database, reuses that plan without consulting the callback again
+		/// (`PreparedStatement::ReusesPlan` reports true). Destroy such statements before releasing the collection.
+		/// The three claim forms, `SetFunctionName`, `SetCollection` and `SetSubquery`, are mutually exclusive.
 		/// @param collection The collection to read.
 		/// @param column_names Names for its columns, in order; empty names them col1..colN.
 		/// @throws InvalidInputException When the names do not match the collection's columns, or a different claim
@@ -4533,6 +4586,10 @@ inline auto Connection::CreateType() -> TypeBuilder<Connection> {
 
 inline auto Connection::Execute(const SqlStatement &statement, const std::vector<Value> &parameters) -> QueryResult {
 	return Execute(statement, parameters.data(), parameters.size());
+}
+
+inline auto PreparedStatement::Execute(const std::vector<Value> &parameters) -> QueryResult {
+	return Execute(parameters.data(), parameters.size());
 }
 
 } // namespace cxx

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -81,6 +81,7 @@ struct TypeParam;
 struct NamedParam;
 
 enum class LogicalTypeId : uint32_t;
+enum class CastMode : uint8_t;
 
 template <class CTX>
 class TypeBuilder;
@@ -3542,6 +3543,115 @@ public:
 };
 
 //----------------------------------------------------------------------------------------------------------------------
+// Bound Expression
+//----------------------------------------------------------------------------------------------------------------------
+
+/// The type of a bound expression node. Mirrors the C API's `DUCKDB_V2_EXPRESSION_TYPE`: the node types a filter
+/// predicate can contain, every other node type reporting `INVALID`.
+///
+/// Comparisons, `BETWEEN` and casts are regular scalar function calls once bound: they have the function's children
+/// and name, and only their type tells them apart from any other function. A cast has one child, the value being
+/// cast, and its target type is the node's return type.
+enum class ExpressionType : uint8_t {
+	/// A node type this API does not model. Its children can still be walked.
+	INVALID = 0,
+	/// A cast. One child; `Expression::GetCastMode` tells a `TRY_CAST` apart.
+	OPERATOR_CAST = 12,
+	/// Logical `NOT`. One child.
+	OPERATOR_NOT = 13,
+	/// `IS NULL`. One child.
+	OPERATOR_IS_NULL = 14,
+	/// `IS NOT NULL`. One child.
+	OPERATOR_IS_NOT_NULL = 15,
+	/// `=`. Two children.
+	COMPARE_EQUAL = 25,
+	/// `<>`. Two children.
+	COMPARE_NOTEQUAL = 26,
+	/// `<`. Two children.
+	COMPARE_LESSTHAN = 27,
+	/// `>`. Two children.
+	COMPARE_GREATERTHAN = 28,
+	/// `<=`. Two children.
+	COMPARE_LESSTHANOREQUALTO = 29,
+	/// `>=`. Two children.
+	COMPARE_GREATERTHANOREQUALTO = 30,
+	/// `IN`. The first child is the value tested, the remaining children are the candidates.
+	COMPARE_IN = 35,
+	/// `NOT IN`. The first child is the value tested, the remaining children are the candidates.
+	COMPARE_NOT_IN = 36,
+	/// `IS DISTINCT FROM`. Two children.
+	COMPARE_DISTINCT_FROM = 37,
+	/// `BETWEEN`. Three children: the value tested, the lower bound and the upper bound.
+	COMPARE_BETWEEN = 38,
+	/// `IS NOT DISTINCT FROM`. Two children.
+	COMPARE_NOT_DISTINCT_FROM = 40,
+	/// Logical `AND`. Two or more children.
+	CONJUNCTION_AND = 50,
+	/// Logical `OR`. Two or more children.
+	CONJUNCTION_OR = 51,
+	/// A constant. No children; read it with `Expression::GetConstantValue`.
+	VALUE_CONSTANT = 75,
+	/// A prepared statement parameter whose value is not known yet. No children.
+	VALUE_PARAMETER = 76,
+	/// A call to a scalar function other than the ones listed above. The children are its arguments; read the name
+	/// with `Expression::GetFunctionName`.
+	BOUND_FUNCTION = 141,
+	/// A `CASE` expression. The children are each `WHEN` condition followed by its `THEN` result, then the `ELSE`
+	/// result.
+	CASE_EXPR = 150,
+	/// `COALESCE`. One or more children.
+	OPERATOR_COALESCE = 152,
+	/// A reference to a column. No children; read it with `Expression::GetColumnIndex`.
+	BOUND_COLUMN_REF = 228,
+};
+
+/// A node of a bound expression tree: an expression the engine has resolved every column and function of, handed
+/// to callbacks that may want to look inside a predicate (see `TableFunction::FilterPushdownInput`). Borrowed and
+/// read-only: valid only for the duration of the callback that handed it out, and the children obtained via
+/// `GetChild` share their parent's lifetime.
+class Expression final : public detail::Handle<Expression> {
+	friend detail::Factory;
+
+public:
+	Expression(Expression &&) noexcept = default;
+	Expression &operator=(Expression &&) noexcept = default;
+	~Expression() override = default;
+
+	/// The node's type, which decides what its children mean and which of the accessors below apply.
+	auto GetType() const -> ExpressionType;
+	/// The logical type the node evaluates to. For a cast, the target type.
+	auto GetReturnType() const -> LogicalType;
+	/// How many child nodes the node has. Works for every type, including `ExpressionType::INVALID`.
+	auto GetChildCount() const -> idx_t;
+	/// A child node, ordered as `ExpressionType` describes.
+	/// @throws InvalidInputException When the index is out of bounds.
+	auto GetChild(idx_t index) const -> Expression;
+	/// The value of a `VALUE_CONSTANT` node.
+	/// @throws InvalidInputException When the node is not a constant.
+	auto GetConstantValue() const -> Value;
+	/// The column a `BOUND_COLUMN_REF` node points at. The index counts the columns of the operator the predicate is
+	/// evaluated against; resolve it through whatever handed out the expression, e.g.
+	/// `TableFunction::FilterPushdownInput::GetColumnIndex`.
+	/// @throws InvalidInputException When the node is not a column reference.
+	auto GetColumnIndex() const -> idx_t;
+	/// The name of the scalar function a function node calls: `BOUND_FUNCTION`, the comparisons, `COMPARE_BETWEEN`
+	/// and `OPERATOR_CAST`. A comparison's name is its operator, e.g. `<`; `BETWEEN` and casts carry internal names,
+	/// so dispatch on the type for those.
+	/// @throws InvalidInputException When the node is not a function call.
+	auto GetFunctionName() const -> std::string;
+	/// The qualified name of the scalar function a function node calls: the name of `GetFunctionName`, qualified with
+	/// the catalog and schema the function was resolved in where known.
+	/// @throws InvalidInputException When the node is not a function call.
+	auto GetFunctionQualifiedName() const -> QualifiedName;
+	/// Whether an `OPERATOR_CAST` node is a regular `CAST` or a `TRY_CAST`.
+	/// @throws InvalidInputException When the node is not a cast.
+	auto GetCastMode() const -> CastMode;
+
+private:
+	explicit Expression(void *impl);
+};
+
+//----------------------------------------------------------------------------------------------------------------------
 // Table Function
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -3567,6 +3677,7 @@ public:
 	class InitLocalInput;
 	class ExecInput;
 	class ProgressInput;
+	class FilterPushdownInput;
 
 	/// Called once per query while the function call is bound; declares the columns the function returns. Required.
 	using BindCallback = void (*)(BindInput &input);
@@ -3578,6 +3689,9 @@ public:
 	using ExecCallback = void (*)(ExecInput &input);
 	/// Called on demand during execution to report how far the scan has advanced. Optional.
 	using ProgressCallback = void (*)(ProgressInput &input);
+	/// Called while the query is optimized, possibly more than once, with the predicates the query applies to the
+	/// function's rows; accepts the ones the function will apply itself. Optional.
+	using FilterPushdownCallback = void (*)(FilterPushdownInput &input);
 
 	TableFunction(TableFunction &&) noexcept = default;
 	TableFunction &operator=(TableFunction &&) noexcept = default;
@@ -3619,6 +3733,13 @@ public:
 	auto SetInitLocalCallback(InitLocalCallback callback) & -> TableFunction &;
 	auto SetExecCallback(ExecCallback callback) & -> TableFunction &;
 	auto SetProgressCallback(ProgressCallback callback) & -> TableFunction &;
+	auto SetFilterPushdownCallback(FilterPushdownCallback callback) & -> TableFunction &;
+
+	/// Declares whether the function supports projection pushdown. Defaults to false. With it, the engine asks for
+	/// only the columns a query uses: the exec callback's output chunk holds one vector per requested column, and
+	/// the init and exec inputs' `GetColumnIndex` says which declared column each vector stands for. Without it the
+	/// output chunk always holds every declared column, and the engine drops the unused ones itself.
+	auto SetProjectionPushdown(bool enable) & -> TableFunction &;
 
 	/// Registers the function in the catalog it was created against. The function object remains valid and may be
 	/// adjusted and registered again; user data set via `SetUserData` is consumed by the first `Register`.
@@ -3636,6 +3757,7 @@ private:
 	InitLocalCallback init_local_callback = nullptr;
 	ExecCallback exec_callback = nullptr;
 	ProgressCallback progress_callback = nullptr;
+	FilterPushdownCallback filter_pushdown_callback = nullptr;
 	detail::UserData user_data;
 
 public:
@@ -3734,6 +3856,14 @@ public:
 		/// @param max_threads The maximum thread count. Must be at least 1.
 		auto SetMaxThreads(idx_t max_threads) -> void;
 
+		/// How many columns the scan produces: with projection pushdown the columns the query uses, which is the number
+		/// of vectors in the exec callback's output chunk; without it, the columns declared in bind.
+		auto GetColumnCount() const -> idx_t;
+		/// Which declared column (in `BindInput::AddResultColumn` order) the scan's column at `index` stands for. The
+		/// identity without projection pushdown.
+		/// @throws InvalidInputException When the index is out of bounds.
+		auto GetColumnIndex(idx_t index) const -> idx_t;
+
 		/// The scan's context. Borrowed, valid only for the callback duration.
 		auto GetContext() const -> Context;
 
@@ -3783,6 +3913,12 @@ public:
 		auto GetUserData() const -> T & {
 			return *static_cast<T *>(GetUserDataInternal());
 		}
+
+		/// How many columns the scan produces; see `InitGlobalInput::GetColumnCount`.
+		auto GetColumnCount() const -> idx_t;
+		/// Which declared column the scan's column at `index` stands for; see `InitGlobalInput::GetColumnIndex`.
+		/// @throws InvalidInputException When the index is out of bounds.
+		auto GetColumnIndex(idx_t index) const -> idx_t;
 
 		/// The scan's context. Borrowed, valid only for the callback duration.
 		auto GetContext() const -> Context;
@@ -3839,6 +3975,13 @@ public:
 		/// chunk's first vector, which the engine propagates to the others. Leaving it empty ends the scan.
 		/// @return A borrowed chunk, valid only for the callback duration.
 		auto GetOutputChunk() const -> DataChunk;
+
+		/// How many vectors the output chunk holds; see `InitGlobalInput::GetColumnCount`.
+		auto GetColumnCount() const -> idx_t;
+		/// Which declared column the output chunk's vector at `index` must be filled with; see
+		/// `InitGlobalInput::GetColumnIndex`.
+		/// @throws InvalidInputException When the index is out of bounds.
+		auto GetColumnIndex(idx_t index) const -> idx_t;
 
 		/// The execution context. Borrowed, valid only for the callback duration.
 		auto GetContext() const -> Context;
@@ -3900,6 +4043,65 @@ public:
 
 		void *GetBindDataInternal() const;
 		void *GetGlobalStateInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the filter pushdown callback works with. Borrowed, valid only for the callback duration.
+	///
+	/// The callback runs while the query is optimized, after bind and before any init callback, with the predicates
+	/// the query applies to the function's rows. Accepting one with `Accept` is a promise: the engine stops
+	/// applying it, so the scan must produce only rows that satisfy it. Predicates left unaccepted are applied by
+	/// the engine as usual, so a callback that recognizes nothing can simply return. The optimizer may run the
+	/// callback more than once for the same query, each time with the predicates not yet accepted, and never with
+	/// none.
+	class FilterPushdownInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `BindInput::SetBindData`, mutable: the same object the init and exec callbacks later
+		/// receive, so an accepted predicate can be recorded in it for the scan to apply.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> T & {
+			return *static_cast<T *>(GetBindDataInternal());
+		}
+
+		/// The user data set via `TableFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// How many predicates are offered. They are combined with `AND`.
+		auto GetFilterCount() const -> idx_t;
+		/// A predicate: a bound expression evaluating to `BOOLEAN`. Resolve the column references it contains via
+		/// `GetColumnIndex`.
+		/// @return A borrowed expression, valid only for the callback duration.
+		/// @throws InvalidInputException When the index is out of bounds.
+		auto GetFilter(idx_t index) const -> Expression;
+		/// Accepts the predicate at `index`: the function will apply it itself.
+		/// @throws InvalidInputException When the index is out of bounds.
+		auto Accept(idx_t index) -> void;
+		/// How many columns the predicates can refer to: the columns the query reads from the function, which is what
+		/// `Expression::GetColumnIndex` indexes.
+		auto GetColumnCount() const -> idx_t;
+		/// Resolves the index a column reference node reports to the declared column (in `BindInput::AddResultColumn`
+		/// order) it refers to.
+		/// @throws InvalidInputException When the index is out of bounds.
+		auto GetColumnIndex(idx_t index) const -> idx_t;
+
+		/// The query's context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		FilterPushdownInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
 		void *GetUserDataInternal() const;
 	};
 };

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -40,9 +40,8 @@
 #include <cstring>
 #include <limits>
 
-// Arrow C Data Interface structs, defined by `duckdb_v2.h` or by the consumer's own Arrow headers, whichever is
-// included first -- both use the same ARROW_C_DATA_INTERFACE / ARROW_C_STREAM_INTERFACE guards, and the layouts are
-// byte-identical by spec. Forward declared so this header carries no Arrow definition of its own.
+// Arrow C Data Interface structs. Forward declared only: the definitions come from `duckdb_v2.h` or from the
+// consumer's own Arrow headers, under the standard ARROW_C_DATA_INTERFACE / ARROW_C_STREAM_INTERFACE guards.
 struct ArrowSchema;
 struct ArrowArray;
 struct ArrowArrayStream;
@@ -75,7 +74,8 @@ class ColumnDataCollection;
 class QueryResult;
 class PreparedStatement;
 class ArrowStream;
-class ArrowConverter;
+class ArrowImporter;
+class ArrowExporter;
 
 struct TypeParam;
 struct NamedParam;
@@ -1022,12 +1022,6 @@ public:
 	/// An owned copy of one field's type.
 	/// @param index Field index in [0, GetFieldCount()).
 	auto GetFieldType(idx_t index) const -> LogicalType;
-
-	/// Exports the fields as an Arrow schema into the caller-allocated `out`, which the caller then owns and
-	/// releases with `out.release(&out)`.
-	/// @param context A context with an active transaction: building the schema reads the catalog for extension
-	/// types and ENUM dictionaries.
-	auto ToArrowSchema(const Context &context, ArrowSchema &out) const -> void;
 
 private:
 	explicit Schema(void *impl);
@@ -2227,12 +2221,6 @@ public:
 	/// The `Context` flavor of `Copy`, inside a callback.
 	auto Copy(const Context &ctx) const -> DataChunk;
 
-	/// Exports this chunk as an Arrow array into the caller-allocated `out`, which the caller then owns and releases
-	/// with `out.release(&out)`. The chunk is borrowed and stays valid. Pair it with `Schema::ToArrowSchema` for the
-	/// schema; this produces data only.
-	/// @param context A context with an active transaction, whose Arrow options drive the conversion.
-	auto ToArrowArray(const Context &context, ArrowArray &out) const -> void;
-
 private:
 	explicit DataChunk(void *impl, bool owned);
 	bool owned = false; // TODO: This should be fixed C++ side
@@ -2470,40 +2458,103 @@ private:
 //----------------------------------------------------------------------------------------------------------------------
 // Arrow
 //----------------------------------------------------------------------------------------------------------------------
-// Interop with the Arrow C Data Interface, in both directions. Exporting fills a caller-allocated Arrow struct, which
-// the caller then releases; importing hands an Arrow array's buffers to a `DataChunk` zero-copy. Reading Arrow needs
-// its schema resolved first, which `ArrowConversionPlan` does once for any number of arrays of the same shape.
+// Interop with the Arrow C Data Interface, in both directions. `ArrowExporter` fills caller-allocated Arrow structs,
+// which the caller then releases; `ArrowImporter` hands an Arrow array's buffers to `DataChunk`s zero-copy. Both
+// resolve their schema once, at construction, and both gather rows up to a batch size across inputs, so the last
+// input is marked with `flush`.
 
-/// An owned, resolved interpretation of an `ArrowSchema`: every column's DuckDB type plus what importing an array
-/// needs. Build it once -- at a table function's bind time, say -- and reuse it for every array of that shape.
-/// The context is a per-call argument rather than something the converter captures, so one built under a bind-time
-/// context can be used at execution time under another.
-class ArrowConverter final : public detail::Handle<ArrowConverter> {
+/// Converts Arrow arrays into `DataChunk`s against one resolved `ArrowSchema`. Construct it once, for example at a
+/// table function's bind time, and reuse it for every array of that shape. Give it an array with `Append`, then call
+/// `NextChunk` until it returns an empty handle. Pass `flush` on the last array, or call `Flush`.
+/// The importer borrows the context it was created with and must not outlive it. One array is in flight at a time,
+/// and an importer must not be used from two threads at once.
+class ArrowImporter final : public detail::Handle<ArrowImporter> {
 	friend detail::Factory;
 
 public:
 	/// Resolves `schema` against `context`, extension types included.
 	/// @param context A context with an active transaction: resolving reads the catalog.
 	/// @param schema The schema to resolve. Read, not consumed; the caller keeps ownership.
-	ArrowConverter(const Context &context, ArrowSchema &schema);
+	/// @param batch_size Maximum rows per chunk. A long array is split across several chunks, and rows left over
+	/// that do not fill a batch are held back and joined with the next array unless flushed. 0 means no maximum:
+	/// one chunk per array.
+	ArrowImporter(const Context &context, ArrowSchema &schema, idx_t batch_size = 0);
 
-	ArrowConverter(ArrowConverter &&) noexcept = default;
-	ArrowConverter &operator=(ArrowConverter &&) noexcept = default;
+	ArrowImporter(ArrowImporter &&) noexcept = default;
+	ArrowImporter &operator=(ArrowImporter &&) noexcept = default;
 
-	~ArrowConverter() override;
+	~ArrowImporter() override;
 
-	/// Converts `array` into an owned chunk sized to the array's length, which may exceed the engine's vector size.
-	/// The chunk adopts the array's buffers zero-copy and `array.release` is set to NULL, so the caller must not
-	/// release `array` afterwards.
-	/// @throws InvalidInputException When the array's shape disagrees with what this converter resolved.
-	auto ArrayToChunk(const Context &context, ArrowArray &array) const -> DataChunk;
-
-	/// The resolved columns as an owned `Schema`: the DuckDB name and type of every column of the source
-	/// `ArrowSchema`, which is how a table function declares its result columns from an Arrow schema.
+	/// The resolved DuckDB schema: the name and logical type of every column, which is how a table function declares
+	/// its result columns from an Arrow schema.
 	auto GetSchema() const -> Schema;
 
+	/// Gives the importer one array to convert. Take the chunks with `NextChunk`.
+	/// @param array The array to convert.
+	/// @param consume True to hand it over: its `release` is set to NULL, and the chunks reference its buffers
+	/// zero-copy and keep them alive. False to keep it, in which case it must stay valid until the drain finishes and
+	/// every chunk is a copy. A chunk that joins rows held back from the previous array is a copy either way.
+	/// @param flush True to mark the end of the input, releasing rows that do not fill a batch as a final short chunk.
+	/// @throws InvalidInputException When the previous array is not drained, or the array's shape does not match the
+	/// resolved schema.
+	auto Append(ArrowArray &array, bool consume = true, bool flush = false) -> void;
+
+	/// Releases the held rows as a short chunk without supplying another array. Same as `Append` with no array and
+	/// `flush` set.
+	auto Flush() -> void;
+
+	/// The next chunk of the appended array, or an empty handle once the array is drained. Rows that do not fill a
+	/// batch are held back for the next array unless flushed, so an empty handle does not mean every row has come
+	/// out. Runs under the context the importer was created with, which must still be alive.
+	auto NextChunk() -> DataChunk;
+
 private:
-	explicit ArrowConverter(void *impl);
+	explicit ArrowImporter(void *impl);
+};
+
+/// Converts `DataChunk`s into Arrow arrays for one fixed column list. The session's Arrow settings are captured at
+/// construction, so the schema it reports and the arrays it produces always agree. Give it a chunk with `Append`,
+/// then call `NextArray` until it returns false. Pass `flush` on the last chunk, or call `Flush`.
+/// An exporter must not be used from two threads at once.
+class ArrowExporter final : public detail::Handle<ArrowExporter> {
+	friend detail::Factory;
+
+public:
+	/// @param context A context with an active transaction, whose Arrow settings are captured.
+	/// @param types The column types.
+	/// @param names The column names, one per type.
+	/// @param batch_size Maximum rows per array. A long chunk is split across several arrays, and rows left over
+	/// that do not fill a batch are held back and joined with the next chunk unless flushed. 0 means no maximum:
+	/// one array per chunk.
+	ArrowExporter(const Context &context, const std::vector<LogicalType> &types, const std::vector<std::string> &names,
+	              idx_t batch_size = 0);
+
+	ArrowExporter(ArrowExporter &&) noexcept = default;
+	ArrowExporter &operator=(ArrowExporter &&) noexcept = default;
+
+	~ArrowExporter() override;
+
+	/// The Arrow schema of the arrays this exporter produces, written into the caller-allocated `out`, which the
+	/// caller then owns and releases with `out.release(&out)`.
+	auto GetSchema(ArrowSchema &out) const -> void;
+
+	/// Converts one chunk in full, making the arrays it completed available from `NextArray`. The chunk is borrowed
+	/// and read before this returns, since the conversion copies. Rows that do not complete a batch are held back
+	/// and finished by the next chunk.
+	/// @param flush True to mark the end of the input, releasing the held rows as a final short array.
+	/// @throws InvalidInputException When the chunk's types do not match the exporter's.
+	auto Append(const DataChunk &chunk, bool flush = false) -> void;
+
+	/// Releases the held rows as a short array without supplying another chunk. Same as `Append` with `flush` set.
+	auto Flush() -> void;
+
+	/// Takes the next completed array into the caller-allocated `out`, which the caller then owns and releases.
+	/// @return False when none is ready, leaving `out` released. Rows held back towards an unfinished batch are not
+	/// an array yet; they come out after a further `Append` or a `Flush`.
+	auto NextArray(ArrowArray &out) -> bool;
+
+private:
+	explicit ArrowExporter(void *impl);
 };
 
 /// An owning handle to an Arrow C Data Interface stream, produced by `QueryResult::ToArrowStream`. Destroying it

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -88,6 +88,8 @@ class CustomType;
 class CastFunction;
 class ReplacementScan;
 class QualifiedName;
+class TableDescription;
+class ColumnDescription;
 class FileSystem;
 class FileHandle;
 class FileOpenOptions;
@@ -647,6 +649,12 @@ public:
 	/// @param statement The statement to bind.
 	/// @return Its signature: the columns it will produce and the parameters it expects.
 	auto Bind(const SqlStatement &statement) const -> Signature;
+
+	/// Resolves a table name and snapshots its description: where it resolved, its columns, and per-column facts.
+	/// @param name A possibly partial table name, resolved through the search path exactly as SQL resolves it.
+	/// @throws Exception When the name resolves to nothing, to a view, or is ambiguous between a schema and an attached
+	/// database.
+	auto DescribeTable(const QualifiedName &name) const -> TableDescription;
 
 	/// Prepares a statement into a handle that can be executed repeatedly, borrowing it rather than consuming it.
 	/// @param statement The statement to prepare.
@@ -4959,6 +4967,68 @@ inline bool operator==(const QualifiedName &lhs, const QualifiedName &rhs) {
 inline bool operator!=(const QualifiedName &lhs, const QualifiedName &rhs) {
 	return !lhs.Equals(rhs);
 }
+
+//----------------------------------------------------------------------------------------------------------------------
+// Table Description
+//----------------------------------------------------------------------------------------------------------------------
+
+/// An owned snapshot of one base table, taken by `Connection::DescribeTable`: where the name resolved, the table's
+/// columns in declared order (generated columns included), and per-column catalog facts. Later DDL does not update it.
+class TableDescription final : public detail::Handle<TableDescription> {
+	friend detail::Factory;
+
+public:
+	TableDescription(TableDescription &&) noexcept = default;
+	TableDescription &operator=(TableDescription &&) noexcept = default;
+
+	~TableDescription() override;
+
+	/// The fully resolved name: the catalog, schema and table the lookup landed on, with the casing the table was
+	/// created with.
+	auto GetQualifiedName() const -> QualifiedName;
+
+	/// How many columns the table has, generated columns included.
+	auto GetColumnCount() const -> idx_t;
+
+	/// An owned description of one column, independent of this table description.
+	/// @param index Column index in [0, GetColumnCount()).
+	/// @throws Exception When the index is out of range.
+	auto GetColumn(idx_t index) const -> ColumnDescription;
+
+	/// Whether the catalog the table lives in was attached read-only.
+	auto IsReadOnly() const -> bool;
+
+private:
+	explicit TableDescription(void *impl);
+};
+
+/// An owned snapshot of one column of a described table, from `TableDescription::GetColumn`: its name, type and
+/// catalog facts. Independent of the table description it came from.
+class ColumnDescription final : public detail::Handle<ColumnDescription> {
+	friend detail::Factory;
+
+public:
+	ColumnDescription(ColumnDescription &&) noexcept = default;
+	ColumnDescription &operator=(ColumnDescription &&) noexcept = default;
+
+	~ColumnDescription() override;
+
+	/// The column name, with the casing it was declared with.
+	/// @return A view borrowed from this description, valid until it is destroyed.
+	auto GetName() const -> std::string_view;
+
+	/// An owned copy of the column type.
+	auto GetType() const -> LogicalType;
+
+	/// Whether the column declares a default expression. Generated columns report false.
+	auto HasDefault() const -> bool;
+
+	/// Whether the column is generated: computed by the engine and not writable.
+	auto HasGenerated() const -> bool;
+
+private:
+	explicit ColumnDescription(void *impl);
+};
 
 //----------------------------------------------------------------------------------------------------------------------
 // Replacement Scan

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -78,6 +78,9 @@ class CustomType;
 class CastFunction;
 class ReplacementScan;
 class QualifiedName;
+class FileSystem;
+class FileHandle;
+class FileOpenOptions;
 
 //----------------------------------------------------------------------------------------------------------------------
 // Internal Implementation Details
@@ -417,6 +420,9 @@ public:
 	/// search path and then in the system catalog; a qualified one is resolved exactly as written.
 	auto CreateType(const QualifiedName &name, const std::vector<TypeParam> &params = {}) const -> LogicalType;
 
+	/// The file system this context reads and writes through. Borrowed, and valid only while the context is.
+	auto GetFileSystem() const -> FileSystem;
+
 	/// The id-keyed twin of `CreateType`: the id resolves to its canonical name and binds like it.
 	/// @param id The type's id. Without parameters, only ids that name a complete type on their own are accepted;
 	/// parameterized kinds such as LIST or DECIMAL require parameters.
@@ -606,6 +612,9 @@ public:
 	/// `CreateType` for a name that may be catalog- or schema-qualified. An unqualified name is resolved along the
 	/// search path and then in the system catalog; a qualified one is resolved exactly as written.
 	auto CreateType(const QualifiedName &name, const std::vector<TypeParam> &params = {}) -> LogicalType;
+
+	/// The file system this connection reads and writes through. Borrowed, and valid only while the connection is.
+	auto GetFileSystem() const -> FileSystem;
 
 	/// The id-keyed twin of `CreateType`: the id resolves to its canonical name and binds like it.
 	/// @param id The type's id. Without parameters, only ids that name a complete type on their own are accepted;
@@ -3865,6 +3874,144 @@ public:
 
 		void *GetUserDataInternal() const;
 	};
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+// File System
+//----------------------------------------------------------------------------------------------------------------------
+
+/// How `FileSystem::OpenFile` opens a file. Not a bitmask -- apply these one at a time with
+/// `FileOpenOptions::SetFlag`, or pass several as a braced list to `FileSystem::OpenFile`.
+enum class FileFlags : uint8_t {
+	/// Not a flag. The zero value, so an uninitialized variable does not name a behaviour; applying it is an error.
+	INVALID = 0,
+	/// Open the file with "read" capabilities.
+	READ = 1,
+	/// Open the file with "write" capabilities.
+	WRITE = 2,
+	/// Create the file if it does not exist, and open it as it is if it does.
+	/// The FILE_ prefix matches the engine's flag names and keeps CREATE clear of the `<windows.h>` macro.
+	FILE_CREATE = 3,
+	/// Create the file if it does not exist, and truncate it to empty if it does. To fail instead of truncating,
+	/// combine `FILE_CREATE` with `EXCLUSIVE_CREATE`.
+	FILE_CREATE_NEW = 4,
+	/// Open the file in "append" mode.
+	APPEND = 5,
+	/// Fail if the file already exists. A modifier on `FILE_CREATE`, and meaningless without it.
+	EXCLUSIVE_CREATE = 6,
+	/// The file will be read and written at explicit offsets from several threads at once. Pass it whenever `ReadAt`
+	/// or `WriteAt` are used concurrently, so that a file system which would otherwise assume sequential access does
+	/// not.
+	PARALLEL_ACCESS = 7,
+};
+
+/// An open file, obtained from `FileSystem::OpenFile`. Closes on destruction.
+/// Only usable while the `FileSystem` it came from is still valid.
+class FileHandle final : public detail::Handle<FileHandle> {
+	friend detail::Factory;
+
+public:
+	FileHandle(FileHandle &&) noexcept = default;
+	FileHandle &operator=(FileHandle &&) noexcept = default;
+
+	~FileHandle() override;
+
+	/// Flushes buffered writes to persistent storage, which is what makes them durable across a crash. Closing or
+	/// destroying the handle flushes as well.
+	void Sync();
+
+	/// Closes the file, releasing its operating-system resources. The handle stays valid but can no longer be used
+	/// to read, write or seek.
+	void Close();
+
+	/// Moves the read/write position to an absolute byte offset from the start of the file. Seeking past the end is
+	/// allowed; reading from there yields nothing.
+	void Seek(idx_t position);
+
+	/// The current read/write position, as a byte offset from the start of the file.
+	auto Tell() const -> idx_t;
+
+	/// The total size of the file in bytes.
+	auto Size() const -> idx_t;
+
+	/// Reads up to `size` bytes from the current position, advancing it by however many were read.
+	/// @return How many bytes were read. Fewer than asked for is normal at the end of the file, and zero means
+	/// there is nothing left; neither is an error.
+	auto Read(void *buffer, idx_t size) -> idx_t;
+
+	/// Writes up to `size` bytes at the current position, advancing it by however many were written.
+	/// @return How many bytes were written.
+	auto Write(const void *buffer, idx_t size) -> idx_t;
+
+	/// Reads exactly `size` bytes from `location`, leaving the file's position alone. Unlike `Read`, a short read is
+	/// an error rather than a result, so there is no count to return. Safe to call from several threads at once when
+	/// the file was opened with `FileFlags::PARALLEL_ACCESS`.
+	/// @throws Exception When the file ends before `size` bytes have been read.
+	void ReadAt(void *buffer, idx_t size, idx_t location);
+
+	/// Writes exactly `size` bytes at `location`, leaving the file's position alone and extending the file when the
+	/// offset is past its end. Safe to call from several threads at once when the file was opened with
+	/// `FileFlags::PARALLEL_ACCESS` and the threads write disjoint ranges.
+	void WriteAt(const void *buffer, idx_t size, idx_t location);
+
+private:
+	explicit FileHandle(void *impl);
+};
+
+/// How a file is opened: the flags, plus any values the file system handling the path cares about.
+/// Created from the `FileSystem` it will be used with, and reusable across any number of opens.
+class FileOpenOptions final : public detail::Handle<FileOpenOptions> {
+	friend detail::Factory;
+
+public:
+	FileOpenOptions(FileOpenOptions &&) noexcept = default;
+	FileOpenOptions &operator=(FileOpenOptions &&) noexcept = default;
+
+	~FileOpenOptions() override;
+
+	/// Creates an empty set of options for `fs`. Flags must be set before they can open anything.
+	static auto Create(const FileSystem &fs) -> FileOpenOptions;
+
+	/// Applies one flag. Additive, and applying the same flag twice is harmless; at least one flag is required
+	/// before the options can open anything. There is no way to take a flag back -- build a fresh set instead.
+	/// @throws InvalidInputException When the value is `FileFlags::INVALID` or not a flag at all.
+	auto SetFlag(FileFlags flag) & -> FileOpenOptions &;
+
+	/// Attaches a named value, a hint for whichever file system ends up handling the path. What a name means is that
+	/// file system's business, and one it does not recognize is ignored. Setting the same name again replaces it.
+	auto SetValue(std::string_view name, const Value &value) & -> FileOpenOptions &;
+
+private:
+	explicit FileOpenOptions(void *impl);
+};
+
+/// The file system DuckDB itself reads and writes through, so files open the way the engine would open them --
+/// including through virtual and remote file systems registered by other extensions.
+/// Borrowed from a `Context` or `Connection`, and valid only for as long as that is.
+class FileSystem final : public detail::Handle<FileSystem> {
+	friend detail::Factory;
+
+public:
+	FileSystem(FileSystem &&) noexcept = default;
+	FileSystem &operator=(FileSystem &&) noexcept = default;
+
+	~FileSystem() override;
+
+	/// Opens a file with nothing but flags, which is what most opens need.
+	/// @param path The path to open, routed the way the engine would route it.
+	/// @param flags How to open it, e.g. `{FileFlags::WRITE, FileFlags::FILE_CREATE}`; at least one is required.
+	/// @throws Exception When the file cannot be opened.
+	auto OpenFile(const std::string &path, std::initializer_list<FileFlags> flags) const -> FileHandle;
+
+	/// Opens a file with a prepared set of options, for when the file system needs values as well as flags.
+	/// @throws Exception When the file cannot be opened, or the options carry no flags.
+	auto OpenFile(const std::string &path, const FileOpenOptions &options) const -> FileHandle;
+
+	/// Creates an empty set of options for this file system, the same as `FileOpenOptions::Create(*this)`.
+	auto CreateOpenOptions() const -> FileOpenOptions;
+
+private:
+	explicit FileSystem(void *impl);
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -3977,6 +3977,381 @@ private:
 };
 
 //----------------------------------------------------------------------------------------------------------------------
+// Copy Function
+//----------------------------------------------------------------------------------------------------------------------
+
+/// A user-defined output format for `COPY ... TO`, built up with the setters and made live with `Register`.
+/// Create one against the `Connection` or `Extension` it will be registered in, describe it (name, callbacks), then
+/// call `Register`. The function object may be destroyed after registration; the registered function lives on in the
+/// catalog and is reached from SQL with `COPY ... TO 'path' (FORMAT name)`.
+///
+/// The engine gathers the rows being copied into batches and drives the callbacks in this order: bind (once, during
+/// planning), init (once per output file), batch (once per batch, possibly on several threads at once), flush (once
+/// per prepared batch, never concurrently for the same file) and finalize (once per output file). The batch callback
+/// prepares a batch for writing, e.g. encodes it into the output format; the flush callback writes the prepared form
+/// out.
+///
+/// The callbacks receive their state through the input objects: `SetUserData` plants data readable from every
+/// callback; the bind callback may plant bind data readable from every later callback; the init callback may plant
+/// per-file init data readable from the batch, flush and finalize callbacks of that file; and the batch callback hands
+/// its prepared batch data to the flush callback. A callback reports failure by throwing; the exception surfaces as
+/// the query's error.
+class CopyFunction final : public detail::Handle<CopyFunction> {
+	friend detail::Factory;
+
+public:
+	class BindInput;
+	class BatchSizeInput;
+	class InitInput;
+	class BatchInput;
+	class FlushInput;
+	class FinalizeInput;
+
+	/// Called once per COPY statement while it is bound. Optional.
+	using BindCallback = void (*)(BindInput &input);
+	/// Called after bind, for a COPY statement that sets no `BATCH_SIZE` itself, to report how many rows a batch
+	/// should carry; must call `SetTarget`. Optional: without it, a batch is cut for every chunk of rows sunk, i.e.
+	/// a vector at a time.
+	using BatchSizeCallback = void (*)(BatchSizeInput &input);
+	/// Called once per output file before its first batch is prepared. Optional; the file path is only available here.
+	using InitCallback = void (*)(InitInput &input);
+	/// Called to prepare a batch of rows for writing; may run on several threads at once. Required.
+	using BatchCallback = void (*)(BatchInput &input);
+	/// Called to write a prepared batch to the output; never concurrently for the same file. Required.
+	using FlushCallback = void (*)(FlushInput &input);
+	/// Called once per output file after its last batch has been flushed. Optional.
+	using FinalizeCallback = void (*)(FinalizeInput &input);
+
+	CopyFunction(CopyFunction &&) noexcept = default;
+	CopyFunction &operator=(CopyFunction &&) noexcept = default;
+
+	~CopyFunction() override;
+
+	/// Creates a function that `Register` adds to the connection's database.
+	static auto Create(const Connection &conn) -> CopyFunction;
+	/// Creates a function that `Register` adds through the loading extension.
+	static auto Create(const Extension &extension) -> CopyFunction;
+
+	/// Sets the function's name: the format SQL selects it with, as in `COPY ... TO 'path' (FORMAT name)`.
+	auto SetName(const std::string &name) & -> CopyFunction &;
+
+	/// Constructs user data of type `T`, carried by the registered function and freed at engine teardown; read it from
+	/// any callback via the inputs' `GetUserData<T>`. Consumed by `Register`: set it again before re-registering.
+	template <class T, class... ARGS>
+	auto SetUserData(ARGS &&... args) & -> CopyFunction & {
+		auto ptr = new T(std::forward<ARGS>(args)...);
+		SetUserDataInternal(ptr, detail::TypedDelete<T>);
+		return *this;
+	}
+
+	auto SetBindCallback(BindCallback callback) & -> CopyFunction &;
+	auto SetBatchSizeCallback(BatchSizeCallback callback) & -> CopyFunction &;
+	auto SetInitCallback(InitCallback callback) & -> CopyFunction &;
+	auto SetBatchCallback(BatchCallback callback) & -> CopyFunction &;
+	auto SetFlushCallback(FlushCallback callback) & -> CopyFunction &;
+	auto SetFinalizeCallback(FinalizeCallback callback) & -> CopyFunction &;
+
+	/// Registers the function in the catalog it was created against. The function object remains valid and may be
+	/// adjusted and registered again; user data set via `SetUserData` is consumed by the first `Register`.
+	/// @throws InvalidInputException When the name, batch callback or flush callback is missing.
+	auto Register() -> void;
+
+private:
+	explicit CopyFunction(void *impl);
+
+	auto SetUserDataInternal(void *data, void (*destructor)(void *)) -> void;
+
+	BindCallback bind_callback = nullptr;
+	BatchSizeCallback batch_size_callback = nullptr;
+	InitCallback init_callback = nullptr;
+	BatchCallback batch_callback = nullptr;
+	FlushCallback flush_callback = nullptr;
+	FinalizeCallback finalize_callback = nullptr;
+	detail::UserData user_data;
+
+public:
+	/// What the bind callback works with. Borrowed, valid only for the callback duration.
+	class BindInput {
+		friend detail::Factory;
+
+	public:
+		/// Constructs bind data of type `T`, owned by the bound statement and readable from every later callback via
+		/// `GetBindData<T>`. The engine compares bind data when it compares statements: by `operator==` when `T` has
+		/// one, by identity otherwise.
+		template <class T, class... ARGS>
+		void SetBindData(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetBindDataInternal(ptr, detail::SelectEquals<T>(), detail::TypedDelete<T>);
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// How many columns are being copied: the columns of every batch's rows. Valid indices for `GetColumnName`
+		/// and `GetColumnType` are [0, GetColumnCount()).
+		auto GetColumnCount() const -> idx_t;
+
+		/// One column's name.
+		/// @param index Column index in [0, GetColumnCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetColumnName(idx_t index) const -> std::string;
+
+		/// One column's type.
+		/// @param index Column index in [0, GetColumnCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetColumnType(idx_t index) const -> LogicalType;
+
+		/// The binding context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		BindInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetBindDataInternal(void *data, bool (*equals)(void *a, void *b), void (*destructor)(void *));
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the batch size callback works with. Borrowed, valid only for the callback duration.
+	class BatchSizeInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// Reports how many rows a batch should carry, as the target the engine cuts batches at; the callback must
+		/// call this. A batch may still be smaller (the last one of a file, or when `BATCH_SIZE_BYTES` cuts it first).
+		/// @param rows The number of rows a batch should carry; must be greater than 0.
+		auto SetTarget(idx_t rows) -> void;
+
+		/// The binding context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		BatchSizeInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the init callback works with. Borrowed, valid only for the callback duration.
+	class InitInput {
+		friend detail::Factory;
+
+	public:
+		/// Constructs init data of type `T`, owned by the file being written and readable from the batch, flush and
+		/// finalize callbacks of that file via `GetInitData<T>`. Batches may be prepared on several threads at once, so
+		/// the batch callback must synchronize its own access to it.
+		template <class T, class... ARGS>
+		void SetInitData(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetInitDataInternal(ptr, detail::TypedDelete<T>);
+		}
+
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The path of the file being written, after the engine's own rewrites (e.g. a temporary name while the file
+		/// is being written, or a per-partition path).
+		auto GetFilePath() const -> std::string;
+
+		/// The query context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		InitInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetInitDataInternal(void *data, void (*destructor)(void *));
+		void *GetBindDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the batch callback works with. Borrowed, valid only for the callback duration.
+	class BatchInput {
+		friend detail::Factory;
+
+	public:
+		/// Constructs batch data of type `T`: the prepared form of the batch, handed to the flush callback via
+		/// `FlushInput::GetBatchData<T>` and freed once the batch has been flushed.
+		template <class T, class... ARGS>
+		void SetBatchData(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetBatchDataInternal(ptr, detail::TypedDelete<T>);
+		}
+
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The init data set via `InitInput::SetInitData` for the file this batch belongs to.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetInitData() const -> T & {
+			return *static_cast<T *>(GetInitDataInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// Takes ownership of the rows of the batch: one column per column reported by `BindInput::GetColumnCount`,
+		/// in the same order. The batch can only be taken once; a batch that is never taken is released when the
+		/// callback returns. It may be kept beyond the callback, e.g. moved into the batch data via `SetBatchData`.
+		/// @throws InvalidInputException When the batch was already taken.
+		auto TakeBatch() -> ColumnDataCollection;
+
+		/// The query context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		BatchInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetBatchDataInternal(void *data, void (*destructor)(void *));
+		void *GetBindDataInternal() const;
+		void *GetInitDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the flush callback works with. Borrowed, valid only for the callback duration.
+	class FlushInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The init data set via `InitInput::SetInitData` for the file this batch belongs to.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetInitData() const -> T & {
+			return *static_cast<T *>(GetInitDataInternal());
+		}
+
+		/// The batch data set via `BatchInput::SetBatchData` for the batch being flushed.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBatchData() const -> T & {
+			return *static_cast<T *>(GetBatchDataInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The query context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		FlushInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
+		void *GetInitDataInternal() const;
+		void *GetBatchDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the finalize callback works with. Borrowed, valid only for the callback duration.
+	class FinalizeInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The init data set via `InitInput::SetInitData` for the file being finalized.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetInitData() const -> T & {
+			return *static_cast<T *>(GetInitDataInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The query context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		FinalizeInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
+		void *GetInitDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+};
+
+//----------------------------------------------------------------------------------------------------------------------
 // Cast Function
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -74,6 +74,8 @@ enum class LogicalTypeId : uint32_t;
 
 template <class CTX>
 class TypeBuilder;
+class CustomType;
+class CastFunction;
 
 //----------------------------------------------------------------------------------------------------------------------
 // Internal Implementation Details
@@ -3584,6 +3586,169 @@ public:
 
 		void *GetBindDataInternal() const;
 		void *GetGlobalStateInternal() const;
+		void *GetUserDataInternal() const;
+	};
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+// Custom Type
+//----------------------------------------------------------------------------------------------------------------------
+
+/// A user-defined type, built up with the setters and made live with `Register`.
+/// Create one against the `Connection` or `Extension` it will be registered in, give it a name and a base type, then
+/// call `Register`. The type object may be destroyed after registration; the registered type lives on in the catalog.
+///
+/// A custom type borrows its base type's internal representation, so the execution engine needs no special handling
+/// for it, while staying logically distinct from the base type so it can carry its own casts. Values of it are
+/// produced and read with the base type's vector accessors; to hand one back out under the custom name, alias the
+/// base type with `LogicalType::WithAlias`.
+class CustomType final : public detail::Handle<CustomType> {
+	friend detail::Factory;
+
+public:
+	CustomType(CustomType &&) noexcept = default;
+	CustomType &operator=(CustomType &&) noexcept = default;
+
+	~CustomType() override;
+
+	/// Creates a type that `Register` adds to the connection's database.
+	static auto Create(const Connection &conn) -> CustomType;
+	/// Creates a type that `Register` adds through the loading extension.
+	static auto Create(const Extension &extension) -> CustomType;
+
+	/// Sets the type's name, as SQL will refer to it, and as every logical type instance of it carries as its alias.
+	auto SetName(const std::string &name) & -> CustomType &;
+
+	/// Sets the type whose representation this type borrows. Must be a fully defined concrete type.
+	auto SetBaseType(const LogicalType &type) & -> CustomType &;
+
+	/// Registers the type in the catalog it was created against. The type object remains valid and may be adjusted
+	/// and registered again.
+	/// @throws InvalidInputException When the name or the base type is missing, or the base type is not concrete.
+	auto Register() -> void;
+
+private:
+	explicit CustomType(void *impl);
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+// Cast Function
+//----------------------------------------------------------------------------------------------------------------------
+
+/// The mode a cast runs in, which decides what a conversion failure means.
+enum class CastMode : uint8_t {
+	/// A regular cast. Throwing from the exec callback aborts the query.
+	NORMAL = 0,
+	/// A "try" cast (SQL TRY_CAST). The rows the callback could not convert should be left NULL in the output; an
+	/// exception thrown anyway is swallowed and those rows stay NULL.
+	TRY = 1,
+};
+
+/// A user-defined cast between two types, built up with the setters and made live with `Register`.
+/// Create one against the `Connection` or `Extension` it will be registered in, describe it (source type, target
+/// type, exec callback), then call `Register`. The function object may be destroyed after registration; the
+/// registered cast lives on.
+///
+/// A cast is keyed by its (source, target) type pair rather than by a name, and is reached from SQL through CAST and
+/// TRY_CAST -- and, when it declares a non-negative implicit cast cost, through the binder converting argument types
+/// on its own. The exec callback converts a whole batch at a time; whether a per-row failure aborts the query or
+/// becomes a NULL follows from `ExecInput::GetMode`.
+class CastFunction final : public detail::Handle<CastFunction> {
+	friend detail::Factory;
+
+public:
+	class ExecInput;
+
+	/// Called for every batch of values; must fill the output vector. Required.
+	using ExecCallback = void (*)(ExecInput &input);
+
+	CastFunction(CastFunction &&) noexcept = default;
+	CastFunction &operator=(CastFunction &&) noexcept = default;
+
+	~CastFunction() override;
+
+	/// Creates a cast that `Register` adds to the connection's database.
+	static auto Create(const Connection &conn) -> CastFunction;
+	/// Creates a cast that `Register` adds through the loading extension.
+	static auto Create(const Extension &extension) -> CastFunction;
+
+	/// Sets the type the cast converts from. Must be a fully defined concrete type.
+	auto SetSourceType(const LogicalType &type) & -> CastFunction &;
+
+	/// Sets the type the cast converts to. Must be a fully defined concrete type.
+	auto SetTargetType(const LogicalType &type) & -> CastFunction &;
+
+	/// Sets what it costs to apply this cast implicitly. The binder uses the cost to choose between candidate
+	/// implicit casts: a lower non-negative cost makes this cast more likely to be picked. Built-in widening casts
+	/// sit in the [0, 20] range. A negative cost -- the default -- keeps the cast out of implicit conversion
+	/// entirely, so it is reached only through an explicit CAST or TRY_CAST.
+	/// @param cost The cost, or a negative value to disable implicit casting.
+	auto SetImplicitCastCost(int64_t cost) & -> CastFunction &;
+
+	/// Constructs user data of type `T`, carried by the registered cast and freed at engine teardown; read it from the
+	/// exec callback via `ExecInput::GetUserData<T>`. Consumed by `Register`: set it again before re-registering.
+	template <class T, class... ARGS>
+	auto SetUserData(ARGS &&... args) & -> CastFunction & {
+		auto ptr = new T(std::forward<ARGS>(args)...);
+		SetUserDataInternal(ptr, detail::TypedDelete<T>);
+		return *this;
+	}
+
+	auto SetExecCallback(ExecCallback callback) & -> CastFunction &;
+
+	/// Registers the cast in the database it was created against, replacing whatever cast was registered for the same
+	/// type pair. The function object remains valid and may be adjusted and registered again; user data set via
+	/// `SetUserData` is consumed by the first `Register`.
+	/// @throws InvalidInputException When the source type, target type, or exec callback is missing, or either type is
+	/// not concrete.
+	auto Register() -> void;
+
+private:
+	explicit CastFunction(void *impl);
+
+	auto SetUserDataInternal(void *data, void (*destructor)(void *)) -> void;
+
+	ExecCallback exec_callback = nullptr;
+	detail::UserData user_data;
+
+public:
+	/// What the exec callback works with. Borrowed, valid only for the callback duration.
+	class ExecInput {
+		friend detail::Factory;
+
+	public:
+		/// The user data set via `CastFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// How many rows this execution must convert: the callback writes exactly this many entries to the output
+		/// vector. May be less than a full vector; a constant input is converted as a single row and the engine
+		/// expands the result.
+		auto GetRowCount() const -> idx_t;
+
+		/// The input vector holding the values to convert.
+		auto GetInput() const -> Vector;
+
+		/// The output vector to fill.
+		auto GetOutput() const -> Vector;
+
+		/// The mode this cast runs in. In `CastMode::TRY` a failed row should be left NULL rather than reported by
+		/// throwing.
+		auto GetMode() const -> CastMode;
+
+		/// The execution context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		ExecInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
 		void *GetUserDataInternal() const;
 	};
 };

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -77,6 +77,7 @@ class TypeBuilder;
 class CustomType;
 class CastFunction;
 class ReplacementScan;
+class QualifiedName;
 
 //----------------------------------------------------------------------------------------------------------------------
 // Internal Implementation Details
@@ -412,6 +413,10 @@ public:
 	/// Parameterless overload of the above.
 	auto CreateType(std::string_view name) const -> LogicalType;
 
+	/// `CreateType` for a name that may be catalog- or schema-qualified. An unqualified name is resolved along the
+	/// search path and then in the system catalog; a qualified one is resolved exactly as written.
+	auto CreateType(const QualifiedName &name, const std::vector<TypeParam> &params = {}) const -> LogicalType;
+
 	/// The id-keyed twin of `CreateType`: the id resolves to its canonical name and binds like it.
 	/// @param id The type's id. Without parameters, only ids that name a complete type on their own are accepted;
 	/// parameterized kinds such as LIST or DECIMAL require parameters.
@@ -597,6 +602,10 @@ public:
 	auto CreateType(std::string_view name, const std::vector<TypeParam> &params) -> LogicalType;
 	/// Parameterless overload of the above.
 	auto CreateType(std::string_view name) -> LogicalType;
+
+	/// `CreateType` for a name that may be catalog- or schema-qualified. An unqualified name is resolved along the
+	/// search path and then in the system catalog; a qualified one is resolved exactly as written.
+	auto CreateType(const QualifiedName &name, const std::vector<TypeParam> &params = {}) -> LogicalType;
 
 	/// The id-keyed twin of `CreateType`: the id resolves to its canonical name and binds like it.
 	/// @param id The type's id. Without parameters, only ids that name a complete type on their own are accepted;
@@ -3859,6 +3868,68 @@ public:
 };
 
 //----------------------------------------------------------------------------------------------------------------------
+// Qualified Name
+//----------------------------------------------------------------------------------------------------------------------
+
+/// The ordered path of identifiers that names a database object.
+/// The path is the whole representation: partial qualification is expressed by having fewer parts (`{"t"}`,
+/// `{"s", "t"}`, `{"c", "s", "t"}`), never by empty placeholders, and the last part is always the object itself.
+/// Whether a two-part name means catalog.object or schema.object is decided by resolution, not by the name.
+///
+/// Owned, so a name obtained from somewhere transient -- a replacement scan callback, say -- can be kept for as long
+/// as you like.
+class QualifiedName final : public detail::Handle<QualifiedName> {
+	friend detail::Factory;
+
+public:
+	QualifiedName(QualifiedName &&) noexcept = default;
+	QualifiedName &operator=(QualifiedName &&) noexcept = default;
+
+	~QualifiedName() override;
+
+	/// Parses SQL text into a qualified name: dots separate parts, and a double-quoted part may contain dots and
+	/// doubled interior quotes.
+	/// @throws Exception When the text does not parse, or yields no parts or more than three.
+	static auto Parse(std::string_view text) -> QualifiedName;
+
+	/// Builds a name from its parts, outermost first, so the last one is the object name.
+	/// @param parts Between one and three non-empty parts.
+	/// @throws InvalidInputException When there are no parts, more than three, or any is empty.
+	static auto Create(const std::vector<std::string> &parts) -> QualifiedName;
+
+	/// How many parts the name has; always at least one.
+	auto GetPartCount() const -> idx_t;
+
+	/// One part, outermost first. The view is valid until this name is destroyed.
+	/// @param index Part index in [0, GetPartCount()).
+	/// @throws Exception When the index is out of range.
+	auto GetPart(idx_t index) const -> std::string_view;
+
+	/// The object name: the last part. The view is valid until this name is destroyed.
+	auto GetName() const -> std::string_view;
+
+	/// The name as SQL text, quoting each part only where the identifier requires it, so it parses back to an equal
+	/// name.
+	auto Render() const -> std::string;
+
+	/// Whether two names have the same parts, compared case-insensitively the way the engine compares identifiers.
+	auto Equals(const QualifiedName &other) const -> bool;
+
+	/// A hash consistent with `Equals`. Not stable across processes or versions: for in-process lookup only.
+	auto Hash() const -> uint64_t;
+
+private:
+	explicit QualifiedName(void *impl);
+};
+
+inline bool operator==(const QualifiedName &lhs, const QualifiedName &rhs) {
+	return lhs.Equals(rhs);
+}
+inline bool operator!=(const QualifiedName &lhs, const QualifiedName &rhs) {
+	return !lhs.Equals(rhs);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 // Replacement Scan
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -3938,20 +4009,19 @@ public:
 			return *static_cast<T *>(GetUserDataInternal());
 		}
 
-		/// The catalog qualifier of the unresolved reference, empty when it carries none.
-		auto GetCatalogName() const -> std::string_view;
-
-		/// The schema qualifier of the unresolved reference, empty when it carries none.
-		auto GetSchemaName() const -> std::string_view;
-
-		/// The table name of the unresolved reference, as written in the query; for a file-backed reference, the path.
-		auto GetTableName() const -> std::string_view;
+		/// The name the catalog could not resolve, as written in the query. An unqualified reference has a single
+		/// part; for a file-backed one that part is the path. Owned, so it can outlive the callback.
+		auto GetName() const -> QualifiedName;
 
 		/// Claims the reference by naming a table function to call instead; its arguments are then supplied with
-		/// `AddArgument` and `AddNamedArgument`. The name is unqualified and matched case-insensitively, and is not
-		/// resolved here: an unknown function fails later, when the replacement is bound. The three claim forms,
-		/// `SetFunctionName`, `SetCollection` and `SetSubquery`, are mutually exclusive.
-		/// @throws InvalidInputException When the name is empty, or a different claim form was already used.
+		/// `AddArgument` and `AddNamedArgument`. Parts are matched case-insensitively, and a qualified name targets a
+		/// function in a particular schema or catalog. The name is not resolved here: an unknown function fails
+		/// later, when the replacement is bound. The three claim forms, `SetFunctionName`, `SetCollection` and
+		/// `SetSubquery`, are mutually exclusive.
+		/// @throws InvalidInputException When a different claim form was already used.
+		auto SetFunctionName(const QualifiedName &name) -> void;
+
+		/// `SetFunctionName` for the common case of an unqualified function.
 		auto SetFunctionName(std::string_view name) -> void;
 
 		/// Appends a positional argument to the claimed table function. Positional arguments are passed in the order

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -3181,6 +3181,414 @@ public:
 };
 
 //----------------------------------------------------------------------------------------------------------------------
+// Table Function
+//----------------------------------------------------------------------------------------------------------------------
+
+/// A user-defined table function, built up with the setters and made live with `Register`.
+/// Create one against the `Connection` or `Extension` it will be registered in, describe it (name, signature,
+/// callbacks), then call `Register`. The function object may be destroyed after registration; the registered function
+/// lives on in the catalog.
+///
+/// A table function produces a table rather than a value: the bind callback declares the columns it returns, and the
+/// exec callback is then invoked repeatedly to fill batches of rows until it produces an empty one. Between them, the
+/// optional init callbacks set up the state the scan runs on: one global state shared by every thread, and one local
+/// state per thread.
+///
+/// The callbacks receive their state through the input objects: `SetUserData` plants data readable from every
+/// callback, and the bind callback may plant bind data readable from every later callback. A callback reports failure
+/// by throwing; the exception surfaces as the query's error.
+class TableFunction final : public detail::Handle<TableFunction> {
+	friend detail::Factory;
+
+public:
+	class BindInput;
+	class InitGlobalInput;
+	class InitLocalInput;
+	class ExecInput;
+	class CardinalityInput;
+	class ProgressInput;
+
+	/// Called once per query while the function call is bound; declares the columns the function returns. Required.
+	using BindCallback = void (*)(BindInput &input);
+	/// Called once per scan, before the first `ExecCallback`. Optional.
+	using InitGlobalCallback = void (*)(InitGlobalInput &input);
+	/// Called once per scanning thread, before the first `ExecCallback` on it. Optional.
+	using InitLocalCallback = void (*)(InitLocalInput &input);
+	/// Called repeatedly to produce the next batch of rows; an empty batch ends the scan. Required.
+	using ExecCallback = void (*)(ExecInput &input);
+	/// Called during optimization to estimate the scan's row count. Optional.
+	using CardinalityCallback = void (*)(CardinalityInput &input);
+	/// Called on demand during execution to report how far the scan has advanced. Optional.
+	using ProgressCallback = void (*)(ProgressInput &input);
+
+	TableFunction(TableFunction &&) noexcept = default;
+	TableFunction &operator=(TableFunction &&) noexcept = default;
+
+	~TableFunction() override;
+
+	/// Creates a function that `Register` adds to the connection's database.
+	static auto Create(const Connection &conn) -> TableFunction;
+	/// Creates a function that `Register` adds through the loading extension.
+	static auto Create(const Extension &extension) -> TableFunction;
+
+	/// Sets the function's name, as SQL will call it.
+	auto SetName(const std::string &name) & -> TableFunction &;
+
+	/// The function's signature, borrowed for in-place mutation. A parameter without a default value becomes a
+	/// required positional argument, one with a default becomes a named argument the caller may omit. Registration
+	/// rejects a return type: a table function declares the columns it returns from its bind callback.
+	auto GetSignature() -> FunctionSignature;
+
+	/// Calls `configure` with the function's signature, borrowed for in-place mutation. See `GetSignature`.
+	template <class F>
+	auto WithSignature(F &&configure) & -> TableFunction & {
+		auto sig = GetSignature();
+		configure(sig);
+		return *this;
+	}
+
+	/// Constructs user data of type `T`, carried by the registered function and freed at engine teardown; read it from
+	/// any callback via the inputs' `GetUserData<T>`. Consumed by `Register`: set it again before re-registering.
+	template <class T, class... ARGS>
+	auto SetUserData(ARGS &&... args) & -> TableFunction & {
+		auto ptr = new T(std::forward<ARGS>(args)...);
+		SetUserDataInternal(ptr, detail::TypedDelete<T>);
+		return *this;
+	}
+
+	auto SetBindCallback(BindCallback callback) & -> TableFunction &;
+	auto SetInitGlobalCallback(InitGlobalCallback callback) & -> TableFunction &;
+	auto SetInitLocalCallback(InitLocalCallback callback) & -> TableFunction &;
+	auto SetExecCallback(ExecCallback callback) & -> TableFunction &;
+	auto SetCardinalityCallback(CardinalityCallback callback) & -> TableFunction &;
+	auto SetProgressCallback(ProgressCallback callback) & -> TableFunction &;
+
+	/// Registers the function in the catalog it was created against. The function object remains valid and may be
+	/// adjusted and registered again; user data set via `SetUserData` is consumed by the first `Register`.
+	/// @throws InvalidInputException When the name, bind callback or exec callback is missing, or the signature
+	/// declares a return type.
+	auto Register() -> void;
+
+private:
+	explicit TableFunction(void *impl);
+
+	auto SetUserDataInternal(void *data, void (*destructor)(void *)) -> void;
+
+	BindCallback bind_callback = nullptr;
+	InitGlobalCallback init_global_callback = nullptr;
+	InitLocalCallback init_local_callback = nullptr;
+	ExecCallback exec_callback = nullptr;
+	CardinalityCallback cardinality_callback = nullptr;
+	ProgressCallback progress_callback = nullptr;
+	detail::UserData user_data;
+
+public:
+	/// What the bind callback works with. Borrowed, valid only for the callback duration.
+	class BindInput {
+		friend detail::Factory;
+
+	public:
+		/// Declares one of the columns the function returns. Call it once per column, in order: the exec callback's
+		/// output chunk carries one vector per declared column, in the same order. At least one column is required.
+		/// @param name The column's name.
+		/// @param type The column's type. Must be a fully defined concrete type; ANY is rejected.
+		auto AddResultColumn(const std::string &name, const LogicalType &type) -> void;
+
+		/// Constructs bind data of type `T`, owned by the bound function call and readable from every later callback
+		/// via `GetBindData<T>`. The engine compares bind data when it compares expressions: by `operator==` when `T`
+		/// has one, by identity otherwise.
+		template <class T, class... ARGS>
+		void SetBindData(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetBindDataInternal(ptr, detail::SelectEquals<T>(), detail::TypedDelete<T>);
+		}
+
+		/// The user data set via `TableFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// How many arguments this call passes. The arguments are the signature's parameters in order -- a parameter
+		/// the call site omitted still appears, carrying its declared default -- followed by any variadic tail
+		/// arguments. Valid indices for `GetArgType` and `GetArgument` are [0, GetArgCount()).
+		auto GetArgCount() const -> idx_t;
+
+		/// One argument's type.
+		/// @param index Argument index in [0, GetArgCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetArgType(idx_t index) const -> LogicalType;
+
+		/// One argument's value. A table function's arguments are always constants, so this only fails on a bad index.
+		/// @param index Argument index in [0, GetArgCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetArgument(idx_t index) const -> Value;
+
+		/// Hints how many rows the scan will produce, for the optimizer. Use `TableFunction::SetCardinalityCallback`
+		/// instead when the estimate is not yet known at bind time. Producing a different number of rows is not an
+		/// error.
+		/// @param cardinality The estimated row count.
+		/// @param is_exact Whether the estimate is exact, which also makes it an upper bound.
+		auto SetCardinality(idx_t cardinality, bool is_exact) -> void;
+
+		/// The binding context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		BindInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetBindDataInternal(void *data, bool (*equals)(void *a, void *b), void (*destructor)(void *));
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the global init callback works with. Borrowed, valid only for the callback duration.
+	class InitGlobalInput {
+		friend detail::Factory;
+
+	public:
+		/// Constructs global state of type `T`, shared by every thread scanning the function and readable from the
+		/// local init, exec and progress callbacks. Since every thread sees the same object, the function must
+		/// synchronize its own access to it.
+		template <class T, class... ARGS>
+		void SetGlobalState(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetGlobalStateInternal(ptr, detail::TypedDelete<T>);
+		}
+
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The user data set via `TableFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// Caps how many threads may scan the function in parallel. Defaults to 1, a single-threaded scan. The engine
+		/// creates at most this many local states, and may use fewer.
+		/// @param max_threads The maximum thread count. Must be at least 1.
+		auto SetMaxThreads(idx_t max_threads) -> void;
+
+		/// The scan's context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		InitGlobalInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetGlobalStateInternal(void *data, void (*destructor)(void *));
+		void *GetBindDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the local init callback works with. Borrowed, valid only for the callback duration.
+	class InitLocalInput {
+		friend detail::Factory;
+
+	public:
+		/// Constructs local state of type `T`, owned by this scanning thread and readable from the exec callback via
+		/// `ExecInput::GetLocalState<T>`. No other thread observes it, so it needs no synchronization.
+		template <class T, class... ARGS>
+		void SetLocalState(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetLocalStateInternal(ptr, detail::TypedDelete<T>);
+		}
+
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The global state set via `InitGlobalInput::SetGlobalState`, typically to claim this thread's share of the
+		/// work from it. Shared with every other scanning thread; access must be synchronized.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetGlobalState() const -> T & {
+			return *static_cast<T *>(GetGlobalStateInternal());
+		}
+
+		/// The user data set via `TableFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The scan's context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		InitLocalInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetLocalStateInternal(void *data, void (*destructor)(void *));
+		void *GetBindDataInternal() const;
+		void *GetGlobalStateInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the exec callback works with. Borrowed, valid only for the callback duration.
+	class ExecInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The global state set via `InitGlobalInput::SetGlobalState`. Shared with every other scanning thread;
+		/// access must be synchronized.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetGlobalState() const -> T & {
+			return *static_cast<T *>(GetGlobalStateInternal());
+		}
+
+		/// The local state set via `InitLocalInput::SetLocalState`, private to this thread.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetLocalState() const -> T & {
+			return *static_cast<T *>(GetLocalStateInternal());
+		}
+
+		/// The user data set via `TableFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The chunk to write the next batch of rows into, with one vector per column declared in bind. It starts out
+		/// empty on every invocation: write the rows, then give the batch its row count with `Vector::SetSize` on the
+		/// chunk's first vector, which the engine propagates to the others. Leaving it empty ends the scan.
+		/// @return A borrowed chunk, valid only for the callback duration.
+		auto GetOutputChunk() const -> DataChunk;
+
+		/// The execution context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		ExecInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
+		void *GetGlobalStateInternal() const;
+		void *GetLocalStateInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the cardinality callback works with. Borrowed, valid only for the callback duration.
+	class CardinalityInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The user data set via `TableFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// Reports how many rows the scan is expected to produce. A hint for the optimizer, not a limit: producing a
+		/// different number of rows is not an error. A callback that returns without calling this reports no estimate.
+		/// @param cardinality The estimated row count.
+		/// @param is_exact Whether the estimate is exact, which also makes it an upper bound.
+		auto SetCardinality(idx_t cardinality, bool is_exact) -> void;
+
+		/// The planning context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		CardinalityInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the progress callback works with. Borrowed, valid only for the callback duration.
+	class ProgressInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `BindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The global state set via `InitGlobalInput::SetGlobalState`. This callback runs while the scan is running,
+		/// so the state must be read in a thread-safe way.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetGlobalState() const -> T & {
+			return *static_cast<T *>(GetGlobalStateInternal());
+		}
+
+		/// The user data set via `TableFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// Reports how far the scan has advanced, as a fraction between 0.0 and 1.0; values outside that range are
+		/// clamped. A callback that returns without calling this reports no progress.
+		/// @param progress The fraction of the scan that is complete.
+		auto SetProgress(double progress) -> void;
+
+		/// The execution context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		ProgressInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
+		void *GetGlobalStateInternal() const;
+		void *GetUserDataInternal() const;
+	};
+};
+
+//----------------------------------------------------------------------------------------------------------------------
 // Scalar Executor
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -3552,7 +3552,6 @@ public:
 	class InitGlobalInput;
 	class InitLocalInput;
 	class ExecInput;
-	class CardinalityInput;
 	class ProgressInput;
 
 	/// Called once per query while the function call is bound; declares the columns the function returns. Required.
@@ -3563,8 +3562,6 @@ public:
 	using InitLocalCallback = void (*)(InitLocalInput &input);
 	/// Called repeatedly to produce the next batch of rows; an empty batch ends the scan. Required.
 	using ExecCallback = void (*)(ExecInput &input);
-	/// Called during optimization to estimate the scan's row count. Optional.
-	using CardinalityCallback = void (*)(CardinalityInput &input);
 	/// Called on demand during execution to report how far the scan has advanced. Optional.
 	using ProgressCallback = void (*)(ProgressInput &input);
 
@@ -3607,7 +3604,6 @@ public:
 	auto SetInitGlobalCallback(InitGlobalCallback callback) & -> TableFunction &;
 	auto SetInitLocalCallback(InitLocalCallback callback) & -> TableFunction &;
 	auto SetExecCallback(ExecCallback callback) & -> TableFunction &;
-	auto SetCardinalityCallback(CardinalityCallback callback) & -> TableFunction &;
 	auto SetProgressCallback(ProgressCallback callback) & -> TableFunction &;
 
 	/// Registers the function in the catalog it was created against. The function object remains valid and may be
@@ -3625,7 +3621,6 @@ private:
 	InitGlobalCallback init_global_callback = nullptr;
 	InitLocalCallback init_local_callback = nullptr;
 	ExecCallback exec_callback = nullptr;
-	CardinalityCallback cardinality_callback = nullptr;
 	ProgressCallback progress_callback = nullptr;
 	detail::UserData user_data;
 
@@ -3672,9 +3667,8 @@ public:
 		/// @throws InvalidInputException When the index is out of range.
 		auto GetArgument(idx_t index) const -> Value;
 
-		/// Hints how many rows the scan will produce, for the optimizer. Use `TableFunction::SetCardinalityCallback`
-		/// instead when the estimate is not yet known at bind time. Producing a different number of rows is not an
-		/// error.
+		/// Hints how many rows the scan will produce, for the optimizer. Producing a different number of rows is not
+		/// an error.
 		/// @param cardinality The estimated row count.
 		/// @param is_exact Whether the estimate is exact, which also makes it an upper bound.
 		auto SetCardinality(idx_t cardinality, bool is_exact) -> void;
@@ -3848,45 +3842,6 @@ public:
 		void *GetUserDataInternal() const;
 	};
 
-	/// What the cardinality callback works with. Borrowed, valid only for the callback duration.
-	class CardinalityInput {
-		friend detail::Factory;
-
-	public:
-		/// The bind data set via `BindInput::SetBindData`.
-		/// @throws InvalidInputException When none was set.
-		template <class T>
-		auto GetBindData() const -> const T & {
-			return *static_cast<const T *>(GetBindDataInternal());
-		}
-
-		/// The user data set via `TableFunction::SetUserData`.
-		/// @throws InvalidInputException When none was set.
-		template <class T>
-		auto GetUserData() const -> T & {
-			return *static_cast<T *>(GetUserDataInternal());
-		}
-
-		/// Reports how many rows the scan is expected to produce. A hint for the optimizer, not a limit: producing a
-		/// different number of rows is not an error. A callback that returns without calling this reports no estimate.
-		/// @param cardinality The estimated row count.
-		/// @param is_exact Whether the estimate is exact, which also makes it an upper bound.
-		auto SetCardinality(idx_t cardinality, bool is_exact) -> void;
-
-		/// The planning context. Borrowed, valid only for the callback duration.
-		auto GetContext() const -> Context;
-
-	private:
-		CardinalityInput(void *args, void *context) : args(args), context(context) {
-		}
-
-		void *args;
-		void *context;
-
-		void *GetBindDataInternal() const;
-		void *GetUserDataInternal() const;
-	};
-
 	/// What the progress callback works with. Borrowed, valid only for the callback duration.
 	class ProgressInput {
 		friend detail::Factory;
@@ -3980,47 +3935,63 @@ private:
 // Copy Function
 //----------------------------------------------------------------------------------------------------------------------
 
-/// A user-defined output format for `COPY ... TO`, built up with the setters and made live with `Register`.
+/// A user-defined file format for `COPY`, built up with the setters and made live with `Register`.
 /// Create one against the `Connection` or `Extension` it will be registered in, describe it (name, callbacks), then
 /// call `Register`. The function object may be destroyed after registration; the registered function lives on in the
-/// catalog and is reached from SQL with `COPY ... TO 'path' (FORMAT name)`.
+/// catalog and is reached from SQL with `COPY ... TO 'path' (FORMAT name)` and `COPY table FROM 'path' (FORMAT name)`.
 ///
-/// The engine gathers the rows being copied into batches and drives the callbacks in this order: bind (once, during
-/// planning), init (once per output file), batch (once per batch, possibly on several threads at once), flush (once
-/// per prepared batch, never concurrently for the same file) and finalize (once per output file). The batch callback
-/// prepares a batch for writing, e.g. encodes it into the output format; the flush callback writes the prepared form
-/// out.
+/// The two directions are configured separately and a function may implement either or both. The `COPY ... TO` side
+/// gathers the rows being written into batches and drives its callbacks in this order: bind (once, during planning),
+/// batch size (once, during planning, unless the statement sets `BATCH_SIZE`), init (once per output file), batch
+/// (once per batch, possibly on several threads at once), flush (once per prepared batch, never concurrently for the
+/// same file) and finalize (once per output file). The `COPY ... FROM` side reads like a table function whose columns
+/// are fixed by the target table: bind (once, during planning), init global (once per statement), init local (once
+/// per thread), exec (repeatedly, until it produces an empty batch), plus an optional progress hook.
 ///
 /// The callbacks receive their state through the input objects: `SetUserData` plants data readable from every
-/// callback; the bind callback may plant bind data readable from every later callback; the init callback may plant
-/// per-file init data readable from the batch, flush and finalize callbacks of that file; and the batch callback hands
-/// its prepared batch data to the flush callback. A callback reports failure by throwing; the exception surfaces as
-/// the query's error.
+/// callback of either side, and each side's bind callback may plant bind data readable from that side's later
+/// callbacks. A callback reports failure by throwing; the exception surfaces as the query's error.
 class CopyFunction final : public detail::Handle<CopyFunction> {
 	friend detail::Factory;
 
 public:
-	class BindInput;
-	class BatchSizeInput;
-	class InitInput;
-	class BatchInput;
-	class FlushInput;
-	class FinalizeInput;
+	class CopyToBindInput;
+	class CopyToBatchSizeInput;
+	class CopyToInitInput;
+	class CopyToBatchInput;
+	class CopyToFlushInput;
+	class CopyToFinalizeInput;
+	class CopyFromBindInput;
+	class CopyFromInitGlobalInput;
+	class CopyFromInitLocalInput;
+	class CopyFromExecInput;
+	class CopyFromProgressInput;
 
-	/// Called once per COPY statement while it is bound. Optional.
-	using BindCallback = void (*)(BindInput &input);
-	/// Called after bind, for a COPY statement that sets no `BATCH_SIZE` itself, to report how many rows a batch
-	/// should carry; must call `SetTarget`. Optional: without it, a batch is cut for every chunk of rows sunk, i.e.
-	/// a vector at a time.
-	using BatchSizeCallback = void (*)(BatchSizeInput &input);
-	/// Called once per output file before its first batch is prepared. Optional; the file path is only available here.
-	using InitCallback = void (*)(InitInput &input);
-	/// Called to prepare a batch of rows for writing; may run on several threads at once. Required.
-	using BatchCallback = void (*)(BatchInput &input);
-	/// Called to write a prepared batch to the output; never concurrently for the same file. Required.
-	using FlushCallback = void (*)(FlushInput &input);
+	/// Called once per `COPY ... TO` statement while it is bound. Optional.
+	using CopyToBindCallback = void (*)(CopyToBindInput &input);
+	/// Called after bind, for a `COPY ... TO` statement that sets no `BATCH_SIZE` itself, to report how many rows a
+	/// batch should carry; must call `SetTarget`. Optional: without it, a batch is cut for every chunk of rows sunk,
+	/// i.e. a vector at a time.
+	using CopyToBatchSizeCallback = void (*)(CopyToBatchSizeInput &input);
+	/// Called once per output file before its first batch is prepared. Optional.
+	using CopyToInitCallback = void (*)(CopyToInitInput &input);
+	/// Called to prepare a batch of rows for writing; may run on several threads at once. Required for the side.
+	using CopyToBatchCallback = void (*)(CopyToBatchInput &input);
+	/// Called to write a prepared batch to the output; never concurrently for the same file. Required for the side.
+	using CopyToFlushCallback = void (*)(CopyToFlushInput &input);
 	/// Called once per output file after its last batch has been flushed. Optional.
-	using FinalizeCallback = void (*)(FinalizeInput &input);
+	using CopyToFinalizeCallback = void (*)(CopyToFinalizeInput &input);
+
+	/// Called once per `COPY ... FROM` statement while it is bound. Required for the side.
+	using CopyFromBindCallback = void (*)(CopyFromBindInput &input);
+	/// Called once per statement at the start of execution. Optional.
+	using CopyFromInitGlobalCallback = void (*)(CopyFromInitGlobalInput &input);
+	/// Called once per thread reading the file. Optional.
+	using CopyFromInitLocalCallback = void (*)(CopyFromInitLocalInput &input);
+	/// Called to fill the next batch of rows; leaving the chunk empty ends the read. Required for the side.
+	using CopyFromExecCallback = void (*)(CopyFromExecInput &input);
+	/// Called on demand during execution to report progress. Optional.
+	using CopyFromProgressCallback = void (*)(CopyFromProgressInput &input);
 
 	CopyFunction(CopyFunction &&) noexcept = default;
 	CopyFunction &operator=(CopyFunction &&) noexcept = default;
@@ -4044,16 +4015,24 @@ public:
 		return *this;
 	}
 
-	auto SetBindCallback(BindCallback callback) & -> CopyFunction &;
-	auto SetBatchSizeCallback(BatchSizeCallback callback) & -> CopyFunction &;
-	auto SetInitCallback(InitCallback callback) & -> CopyFunction &;
-	auto SetBatchCallback(BatchCallback callback) & -> CopyFunction &;
-	auto SetFlushCallback(FlushCallback callback) & -> CopyFunction &;
-	auto SetFinalizeCallback(FinalizeCallback callback) & -> CopyFunction &;
+	auto SetCopyToBindCallback(CopyToBindCallback callback) & -> CopyFunction &;
+	auto SetCopyToBatchSizeCallback(CopyToBatchSizeCallback callback) & -> CopyFunction &;
+	auto SetCopyToInitCallback(CopyToInitCallback callback) & -> CopyFunction &;
+	auto SetCopyToBatchCallback(CopyToBatchCallback callback) & -> CopyFunction &;
+	auto SetCopyToFlushCallback(CopyToFlushCallback callback) & -> CopyFunction &;
+	auto SetCopyToFinalizeCallback(CopyToFinalizeCallback callback) & -> CopyFunction &;
+
+	auto SetCopyFromBindCallback(CopyFromBindCallback callback) & -> CopyFunction &;
+	auto SetCopyFromInitGlobalCallback(CopyFromInitGlobalCallback callback) & -> CopyFunction &;
+	auto SetCopyFromInitLocalCallback(CopyFromInitLocalCallback callback) & -> CopyFunction &;
+	auto SetCopyFromExecCallback(CopyFromExecCallback callback) & -> CopyFunction &;
+	auto SetCopyFromProgressCallback(CopyFromProgressCallback callback) & -> CopyFunction &;
 
 	/// Registers the function in the catalog it was created against. The function object remains valid and may be
 	/// adjusted and registered again; user data set via `SetUserData` is consumed by the first `Register`.
-	/// @throws InvalidInputException When the name, batch callback or flush callback is missing.
+	/// @throws InvalidInputException When the name is missing, neither side is configured, a configured
+	/// `COPY ... TO` side lacks its batch or flush callback, or a configured `COPY ... FROM` side lacks its bind or
+	/// exec callback.
 	auto Register() -> void;
 
 private:
@@ -4061,23 +4040,28 @@ private:
 
 	auto SetUserDataInternal(void *data, void (*destructor)(void *)) -> void;
 
-	BindCallback bind_callback = nullptr;
-	BatchSizeCallback batch_size_callback = nullptr;
-	InitCallback init_callback = nullptr;
-	BatchCallback batch_callback = nullptr;
-	FlushCallback flush_callback = nullptr;
-	FinalizeCallback finalize_callback = nullptr;
+	CopyToBindCallback copy_to_bind_callback = nullptr;
+	CopyToBatchSizeCallback copy_to_batch_size_callback = nullptr;
+	CopyToInitCallback copy_to_init_callback = nullptr;
+	CopyToBatchCallback copy_to_batch_callback = nullptr;
+	CopyToFlushCallback copy_to_flush_callback = nullptr;
+	CopyToFinalizeCallback copy_to_finalize_callback = nullptr;
+	CopyFromBindCallback copy_from_bind_callback = nullptr;
+	CopyFromInitGlobalCallback copy_from_init_global_callback = nullptr;
+	CopyFromInitLocalCallback copy_from_init_local_callback = nullptr;
+	CopyFromExecCallback copy_from_exec_callback = nullptr;
+	CopyFromProgressCallback copy_from_progress_callback = nullptr;
 	detail::UserData user_data;
 
 public:
-	/// What the bind callback works with. Borrowed, valid only for the callback duration.
-	class BindInput {
+	/// What the `COPY ... TO` bind callback works with. Borrowed, valid only for the callback duration.
+	class CopyToBindInput {
 		friend detail::Factory;
 
 	public:
-		/// Constructs bind data of type `T`, owned by the bound statement and readable from every later callback via
-		/// `GetBindData<T>`. The engine compares bind data when it compares statements: by `operator==` when `T` has
-		/// one, by identity otherwise.
+		/// Constructs bind data of type `T`, owned by the bound statement and readable from every later `COPY ... TO`
+		/// callback via `GetBindData<T>`. The engine compares bind data when it compares statements: by `operator==`
+		/// when `T` has one, by identity otherwise.
 		template <class T, class... ARGS>
 		void SetBindData(ARGS &&... args) {
 			auto ptr = new T(std::forward<ARGS>(args)...);
@@ -4091,7 +4075,11 @@ public:
 			return *static_cast<T *>(GetUserDataInternal());
 		}
 
-		/// How many columns are being copied: the columns of every batch's rows. Valid indices for `GetColumnName`
+		/// The path the statement writes to, as written. The path of each file actually written is only known to the
+		/// init callback.
+		auto GetFilePath() const -> std::string;
+
+		/// How many columns are being written: the columns of every batch's rows. Valid indices for `GetColumnName`
 		/// and `GetColumnType` are [0, GetColumnCount()).
 		auto GetColumnCount() const -> idx_t;
 
@@ -4105,11 +4093,26 @@ public:
 		/// @throws InvalidInputException When the index is out of range.
 		auto GetColumnType(idx_t index) const -> LogicalType;
 
+		/// How many options the statement passed to the function, ordered by name. The engine's own options (e.g.
+		/// `USE_TMP_FILE`) are not included. Valid indices for the option accessors are [0, GetOptionCount()).
+		auto GetOptionCount() const -> idx_t;
+
+		/// One option's name, a SQL identifier matched case-insensitively.
+		/// @param index Option index in [0, GetOptionCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetOptionName(idx_t index) const -> std::string;
+
+		/// One option's value: the value itself for `DELIM ','`, the BOOLEAN true for a bare option such as `HEADER`,
+		/// and a tuple (an unnamed STRUCT with one field per element, in order) for a parenthesized list.
+		/// @param index Option index in [0, GetOptionCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetOptionValue(idx_t index) const -> Value;
+
 		/// The binding context. Borrowed, valid only for the callback duration.
 		auto GetContext() const -> Context;
 
 	private:
-		BindInput(void *args, void *context) : args(args), context(context) {
+		CopyToBindInput(void *args, void *context) : args(args), context(context) {
 		}
 
 		void *args;
@@ -4119,12 +4122,12 @@ public:
 		void *GetUserDataInternal() const;
 	};
 
-	/// What the batch size callback works with. Borrowed, valid only for the callback duration.
-	class BatchSizeInput {
+	/// What the `COPY ... TO` batch size callback works with. Borrowed, valid only for the callback duration.
+	class CopyToBatchSizeInput {
 		friend detail::Factory;
 
 	public:
-		/// The bind data set via `BindInput::SetBindData`.
+		/// The bind data set via `CopyToBindInput::SetBindData`.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetBindData() const -> const T & {
@@ -4147,7 +4150,7 @@ public:
 		auto GetContext() const -> Context;
 
 	private:
-		BatchSizeInput(void *args, void *context) : args(args), context(context) {
+		CopyToBatchSizeInput(void *args, void *context) : args(args), context(context) {
 		}
 
 		void *args;
@@ -4157,8 +4160,8 @@ public:
 		void *GetUserDataInternal() const;
 	};
 
-	/// What the init callback works with. Borrowed, valid only for the callback duration.
-	class InitInput {
+	/// What the `COPY ... TO` init callback works with. Borrowed, valid only for the callback duration.
+	class CopyToInitInput {
 		friend detail::Factory;
 
 	public:
@@ -4171,7 +4174,7 @@ public:
 			SetInitDataInternal(ptr, detail::TypedDelete<T>);
 		}
 
-		/// The bind data set via `BindInput::SetBindData`.
+		/// The bind data set via `CopyToBindInput::SetBindData`.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetBindData() const -> const T & {
@@ -4193,7 +4196,7 @@ public:
 		auto GetContext() const -> Context;
 
 	private:
-		InitInput(void *args, void *context) : args(args), context(context) {
+		CopyToInitInput(void *args, void *context) : args(args), context(context) {
 		}
 
 		void *args;
@@ -4204,27 +4207,27 @@ public:
 		void *GetUserDataInternal() const;
 	};
 
-	/// What the batch callback works with. Borrowed, valid only for the callback duration.
-	class BatchInput {
+	/// What the `COPY ... TO` batch callback works with. Borrowed, valid only for the callback duration.
+	class CopyToBatchInput {
 		friend detail::Factory;
 
 	public:
 		/// Constructs batch data of type `T`: the prepared form of the batch, handed to the flush callback via
-		/// `FlushInput::GetBatchData<T>` and freed once the batch has been flushed.
+		/// `CopyToFlushInput::GetBatchData<T>` and freed once the batch has been flushed.
 		template <class T, class... ARGS>
 		void SetBatchData(ARGS &&... args) {
 			auto ptr = new T(std::forward<ARGS>(args)...);
 			SetBatchDataInternal(ptr, detail::TypedDelete<T>);
 		}
 
-		/// The bind data set via `BindInput::SetBindData`.
+		/// The bind data set via `CopyToBindInput::SetBindData`.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetBindData() const -> const T & {
 			return *static_cast<const T *>(GetBindDataInternal());
 		}
 
-		/// The init data set via `InitInput::SetInitData` for the file this batch belongs to.
+		/// The init data set via `CopyToInitInput::SetInitData` for the file this batch belongs to.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetInitData() const -> T & {
@@ -4238,9 +4241,10 @@ public:
 			return *static_cast<T *>(GetUserDataInternal());
 		}
 
-		/// Takes ownership of the rows of the batch: one column per column reported by `BindInput::GetColumnCount`,
-		/// in the same order. The batch can only be taken once; a batch that is never taken is released when the
-		/// callback returns. It may be kept beyond the callback, e.g. moved into the batch data via `SetBatchData`.
+		/// Takes ownership of the rows of the batch: one column per column reported by
+		/// `CopyToBindInput::GetColumnCount`, in the same order. The batch can only be taken once; a batch that is
+		/// never taken is released when the callback returns. It may be kept beyond the callback, e.g. moved into the
+		/// batch data via `SetBatchData`.
 		/// @throws InvalidInputException When the batch was already taken.
 		auto TakeBatch() -> ColumnDataCollection;
 
@@ -4248,7 +4252,7 @@ public:
 		auto GetContext() const -> Context;
 
 	private:
-		BatchInput(void *args, void *context) : args(args), context(context) {
+		CopyToBatchInput(void *args, void *context) : args(args), context(context) {
 		}
 
 		void *args;
@@ -4260,26 +4264,26 @@ public:
 		void *GetUserDataInternal() const;
 	};
 
-	/// What the flush callback works with. Borrowed, valid only for the callback duration.
-	class FlushInput {
+	/// What the `COPY ... TO` flush callback works with. Borrowed, valid only for the callback duration.
+	class CopyToFlushInput {
 		friend detail::Factory;
 
 	public:
-		/// The bind data set via `BindInput::SetBindData`.
+		/// The bind data set via `CopyToBindInput::SetBindData`.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetBindData() const -> const T & {
 			return *static_cast<const T *>(GetBindDataInternal());
 		}
 
-		/// The init data set via `InitInput::SetInitData` for the file this batch belongs to.
+		/// The init data set via `CopyToInitInput::SetInitData` for the file this batch belongs to.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetInitData() const -> T & {
 			return *static_cast<T *>(GetInitDataInternal());
 		}
 
-		/// The batch data set via `BatchInput::SetBatchData` for the batch being flushed.
+		/// The batch data set via `CopyToBatchInput::SetBatchData` for the batch being flushed.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetBatchData() const -> T & {
@@ -4297,7 +4301,7 @@ public:
 		auto GetContext() const -> Context;
 
 	private:
-		FlushInput(void *args, void *context) : args(args), context(context) {
+		CopyToFlushInput(void *args, void *context) : args(args), context(context) {
 		}
 
 		void *args;
@@ -4309,19 +4313,19 @@ public:
 		void *GetUserDataInternal() const;
 	};
 
-	/// What the finalize callback works with. Borrowed, valid only for the callback duration.
-	class FinalizeInput {
+	/// What the `COPY ... TO` finalize callback works with. Borrowed, valid only for the callback duration.
+	class CopyToFinalizeInput {
 		friend detail::Factory;
 
 	public:
-		/// The bind data set via `BindInput::SetBindData`.
+		/// The bind data set via `CopyToBindInput::SetBindData`.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetBindData() const -> const T & {
 			return *static_cast<const T *>(GetBindDataInternal());
 		}
 
-		/// The init data set via `InitInput::SetInitData` for the file being finalized.
+		/// The init data set via `CopyToInitInput::SetInitData` for the file being finalized.
 		/// @throws InvalidInputException When none was set.
 		template <class T>
 		auto GetInitData() const -> T & {
@@ -4339,7 +4343,7 @@ public:
 		auto GetContext() const -> Context;
 
 	private:
-		FinalizeInput(void *args, void *context) : args(args), context(context) {
+		CopyToFinalizeInput(void *args, void *context) : args(args), context(context) {
 		}
 
 		void *args;
@@ -4347,6 +4351,283 @@ public:
 
 		void *GetBindDataInternal() const;
 		void *GetInitDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the `COPY ... FROM` bind callback works with. Borrowed, valid only for the callback duration.
+	class CopyFromBindInput {
+		friend detail::Factory;
+
+	public:
+		/// Constructs bind data of type `T`, owned by the bound statement and readable from every later
+		/// `COPY ... FROM` callback via `GetBindData<T>`. The engine compares bind data when it compares statements:
+		/// by `operator==` when `T` has one, by identity otherwise.
+		template <class T, class... ARGS>
+		void SetBindData(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetBindDataInternal(ptr, detail::SelectEquals<T>(), detail::TypedDelete<T>);
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The path the statement reads from, as written. The engine expands no globs and checks nothing; both are
+		/// left to the function.
+		auto GetFilePath() const -> std::string;
+
+		/// How many columns the target table expects: the columns every batch the exec callback produces must carry,
+		/// in this order. Valid indices for `GetColumnName` and `GetColumnType` are [0, GetColumnCount()).
+		auto GetColumnCount() const -> idx_t;
+
+		/// One column's name.
+		/// @param index Column index in [0, GetColumnCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetColumnName(idx_t index) const -> std::string;
+
+		/// One column's type.
+		/// @param index Column index in [0, GetColumnCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetColumnType(idx_t index) const -> LogicalType;
+
+		/// How many options the statement passed to the function, ordered by name; every option other than `FORMAT`.
+		/// Valid indices for the option accessors are [0, GetOptionCount()).
+		auto GetOptionCount() const -> idx_t;
+
+		/// One option's name, a SQL identifier matched case-insensitively.
+		/// @param index Option index in [0, GetOptionCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetOptionName(idx_t index) const -> std::string;
+
+		/// One option's value: the value itself for `DELIM ','`, the BOOLEAN true for a bare option such as `HEADER`,
+		/// and a tuple (an unnamed STRUCT with one field per element, in order) for a parenthesized list.
+		/// @param index Option index in [0, GetOptionCount()).
+		/// @throws InvalidInputException When the index is out of range.
+		auto GetOptionValue(idx_t index) const -> Value;
+
+		/// Hints how many rows the read will produce, for the optimizer. Producing a different number of rows is not
+		/// an error.
+		/// @param cardinality The estimated row count.
+		/// @param is_exact Whether the estimate is exact, which also makes it an upper bound.
+		auto SetCardinality(idx_t cardinality, bool is_exact) -> void;
+
+		/// The binding context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		CopyFromBindInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetBindDataInternal(void *data, bool (*equals)(void *a, void *b), void (*destructor)(void *));
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the `COPY ... FROM` global init callback works with. Borrowed, valid only for the callback duration.
+	class CopyFromInitGlobalInput {
+		friend detail::Factory;
+
+	public:
+		/// Constructs global state of type `T`, shared by every thread reading the file and readable from the local
+		/// init, exec and progress callbacks. Since every thread sees the same object, the function must synchronize
+		/// its own access to it.
+		template <class T, class... ARGS>
+		void SetGlobalState(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetGlobalStateInternal(ptr, detail::TypedDelete<T>);
+		}
+
+		/// The bind data set via `CopyFromBindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// Caps how many threads may read the file in parallel. Defaults to 1, a single-threaded read. The engine
+		/// creates at most this many local states, and may use fewer.
+		/// @param max_threads The maximum thread count. Must be at least 1.
+		auto SetMaxThreads(idx_t max_threads) -> void;
+
+		/// The query context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		CopyFromInitGlobalInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetGlobalStateInternal(void *data, void (*destructor)(void *));
+		void *GetBindDataInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the `COPY ... FROM` local init callback works with. Borrowed, valid only for the callback duration.
+	class CopyFromInitLocalInput {
+		friend detail::Factory;
+
+	public:
+		/// Constructs local state of type `T`, owned by this reading thread and readable from the exec callback via
+		/// `CopyFromExecInput::GetLocalState<T>`. No other thread observes it, so it needs no synchronization.
+		template <class T, class... ARGS>
+		void SetLocalState(ARGS &&... args) {
+			auto ptr = new T(std::forward<ARGS>(args)...);
+			SetLocalStateInternal(ptr, detail::TypedDelete<T>);
+		}
+
+		/// The bind data set via `CopyFromBindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The global state set via `CopyFromInitGlobalInput::SetGlobalState`, typically to claim this thread's share
+		/// of the work from it. Shared with every other reading thread; access must be synchronized.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetGlobalState() const -> T & {
+			return *static_cast<T *>(GetGlobalStateInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The query context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		CopyFromInitLocalInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void SetLocalStateInternal(void *data, void (*destructor)(void *));
+		void *GetBindDataInternal() const;
+		void *GetGlobalStateInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the `COPY ... FROM` exec callback works with. Borrowed, valid only for the callback duration.
+	class CopyFromExecInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `CopyFromBindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The global state set via `CopyFromInitGlobalInput::SetGlobalState`. Shared with every other reading thread;
+		/// access must be synchronized.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetGlobalState() const -> T & {
+			return *static_cast<T *>(GetGlobalStateInternal());
+		}
+
+		/// The local state set via `CopyFromInitLocalInput::SetLocalState`, private to this thread.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetLocalState() const -> T & {
+			return *static_cast<T *>(GetLocalStateInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// The chunk to write the next batch of rows into, with one vector per column reported by
+		/// `CopyFromBindInput::GetColumnCount`. It starts out empty on every invocation: write the rows, then give the
+		/// batch its row count with `Vector::SetSize` on the chunk's first vector, which the engine propagates to the
+		/// others. Leaving it empty ends the read.
+		/// @return A borrowed chunk, valid only for the callback duration.
+		auto GetOutputChunk() const -> DataChunk;
+
+		/// The execution context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		CopyFromExecInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
+		void *GetGlobalStateInternal() const;
+		void *GetLocalStateInternal() const;
+		void *GetUserDataInternal() const;
+	};
+
+	/// What the `COPY ... FROM` progress callback works with. Borrowed, valid only for the callback duration.
+	class CopyFromProgressInput {
+		friend detail::Factory;
+
+	public:
+		/// The bind data set via `CopyFromBindInput::SetBindData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetBindData() const -> const T & {
+			return *static_cast<const T *>(GetBindDataInternal());
+		}
+
+		/// The global state set via `CopyFromInitGlobalInput::SetGlobalState`. This callback runs while the read is
+		/// running, so the state must be read in a thread-safe way.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetGlobalState() const -> T & {
+			return *static_cast<T *>(GetGlobalStateInternal());
+		}
+
+		/// The user data set via `CopyFunction::SetUserData`.
+		/// @throws InvalidInputException When none was set.
+		template <class T>
+		auto GetUserData() const -> T & {
+			return *static_cast<T *>(GetUserDataInternal());
+		}
+
+		/// Reports how far the read has advanced, as a fraction between 0.0 and 1.0; values outside that range are
+		/// clamped. A callback that returns without calling this reports no progress.
+		/// @param progress The fraction of the read that is complete.
+		auto SetProgress(double progress) -> void;
+
+		/// The execution context. Borrowed, valid only for the callback duration.
+		auto GetContext() const -> Context;
+
+	private:
+		CopyFromProgressInput(void *args, void *context) : args(args), context(context) {
+		}
+
+		void *args;
+		void *context;
+
+		void *GetBindDataInternal() const;
+		void *GetGlobalStateInternal() const;
 		void *GetUserDataInternal() const;
 	};
 };

--- a/tools/cpp/tests/test_cpp_api_appender.cpp
+++ b/tools/cpp/tests/test_cpp_api_appender.cpp
@@ -1,0 +1,206 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: Appender. A ColumnDataCollection plus a statement that
+// reads it, wired together with a connection-scoped replacement scan.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+// Collect a single BIGINT column, asserting every row valid.
+std::vector<int64_t> CollectAppended(QueryResult result) {
+	std::vector<int64_t> out;
+	while (auto chunk = result.FetchChunk()) {
+		auto view = chunk.GetVector(0).GetView();
+		for (idx_t i = 0; i < chunk.GetRowCount(); i++) {
+			REQUIRE(view.IsValid(i));
+			out.push_back(view.Data<int64_t>()[view.SelAt(i)]);
+		}
+	}
+	return out;
+}
+
+// Buffers one chunk of BIGINTs through the appender.
+void AppendValues(Appender &appender, const std::vector<int64_t> &values) {
+	DataChunk chunk(appender.ColumnTypes());
+	auto vec = chunk.GetVector(0);
+	auto *data = vec.GetDataMutable<int64_t>();
+	for (size_t i = 0; i < values.size(); i++) {
+		data[i] = values[i];
+	}
+	vec.SetSize(values.size());
+	appender.AppendChunk(chunk);
+}
+
+} // namespace
+
+TEST_CASE("Stable C++API: appender buffers and flushes into a table", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE t (v BIGINT)").Drain();
+
+	Appender appender(conn, "t");
+	REQUIRE(appender.ColumnTypes().size() == 1);
+
+	// Buffering touches nothing until the flush.
+	AppendValues(appender, {1, 2});
+	REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM t")) == std::vector<int64_t> {0});
+
+	appender.Flush();
+	REQUIRE(CollectAppended(conn.Execute("SELECT v FROM t ORDER BY v")) == std::vector<int64_t> {1, 2});
+
+	// The buffer is empty and reusable afterwards, and a flush of nothing is a no-op.
+	appender.Flush();
+	REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM t")) == std::vector<int64_t> {2});
+
+	// Several batches in a row.
+	for (int64_t round = 0; round < 3; round++) {
+		AppendValues(appender, {10 + round, 20 + round});
+		appender.Flush();
+	}
+	REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM t")) == std::vector<int64_t> {8});
+	REQUIRE(CollectAppended(conn.Execute("SELECT sum(v)::BIGINT FROM t")) == std::vector<int64_t> {3 + 33 + 63});
+}
+
+TEST_CASE("Stable C++API: appender buffers across several chunks before flushing", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE t (v BIGINT)").Drain();
+
+	Appender appender(conn, "t");
+	for (int64_t i = 0; i < 5; i++) {
+		AppendValues(appender, {i, i + 100});
+	}
+	appender.Flush();
+	REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM t")) == std::vector<int64_t> {10});
+	REQUIRE(CollectAppended(conn.Execute("SELECT v FROM t ORDER BY v LIMIT 2")) == std::vector<int64_t> {0, 1});
+}
+
+TEST_CASE("Stable C++API: appender Clear drops the buffer without writing", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE t (v BIGINT)").Drain();
+
+	Appender appender(conn, "t");
+	AppendValues(appender, {1, 2});
+	appender.Clear();
+	appender.Flush();
+	REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM t")) == std::vector<int64_t> {0});
+
+	// Usable again after a clear.
+	AppendValues(appender, {7, 8});
+	appender.Flush();
+	REQUIRE(CollectAppended(conn.Execute("SELECT v FROM t ORDER BY v")) == std::vector<int64_t> {7, 8});
+}
+
+TEST_CASE("Stable C++API: appender destruction drops unflushed rows", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE t (v BIGINT)").Drain();
+
+	// Named explicitly, so the test can ask for the buffer by name after the appender is gone.
+	std::vector<LogicalType> types;
+	types.push_back(conn.ParseType("BIGINT"));
+	{
+		Appender appender(conn, "INSERT INTO t SELECT * FROM gone_rows", std::move(types), "gone_rows");
+		AppendValues(appender, {1, 2});
+		// While it lives, the buffer is visible and holds the rows.
+		REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM gone_rows")) == std::vector<int64_t> {2});
+	}
+	REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM t")) == std::vector<int64_t> {0});
+
+	// The scan the appender left behind outlives it, but declines now that the buffer is gone -- rather than
+	// reading through a dangling pointer.
+	REQUIRE_THROWS_AS(conn.Execute("SELECT * FROM gone_rows").Drain(), Exception);
+}
+
+TEST_CASE("Stable C++API: appender with an explicit query", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE t (v BIGINT, tag VARCHAR DEFAULT 'seen')").Drain();
+
+	// A subset of columns, which is what the table constructor cannot express.
+	std::vector<LogicalType> types;
+	types.push_back(conn.ParseType("BIGINT"));
+	Appender appender(conn, "INSERT INTO t (v) SELECT amount FROM my_rows", std::move(types), "my_rows", {"amount"});
+
+	AppendValues(appender, {5, 6});
+	appender.Flush();
+	REQUIRE(CollectAppended(conn.Execute("SELECT v FROM t ORDER BY v")) == std::vector<int64_t> {5, 6});
+	REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM t WHERE tag = 'seen'")) ==
+	        std::vector<int64_t> {2});
+
+	// The buffer is a table like any other, so it can drive a read too.
+	std::vector<LogicalType> read_types;
+	read_types.push_back(conn.ParseType("BIGINT"));
+	Appender reader(conn, "SELECT amount FROM other_rows", std::move(read_types), "other_rows", {"amount"});
+	AppendValues(reader, {9, 9});
+	// Flushing a SELECT just drains it; the rows are consumed either way.
+	reader.Flush();
+}
+
+TEST_CASE("Stable C++API: appender is scoped to its connection", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto other = db.Connect();
+	conn.Execute("CREATE TABLE t (v BIGINT)").Drain();
+
+	std::vector<LogicalType> types;
+	types.push_back(conn.ParseType("BIGINT"));
+	Appender appender(conn, "INSERT INTO t SELECT * FROM scoped_rows", std::move(types), "scoped_rows");
+
+	// The buffer's name resolves on the appender's connection only.
+	REQUIRE(CollectAppended(conn.Execute("SELECT count(*)::BIGINT FROM scoped_rows")) == std::vector<int64_t> {0});
+	REQUIRE_THROWS_AS(other.Execute("SELECT * FROM scoped_rows").Drain(), Exception);
+}
+
+TEST_CASE("Stable C++API: appender refuses a mismatching chunk", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE t (v BIGINT)").Drain();
+
+	Appender appender(conn, "t");
+
+	std::vector<LogicalType> wrong;
+	wrong.push_back(conn.ParseType("VARCHAR"));
+	DataChunk chunk(wrong);
+	chunk.GetVector(0).SetSize(0);
+	REQUIRE_THROWS_MATCHES(appender.AppendChunk(chunk), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+
+	// A refused chunk leaves the appender usable.
+	AppendValues(appender, {3});
+	appender.Flush();
+	REQUIRE(CollectAppended(conn.Execute("SELECT v FROM t")) == std::vector<int64_t> {3});
+}
+
+TEST_CASE("Stable C++API: appender construction refusals", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	// No columns.
+	REQUIRE_THROWS_MATCHES(Appender(conn, "SELECT 1", {}, "buf"), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	// More than one statement.
+	std::vector<LogicalType> types;
+	types.push_back(conn.ParseType("BIGINT"));
+	REQUIRE_THROWS_MATCHES(Appender(conn, "SELECT 1; SELECT 2", std::move(types), "buf"), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	// A table that does not exist.
+	REQUIRE_THROWS_AS(Appender(conn, "no_such_table"), Exception);
+}

--- a/tools/cpp/tests/test_cpp_api_arrow.cpp
+++ b/tools/cpp/tests/test_cpp_api_arrow.cpp
@@ -1,0 +1,181 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: Arrow. The chunk converters need a Context, which only a
+// callback has, so what is reachable from a test is the stream export plus the
+// schema exporter driven from inside a scalar function.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+struct ArrowStreamStats {
+	int64_t rows = 0;
+	idx_t arrays = 0;
+	int64_t first_array_rows = 0;
+};
+
+// Drives the stream to exhaustion, releasing each array.
+ArrowStreamStats DrainCppArrowStream(const ArrowStream &stream) {
+	ArrowStreamStats stats;
+	while (true) {
+		ArrowArray array {};
+		if (!stream.Next(array)) {
+			break;
+		}
+		if (stats.arrays == 0) {
+			stats.first_array_rows = array.length;
+		}
+		stats.rows += array.length;
+		stats.arrays++;
+		array.release(&array);
+	}
+	return stats;
+}
+
+} // namespace
+
+TEST_CASE("Stable C++API: ArrowStream export", "[cpp_api][arrow]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	SECTION("every row and a stable schema") {
+		auto stream = conn.Execute("SELECT i, 'r' || i AS s FROM range(1000) t(i)").ToArrowStream();
+		REQUIRE(static_cast<bool>(stream));
+
+		ArrowSchema schema {};
+		stream.GetSchema(schema);
+		REQUIRE(schema.n_children == 2);
+		REQUIRE(std::string(schema.children[0]->name) == "i");
+		REQUIRE(std::string(schema.children[1]->name) == "s");
+		schema.release(&schema);
+
+		auto stats = DrainCppArrowStream(stream);
+		REQUIRE(stats.rows == 1000);
+		REQUIRE(stats.arrays >= 1);
+
+		// The schema stays readable once the rows are gone: it was cached under the
+		// producing transaction rather than built on demand.
+		ArrowSchema after {};
+		stream.GetSchema(after);
+		REQUIRE(after.n_children == 2);
+		after.release(&after);
+	}
+
+	SECTION("batch_size is honored") {
+		auto stream = conn.Execute("SELECT i FROM range(7) t(i)").ToArrowStream(1);
+		auto stats = DrainCppArrowStream(stream);
+		REQUIRE(stats.rows == 7);
+		REQUIRE(stats.arrays == 7);
+		REQUIRE(stats.first_array_rows == 1);
+	}
+
+	SECTION("the stream holds the connection until destroyed") {
+		{
+			auto stream = conn.Execute("SELECT i FROM range(100000) t(i)").ToArrowStream();
+			REQUIRE_THROWS_MATCHES(conn.Execute("SELECT 1"), Exception, HasErrorCode(DUCKDB_V2_ERROR_RESOURCE_IN_USE));
+		}
+		// Destroying it releases the stream, which frees the connection even undrained.
+		REQUIRE(conn.Execute("SELECT 1").Drain() == 0);
+	}
+
+	SECTION("Detach hands the stream over") {
+		auto stream = conn.Execute("SELECT i FROM range(10) t(i)").ToArrowStream();
+		auto *raw = stream.Detach();
+		REQUIRE(raw != nullptr);
+		REQUIRE_FALSE(static_cast<bool>(stream));
+		// The wrapper is empty, so it releases nothing and the caller owns the stream.
+		ArrowSchema schema {};
+		REQUIRE(raw->get_schema(raw, &schema) == 0);
+		schema.release(&schema);
+		raw->release(raw);
+		delete raw;
+	}
+
+	SECTION("an empty stream refuses reads") {
+		auto stream = conn.Execute("SELECT 1").ToArrowStream();
+		auto *raw = stream.Detach();
+		ArrowSchema schema {};
+		REQUIRE_THROWS_MATCHES(stream.GetSchema(schema), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+		ArrowArray array {};
+		REQUIRE_THROWS_MATCHES(stream.Next(array), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+		raw->release(raw);
+		delete raw;
+	}
+
+	SECTION("an execution error surfaces from Next") {
+		auto stream = conn.Execute("SELECT CASE WHEN i = 500 THEN error('boom') ELSE i::VARCHAR END "
+		                           "FROM range(1000) t(i)")
+		                  .ToArrowStream();
+		REQUIRE_THROWS_AS(DrainCppArrowStream(stream), Exception);
+	}
+}
+
+TEST_CASE("Stable C++API: ArrowConverter round-trips a schema", "[cpp_api][arrow]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	// Both `Schema::ToArrowSchema` and `ArrowConverter` need a `Context`, which only a callback
+	// has, so the schema is bound outside and carried in as user data. A callback must not use
+	// Catch assertions, so what it observes is latched and checked after the query.
+	static idx_t observed_count = 0;
+	static std::string observed_names;
+	static std::string observed_first_type;
+	observed_count = 0;
+	observed_names.clear();
+	observed_first_type.clear();
+
+	struct SchemaHolder {
+		Schema schema;
+	};
+
+	auto statements = conn.ParseSQL("SELECT 1::BIGINT AS a, 'x' AS b");
+	auto statement = statements.Next();
+
+	auto function = ScalarFunction::Create(conn);
+	function.SetName("cpp_arrow_probe");
+	function.SetUserData<SchemaHolder>(SchemaHolder {conn.Bind(statement).output});
+	function.SetExecCallback([](ScalarFunction::ExecInput &input) {
+		auto context = input.GetContext();
+		auto &holder = input.GetUserData<SchemaHolder>();
+
+		// Export the DuckDB schema to Arrow, then resolve it straight back: the shape a
+		// converter reports should be the types we started from.
+		ArrowSchema schema {};
+		holder.schema.ToArrowSchema(context, schema);
+		ArrowConverter converter(context, schema);
+		schema.release(&schema);
+
+		auto resolved = converter.GetSchema();
+		observed_count = resolved.GetFieldCount();
+		for (idx_t i = 0; i < observed_count; i++) {
+			observed_names += std::string(resolved.GetFieldName(i));
+		}
+		if (observed_count > 0) {
+			observed_first_type = resolved.GetFieldType(0).ToText();
+		}
+
+		auto result = input.GetResult();
+		auto *out = result.GetDataMutable<int32_t>();
+		for (idx_t i = 0; i < input.GetRowCount(); i++) {
+			out[i] = 1;
+		}
+	});
+	const auto integer = conn.ParseType("INTEGER");
+	function.GetSignature().AddParameter("x", integer).SetReturnType(integer);
+	function.Register();
+
+	conn.Execute("SELECT cpp_arrow_probe(1)").Drain();
+	REQUIRE(observed_count == 2);
+	REQUIRE(observed_names == "ab");
+	REQUIRE(observed_first_type == "BIGINT");
+}

--- a/tools/cpp/tests/test_cpp_api_arrow.cpp
+++ b/tools/cpp/tests/test_cpp_api_arrow.cpp
@@ -119,49 +119,63 @@ TEST_CASE("Stable C++API: ArrowStream export", "[cpp_api][arrow]") {
 	}
 }
 
-TEST_CASE("Stable C++API: ArrowConverter round-trips a schema", "[cpp_api][arrow]") {
+TEST_CASE("Stable C++API: ArrowExporter and ArrowImporter round-trip", "[cpp_api][arrow]") {
 	Environment env;
 	auto db = env.Open(":memory:");
 	auto conn = db.Connect();
 
-	// Both `Schema::ToArrowSchema` and `ArrowConverter` need a `Context`, which only a callback
-	// has, so the schema is bound outside and carried in as user data. A callback must not use
-	// Catch assertions, so what it observes is latched and checked after the query.
+	// Both handles need a Context, which only a callback has, so the round-trip runs inside a scalar function. A
+	// callback must not use Catch assertions, so what it observes is latched and checked after the query.
 	static idx_t observed_count = 0;
 	static std::string observed_names;
 	static std::string observed_first_type;
+	static int64_t observed_value = 0;
+	static int64_t observed_arrays = 0;
 	observed_count = 0;
 	observed_names.clear();
 	observed_first_type.clear();
-
-	struct SchemaHolder {
-		Schema schema;
-	};
-
-	auto statements = conn.ParseSQL("SELECT 1::BIGINT AS a, 'x' AS b");
-	auto statement = statements.Next();
+	observed_value = 0;
+	observed_arrays = 0;
 
 	auto function = ScalarFunction::Create(conn);
 	function.SetName("cpp_arrow_probe");
-	function.SetUserData<SchemaHolder>(SchemaHolder {conn.Bind(statement).output});
 	function.SetExecCallback([](ScalarFunction::ExecInput &input) {
 		auto context = input.GetContext();
-		auto &holder = input.GetUserData<SchemaHolder>();
 
-		// Export the DuckDB schema to Arrow, then resolve it straight back: the shape a
-		// converter reports should be the types we started from.
+		std::vector<LogicalType> types;
+		types.push_back(context.ParseType("BIGINT"));
+		ArrowExporter exporter(context, types, {"a"});
+
+		// The exporter's schema is what an importer resolves, so the two agree by construction.
 		ArrowSchema schema {};
-		holder.schema.ToArrowSchema(context, schema);
-		ArrowConverter converter(context, schema);
+		exporter.GetSchema(schema);
+		ArrowImporter importer(context, schema);
 		schema.release(&schema);
 
-		auto resolved = converter.GetSchema();
+		auto resolved = importer.GetSchema();
 		observed_count = resolved.GetFieldCount();
 		for (idx_t i = 0; i < observed_count; i++) {
 			observed_names += std::string(resolved.GetFieldName(i));
 		}
 		if (observed_count > 0) {
 			observed_first_type = resolved.GetFieldType(0).ToText();
+		}
+
+		// Build a one-row chunk, push it out to Arrow and read it straight back.
+		DataChunk chunk(context, types);
+		auto column = chunk.GetVector(0);
+		column.GetDataMutable<int64_t>()[0] = 4242;
+		column.SetSize(1);
+
+		exporter.Append(chunk, /*flush=*/true);
+		ArrowArray array {};
+		while (exporter.NextArray(array)) {
+			observed_arrays++;
+			importer.Append(array, /*consume=*/true, /*flush=*/true);
+			auto imported = importer.NextChunk();
+			if (imported) {
+				observed_value = imported.GetVector(0).GetView().Data<int64_t>()[0];
+			}
 		}
 
 		auto result = input.GetResult();
@@ -175,7 +189,9 @@ TEST_CASE("Stable C++API: ArrowConverter round-trips a schema", "[cpp_api][arrow
 	function.Register();
 
 	conn.Execute("SELECT cpp_arrow_probe(1)").Drain();
-	REQUIRE(observed_count == 2);
-	REQUIRE(observed_names == "ab");
+	REQUIRE(observed_count == 1);
+	REQUIRE(observed_names == "a");
 	REQUIRE(observed_first_type == "BIGINT");
+	REQUIRE(observed_arrays == 1);
+	REQUIRE(observed_value == 4242);
 }

--- a/tools/cpp/tests/test_cpp_api_cast_function.cpp
+++ b/tools/cpp/tests/test_cpp_api_cast_function.cpp
@@ -1,0 +1,305 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: CustomType and CastFunction. A custom type TEMPERATURE
+// (an alias of INTEGER) plus the two casts between it and VARCHAR, reached
+// through CAST, TRY_CAST and implicit argument conversion.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+// Collect a single VARCHAR column, asserting every row valid.
+std::vector<std::string> CollectCastStrings(QueryResult result) {
+	std::vector<std::string> out;
+	while (auto chunk = result.FetchChunk()) {
+		auto view = chunk.GetVector(0).GetView();
+		for (idx_t i = 0; i < chunk.GetRowCount(); i++) {
+			REQUIRE(view.IsValid(i));
+			out.emplace_back(view.Data<varchar_t>()[view.SelAt(i)].view());
+		}
+	}
+	return out;
+}
+
+// Collect a single INTEGER column, reading a NULL row as nullopt.
+std::vector<std::optional<int32_t>> CollectMaybeInts(QueryResult result) {
+	std::vector<std::optional<int32_t>> out;
+	while (auto chunk = result.FetchChunk()) {
+		auto view = chunk.GetVector(0).GetView();
+		for (idx_t i = 0; i < chunk.GetRowCount(); i++) {
+			if (!view.IsValid(i)) {
+				out.emplace_back();
+			} else {
+				out.emplace_back(view.Data<int32_t>()[view.SelAt(i)]);
+			}
+		}
+	}
+	return out;
+}
+
+// The suffix a temperature renders with. Together with the digits it is longer than blob_t::INLINE_LENGTH, so the
+// bytes land in the vector's arena: an assertion build compiles the engine with DUCKDB_DEBUG_NO_INLINE, whose
+// string_t reads the pointer even for values the API would inline.
+constexpr const char *SUFFIX = " degrees celsius";
+
+// Carried through SetUserData to pin that the exec callback sees it.
+struct CastTag {
+	std::string value;
+};
+
+// The mode the last cast ran in, latched for the tests to assert on.
+CastMode last_mode = CastMode::NORMAL;
+
+// TEMPERATURE -> VARCHAR. Infallible: every value renders.
+void TempToText(CastFunction::ExecInput &input) {
+	last_mode = input.GetMode();
+	auto in = input.GetInput();
+	auto out = input.GetOutput();
+	auto view = in.GetView();
+	auto validity = out.GetValidityMutable();
+	for (idx_t i = 0; i < input.GetRowCount(); i++) {
+		if (!view.IsValid(i)) {
+			validity.SetInvalid(i);
+			continue;
+		}
+		out.AssignString(i, std::to_string(view.Data<int32_t>()[view.SelAt(i)]) + SUFFIX);
+	}
+}
+
+// VARCHAR -> TEMPERATURE. A row that does not parse is left NULL and reported by throwing: a normal cast aborts on
+// the exception, a try cast swallows it and keeps the NULL.
+void TextToTemp(CastFunction::ExecInput &input) {
+	last_mode = input.GetMode();
+	REQUIRE(input.GetUserData<CastTag>().value == "secret");
+
+	auto in = input.GetInput();
+	auto out = input.GetOutput();
+	auto view = in.GetView();
+	auto validity = out.GetValidityMutable();
+	auto *values = out.GetDataMutable<int32_t>();
+
+	std::string failure;
+	for (idx_t i = 0; i < input.GetRowCount(); i++) {
+		if (!view.IsValid(i)) {
+			validity.SetInvalid(i);
+			continue;
+		}
+		const auto text = std::string(view.Data<varchar_t>()[view.SelAt(i)].view());
+		const auto suffix = std::string(SUFFIX);
+		if (text.size() <= suffix.size() || text.compare(text.size() - suffix.size(), suffix.size(), suffix) != 0) {
+			validity.SetInvalid(i);
+			failure = text;
+			continue;
+		}
+		try {
+			values[i] = std::stoi(text.substr(0, text.size() - suffix.size()));
+		} catch (const std::exception &) {
+			validity.SetInvalid(i);
+			failure = text;
+		}
+	}
+	// Reported once the whole batch is written, so the rows that did convert are in place either way.
+	if (!failure.empty()) {
+		throw InvalidInputException("could not convert '" + failure + "' to TEMPERATURE_CELSIUS");
+	}
+}
+
+void NoopCast(CastFunction::ExecInput &) {
+}
+
+// Registers the TEMPERATURE type and hands back a logical type handle for it.
+auto RegisterTemperature(Connection &conn) -> LogicalType {
+	auto type = CustomType::Create(conn);
+	type.SetName("TEMPERATURE_CELSIUS").SetBaseType(conn.ParseType("INTEGER"));
+	type.Register();
+	return conn.ParseType("INTEGER").WithAlias(conn, "TEMPERATURE_CELSIUS");
+}
+
+// Registers both casts, with `cost` as the VARCHAR -> TEMPERATURE implicit cast cost.
+void RegisterTemperatureCasts(Connection &conn, const LogicalType &temperature, int64_t cost) {
+	const auto varchar = conn.ParseType("VARCHAR");
+
+	auto to_text = CastFunction::Create(conn);
+	to_text.SetSourceType(temperature).SetTargetType(varchar).SetExecCallback(TempToText);
+	to_text.Register();
+
+	auto from_text = CastFunction::Create(conn);
+	from_text.SetSourceType(varchar).SetTargetType(temperature).SetImplicitCastCost(cost).SetExecCallback(TextToTemp);
+	from_text.SetUserData<CastTag>(CastTag {"secret"});
+	from_text.Register();
+}
+
+// reading(t TEMPERATURE_CELSIUS) -> INTEGER: an identity scalar function, to observe implicit argument conversion.
+void ReadingExec(ScalarFunction::ExecInput &input) {
+	auto view = input.GetArg(0).GetView();
+	auto *out = input.GetResult().GetDataMutable<int32_t>();
+	for (idx_t i = 0; i < input.GetRowCount(); i++) {
+		out[i] = view.Data<int32_t>()[view.SelAt(i)];
+	}
+}
+
+void RegisterReading(Connection &conn, const LogicalType &temperature) {
+	auto function = ScalarFunction::Create(conn);
+	function.SetName("reading");
+	function.WithSignature([&](FunctionSignature &sig) {
+		sig.AddParameter("t", temperature);
+		sig.SetReturnType(conn.ParseType("INTEGER"));
+	});
+	function.SetExecCallback(ReadingExec);
+	function.Register();
+}
+
+} // namespace
+
+TEST_CASE("Stable C++API: custom type registers and resolves in SQL", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto type = CustomType::Create(conn);
+	type.SetName("TEMPERATURE_CELSIUS").SetBaseType(conn.ParseType("INTEGER"));
+	type.Register();
+
+	// The name resolves case-insensitively, and a value of it reports the custom name rather than the base type's.
+	REQUIRE(CollectCastStrings(conn.Execute("SELECT typeof(CAST(42 AS temperature_celsius))")) ==
+	        std::vector<std::string> {"TEMPERATURE_CELSIUS"});
+	// The representation is the base type's, so the base type's operations still apply.
+	REQUIRE(CollectMaybeInts(conn.Execute("SELECT CAST(42 AS temperature_celsius)::INTEGER + 1")) ==
+	        std::vector<std::optional<int32_t>> {43});
+}
+
+TEST_CASE("Stable C++API: custom type registration errors", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	// No name.
+	{
+		auto type = CustomType::Create(conn);
+		type.SetBaseType(conn.ParseType("INTEGER"));
+		REQUIRE_THROWS_MATCHES(type.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+	// No base type.
+	{
+		auto type = CustomType::Create(conn);
+		type.SetName("no_base");
+		REQUIRE_THROWS_MATCHES(type.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+}
+
+TEST_CASE("Stable C++API: cast function round-trips a custom type", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto temperature = RegisterTemperature(conn);
+	RegisterTemperatureCasts(conn, temperature, -1);
+
+	last_mode = CastMode::TRY;
+	REQUIRE(CollectCastStrings(conn.Execute("SELECT CAST(CAST(42 AS TEMPERATURE_CELSIUS) AS VARCHAR)")) ==
+	        std::vector<std::string> {"42 degrees celsius"});
+	// An explicit CAST runs in normal mode.
+	REQUIRE(last_mode == CastMode::NORMAL);
+
+	// And back the other way, through the base type so the result reads as an integer.
+	REQUIRE(
+	    CollectMaybeInts(conn.Execute("SELECT CAST(CAST('100 degrees celsius' AS TEMPERATURE_CELSIUS) AS INTEGER)")) ==
+	    std::vector<std::optional<int32_t>> {100});
+
+	// NULLs reach the callback, which propagates them.
+	REQUIRE(CollectMaybeInts(conn.Execute("SELECT CAST(CAST(NULL AS TEMPERATURE_CELSIUS) AS VARCHAR)::INTEGER")) ==
+	        std::vector<std::optional<int32_t>> {std::nullopt});
+
+	// Several rows in one batch, so the callback sees a vector rather than a constant.
+	REQUIRE(CollectCastStrings(conn.Execute("SELECT CAST(CAST(t AS TEMPERATURE_CELSIUS) AS VARCHAR) "
+	                                        "FROM (VALUES (1), (2)) v(t) ORDER BY t")) ==
+	        std::vector<std::string> {"1 degrees celsius", "2 degrees celsius"});
+}
+
+TEST_CASE("Stable C++API: cast function normal and try modes", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto temperature = RegisterTemperature(conn);
+	RegisterTemperatureCasts(conn, temperature, -1);
+
+	// A normal cast: the callback's exception aborts the query.
+	last_mode = CastMode::TRY;
+	REQUIRE_THROWS_AS(conn.Execute("SELECT CAST('not-a-temp' AS TEMPERATURE_CELSIUS)").Drain(), Exception);
+	REQUIRE(last_mode == CastMode::NORMAL);
+
+	// A try cast: the exception is swallowed and the row the callback left NULL is kept.
+	last_mode = CastMode::NORMAL;
+	REQUIRE(CollectMaybeInts(conn.Execute("SELECT TRY_CAST('not-a-temp' AS TEMPERATURE_CELSIUS)::INTEGER")) ==
+	        std::vector<std::optional<int32_t>> {std::nullopt});
+	REQUIRE(last_mode == CastMode::TRY);
+
+	// A try cast over valid input still converts.
+	REQUIRE(CollectMaybeInts(conn.Execute("SELECT TRY_CAST('12 degrees celsius' AS TEMPERATURE_CELSIUS)::INTEGER")) ==
+	        std::vector<std::optional<int32_t>> {12});
+}
+
+TEST_CASE("Stable C++API: cast function implicit cast cost", "[cpp_api]") {
+	// The probe is a scalar function whose only parameter is the custom type: reaching it from a VARCHAR column is
+	// exactly the implicit conversion the cost governs. The argument has to come from a column, since a string
+	// literal is bound loosely and reaches any parameter type regardless of the cast's cost.
+	const auto probe = "SELECT reading(v) FROM (VALUES ('30 degrees celsius')) t(v)";
+
+	// A negative cost -- the default -- keeps the cast out of implicit conversion.
+	{
+		Environment env;
+		auto db = env.Open(":memory:");
+		auto conn = db.Connect();
+		auto temperature = RegisterTemperature(conn);
+		RegisterTemperatureCasts(conn, temperature, -1);
+		RegisterReading(conn, temperature);
+
+		REQUIRE(CollectMaybeInts(conn.Execute("SELECT reading(CAST('30 degrees celsius' AS TEMPERATURE_CELSIUS))")) ==
+		        std::vector<std::optional<int32_t>> {30});
+		REQUIRE_THROWS_AS(conn.Execute(probe).Drain(), Exception);
+	}
+
+	// A non-negative cost makes the same cast available to the binder.
+	{
+		Environment env;
+		auto db = env.Open(":memory:");
+		auto conn = db.Connect();
+		auto temperature = RegisterTemperature(conn);
+		RegisterTemperatureCasts(conn, temperature, 0);
+		RegisterReading(conn, temperature);
+
+		REQUIRE(CollectMaybeInts(conn.Execute(probe)) == std::vector<std::optional<int32_t>> {30});
+	}
+}
+
+TEST_CASE("Stable C++API: cast function registration errors", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	const auto integer = conn.ParseType("INTEGER");
+	const auto varchar = conn.ParseType("VARCHAR");
+
+	// Nothing configured, then each missing piece in turn.
+	auto function = CastFunction::Create(conn);
+	REQUIRE_THROWS_MATCHES(function.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	function.SetSourceType(integer);
+	REQUIRE_THROWS_MATCHES(function.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	function.SetTargetType(varchar);
+	REQUIRE_THROWS_MATCHES(function.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	function.SetExecCallback(NoopCast);
+	function.Register();
+
+	// A cast whose exec callback never asks for user data still needs none.
+	auto other = CastFunction::Create(conn);
+	other.SetSourceType(varchar).SetTargetType(integer).SetExecCallback(NoopCast);
+	other.Register();
+}

--- a/tools/cpp/tests/test_cpp_api_catalog.cpp
+++ b/tools/cpp/tests/test_cpp_api_catalog.cpp
@@ -1,0 +1,71 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: TableDescription. Resolution through the search
+// path, the resolved name, the column getters, and the error path.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+} // namespace
+
+TEST_CASE("Stable C++API: table description resolves and reports columns", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE SCHEMA s").Drain();
+	conn.Execute("CREATE TABLE s.\"Facts\"(i INTEGER, j VARCHAR DEFAULT 'x', k INTEGER GENERATED ALWAYS AS (i + 1))")
+	    .Drain();
+
+	// A partial name resolves to its full location, with the casing the table was created with.
+	auto desc = conn.DescribeTable(QualifiedName::Create({"s", "facts"}));
+	REQUIRE(desc.GetQualifiedName().Render() == "memory.s.Facts");
+	REQUIRE_FALSE(desc.IsReadOnly());
+
+	// Every column in declared order, the generated one included.
+	REQUIRE(desc.GetColumnCount() == 3);
+	std::vector<ColumnDescription> columns;
+	for (idx_t i = 0; i < desc.GetColumnCount(); i++) {
+		columns.push_back(desc.GetColumn(i));
+	}
+	REQUIRE(columns[0].GetName() == "i");
+	REQUIRE(columns[1].GetName() == "j");
+	REQUIRE(columns[2].GetName() == "k");
+	REQUIRE(columns[0].GetType().GetTypeId() == LogicalTypeId::INTEGER);
+	REQUIRE(columns[1].GetType().GetTypeId() == LogicalTypeId::VARCHAR);
+	REQUIRE(columns[2].GetType().GetTypeId() == LogicalTypeId::INTEGER);
+	REQUIRE_FALSE(columns[0].HasDefault());
+	REQUIRE(columns[1].HasDefault());
+	REQUIRE_FALSE(columns[2].HasDefault());
+	REQUIRE_FALSE(columns[0].HasGenerated());
+	REQUIRE_FALSE(columns[1].HasGenerated());
+	REQUIRE(columns[2].HasGenerated());
+
+	// The description is a snapshot: it outlives the table.
+	conn.Execute("DROP TABLE s.\"Facts\"").Drain();
+	REQUIRE(desc.GetColumnCount() == 3);
+	REQUIRE(desc.GetColumn(1).GetType().ToText() == "VARCHAR");
+
+	// An out-of-range column index is rejected.
+	REQUIRE_THROWS_MATCHES(desc.GetColumn(3), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_OUT_OF_RANGE));
+}
+
+TEST_CASE("Stable C++API: table description rejects missing tables and views", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE VIEW v AS SELECT 42 AS i").Drain();
+
+	REQUIRE_THROWS_MATCHES(conn.DescribeTable(QualifiedName::Create({"no_such_table"})), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_DATABASE_CATALOG));
+	REQUIRE_THROWS_MATCHES(conn.DescribeTable(QualifiedName::Parse("v")), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_DATABASE_CATALOG));
+}

--- a/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
+++ b/tools/cpp/tests/test_cpp_api_column_data_collection.cpp
@@ -112,6 +112,28 @@ TEST_CASE("Stable C++API: ColumnDataCollection reset", "[cpp_api]") {
 	REQUIRE(ScanInts(conn, collection) == std::vector<int32_t> {9});
 }
 
+TEST_CASE("Stable C++API: ColumnDataCollection clear", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	std::vector<LogicalType> types;
+	types.push_back(conn.ParseType("INTEGER"));
+	ColumnDataCollection collection(conn, types);
+
+	// Same observable effect as Reset; the difference is that the buffers survive for the next appends.
+	for (int32_t round = 0; round < 3; round++) {
+		collection.Append(MakeIntChunk(conn, {round, round}));
+		REQUIRE(collection.GetRowCount() == 2);
+		collection.Clear();
+		REQUIRE(collection.GetRowCount() == 0);
+		REQUIRE(ScanInts(conn, collection).empty());
+	}
+
+	collection.Append(MakeIntChunk(conn, {7}));
+	REQUIRE(ScanInts(conn, collection) == std::vector<int32_t> {7});
+}
+
 TEST_CASE("Stable C++API: ColumnDataCollection scan refuses a mismatching chunk", "[cpp_api]") {
 	Environment env;
 	auto db = env.Open(":memory:");

--- a/tools/cpp/tests/test_cpp_api_copy_function.cpp
+++ b/tools/cpp/tests/test_cpp_api_copy_function.cpp
@@ -1,0 +1,369 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+#include "test_helpers.hpp"
+
+#include <atomic>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: CopyFunction. The extension-registration path is
+// covered by the static extension demo (test/api/capi/v2/static_extension);
+// these cover the connection path.
+//
+// Callbacks latch what they observe into file-scope statics rather than
+// asserting in place: a failed REQUIRE inside a callback would surface as a
+// query error rather than as the assertion itself.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+// The COPY statement driving a format, writing `source` to `path`.
+std::string CopyStatement(const std::string &source, const std::string &path, const std::string &format) {
+	return "COPY (" + source + ") TO '" + path + "' (FORMAT " + format + ", USE_TMP_FILE FALSE)";
+}
+
+std::string ReadFile(const std::string &path) {
+	std::ifstream in(path, std::ios::binary);
+	std::stringstream out;
+	out << in.rdbuf();
+	return out.str();
+}
+
+// ---------------------------------------------------------------------------
+// cpp_copy: the bind data records the column count, the init data owns the
+// output path and accumulates the rows flushed to it, and each batch is kept
+// as its own batch data until the flush counts its rows. Finalize writes
+// "<columns> <rows>" to the target through the engine's file system.
+// ---------------------------------------------------------------------------
+
+struct FileState {
+	std::string path;
+	idx_t columns = 0;
+	idx_t total_rows = 0;
+};
+
+struct {
+	idx_t column_count = 0;
+	std::string column_name;
+	LogicalTypeId column_type = LogicalTypeId::INVALID;
+	std::atomic<idx_t> batches {0};
+
+	void Reset() {
+		column_count = 0;
+		column_name.clear();
+		column_type = LogicalTypeId::INVALID;
+		batches = 0;
+	}
+} summary_seen;
+
+void SummaryBind(CopyFunction::BindInput &input) {
+	summary_seen.column_count = input.GetColumnCount();
+	summary_seen.column_name = input.GetColumnName(0);
+	summary_seen.column_type = input.GetColumnType(0).GetTypeId();
+	input.SetBindData<idx_t>(input.GetColumnCount());
+}
+
+// Asks for batches larger than the input: the whole copy arrives as one batch per thread.
+void SummaryBatchSize(CopyFunction::BatchSizeInput &input) {
+	// The batch size callback runs after bind and sees its data.
+	if (input.GetBindData<idx_t>() != 1) {
+		throw InvalidInputException("batch size callback did not see the bind data");
+	}
+	input.SetTarget(100000);
+}
+
+void SummaryInit(CopyFunction::InitInput &input) {
+	input.SetInitData<FileState>(FileState {input.GetFilePath(), input.GetBindData<idx_t>(), 0});
+}
+
+void SummaryBatch(CopyFunction::BatchInput &input) {
+	summary_seen.batches++;
+	// The batch is ours: hand it over to the flush as is.
+	input.SetBatchData<ColumnDataCollection>(input.TakeBatch());
+}
+
+void SummaryFlush(CopyFunction::FlushInput &input) {
+	input.GetInitData<FileState>().total_rows += input.GetBatchData<ColumnDataCollection>().GetRowCount();
+}
+
+void SummaryFinalize(CopyFunction::FinalizeInput &input) {
+	const auto &state = input.GetInitData<FileState>();
+	const auto contents = std::to_string(state.columns) + " " + std::to_string(state.total_rows);
+
+	auto fs = input.GetContext().GetFileSystem();
+	auto file = fs.OpenFile(state.path, {FileFlags::WRITE, FileFlags::FILE_CREATE});
+	file.Write(contents.data(), contents.size());
+}
+
+// Data-flow probes: each callback latches the user data it was handed.
+struct {
+	std::atomic<const std::string *> in_bind {nullptr};
+	std::atomic<const std::string *> in_init {nullptr};
+	std::atomic<const std::string *> in_batch {nullptr};
+	std::atomic<const std::string *> in_flush {nullptr};
+	std::atomic<const std::string *> in_finalize {nullptr};
+
+	void Reset() {
+		in_bind = nullptr;
+		in_init = nullptr;
+		in_batch = nullptr;
+		in_flush = nullptr;
+		in_finalize = nullptr;
+	}
+} user_data_seen;
+
+void UserDataBind(CopyFunction::BindInput &input) {
+	user_data_seen.in_bind = &input.GetUserData<std::string>();
+}
+void UserDataInit(CopyFunction::InitInput &input) {
+	user_data_seen.in_init = &input.GetUserData<std::string>();
+}
+void UserDataBatch(CopyFunction::BatchInput &input) {
+	user_data_seen.in_batch = &input.GetUserData<std::string>();
+}
+void UserDataFlush(CopyFunction::FlushInput &input) {
+	user_data_seen.in_flush = &input.GetUserData<std::string>();
+}
+void UserDataFinalize(CopyFunction::FinalizeInput &input) {
+	user_data_seen.in_finalize = &input.GetUserData<std::string>();
+}
+
+// Reads a slot that was never set: the wrapper refuses instead of handing out null.
+void NoUserDataBind(CopyFunction::BindInput &input) {
+	input.GetUserData<int>();
+}
+void NoBindDataInit(CopyFunction::InitInput &input) {
+	input.GetBindData<int>();
+}
+void NoInitDataBatch(CopyFunction::BatchInput &input) {
+	input.GetInitData<int>();
+}
+void NoBatchDataFlush(CopyFunction::FlushInput &input) {
+	input.GetBatchData<int>();
+}
+
+void NoopBind(CopyFunction::BindInput &) {
+}
+void NoopInit(CopyFunction::InitInput &) {
+}
+void NoopBatch(CopyFunction::BatchInput &) {
+}
+void NoopFlush(CopyFunction::FlushInput &) {
+}
+
+void FailingBatch(CopyFunction::BatchInput &) {
+	throw InvalidInputException("copy batch failed on purpose");
+}
+
+// A batch size callback that sets no target fails the statement.
+void EmptyBatchSize(CopyFunction::BatchSizeInput &) {
+}
+
+// The batch can only be taken once.
+void TakeTwiceBatch(CopyFunction::BatchInput &input) {
+	auto first = input.TakeBatch();
+	input.TakeBatch();
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Register on a connection and drive through COPY ... TO.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Stable C++API: copy function registers and executes", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	// One sink thread and a batch size beyond the input: the whole copy arrives as a single batch.
+	conn.Execute("SET threads = 1").Drain();
+	auto function = CopyFunction::Create(conn);
+	function.SetName("cpp_copy")
+	    .SetBindCallback(SummaryBind)
+	    .SetBatchSizeCallback(SummaryBatchSize)
+	    .SetInitCallback(SummaryInit)
+	    .SetBatchCallback(SummaryBatch)
+	    .SetFlushCallback(SummaryFlush)
+	    .SetFinalizeCallback(SummaryFinalize);
+	function.Register();
+
+	summary_seen.Reset();
+	const auto path = duckdb::TestCreatePath("cpp_copy_summary.txt");
+	// COPY reports the number of rows written.
+	REQUIRE(conn.Execute(CopyStatement("SELECT r AS i FROM range(5000) t(r)", path, "cpp_copy")).Drain() == 5000);
+
+	// Bind saw the SELECT's single BIGINT column.
+	REQUIRE(summary_seen.column_count == 1);
+	REQUIRE(summary_seen.column_name == "i");
+	REQUIRE(summary_seen.column_type == LogicalTypeId::BIGINT);
+	REQUIRE(summary_seen.batches.load() == 1);
+
+	// The bind -> init -> batch -> flush -> finalize chain observed 1 column and 5000 rows.
+	REQUIRE(ReadFile(path) == "1 5000");
+}
+
+// ---------------------------------------------------------------------------
+// Data flow: user data reaches every phase; a slot that was never set is refused.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Stable C++API: copy function data flows through the phases", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	const auto path = duckdb::TestCreatePath("cpp_copy_user_data.txt");
+
+	auto function = CopyFunction::Create(conn);
+	function.SetName("cpp_copy_user_data")
+	    .SetUserData<std::string>("copy user data")
+	    .SetBindCallback(UserDataBind)
+	    .SetInitCallback(UserDataInit)
+	    .SetBatchCallback(UserDataBatch)
+	    .SetFlushCallback(UserDataFlush)
+	    .SetFinalizeCallback(UserDataFinalize);
+	function.Register();
+
+	user_data_seen.Reset();
+	conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_user_data")).Drain();
+
+	// One object, visible in all five phases.
+	const std::string *seen = user_data_seen.in_bind;
+	REQUIRE(seen != nullptr);
+	REQUIRE(*seen == "copy user data");
+	REQUIRE(user_data_seen.in_init.load() == seen);
+	REQUIRE(user_data_seen.in_batch.load() == seen);
+	REQUIRE(user_data_seen.in_flush.load() == seen);
+	REQUIRE(user_data_seen.in_finalize.load() == seen);
+
+	// A slot that was never set is a clear error, not a null deref, from whichever phase reads it.
+	auto no_user_data = CopyFunction::Create(conn);
+	no_user_data.SetName("cpp_copy_no_user_data")
+	    .SetBindCallback(NoUserDataBind)
+	    .SetBatchCallback(NoopBatch)
+	    .SetFlushCallback(NoopFlush);
+	no_user_data.Register();
+	REQUIRE_THROWS_MATCHES(conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_user_data")),
+	                       Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+
+	auto no_bind_data = CopyFunction::Create(conn);
+	no_bind_data.SetName("cpp_copy_no_bind_data")
+	    .SetBindCallback(NoopBind)
+	    .SetInitCallback(NoBindDataInit)
+	    .SetBatchCallback(NoopBatch)
+	    .SetFlushCallback(NoopFlush);
+	no_bind_data.Register();
+	REQUIRE_THROWS_MATCHES(
+	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_bind_data")).Drain(), Exception,
+	    HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+
+	auto no_init_data = CopyFunction::Create(conn);
+	no_init_data.SetName("cpp_copy_no_init_data")
+	    .SetInitCallback(NoopInit)
+	    .SetBatchCallback(NoInitDataBatch)
+	    .SetFlushCallback(NoopFlush);
+	no_init_data.Register();
+	REQUIRE_THROWS_MATCHES(
+	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_init_data")).Drain(), Exception,
+	    HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+
+	auto no_batch_data = CopyFunction::Create(conn);
+	no_batch_data.SetName("cpp_copy_no_batch_data").SetBatchCallback(NoopBatch).SetFlushCallback(NoBatchDataFlush);
+	no_batch_data.Register();
+	REQUIRE_THROWS_MATCHES(
+	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_batch_data")).Drain(), Exception,
+	    HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+}
+
+TEST_CASE("Stable C++API: copy SetUserData is consumed by Register", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	const auto path = duckdb::TestCreatePath("cpp_copy_consumed.txt");
+
+	auto function = CopyFunction::Create(conn);
+	function.SetName("cpp_copy_consumed")
+	    .SetUserData<std::string>("first")
+	    .SetBindCallback(UserDataBind)
+	    .SetBatchCallback(NoopBatch)
+	    .SetFlushCallback(NoopFlush);
+	function.Register();
+
+	user_data_seen.Reset();
+	conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_consumed")).Drain();
+	REQUIRE(user_data_seen.in_bind.load() != nullptr);
+	REQUIRE(*user_data_seen.in_bind.load() == "first");
+
+	// Register consumed the user data: the second registration has none.
+	function.SetName("cpp_copy_consumed2").SetBindCallback(NoUserDataBind);
+	function.Register();
+	REQUIRE_THROWS_MATCHES(conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_consumed2")),
+	                       Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Stable C++API: copy function callback errors fail the query", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	const auto path = duckdb::TestCreatePath("cpp_copy_fails.txt");
+
+	auto function = CopyFunction::Create(conn);
+	function.SetName("cpp_copy_fails").SetBatchCallback(FailingBatch).SetFlushCallback(NoopFlush);
+	function.Register();
+
+	REQUIRE_THROWS_MATCHES(conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_fails")).Drain(),
+	                       InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+
+	auto empty_batch_size = CopyFunction::Create(conn);
+	empty_batch_size.SetName("cpp_copy_empty_batch_size")
+	    .SetBatchSizeCallback(EmptyBatchSize)
+	    .SetBatchCallback(NoopBatch)
+	    .SetFlushCallback(NoopFlush);
+	empty_batch_size.Register();
+	REQUIRE_THROWS_MATCHES(
+	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_empty_batch_size")),
+	    InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+
+	auto take_twice = CopyFunction::Create(conn);
+	take_twice.SetName("cpp_copy_take_twice").SetBatchCallback(TakeTwiceBatch).SetFlushCallback(NoopFlush);
+	take_twice.Register();
+	REQUIRE_THROWS_MATCHES(
+	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_take_twice")).Drain(),
+	    InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+}
+
+TEST_CASE("Stable C++API: copy function registration validation", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	// No name.
+	{
+		auto function = CopyFunction::Create(conn);
+		function.SetBatchCallback(NoopBatch).SetFlushCallback(NoopFlush);
+		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+
+	// The batch callback missing.
+	{
+		auto function = CopyFunction::Create(conn);
+		function.SetName("cpp_copy_no_batch").SetFlushCallback(NoopFlush);
+		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+
+	// The flush callback missing.
+	{
+		auto function = CopyFunction::Create(conn);
+		function.SetName("cpp_copy_no_flush").SetBatchCallback(NoopBatch);
+		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+}

--- a/tools/cpp/tests/test_cpp_api_copy_function.cpp
+++ b/tools/cpp/tests/test_cpp_api_copy_function.cpp
@@ -23,9 +23,15 @@ namespace {
 
 using namespace duckdb::cxx;
 
-// The COPY statement driving a format, writing `source` to `path`.
-std::string CopyStatement(const std::string &source, const std::string &path, const std::string &format) {
-	return "COPY (" + source + ") TO '" + path + "' (FORMAT " + format + ", USE_TMP_FILE FALSE)";
+// The COPY statements driving a format.
+std::string CopyToStatement(const std::string &source, const std::string &path, const std::string &format,
+                            const std::string &options = "") {
+	return "COPY (" + source + ") TO '" + path + "' (FORMAT " + format + ", USE_TMP_FILE FALSE" + options + ")";
+}
+
+std::string CopyFromStatement(const std::string &table, const std::string &path, const std::string &format,
+                              const std::string &options = "") {
+	return "COPY " + table + " FROM '" + path + "' (FORMAT " + format + options + ")";
 }
 
 std::string ReadFile(const std::string &path) {
@@ -35,11 +41,24 @@ std::string ReadFile(const std::string &path) {
 	return out.str();
 }
 
+// Collect a single BIGINT column, asserting every row valid.
+std::vector<int64_t> CollectBigints(QueryResult result) {
+	std::vector<int64_t> out;
+	while (auto chunk = result.FetchChunk()) {
+		auto view = chunk.GetVector(0).GetView();
+		for (idx_t i = 0; i < chunk.GetRowCount(); i++) {
+			REQUIRE(view.IsValid(i));
+			out.push_back(view.Data<int64_t>()[view.SelAt(i)]);
+		}
+	}
+	return out;
+}
+
 // ---------------------------------------------------------------------------
-// cpp_copy: the bind data records the column count, the init data owns the
-// output path and accumulates the rows flushed to it, and each batch is kept
-// as its own batch data until the flush counts its rows. Finalize writes
-// "<columns> <rows>" to the target through the engine's file system.
+// cpp_copy (COPY TO): the bind data records the column count, the init data
+// owns the output path and accumulates the rows flushed to it, and each batch
+// is kept as its own batch data until the flush counts its rows. Finalize
+// writes "<columns> <rows>" to the target through the engine's file system.
 // ---------------------------------------------------------------------------
 
 struct FileState {
@@ -52,25 +71,30 @@ struct {
 	idx_t column_count = 0;
 	std::string column_name;
 	LogicalTypeId column_type = LogicalTypeId::INVALID;
+	std::string options;
 	std::atomic<idx_t> batches {0};
 
 	void Reset() {
 		column_count = 0;
 		column_name.clear();
 		column_type = LogicalTypeId::INVALID;
+		options.clear();
 		batches = 0;
 	}
 } summary_seen;
 
-void SummaryBind(CopyFunction::BindInput &input) {
+void SummaryBind(CopyFunction::CopyToBindInput &input) {
 	summary_seen.column_count = input.GetColumnCount();
 	summary_seen.column_name = input.GetColumnName(0);
 	summary_seen.column_type = input.GetColumnType(0).GetTypeId();
+	for (idx_t i = 0; i < input.GetOptionCount(); i++) {
+		summary_seen.options += input.GetOptionName(i) + "=" + input.GetOptionValue(i).ToText() + "\n";
+	}
 	input.SetBindData<idx_t>(input.GetColumnCount());
 }
 
 // Asks for batches larger than the input: the whole copy arrives as one batch per thread.
-void SummaryBatchSize(CopyFunction::BatchSizeInput &input) {
+void SummaryBatchSize(CopyFunction::CopyToBatchSizeInput &input) {
 	// The batch size callback runs after bind and sees its data.
 	if (input.GetBindData<idx_t>() != 1) {
 		throw InvalidInputException("batch size callback did not see the bind data");
@@ -78,27 +102,130 @@ void SummaryBatchSize(CopyFunction::BatchSizeInput &input) {
 	input.SetTarget(100000);
 }
 
-void SummaryInit(CopyFunction::InitInput &input) {
+void SummaryInit(CopyFunction::CopyToInitInput &input) {
 	input.SetInitData<FileState>(FileState {input.GetFilePath(), input.GetBindData<idx_t>(), 0});
 }
 
-void SummaryBatch(CopyFunction::BatchInput &input) {
+void SummaryBatch(CopyFunction::CopyToBatchInput &input) {
 	summary_seen.batches++;
 	// The batch is ours: hand it over to the flush as is.
 	input.SetBatchData<ColumnDataCollection>(input.TakeBatch());
 }
 
-void SummaryFlush(CopyFunction::FlushInput &input) {
+void SummaryFlush(CopyFunction::CopyToFlushInput &input) {
 	input.GetInitData<FileState>().total_rows += input.GetBatchData<ColumnDataCollection>().GetRowCount();
 }
 
-void SummaryFinalize(CopyFunction::FinalizeInput &input) {
+void SummaryFinalize(CopyFunction::CopyToFinalizeInput &input) {
 	const auto &state = input.GetInitData<FileState>();
 	const auto contents = std::to_string(state.columns) + " " + std::to_string(state.total_rows);
 
 	auto fs = input.GetContext().GetFileSystem();
 	auto file = fs.OpenFile(state.path, {FileFlags::WRITE, FileFlags::FILE_CREATE});
 	file.Write(contents.data(), contents.size());
+}
+
+// ---------------------------------------------------------------------------
+// cpp_reader (COPY FROM): produces the target table's single BIGINT column as
+// 0, 1, ... ROWS-1, claiming slices of rows from a shared cursor.
+// ---------------------------------------------------------------------------
+
+struct ReaderBind {
+	int64_t rows = 0;
+	std::string path;
+	std::string options;
+};
+
+struct ReaderGlobal {
+	std::atomic<int64_t> position {0};
+};
+
+struct ReaderLocal {
+	int64_t produced = 0;
+};
+
+struct {
+	std::string path;
+	std::string options;
+	std::string column_name;
+	LogicalTypeId column_type = LogicalTypeId::INVALID;
+	std::atomic<idx_t> execs {0};
+	std::atomic<idx_t> locals {0};
+
+	void Reset() {
+		path.clear();
+		options.clear();
+		column_name.clear();
+		column_type = LogicalTypeId::INVALID;
+		execs = 0;
+		locals = 0;
+	}
+} reader_seen;
+
+// How many rows a batch produces. The API exposes no output-chunk capacity, so the tests stay within the smallest
+// vector size the build can be configured with.
+constexpr int64_t READER_BATCH_ROWS = 2;
+
+void ReaderBind_(CopyFunction::CopyFromBindInput &input) {
+	ReaderBind bind;
+	bind.path = input.GetFilePath();
+	for (idx_t i = 0; i < input.GetOptionCount(); i++) {
+		const auto name = input.GetOptionName(i);
+		auto value = input.GetOptionValue(i);
+		bind.options += name + "=" + value.ToText() + "\n";
+		if (name == "rows") {
+			bind.rows = value.Get<int32_t>();
+		}
+	}
+	reader_seen.path = bind.path;
+	reader_seen.options = bind.options;
+	reader_seen.column_name = input.GetColumnName(0);
+	reader_seen.column_type = input.GetColumnType(0).GetTypeId();
+	input.SetCardinality(static_cast<idx_t>(bind.rows), true);
+	input.SetBindData<ReaderBind>(std::move(bind));
+}
+
+void ReaderInitGlobal(CopyFunction::CopyFromInitGlobalInput &input) {
+	input.SetGlobalState<ReaderGlobal>();
+	input.SetMaxThreads(2);
+}
+
+void ReaderInitLocal(CopyFunction::CopyFromInitLocalInput &input) {
+	reader_seen.locals++;
+	input.SetLocalState<ReaderLocal>();
+}
+
+void ReaderExec(CopyFunction::CopyFromExecInput &input) {
+	reader_seen.execs++;
+	const auto &bind = input.GetBindData<ReaderBind>();
+	auto &global = input.GetGlobalState<ReaderGlobal>();
+	auto &local = input.GetLocalState<ReaderLocal>();
+
+	auto chunk = input.GetOutputChunk();
+	auto vec = chunk.GetVector(0);
+	auto *out = vec.GetDataMutable<int64_t>();
+
+	const auto start = global.position.fetch_add(READER_BATCH_ROWS);
+	auto produced = bind.rows - start;
+	if (produced > READER_BATCH_ROWS) {
+		produced = READER_BATCH_ROWS;
+	}
+	if (produced < 0) {
+		produced = 0;
+	}
+	for (int64_t i = 0; i < produced; i++) {
+		out[i] = start + i;
+	}
+	local.produced += produced;
+
+	// The first vector's size is the batch's row count; 0 ends the read.
+	vec.SetSize(static_cast<idx_t>(produced));
+}
+
+void ReaderProgress(CopyFunction::CopyFromProgressInput &input) {
+	const auto &bind = input.GetBindData<ReaderBind>();
+	const auto &global = input.GetGlobalState<ReaderGlobal>();
+	input.SetProgress(bind.rows > 0 ? static_cast<double>(global.position) / static_cast<double>(bind.rows) : 1.0);
 }
 
 // Data-flow probes: each callback latches the user data it was handed.
@@ -108,6 +235,8 @@ struct {
 	std::atomic<const std::string *> in_batch {nullptr};
 	std::atomic<const std::string *> in_flush {nullptr};
 	std::atomic<const std::string *> in_finalize {nullptr};
+	std::atomic<const std::string *> in_from_bind {nullptr};
+	std::atomic<const std::string *> in_from_exec {nullptr};
 
 	void Reset() {
 		in_bind = nullptr;
@@ -115,58 +244,78 @@ struct {
 		in_batch = nullptr;
 		in_flush = nullptr;
 		in_finalize = nullptr;
+		in_from_bind = nullptr;
+		in_from_exec = nullptr;
 	}
 } user_data_seen;
 
-void UserDataBind(CopyFunction::BindInput &input) {
+void UserDataBind(CopyFunction::CopyToBindInput &input) {
 	user_data_seen.in_bind = &input.GetUserData<std::string>();
 }
-void UserDataInit(CopyFunction::InitInput &input) {
+void UserDataInit(CopyFunction::CopyToInitInput &input) {
 	user_data_seen.in_init = &input.GetUserData<std::string>();
 }
-void UserDataBatch(CopyFunction::BatchInput &input) {
+void UserDataBatch(CopyFunction::CopyToBatchInput &input) {
 	user_data_seen.in_batch = &input.GetUserData<std::string>();
 }
-void UserDataFlush(CopyFunction::FlushInput &input) {
+void UserDataFlush(CopyFunction::CopyToFlushInput &input) {
 	user_data_seen.in_flush = &input.GetUserData<std::string>();
 }
-void UserDataFinalize(CopyFunction::FinalizeInput &input) {
+void UserDataFinalize(CopyFunction::CopyToFinalizeInput &input) {
 	user_data_seen.in_finalize = &input.GetUserData<std::string>();
+}
+void UserDataFromBind(CopyFunction::CopyFromBindInput &input) {
+	user_data_seen.in_from_bind = &input.GetUserData<std::string>();
+}
+void UserDataFromExec(CopyFunction::CopyFromExecInput &input) {
+	user_data_seen.in_from_exec = &input.GetUserData<std::string>();
+	// Produce nothing: the read ends at once.
 }
 
 // Reads a slot that was never set: the wrapper refuses instead of handing out null.
-void NoUserDataBind(CopyFunction::BindInput &input) {
+void NoUserDataBind(CopyFunction::CopyToBindInput &input) {
 	input.GetUserData<int>();
 }
-void NoBindDataInit(CopyFunction::InitInput &input) {
+void NoBindDataInit(CopyFunction::CopyToInitInput &input) {
 	input.GetBindData<int>();
 }
-void NoInitDataBatch(CopyFunction::BatchInput &input) {
+void NoInitDataBatch(CopyFunction::CopyToBatchInput &input) {
 	input.GetInitData<int>();
 }
-void NoBatchDataFlush(CopyFunction::FlushInput &input) {
+void NoBatchDataFlush(CopyFunction::CopyToFlushInput &input) {
 	input.GetBatchData<int>();
 }
-
-void NoopBind(CopyFunction::BindInput &) {
-}
-void NoopInit(CopyFunction::InitInput &) {
-}
-void NoopBatch(CopyFunction::BatchInput &) {
-}
-void NoopFlush(CopyFunction::FlushInput &) {
+void NoGlobalStateExec(CopyFunction::CopyFromExecInput &input) {
+	input.GetGlobalState<int>();
 }
 
-void FailingBatch(CopyFunction::BatchInput &) {
+void NoopBind(CopyFunction::CopyToBindInput &) {
+}
+void NoopInit(CopyFunction::CopyToInitInput &) {
+}
+void NoopBatch(CopyFunction::CopyToBatchInput &) {
+}
+void NoopFlush(CopyFunction::CopyToFlushInput &) {
+}
+void NoopFromBind(CopyFunction::CopyFromBindInput &) {
+}
+void NoopFromExec(CopyFunction::CopyFromExecInput &) {
+}
+
+void FailingBatch(CopyFunction::CopyToBatchInput &) {
 	throw InvalidInputException("copy batch failed on purpose");
 }
 
+void FailingFromExec(CopyFunction::CopyFromExecInput &) {
+	throw InvalidInputException("copy from exec failed on purpose");
+}
+
 // A batch size callback that sets no target fails the statement.
-void EmptyBatchSize(CopyFunction::BatchSizeInput &) {
+void EmptyBatchSize(CopyFunction::CopyToBatchSizeInput &) {
 }
 
 // The batch can only be taken once.
-void TakeTwiceBatch(CopyFunction::BatchInput &input) {
+void TakeTwiceBatch(CopyFunction::CopyToBatchInput &input) {
 	auto first = input.TakeBatch();
 	input.TakeBatch();
 }
@@ -174,10 +323,10 @@ void TakeTwiceBatch(CopyFunction::BatchInput &input) {
 } // namespace
 
 // ---------------------------------------------------------------------------
-// Register on a connection and drive through COPY ... TO.
+// COPY TO: register on a connection and drive through COPY ... TO.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Stable C++API: copy function registers and executes", "[cpp_api]") {
+TEST_CASE("Stable C++API: copy function writes through COPY TO", "[cpp_api]") {
 	Environment env;
 	auto db = env.Open(":memory:");
 	auto conn = db.Connect();
@@ -186,27 +335,71 @@ TEST_CASE("Stable C++API: copy function registers and executes", "[cpp_api]") {
 	conn.Execute("SET threads = 1").Drain();
 	auto function = CopyFunction::Create(conn);
 	function.SetName("cpp_copy")
-	    .SetBindCallback(SummaryBind)
-	    .SetBatchSizeCallback(SummaryBatchSize)
-	    .SetInitCallback(SummaryInit)
-	    .SetBatchCallback(SummaryBatch)
-	    .SetFlushCallback(SummaryFlush)
-	    .SetFinalizeCallback(SummaryFinalize);
+	    .SetCopyToBindCallback(SummaryBind)
+	    .SetCopyToBatchSizeCallback(SummaryBatchSize)
+	    .SetCopyToInitCallback(SummaryInit)
+	    .SetCopyToBatchCallback(SummaryBatch)
+	    .SetCopyToFlushCallback(SummaryFlush)
+	    .SetCopyToFinalizeCallback(SummaryFinalize);
 	function.Register();
 
 	summary_seen.Reset();
 	const auto path = duckdb::TestCreatePath("cpp_copy_summary.txt");
 	// COPY reports the number of rows written.
-	REQUIRE(conn.Execute(CopyStatement("SELECT r AS i FROM range(5000) t(r)", path, "cpp_copy")).Drain() == 5000);
+	REQUIRE(conn.Execute(CopyToStatement("SELECT r AS i FROM range(5000) t(r)", path, "cpp_copy", ", TAG 'x', FLAG"))
+	            .Drain() == 5000);
 
-	// Bind saw the SELECT's single BIGINT column.
+	// Bind saw the SELECT's single BIGINT column and the function's own options.
 	REQUIRE(summary_seen.column_count == 1);
 	REQUIRE(summary_seen.column_name == "i");
 	REQUIRE(summary_seen.column_type == LogicalTypeId::BIGINT);
+	REQUIRE(summary_seen.options == "flag=true\ntag=x\n");
 	REQUIRE(summary_seen.batches.load() == 1);
 
 	// The bind -> init -> batch -> flush -> finalize chain observed 1 column and 5000 rows.
 	REQUIRE(ReadFile(path) == "1 5000");
+}
+
+// ---------------------------------------------------------------------------
+// COPY FROM: register on a connection and drive through COPY ... FROM.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Stable C++API: copy function reads through COPY FROM", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE target(i BIGINT)").Drain();
+
+	auto function = CopyFunction::Create(conn);
+	function.SetName("cpp_reader")
+	    .SetCopyFromBindCallback(ReaderBind_)
+	    .SetCopyFromInitGlobalCallback(ReaderInitGlobal)
+	    .SetCopyFromInitLocalCallback(ReaderInitLocal)
+	    .SetCopyFromExecCallback(ReaderExec)
+	    .SetCopyFromProgressCallback(ReaderProgress);
+	function.Register();
+
+	reader_seen.Reset();
+	REQUIRE(conn.Execute(CopyFromStatement("target", "some/where.cpp", "cpp_reader", ", ROWS 25, PAIR (1, 'two')"))
+	            .Drain() == 25);
+
+	// Bind saw the path as written, the target's column and the options; a parenthesized option is a tuple.
+	REQUIRE(reader_seen.path == "some/where.cpp");
+	REQUIRE(reader_seen.column_name == "i");
+	REQUIRE(reader_seen.column_type == LogicalTypeId::BIGINT);
+	REQUIRE(reader_seen.options == "pair=(1, two)\nrows=25\n");
+	REQUIRE(reader_seen.locals.load() >= 1);
+	REQUIRE(reader_seen.execs.load() >= 1);
+
+	// Every row landed in the table.
+	auto rows = CollectBigints(conn.Execute("SELECT i FROM target ORDER BY i"));
+	REQUIRE(rows.size() == 25);
+	for (idx_t i = 0; i < rows.size(); i++) {
+		REQUIRE(rows[i] == static_cast<int64_t>(i));
+	}
+
+	// A COPY FROM only function cannot be written to.
+	REQUIRE_THROWS(conn.Execute(CopyToStatement("SELECT 1", "nowhere", "cpp_reader")).Drain());
 }
 
 // ---------------------------------------------------------------------------
@@ -217,22 +410,26 @@ TEST_CASE("Stable C++API: copy function data flows through the phases", "[cpp_ap
 	Environment env;
 	auto db = env.Open(":memory:");
 	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE target(i BIGINT)").Drain();
 	const auto path = duckdb::TestCreatePath("cpp_copy_user_data.txt");
 
 	auto function = CopyFunction::Create(conn);
 	function.SetName("cpp_copy_user_data")
 	    .SetUserData<std::string>("copy user data")
-	    .SetBindCallback(UserDataBind)
-	    .SetInitCallback(UserDataInit)
-	    .SetBatchCallback(UserDataBatch)
-	    .SetFlushCallback(UserDataFlush)
-	    .SetFinalizeCallback(UserDataFinalize);
+	    .SetCopyToBindCallback(UserDataBind)
+	    .SetCopyToInitCallback(UserDataInit)
+	    .SetCopyToBatchCallback(UserDataBatch)
+	    .SetCopyToFlushCallback(UserDataFlush)
+	    .SetCopyToFinalizeCallback(UserDataFinalize)
+	    .SetCopyFromBindCallback(UserDataFromBind)
+	    .SetCopyFromExecCallback(UserDataFromExec);
 	function.Register();
 
 	user_data_seen.Reset();
-	conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_user_data")).Drain();
+	conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_user_data")).Drain();
+	conn.Execute(CopyFromStatement("target", path, "cpp_copy_user_data")).Drain();
 
-	// One object, visible in all five phases.
+	// One object, visible in every phase of both sides.
 	const std::string *seen = user_data_seen.in_bind;
 	REQUIRE(seen != nullptr);
 	REQUIRE(*seen == "copy user data");
@@ -240,44 +437,56 @@ TEST_CASE("Stable C++API: copy function data flows through the phases", "[cpp_ap
 	REQUIRE(user_data_seen.in_batch.load() == seen);
 	REQUIRE(user_data_seen.in_flush.load() == seen);
 	REQUIRE(user_data_seen.in_finalize.load() == seen);
+	REQUIRE(user_data_seen.in_from_bind.load() == seen);
+	REQUIRE(user_data_seen.in_from_exec.load() == seen);
 
 	// A slot that was never set is a clear error, not a null deref, from whichever phase reads it.
 	auto no_user_data = CopyFunction::Create(conn);
 	no_user_data.SetName("cpp_copy_no_user_data")
-	    .SetBindCallback(NoUserDataBind)
-	    .SetBatchCallback(NoopBatch)
-	    .SetFlushCallback(NoopFlush);
+	    .SetCopyToBindCallback(NoUserDataBind)
+	    .SetCopyToBatchCallback(NoopBatch)
+	    .SetCopyToFlushCallback(NoopFlush);
 	no_user_data.Register();
-	REQUIRE_THROWS_MATCHES(conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_user_data")),
+	REQUIRE_THROWS_MATCHES(conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_user_data")),
 	                       Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 
 	auto no_bind_data = CopyFunction::Create(conn);
 	no_bind_data.SetName("cpp_copy_no_bind_data")
-	    .SetBindCallback(NoopBind)
-	    .SetInitCallback(NoBindDataInit)
-	    .SetBatchCallback(NoopBatch)
-	    .SetFlushCallback(NoopFlush);
+	    .SetCopyToBindCallback(NoopBind)
+	    .SetCopyToInitCallback(NoBindDataInit)
+	    .SetCopyToBatchCallback(NoopBatch)
+	    .SetCopyToFlushCallback(NoopFlush);
 	no_bind_data.Register();
 	REQUIRE_THROWS_MATCHES(
-	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_bind_data")).Drain(), Exception,
+	    conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_bind_data")).Drain(), Exception,
 	    HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 
 	auto no_init_data = CopyFunction::Create(conn);
 	no_init_data.SetName("cpp_copy_no_init_data")
-	    .SetInitCallback(NoopInit)
-	    .SetBatchCallback(NoInitDataBatch)
-	    .SetFlushCallback(NoopFlush);
+	    .SetCopyToInitCallback(NoopInit)
+	    .SetCopyToBatchCallback(NoInitDataBatch)
+	    .SetCopyToFlushCallback(NoopFlush);
 	no_init_data.Register();
 	REQUIRE_THROWS_MATCHES(
-	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_init_data")).Drain(), Exception,
+	    conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_init_data")).Drain(), Exception,
 	    HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 
 	auto no_batch_data = CopyFunction::Create(conn);
-	no_batch_data.SetName("cpp_copy_no_batch_data").SetBatchCallback(NoopBatch).SetFlushCallback(NoBatchDataFlush);
+	no_batch_data.SetName("cpp_copy_no_batch_data")
+	    .SetCopyToBatchCallback(NoopBatch)
+	    .SetCopyToFlushCallback(NoBatchDataFlush);
 	no_batch_data.Register();
 	REQUIRE_THROWS_MATCHES(
-	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_batch_data")).Drain(), Exception,
+	    conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_no_batch_data")).Drain(), Exception,
 	    HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+
+	auto no_global_state = CopyFunction::Create(conn);
+	no_global_state.SetName("cpp_copy_no_global_state")
+	    .SetCopyFromBindCallback(NoopFromBind)
+	    .SetCopyFromExecCallback(NoGlobalStateExec);
+	no_global_state.Register();
+	REQUIRE_THROWS_MATCHES(conn.Execute(CopyFromStatement("target", path, "cpp_copy_no_global_state")).Drain(),
+	                       Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 }
 
 TEST_CASE("Stable C++API: copy SetUserData is consumed by Register", "[cpp_api]") {
@@ -289,20 +498,20 @@ TEST_CASE("Stable C++API: copy SetUserData is consumed by Register", "[cpp_api]"
 	auto function = CopyFunction::Create(conn);
 	function.SetName("cpp_copy_consumed")
 	    .SetUserData<std::string>("first")
-	    .SetBindCallback(UserDataBind)
-	    .SetBatchCallback(NoopBatch)
-	    .SetFlushCallback(NoopFlush);
+	    .SetCopyToBindCallback(UserDataBind)
+	    .SetCopyToBatchCallback(NoopBatch)
+	    .SetCopyToFlushCallback(NoopFlush);
 	function.Register();
 
 	user_data_seen.Reset();
-	conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_consumed")).Drain();
+	conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_consumed")).Drain();
 	REQUIRE(user_data_seen.in_bind.load() != nullptr);
 	REQUIRE(*user_data_seen.in_bind.load() == "first");
 
 	// Register consumed the user data: the second registration has none.
-	function.SetName("cpp_copy_consumed2").SetBindCallback(NoUserDataBind);
+	function.SetName("cpp_copy_consumed2").SetCopyToBindCallback(NoUserDataBind);
 	function.Register();
-	REQUIRE_THROWS_MATCHES(conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_consumed2")),
+	REQUIRE_THROWS_MATCHES(conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_consumed2")),
 	                       Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 }
 
@@ -314,30 +523,38 @@ TEST_CASE("Stable C++API: copy function callback errors fail the query", "[cpp_a
 	Environment env;
 	auto db = env.Open(":memory:");
 	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE target(i BIGINT)").Drain();
 	const auto path = duckdb::TestCreatePath("cpp_copy_fails.txt");
 
 	auto function = CopyFunction::Create(conn);
-	function.SetName("cpp_copy_fails").SetBatchCallback(FailingBatch).SetFlushCallback(NoopFlush);
+	function.SetName("cpp_copy_fails").SetCopyToBatchCallback(FailingBatch).SetCopyToFlushCallback(NoopFlush);
 	function.Register();
+	REQUIRE_THROWS_MATCHES(conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_fails")).Drain(),
+	                       InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 
-	REQUIRE_THROWS_MATCHES(conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_fails")).Drain(),
+	auto reader_fails = CopyFunction::Create(conn);
+	reader_fails.SetName("cpp_reader_fails")
+	    .SetCopyFromBindCallback(NoopFromBind)
+	    .SetCopyFromExecCallback(FailingFromExec);
+	reader_fails.Register();
+	REQUIRE_THROWS_MATCHES(conn.Execute(CopyFromStatement("target", path, "cpp_reader_fails")).Drain(),
 	                       InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 
 	auto empty_batch_size = CopyFunction::Create(conn);
 	empty_batch_size.SetName("cpp_copy_empty_batch_size")
-	    .SetBatchSizeCallback(EmptyBatchSize)
-	    .SetBatchCallback(NoopBatch)
-	    .SetFlushCallback(NoopFlush);
+	    .SetCopyToBatchSizeCallback(EmptyBatchSize)
+	    .SetCopyToBatchCallback(NoopBatch)
+	    .SetCopyToFlushCallback(NoopFlush);
 	empty_batch_size.Register();
 	REQUIRE_THROWS_MATCHES(
-	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_empty_batch_size")),
+	    conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_empty_batch_size")),
 	    InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 
 	auto take_twice = CopyFunction::Create(conn);
-	take_twice.SetName("cpp_copy_take_twice").SetBatchCallback(TakeTwiceBatch).SetFlushCallback(NoopFlush);
+	take_twice.SetName("cpp_copy_take_twice").SetCopyToBatchCallback(TakeTwiceBatch).SetCopyToFlushCallback(NoopFlush);
 	take_twice.Register();
 	REQUIRE_THROWS_MATCHES(
-	    conn.Execute(CopyStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_take_twice")).Drain(),
+	    conn.Execute(CopyToStatement("SELECT r FROM range(3) t(r)", path, "cpp_copy_take_twice")).Drain(),
 	    InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 }
 
@@ -349,21 +566,38 @@ TEST_CASE("Stable C++API: copy function registration validation", "[cpp_api]") {
 	// No name.
 	{
 		auto function = CopyFunction::Create(conn);
-		function.SetBatchCallback(NoopBatch).SetFlushCallback(NoopFlush);
+		function.SetCopyToBatchCallback(NoopBatch).SetCopyToFlushCallback(NoopFlush);
 		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 	}
 
-	// The batch callback missing.
+	// Neither side configured.
 	{
 		auto function = CopyFunction::Create(conn);
-		function.SetName("cpp_copy_no_batch").SetFlushCallback(NoopFlush);
+		function.SetName("cpp_copy_no_side");
 		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 	}
 
-	// The flush callback missing.
+	// The COPY TO batch callback missing, then the flush callback.
 	{
 		auto function = CopyFunction::Create(conn);
-		function.SetName("cpp_copy_no_flush").SetBatchCallback(NoopBatch);
+		function.SetName("cpp_copy_no_batch").SetCopyToFlushCallback(NoopFlush);
+		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+	{
+		auto function = CopyFunction::Create(conn);
+		function.SetName("cpp_copy_no_flush").SetCopyToBatchCallback(NoopBatch);
+		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+
+	// The COPY FROM bind callback missing, then the exec callback.
+	{
+		auto function = CopyFunction::Create(conn);
+		function.SetName("cpp_reader_no_bind").SetCopyFromExecCallback(NoopFromExec);
+		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+	{
+		auto function = CopyFunction::Create(conn);
+		function.SetName("cpp_reader_no_exec").SetCopyFromBindCallback(NoopFromBind);
 		REQUIRE_THROWS_MATCHES(function.Register(), InvalidInputException, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 	}
 }

--- a/tools/cpp/tests/test_cpp_api_core.cpp
+++ b/tools/cpp/tests/test_cpp_api_core.cpp
@@ -36,6 +36,15 @@ TEST_CASE("Stable C++API: Database GetOption by name and option target scope", "
 
 	REQUIRE_THROWS_MATCHES(db.GetOption("no_such_option"), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
 }
+TEST_CASE("Stable C++API: RenderQuotedIdentifier quotes only when required", "[cpp_api]") {
+	using duckdb::cxx::RenderQuotedIdentifier;
+	REQUIRE(RenderQuotedIdentifier("col") == "col");
+	REQUIRE(RenderQuotedIdentifier("MyCol") == "MyCol");
+	REQUIRE(RenderQuotedIdentifier("select") == "\"select\"");
+	REQUIRE(RenderQuotedIdentifier("my col") == "\"my col\"");
+	REQUIRE(RenderQuotedIdentifier("a\"b") == "\"a\"\"b\"");
+}
+
 TEST_CASE("Stable C++API: LibraryVersion reports the engine version", "[cpp_api]") {
 	const auto version = duckdb::cxx::LibraryVersion();
 	REQUIRE_FALSE(version.empty());

--- a/tools/cpp/tests/test_cpp_api_file_system.cpp
+++ b/tools/cpp/tests/test_cpp_api_file_system.cpp
@@ -1,0 +1,182 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+#include "test_helpers.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: FileSystem and FileHandle.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+void WriteAll(FileHandle &file, const std::string &data) {
+	REQUIRE(file.Write(data.data(), data.size()) == data.size());
+}
+
+std::string ReadAll(FileHandle &file, idx_t capacity) {
+	std::vector<char> buffer(capacity, '\0');
+	auto read = file.Read(buffer.data(), capacity);
+	return std::string(buffer.data(), read);
+}
+
+} // namespace
+
+TEST_CASE("Stable C++API: file system round-trip", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto fs = conn.GetFileSystem();
+	auto path = duckdb::TestCreatePath("cpp_fs_roundtrip.bin");
+
+	{
+		auto file = fs.OpenFile(path, {FileFlags::WRITE, FileFlags::FILE_CREATE_NEW});
+		WriteAll(file, "hello world");
+		REQUIRE(file.Tell() == 11);
+		REQUIRE(file.Size() == 11);
+		file.Sync();
+	}
+
+	auto file = fs.OpenFile(path, {FileFlags::READ});
+	REQUIRE(file.Size() == 11);
+	REQUIRE(ReadAll(file, 32) == "hello world");
+	// At the end, a read yields nothing rather than failing.
+	REQUIRE(ReadAll(file, 32).empty());
+
+	file.Seek(6);
+	REQUIRE(file.Tell() == 6);
+	REQUIRE(ReadAll(file, 5) == "world");
+}
+
+TEST_CASE("Stable C++API: file flags", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto fs = conn.GetFileSystem();
+	auto path = duckdb::TestCreatePath("cpp_fs_flags.bin");
+
+	{
+		auto file = fs.OpenFile(path, {FileFlags::WRITE, FileFlags::FILE_CREATE});
+		WriteAll(file, "hello");
+	}
+	{
+		// FILE_CREATE leaves an existing file alone.
+		auto file = fs.OpenFile(path, {FileFlags::WRITE, FileFlags::FILE_CREATE});
+		REQUIRE(file.Size() == 5);
+	}
+	{
+		// FILE_CREATE_NEW truncates it.
+		auto file = fs.OpenFile(path, {FileFlags::WRITE, FileFlags::FILE_CREATE_NEW});
+		REQUIRE(file.Size() == 0);
+		WriteAll(file, "hi");
+	}
+	// EXCLUSIVE_CREATE refuses it, and leaves the contents intact.
+	REQUIRE_THROWS_AS(fs.OpenFile(path, {FileFlags::WRITE, FileFlags::FILE_CREATE, FileFlags::EXCLUSIVE_CREATE}),
+	                  Exception);
+	{
+		auto file = fs.OpenFile(path, {FileFlags::READ});
+		REQUIRE(ReadAll(file, 32) == "hi");
+	}
+	{
+		// APPEND writes at the end.
+		auto file = fs.OpenFile(path, {FileFlags::WRITE, FileFlags::APPEND});
+		WriteAll(file, "there");
+	}
+	{
+		auto file = fs.OpenFile(path, {FileFlags::READ});
+		REQUIRE(ReadAll(file, 32) == "hithere");
+	}
+}
+
+TEST_CASE("Stable C++API: file system refusals", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto fs = conn.GetFileSystem();
+
+	// A missing file without a create flag.
+	REQUIRE_THROWS_AS(fs.OpenFile(duckdb::TestCreatePath("cpp_fs_missing.bin"), {FileFlags::READ}), Exception);
+	// No capability at all.
+	REQUIRE_THROWS_MATCHES(fs.OpenFile(duckdb::TestCreatePath("cpp_fs_none.bin"), {}), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	// INVALID names no behaviour.
+	REQUIRE_THROWS_MATCHES(fs.OpenFile(duckdb::TestCreatePath("cpp_fs_none.bin"), {FileFlags::INVALID}), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+}
+
+TEST_CASE("Stable C++API: file handle close then destroy", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto fs = conn.GetFileSystem();
+	auto path = duckdb::TestCreatePath("cpp_fs_close.bin");
+
+	auto file = fs.OpenFile(path, {FileFlags::WRITE, FileFlags::FILE_CREATE_NEW});
+	WriteAll(file, "data");
+	file.Close();
+	// The handle is still alive; its destructor runs at the end of the scope.
+}
+
+TEST_CASE("Stable C++API: positional file read and write", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto fs = conn.GetFileSystem();
+	auto path = duckdb::TestCreatePath("cpp_fs_positional.bin");
+
+	auto file =
+	    fs.OpenFile(path, {FileFlags::READ, FileFlags::WRITE, FileFlags::FILE_CREATE_NEW, FileFlags::PARALLEL_ACCESS});
+	WriteAll(file, "abcdefghij");
+	REQUIRE(file.Tell() == 10);
+
+	// Positional access leaves the file's own position alone.
+	char buffer[4] = {0};
+	file.ReadAt(buffer, 4, 2);
+	REQUIRE(std::string(buffer, 4) == "cdef");
+	REQUIRE(file.Tell() == 10);
+
+	file.WriteAt("XY", 2, 4);
+	REQUIRE(file.Tell() == 10);
+	file.ReadAt(buffer, 4, 2);
+	REQUIRE(std::string(buffer, 4) == "cdXY");
+
+	// A short positional read is an error, not a result.
+	REQUIRE_THROWS_AS(file.ReadAt(buffer, 4, 8), Exception);
+}
+
+TEST_CASE("Stable C++API: file open options", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto fs = conn.GetFileSystem();
+	auto path = duckdb::TestCreatePath("cpp_fs_options.bin");
+
+	auto options = fs.CreateOpenOptions();
+	options.SetFlag(FileFlags::WRITE)
+	    .SetFlag(FileFlags::FILE_CREATE_NEW)
+	    .SetValue("file_size", Value::Create(conn, int64_t {4}))
+	    .SetValue("made_up_option", Value::Create(conn, varchar_t("nobody-reads-this")));
+
+	{
+		auto file = fs.OpenFile(path, options);
+		WriteAll(file, "data");
+	}
+	// One options object opens as many files as you like.
+	{
+		auto file = fs.OpenFile(duckdb::TestCreatePath("cpp_fs_options_second.bin"), options);
+		WriteAll(file, "more");
+	}
+	{
+		auto file = fs.OpenFile(path, {FileFlags::READ});
+		REQUIRE(ReadAll(file, 32) == "data");
+	}
+
+	// Options carrying no flags cannot say whether the file is read or written.
+	auto empty = fs.CreateOpenOptions();
+	REQUIRE_THROWS_MATCHES(fs.OpenFile(path, empty), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+}

--- a/tools/cpp/tests/test_cpp_api_prepared_statement.cpp
+++ b/tools/cpp/tests/test_cpp_api_prepared_statement.cpp
@@ -1,0 +1,166 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: PreparedStatement. Prepare once and execute many, the
+// honest reuse report, and the lifetimes the handle promises.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+// Collects one BIGINT column. STANDARD_VECTOR_SIZE can be 2 in the assertion build, so
+// this must not assume a single chunk.
+std::vector<int64_t> CollectPreparedBigints(QueryResult result) {
+	std::vector<int64_t> rows;
+	while (auto chunk = result.FetchChunk()) {
+		auto view = chunk.GetVector(0).GetView();
+		for (idx_t i = 0; i < chunk.GetRowCount(); i++) {
+			REQUIRE(view.IsValid(i));
+			rows.push_back(view.Data<int64_t>()[view.SelAt(i)]);
+		}
+	}
+	return rows;
+}
+
+} // namespace
+
+TEST_CASE("Stable C++API: PreparedStatement executes repeatedly", "[cpp_api][prepared_statement]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE t(x BIGINT)").Drain();
+	conn.Execute("INSERT INTO t VALUES (1), (2), (3), (4)").Drain();
+
+	// Value is move-only, so a parameter list is built by move rather than brace-init.
+	auto Params = [&conn](std::initializer_list<int64_t> values) {
+		std::vector<Value> params;
+		for (auto value : values) {
+			params.push_back(Value::Create(conn, int64_t(value)));
+		}
+		return params;
+	};
+
+	auto iter = conn.ParseSQL("SELECT x FROM t WHERE x > $1 ORDER BY x");
+	auto stmt = iter.Next();
+	auto prepared = conn.Prepare(stmt);
+
+	// The statement was borrowed, not consumed.
+	REQUIRE(static_cast<bool>(stmt));
+
+	REQUIRE(CollectPreparedBigints(prepared.Execute(Params({0}))) == std::vector<int64_t> {1, 2, 3, 4});
+	REQUIRE(CollectPreparedBigints(prepared.Execute(Params({2}))) == std::vector<int64_t> {3, 4});
+	REQUIRE(CollectPreparedBigints(prepared.Execute(Params({0}))) == std::vector<int64_t> {1, 2, 3, 4});
+}
+
+TEST_CASE("Stable C++API: PreparedStatement binds named parameters", "[cpp_api][prepared_statement]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto iter = conn.ParseSQL("SELECT $a - $b");
+	auto stmt = iter.Next();
+	auto prepared = conn.Prepare(stmt);
+
+	std::vector<NamedParam> params;
+	params.push_back({"a", Value::Create(conn, int64_t(10))});
+	params.push_back({"b", Value::Create(conn, int64_t(4))});
+	REQUIRE(CollectPreparedBigints(prepared.Execute(params)) == std::vector<int64_t> {6});
+
+	// Keyed by name, so swapping the entries changes nothing.
+	std::vector<NamedParam> swapped;
+	swapped.push_back({"b", Value::Create(conn, int64_t(4))});
+	swapped.push_back({"a", Value::Create(conn, int64_t(10))});
+	REQUIRE(CollectPreparedBigints(prepared.Execute(swapped)) == std::vector<int64_t> {6});
+}
+
+TEST_CASE("Stable C++API: PreparedStatement reports plan reuse", "[cpp_api][prepared_statement]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	conn.Execute("CREATE TABLE t(x BIGINT)").Drain();
+
+	auto Prepare = [&conn](const char *sql, bool require_cacheable = false) {
+		auto iter = conn.ParseSQL(sql);
+		auto stmt = iter.Next();
+		return conn.Prepare(stmt, require_cacheable);
+	};
+
+	REQUIRE(Prepare("SELECT 42").ReusesPlan());
+	REQUIRE(Prepare("SELECT $1::BIGINT + 1").ReusesPlan());
+	// A table scan re-binds each execution so a catalog change is picked up.
+	REQUIRE_FALSE(Prepare("SELECT x FROM t WHERE x = $1").ReusesPlan());
+
+	// require_cacheable turns that into a failure at prepare time rather than a silent
+	// slow path.
+	REQUIRE_NOTHROW(Prepare("SELECT $1::BIGINT + 1", true));
+	REQUIRE_THROWS_MATCHES(Prepare("SELECT x FROM t WHERE x = $1", true), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+}
+
+TEST_CASE("Stable C++API: PreparedStatement lifetimes", "[cpp_api][prepared_statement]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+
+	SECTION("a result outlives the statement that made it") {
+		auto conn = db.Connect();
+		conn.Execute("CREATE TABLE t(x BIGINT)").Drain();
+		conn.Execute("INSERT INTO t VALUES (1), (2), (3), (4)").Drain();
+
+		QueryResult result = [&]() {
+			auto iter = conn.ParseSQL("SELECT x FROM t ORDER BY x");
+			auto stmt = iter.Next();
+			auto prepared = conn.Prepare(stmt);
+			return prepared.Execute();
+		}();
+		REQUIRE(CollectPreparedBigints(std::move(result)) == std::vector<int64_t> {1, 2, 3, 4});
+	}
+
+	SECTION("the statement outlives its connection") {
+		auto reader = db.Connect();
+		reader.Execute("CREATE TABLE t(x BIGINT)").Drain();
+		reader.Execute("INSERT INTO t VALUES (1), (2), (3), (4)").Drain();
+
+		PreparedStatement prepared = [&]() {
+			auto conn = db.Connect();
+			auto iter = conn.ParseSQL("SELECT x FROM t ORDER BY x");
+			auto stmt = iter.Next();
+			return conn.Prepare(stmt);
+		}();
+		// The handle kept the session alive, the same guarantee an undrained result carries.
+		REQUIRE(CollectPreparedBigints(prepared.Execute()) == std::vector<int64_t> {1, 2, 3, 4});
+	}
+}
+
+TEST_CASE("Stable C++API: PreparedStatement error paths", "[cpp_api][prepared_statement]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	SECTION("a prepare-time catalog error throws") {
+		auto iter = conn.ParseSQL("SELECT * FROM no_such_table");
+		auto stmt = iter.Next();
+		REQUIRE_THROWS_MATCHES(conn.Prepare(stmt), Exception, HasErrorCode(DUCKDB_V2_ERROR_DATABASE_CATALOG));
+		REQUIRE(static_cast<bool>(stmt)); // intact: only a copy was prepared
+	}
+
+	SECTION("a live result blocks preparing and executing") {
+		auto iter = conn.ParseSQL("SELECT 1::BIGINT");
+		auto stmt = iter.Next();
+		auto prepared = conn.Prepare(stmt);
+
+		{
+			auto live = conn.Execute("SELECT i FROM range(100000) t(i)");
+			REQUIRE_THROWS_MATCHES(conn.Prepare(stmt), Exception, HasErrorCode(DUCKDB_V2_ERROR_RESOURCE_IN_USE));
+			REQUIRE_THROWS_MATCHES(prepared.Execute(), Exception, HasErrorCode(DUCKDB_V2_ERROR_RESOURCE_IN_USE));
+		}
+		// The live result is gone, so the connection is free for both paths again.
+		REQUIRE(CollectPreparedBigints(prepared.Execute()) == std::vector<int64_t> {1});
+	}
+}

--- a/tools/cpp/tests/test_cpp_api_replacement_scan.cpp
+++ b/tools/cpp/tests/test_cpp_api_replacement_scan.cpp
@@ -38,9 +38,8 @@ struct ScanRegistry {
 // What the callback saw, latched for the test to assert on afterwards. A callback must not use REQUIRE: it would
 // throw through the callback boundary into the engine.
 struct ScanObserved {
-	std::string catalog;
-	std::string schema;
-	std::string table;
+	std::vector<std::string> parts;
+	std::string rendered;
 	int calls = 0;
 };
 ScanObserved scan_observed;
@@ -48,9 +47,12 @@ ScanObserved scan_observed;
 // Claims every name with range(2), recording what it saw.
 void ClaimRange(ReplacementScan::Input &input) {
 	scan_observed.calls++;
-	scan_observed.table = input.GetTableName();
-	scan_observed.catalog = input.GetCatalogName();
-	scan_observed.schema = input.GetSchemaName();
+	auto name = input.GetName();
+	scan_observed.parts.clear();
+	for (idx_t i = 0; i < name.GetPartCount(); i++) {
+		scan_observed.parts.emplace_back(name.GetPart(i));
+	}
+	scan_observed.rendered = name.Render();
 
 	auto ctx = input.GetContext();
 	input.SetFunctionName("range");
@@ -61,7 +63,8 @@ void ClaimRange(ReplacementScan::Input &input) {
 // Claims only the registry's name, with its collection.
 void ClaimCollection(ReplacementScan::Input &input) {
 	auto &registry = input.GetUserData<ScanRegistry>();
-	if (input.GetTableName() != registry.name) {
+	auto name = input.GetName();
+	if (name.GetPartCount() != 1 || name.GetName() != registry.name) {
 		return; // decline
 	}
 	registry.calls++;
@@ -112,7 +115,7 @@ TEST_CASE("Stable C++API: replacement scan claims a table function", "[cpp_api]"
 
 	REQUIRE(CollectScanBigints(conn.Execute("SELECT * FROM not_a_table")) == std::vector<int64_t> {0, 1});
 	REQUIRE(scan_observed.calls == 1);
-	REQUIRE(scan_observed.table == "not_a_table");
+	REQUIRE(scan_observed.parts == std::vector<std::string> {"not_a_table"});
 	// The scan's alias names the binding, so a qualified reference resolves.
 	REQUIRE(CollectScanBigints(conn.Execute("SELECT claimed.range FROM not_a_table")) == std::vector<int64_t> {0, 1});
 	// A query-written alias wins over the scan's.
@@ -128,21 +131,50 @@ TEST_CASE("Stable C++API: replacement scan reports the unresolved name", "[cpp_a
 	scan.SetCallback(ClaimRange);
 	scan.Register();
 
-	// An unqualified reference reports empty qualifiers.
+	// An unqualified reference is a single part -- absence is a shorter path, not an empty placeholder.
 	scan_observed = ScanObserved();
 	conn.Execute("SELECT * FROM plain_name").Drain();
 	REQUIRE(scan_observed.calls == 1);
-	REQUIRE(scan_observed.table == "plain_name");
-	REQUIRE(scan_observed.catalog.empty());
-	REQUIRE(scan_observed.schema.empty());
+	REQUIRE(scan_observed.parts == std::vector<std::string> {"plain_name"});
+	REQUIRE(scan_observed.rendered == "plain_name");
 
-	// A fully qualified one reports all three parts.
+	// A fully qualified one carries all three, outermost first.
 	scan_observed = ScanObserved();
 	conn.Execute("SELECT * FROM memory.main.qualified_name").Drain();
 	REQUIRE(scan_observed.calls == 1);
-	REQUIRE(scan_observed.catalog == "memory");
-	REQUIRE(scan_observed.schema == "main");
-	REQUIRE(scan_observed.table == "qualified_name");
+	REQUIRE(scan_observed.parts == std::vector<std::string> {"memory", "main", "qualified_name"});
+	REQUIRE(scan_observed.rendered == "memory.main.qualified_name");
+}
+
+TEST_CASE("Stable C++API: qualified name", "[cpp_api]") {
+	auto one = QualifiedName::Create({"tbl"});
+	REQUIRE(one.GetPartCount() == 1);
+	REQUIRE(one.GetPart(0) == "tbl");
+	REQUIRE(one.GetName() == "tbl");
+	REQUIRE(one.Render() == "tbl");
+
+	auto three = QualifiedName::Create({"cat", "sch", "tbl"});
+	REQUIRE(three.GetPartCount() == 3);
+	REQUIRE(three.GetName() == "tbl");
+	REQUIRE(three.Render() == "cat.sch.tbl");
+
+	// Rendering round-trips through Parse, quoting only where the identifier needs it.
+	auto quoted = QualifiedName::Create({"we.ird", "tbl"});
+	REQUIRE(quoted.Render() == "\"we.ird\".tbl");
+	REQUIRE(QualifiedName::Parse(quoted.Render()) == quoted);
+
+	// Equality is case-insensitive, and hashes agree with it.
+	REQUIRE(QualifiedName::Parse("Cat.Sch.Tbl") == three);
+	REQUIRE(QualifiedName::Parse("Cat.Sch.Tbl").Hash() == three.Hash());
+	REQUIRE(one != three);
+
+	// Partial qualification is fewer parts, never an empty placeholder.
+	REQUIRE(QualifiedName::Parse("sch.tbl").GetPartCount() == 2);
+	REQUIRE_THROWS_MATCHES(QualifiedName::Create({}), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	REQUIRE_THROWS_MATCHES(QualifiedName::Create({"a", "b", "c", "d"}), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	REQUIRE_THROWS_MATCHES(QualifiedName::Create({"a", ""}), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	REQUIRE_THROWS_AS(one.GetPart(1), Exception);
 }
 
 TEST_CASE("Stable C++API: replacement scan reports the name and can decline", "[cpp_api]") {

--- a/tools/cpp/tests/test_cpp_api_replacement_scan.cpp
+++ b/tools/cpp/tests/test_cpp_api_replacement_scan.cpp
@@ -1,0 +1,244 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: ReplacementScan. Each of the three claim forms, the
+// scoping rules, and the error path.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+// Collect a single BIGINT column, asserting every row valid.
+std::vector<int64_t> CollectScanBigints(QueryResult result) {
+	std::vector<int64_t> out;
+	while (auto chunk = result.FetchChunk()) {
+		auto view = chunk.GetVector(0).GetView();
+		for (idx_t i = 0; i < chunk.GetRowCount(); i++) {
+			REQUIRE(view.IsValid(i));
+			out.push_back(view.Data<int64_t>()[view.SelAt(i)]);
+		}
+	}
+	return out;
+}
+
+// What a scan resolves names against, carried as user data.
+struct ScanRegistry {
+	std::string name;
+	const ColumnDataCollection *collection = nullptr;
+	int calls = 0;
+};
+
+// What the callback saw, latched for the test to assert on afterwards. A callback must not use REQUIRE: it would
+// throw through the callback boundary into the engine.
+struct ScanObserved {
+	std::string catalog;
+	std::string schema;
+	std::string table;
+	int calls = 0;
+};
+ScanObserved scan_observed;
+
+// Claims every name with range(2), recording what it saw.
+void ClaimRange(ReplacementScan::Input &input) {
+	scan_observed.calls++;
+	scan_observed.table = input.GetTableName();
+	scan_observed.catalog = input.GetCatalogName();
+	scan_observed.schema = input.GetSchemaName();
+
+	auto ctx = input.GetContext();
+	input.SetFunctionName("range");
+	input.AddArgument(Value::Create(ctx, int64_t {2}));
+	input.SetAlias("claimed");
+}
+
+// Claims only the registry's name, with its collection.
+void ClaimCollection(ReplacementScan::Input &input) {
+	auto &registry = input.GetUserData<ScanRegistry>();
+	if (input.GetTableName() != registry.name) {
+		return; // decline
+	}
+	registry.calls++;
+	input.SetCollection(*registry.collection, {"amount"});
+}
+
+void ClaimSubquery(ReplacementScan::Input &input) {
+	input.SetSubquery("SELECT 41 + 1 AS v");
+}
+
+void ThrowingScan(ReplacementScan::Input &) {
+	throw InvalidInputException("the replacement scan refused");
+}
+
+// A scan that claims nothing.
+void DeclineEverything(ReplacementScan::Input &input) {
+	input.GetUserData<ScanRegistry>().calls++;
+}
+
+// Builds a single-column BIGINT collection holding the given values.
+auto MakeScanCollection(Connection &conn, const std::vector<int64_t> &values) -> ColumnDataCollection {
+	std::vector<LogicalType> types;
+	types.push_back(conn.ParseType("BIGINT"));
+	ColumnDataCollection collection(conn, types);
+
+	DataChunk chunk(types);
+	auto vec = chunk.GetVector(0);
+	auto *data = vec.GetDataMutable<int64_t>();
+	for (size_t i = 0; i < values.size(); i++) {
+		data[i] = values[i];
+	}
+	vec.SetSize(values.size());
+	collection.Append(chunk);
+	return collection;
+}
+
+} // namespace
+
+TEST_CASE("Stable C++API: replacement scan claims a table function", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	scan_observed = ScanObserved();
+	auto scan = ReplacementScan::Create(conn);
+	scan.SetCallback(ClaimRange);
+	scan.Register();
+
+	REQUIRE(CollectScanBigints(conn.Execute("SELECT * FROM not_a_table")) == std::vector<int64_t> {0, 1});
+	REQUIRE(scan_observed.calls == 1);
+	REQUIRE(scan_observed.table == "not_a_table");
+	// The scan's alias names the binding, so a qualified reference resolves.
+	REQUIRE(CollectScanBigints(conn.Execute("SELECT claimed.range FROM not_a_table")) == std::vector<int64_t> {0, 1});
+	// A query-written alias wins over the scan's.
+	REQUIRE(CollectScanBigints(conn.Execute("SELECT t.range FROM not_a_table AS t")) == std::vector<int64_t> {0, 1});
+}
+
+TEST_CASE("Stable C++API: replacement scan reports the unresolved name", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto scan = ReplacementScan::Create(conn);
+	scan.SetCallback(ClaimRange);
+	scan.Register();
+
+	// An unqualified reference reports empty qualifiers.
+	scan_observed = ScanObserved();
+	conn.Execute("SELECT * FROM plain_name").Drain();
+	REQUIRE(scan_observed.calls == 1);
+	REQUIRE(scan_observed.table == "plain_name");
+	REQUIRE(scan_observed.catalog.empty());
+	REQUIRE(scan_observed.schema.empty());
+
+	// A fully qualified one reports all three parts.
+	scan_observed = ScanObserved();
+	conn.Execute("SELECT * FROM memory.main.qualified_name").Drain();
+	REQUIRE(scan_observed.calls == 1);
+	REQUIRE(scan_observed.catalog == "memory");
+	REQUIRE(scan_observed.schema == "main");
+	REQUIRE(scan_observed.table == "qualified_name");
+}
+
+TEST_CASE("Stable C++API: replacement scan reports the name and can decline", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto scan = ReplacementScan::Create(conn);
+	scan.SetCallback(DeclineEverything).SetUserData<ScanRegistry>();
+	scan.Register();
+
+	// Declining leaves the reference unresolved.
+	REQUIRE_THROWS_AS(conn.Execute("SELECT * FROM missing_table").Drain(), Exception);
+}
+
+TEST_CASE("Stable C++API: replacement scan claims a column data collection", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto collection = MakeScanCollection(conn, {10, 20});
+
+	ScanRegistry seed;
+	seed.name = "my_batch";
+	seed.collection = &collection;
+
+	auto scan = ReplacementScan::Create(conn);
+	scan.SetCallback(ClaimCollection).SetUserData<ScanRegistry>(seed);
+	scan.Register();
+
+	REQUIRE(CollectScanBigints(conn.Execute("SELECT amount FROM my_batch ORDER BY amount")) ==
+	        std::vector<int64_t> {10, 20});
+
+	// The motivating case: a client-side buffer as the source of an INSERT.
+	conn.Execute("CREATE TABLE sink (v BIGINT)").Drain();
+	conn.Execute("INSERT INTO sink SELECT * FROM my_batch").Drain();
+	REQUIRE(CollectScanBigints(conn.Execute("SELECT v FROM sink ORDER BY v")) == std::vector<int64_t> {10, 20});
+
+	// Names it does not recognise are declined.
+	REQUIRE_THROWS_AS(conn.Execute("SELECT * FROM some_other_name").Drain(), Exception);
+}
+
+TEST_CASE("Stable C++API: replacement scan claims a subquery", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto scan = ReplacementScan::Create(conn);
+	scan.SetCallback(ClaimSubquery);
+	scan.Register();
+
+	REQUIRE(CollectScanBigints(conn.Execute("SELECT v::BIGINT FROM anything")) == std::vector<int64_t> {42});
+}
+
+TEST_CASE("Stable C++API: replacement scan scoping", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto other = db.Connect();
+
+	auto scan = ReplacementScan::Create(conn);
+	scan.SetCallback(ClaimSubquery);
+	scan.Register();
+
+	// Visible on the registering connection only.
+	REQUIRE(CollectScanBigints(conn.Execute("SELECT v::BIGINT FROM anything")) == std::vector<int64_t> {42});
+	REQUIRE_THROWS_AS(other.Execute("SELECT * FROM anything").Drain(), Exception);
+
+	// A database-scoped scan reaches every connection.
+	auto db_scan = ReplacementScan::Create(db);
+	db_scan.SetCallback(ClaimSubquery);
+	db_scan.Register();
+	REQUIRE(CollectScanBigints(other.Execute("SELECT v::BIGINT FROM anything")) == std::vector<int64_t> {42});
+}
+
+TEST_CASE("Stable C++API: replacement scan errors", "[cpp_api]") {
+	SECTION("a throwing callback fails the query") {
+		Environment env;
+		auto db = env.Open(":memory:");
+		auto conn = db.Connect();
+
+		auto scan = ReplacementScan::Create(conn);
+		scan.SetCallback(ThrowingScan);
+		scan.Register();
+		REQUIRE_THROWS_MATCHES(conn.Execute("SELECT * FROM anything").Drain(), Exception,
+		                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+	SECTION("registration requires a callback, and happens once") {
+		Environment env;
+		auto db = env.Open(":memory:");
+		auto conn = db.Connect();
+
+		auto scan = ReplacementScan::Create(conn);
+		REQUIRE_THROWS_MATCHES(scan.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+		scan.SetCallback(ClaimSubquery);
+		scan.Register();
+		REQUIRE_THROWS_MATCHES(scan.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+}

--- a/tools/cpp/tests/test_cpp_api_table_function.cpp
+++ b/tools/cpp/tests/test_cpp_api_table_function.cpp
@@ -250,8 +250,10 @@ void ThrowingExec(TableFunction::ExecInput &) {
 // ---------------------------------------------------------------------------
 
 struct ProjGlobal {
-	bool done = false;
+	idx_t position = 0;
 };
+
+constexpr idx_t PROJ_ROWS = 3;
 
 std::vector<idx_t> proj_columns;
 
@@ -272,8 +274,10 @@ void ProjInitGlobal(TableFunction::InitGlobalInput &input) {
 
 void ProjExec(TableFunction::ExecInput &input) {
 	auto &global = input.GetGlobalState<ProjGlobal>();
-	const idx_t rows = global.done ? 0 : 3;
-	global.done = true;
+	idx_t rows = PROJ_ROWS - global.position;
+	if (rows > static_cast<idx_t>(BATCH_ROWS)) {
+		rows = static_cast<idx_t>(BATCH_ROWS);
+	}
 
 	auto chunk = input.GetOutputChunk();
 	for (idx_t i = 0; i < input.GetColumnCount(); i++) {
@@ -281,12 +285,13 @@ void ProjExec(TableFunction::ExecInput &input) {
 		auto vec = chunk.GetVector(i);
 		auto *out = vec.GetDataMutable<int64_t>();
 		for (idx_t row = 0; row < rows; row++) {
-			out[row] = static_cast<int64_t>(column * 100 + row);
+			out[row] = static_cast<int64_t>(column * 100 + global.position + row);
 		}
 		if (i == 0) {
 			vec.SetSize(rows);
 		}
 	}
+	global.position += rows;
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/cpp/tests/test_cpp_api_table_function.cpp
+++ b/tools/cpp/tests/test_cpp_api_table_function.cpp
@@ -3,6 +3,7 @@
 #include "duckdb_v2.h"
 #include "test_cpp_api.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <string>
 #include <vector>
@@ -243,7 +244,238 @@ void ThrowingExec(TableFunction::ExecInput &) {
 	throw InvalidInputException("exec refused");
 }
 
+// ---------------------------------------------------------------------------
+// cpp_proj(): three BIGINT columns x, y, z, three rows, cell = declared column * 100 + row. The exec callback
+// fills whatever the scan asks for through the column mapping.
+// ---------------------------------------------------------------------------
+
+struct ProjGlobal {
+	bool done = false;
+};
+
+std::vector<idx_t> proj_columns;
+
+void ProjBind(TableFunction::BindInput &input) {
+	auto bigint = input.GetContext().ParseType("BIGINT");
+	input.AddResultColumn("x", bigint);
+	input.AddResultColumn("y", bigint);
+	input.AddResultColumn("z", bigint);
+}
+
+void ProjInitGlobal(TableFunction::InitGlobalInput &input) {
+	proj_columns.clear();
+	for (idx_t i = 0; i < input.GetColumnCount(); i++) {
+		proj_columns.push_back(input.GetColumnIndex(i));
+	}
+	input.SetGlobalState<ProjGlobal>();
+}
+
+void ProjExec(TableFunction::ExecInput &input) {
+	auto &global = input.GetGlobalState<ProjGlobal>();
+	const idx_t rows = global.done ? 0 : 3;
+	global.done = true;
+
+	auto chunk = input.GetOutputChunk();
+	for (idx_t i = 0; i < input.GetColumnCount(); i++) {
+		auto column = input.GetColumnIndex(i);
+		auto vec = chunk.GetVector(i);
+		auto *out = vec.GetDataMutable<int64_t>();
+		for (idx_t row = 0; row < rows; row++) {
+			out[row] = static_cast<int64_t>(column * 100 + row);
+		}
+		if (i == 0) {
+			vec.SetSize(rows);
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cpp_claim(n): column i BIGINT with 0..n-1. Claims every "i < constant" predicate, then deliberately produces two
+// rows past the bound, which only reach the result if the engine really stopped applying the predicate.
+// ---------------------------------------------------------------------------
+
+struct ClaimBind {
+	int64_t count = 0;
+	int64_t bound = -1;
+};
+
+// Every predicate the pushdown callback saw, rendered.
+std::vector<std::string> claim_seen;
+
+std::string RenderExpression(const TableFunction::FilterPushdownInput &input, const Expression &expr) {
+	switch (expr.GetType()) {
+	case ExpressionType::VALUE_CONSTANT:
+		return expr.GetConstantValue().ToText();
+	case ExpressionType::BOUND_COLUMN_REF:
+		return "col" + std::to_string(input.GetColumnIndex(expr.GetColumnIndex()));
+	default:
+		break;
+	}
+	std::string children;
+	for (idx_t i = 0; i < expr.GetChildCount(); i++) {
+		if (i > 0) {
+			children += ", ";
+		}
+		children += RenderExpression(input, expr.GetChild(i));
+	}
+	switch (expr.GetType()) {
+	case ExpressionType::OPERATOR_CAST:
+		return std::string(expr.GetCastMode() == CastMode::TRY ? "try_cast(" : "cast(") + children +
+		       ")::" + expr.GetReturnType().ToText();
+	case ExpressionType::CONJUNCTION_AND:
+		return "and(" + children + ")";
+	case ExpressionType::CONJUNCTION_OR:
+		return "or(" + children + ")";
+	case ExpressionType::OPERATOR_IS_NULL:
+		return "is_null(" + children + ")";
+	case ExpressionType::INVALID:
+		return "invalid(" + children + ")";
+	case ExpressionType::BOUND_FUNCTION:
+		return expr.GetFunctionQualifiedName().Render() + "(" + children + ")";
+	default:
+		return expr.GetFunctionName() + "(" + children + ")";
+	}
+}
+
+void ClaimBind_(TableFunction::BindInput &input) {
+	const auto count = input.GetArgument(0).Get<int64_t>();
+	input.AddResultColumn("i", input.GetContext().ParseType("BIGINT"));
+	input.SetBindData<ClaimBind>(ClaimBind {count, -1});
+}
+
+void ClaimPushdown(TableFunction::FilterPushdownInput &input) {
+	auto &bind = input.GetBindData<ClaimBind>();
+	for (idx_t i = 0; i < input.GetFilterCount(); i++) {
+		auto filter = input.GetFilter(i);
+		claim_seen.push_back(RenderExpression(input, filter));
+		if (filter.GetType() != ExpressionType::COMPARE_LESSTHAN) {
+			continue;
+		}
+		auto left = filter.GetChild(0);
+		auto right = filter.GetChild(1);
+		if (left.GetType() != ExpressionType::BOUND_COLUMN_REF || right.GetType() != ExpressionType::VALUE_CONSTANT ||
+		    input.GetColumnIndex(left.GetColumnIndex()) != 0) {
+			continue;
+		}
+		bind.bound = right.GetConstantValue().Get<int64_t>();
+		input.Accept(i);
+	}
+}
+
+void ClaimExec(TableFunction::ExecInput &input) {
+	const auto &bind = input.GetBindData<ClaimBind>();
+	auto &global = input.GetGlobalState<RangeGlobal>();
+
+	auto chunk = input.GetOutputChunk();
+	auto vec = chunk.GetVector(0);
+	auto *out = vec.GetDataMutable<int64_t>();
+
+	auto limit = bind.bound < 0 ? bind.count : bind.bound + 2;
+	if (limit > bind.count) {
+		limit = bind.count;
+	}
+	auto produced = limit - global.position;
+	if (produced > BATCH_ROWS) {
+		produced = BATCH_ROWS;
+	}
+	if (produced < 0) {
+		produced = 0;
+	}
+	for (int64_t i = 0; i < produced; i++) {
+		out[i] = global.position + i;
+	}
+	global.position += produced;
+	vec.SetSize(static_cast<idx_t>(produced));
+}
+
+// Whether an accessor refused a node it does not apply to, checked inside the callback where the node lives.
+bool misuse_refused = false;
+
+void MisusePushdown(TableFunction::FilterPushdownInput &input) {
+	auto filter = input.GetFilter(0);
+	misuse_refused = false;
+	try {
+		filter.GetConstantValue();
+	} catch (const InvalidInputException &) {
+		misuse_refused = true;
+	}
+}
+
+void ThrowingPushdown(TableFunction::FilterPushdownInput &) {
+	throw InvalidInputException("pushdown refused");
+}
+
+void RegisterClaim(Connection &conn, const std::string &name, TableFunction::FilterPushdownCallback pushdown) {
+	auto function = TableFunction::Create(conn);
+	function.SetName(name);
+	function.GetSignature().AddParameter("n", conn.ParseType("BIGINT"));
+	function.SetBindCallback(ClaimBind_)
+	    .SetInitGlobalCallback(RangeInitGlobal)
+	    .SetExecCallback(ClaimExec)
+	    .SetFilterPushdownCallback(pushdown);
+	function.Register();
+}
+
 } // namespace
+
+TEST_CASE("Stable C++API: table function projection pushdown", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto function = TableFunction::Create(conn);
+	function.SetName("cpp_proj")
+	    .SetBindCallback(ProjBind)
+	    .SetInitGlobalCallback(ProjInitGlobal)
+	    .SetExecCallback(ProjExec)
+	    .SetProjectionPushdown(true);
+	function.Register();
+
+	REQUIRE(CollectBigints(conn.Execute("SELECT z FROM cpp_proj()")) == std::vector<int64_t> {200, 201, 202});
+	REQUIRE(proj_columns == std::vector<idx_t> {2});
+	REQUIRE(CollectBigints(conn.Execute("SELECT x + z FROM cpp_proj()")) == std::vector<int64_t> {200, 202, 204});
+	REQUIRE(proj_columns.size() == 2);
+}
+
+TEST_CASE("Stable C++API: table function filter pushdown", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	RegisterClaim(conn, "cpp_claim", ClaimPushdown);
+
+	claim_seen.clear();
+	REQUIRE(CollectBigints(conn.Execute("SELECT count(*) FROM cpp_claim(100) WHERE i < 10")) ==
+	        std::vector<int64_t> {12});
+	REQUIRE(claim_seen == std::vector<std::string> {"<(col0, 10)"});
+
+	// The optimizer may offer the unclaimed predicates more than once, so only membership is pinned here.
+	claim_seen.clear();
+	REQUIRE(CollectBigints(conn.Execute("SELECT count(*) FROM cpp_claim(100) WHERE i < 10 AND i % 2 = 0")) ==
+	        std::vector<int64_t> {6});
+	REQUIRE(std::count(claim_seen.begin(), claim_seen.end(), "<(col0, 10)") == 1);
+	REQUIRE(std::count(claim_seen.begin(), claim_seen.end(), "=(\"system\".main.\"%\"(col0, 2), 0)") >= 1);
+
+	claim_seen.clear();
+	REQUIRE(CollectBigints(conn.Execute(
+	            "SELECT count(*) FROM cpp_claim(100) WHERE (i = 1 OR i IS NULL) AND TRY_CAST(i AS VARCHAR) = '1'")) ==
+	        std::vector<int64_t> {1});
+	std::sort(claim_seen.begin(), claim_seen.end());
+	claim_seen.erase(std::unique(claim_seen.begin(), claim_seen.end()), claim_seen.end());
+	REQUIRE(claim_seen == std::vector<std::string> {"=(try_cast(col0)::VARCHAR, 1)", "or(=(col0, 1), is_null(col0))"});
+}
+
+TEST_CASE("Stable C++API: expression accessors refuse other node types and errors propagate", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	RegisterClaim(conn, "cpp_misuse", MisusePushdown);
+	RegisterClaim(conn, "cpp_throwing", ThrowingPushdown);
+
+	REQUIRE(CollectBigints(conn.Execute("SELECT count(*) FROM cpp_misuse(5) WHERE i < 3")) == std::vector<int64_t> {3});
+	REQUIRE(misuse_refused);
+	REQUIRE_THROWS_MATCHES(conn.Execute("SELECT count(*) FROM cpp_throwing(5) WHERE i < 3").Drain(), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+}
 
 TEST_CASE("Stable C++API: table function registers and scans", "[cpp_api]") {
 	Environment env;

--- a/tools/cpp/tests/test_cpp_api_table_function.cpp
+++ b/tools/cpp/tests/test_cpp_api_table_function.cpp
@@ -1,0 +1,388 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+
+#include <atomic>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: TableFunction. The extension-registration path is
+// covered by the static extension demo (test/api/capi/v2/static_extension);
+// these cover the connection path.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using namespace duckdb::cxx;
+
+// Collect a single BIGINT column, asserting every row valid.
+std::vector<int64_t> CollectBigints(QueryResult result) {
+	std::vector<int64_t> out;
+	while (auto chunk = result.FetchChunk()) {
+		auto view = chunk.GetVector(0).GetView();
+		for (idx_t i = 0; i < chunk.GetRowCount(); i++) {
+			REQUIRE(view.IsValid(i));
+			out.push_back(view.Data<int64_t>()[view.SelAt(i)]);
+		}
+	}
+	return out;
+}
+
+// Collect a single VARCHAR column, asserting every row valid.
+std::vector<std::string> CollectStrings(QueryResult result) {
+	std::vector<std::string> out;
+	while (auto chunk = result.FetchChunk()) {
+		auto view = chunk.GetVector(0).GetView();
+		for (idx_t i = 0; i < chunk.GetRowCount(); i++) {
+			REQUIRE(view.IsValid(i));
+			out.emplace_back(view.Data<varchar_t>()[view.SelAt(i)].view());
+		}
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// cpp_range(n): one BIGINT column "i" carrying 0..n-1, produced in batches.
+// ---------------------------------------------------------------------------
+
+struct RangeBind {
+	int64_t count = 0;
+};
+struct RangeGlobal {
+	int64_t position = 0;
+};
+
+void RangeBind_(TableFunction::BindInput &input) {
+	const auto count = input.GetArgument(0).Get<int64_t>();
+	input.AddResultColumn("i", input.GetContext().ParseType("BIGINT"));
+	input.SetCardinality(static_cast<idx_t>(count), true);
+	input.SetBindData<RangeBind>(RangeBind {count});
+}
+
+void RangeInitGlobal(TableFunction::InitGlobalInput &input) {
+	input.SetGlobalState<RangeGlobal>(RangeGlobal {0});
+}
+
+// How many rows a batch produces. The API exposes no output-chunk capacity, so the tests stay within the smallest
+// vector size the build can be configured with.
+constexpr int64_t BATCH_ROWS = 2;
+
+void RangeExec(TableFunction::ExecInput &input) {
+	const auto &bind = input.GetBindData<RangeBind>();
+	auto &global = input.GetGlobalState<RangeGlobal>();
+
+	auto chunk = input.GetOutputChunk();
+	auto vec = chunk.GetVector(0);
+	auto *out = vec.GetDataMutable<int64_t>();
+
+	auto produced = bind.count - global.position;
+	if (produced > BATCH_ROWS) {
+		produced = BATCH_ROWS;
+	}
+	if (produced < 0) {
+		produced = 0;
+	}
+	for (int64_t i = 0; i < produced; i++) {
+		out[i] = global.position + i;
+	}
+	global.position += produced;
+
+	// The first vector's size is the batch's row count; 0 ends the scan.
+	vec.SetSize(static_cast<idx_t>(produced));
+}
+
+// Registers cpp_range on the connection.
+void RegisterRange(Connection &conn, const std::string &name) {
+	auto function = TableFunction::Create(conn);
+	function.SetName(name);
+	function.GetSignature().AddParameter("n", conn.ParseType("BIGINT"));
+	function.SetBindCallback(RangeBind_).SetInitGlobalCallback(RangeInitGlobal).SetExecCallback(RangeExec);
+	function.Register();
+}
+
+// ---------------------------------------------------------------------------
+// cpp_pairs(n): two columns, to pin that the row count set on the first vector
+// reaches the others.
+// ---------------------------------------------------------------------------
+
+void PairsBind_(TableFunction::BindInput &input) {
+	const auto count = input.GetArgument(0).Get<int64_t>();
+	auto ctx = input.GetContext();
+	input.AddResultColumn("a", ctx.ParseType("INTEGER"));
+	input.AddResultColumn("b", ctx.ParseType("VARCHAR"));
+	input.SetBindData<RangeBind>(RangeBind {count});
+}
+
+void PairsExec(TableFunction::ExecInput &input) {
+	const auto &bind = input.GetBindData<RangeBind>();
+	auto &global = input.GetGlobalState<RangeGlobal>();
+
+	auto chunk = input.GetOutputChunk();
+	auto produced = bind.count - global.position;
+	if (produced > BATCH_ROWS) {
+		produced = BATCH_ROWS;
+	}
+	if (produced < 0) {
+		produced = 0;
+	}
+
+	auto a = chunk.GetVector(0);
+	auto b = chunk.GetVector(1);
+	auto *values = a.GetDataMutable<int32_t>();
+	for (int64_t i = 0; i < produced; i++) {
+		values[i] = static_cast<int32_t>(global.position + i);
+		// Longer than blob_t::INLINE_LENGTH, so the bytes land in the vector's arena: an assertion build compiles the
+		// engine with DUCKDB_DEBUG_NO_INLINE, whose string_t reads the pointer even for values the API would inline.
+		b.AssignString(static_cast<idx_t>(i), "row-payload-" + std::to_string(global.position + i));
+	}
+	global.position += produced;
+
+	// Only the first vector is sized; the engine propagates the count to "b".
+	a.SetSize(static_cast<idx_t>(produced));
+}
+
+// ---------------------------------------------------------------------------
+// cpp_args(a, b := 7, ...): reports the argument slots the bind callback sees.
+// ---------------------------------------------------------------------------
+
+struct ArgsBind {
+	std::vector<int64_t> values;
+};
+
+void ArgsBind_(TableFunction::BindInput &input) {
+	ArgsBind bind;
+	for (idx_t i = 0; i < input.GetArgCount(); i++) {
+		REQUIRE(input.GetArgType(i).GetTypeId() == LogicalTypeId::BIGINT);
+		bind.values.push_back(input.GetArgument(i).Get<int64_t>());
+	}
+	input.AddResultColumn("v", input.GetContext().ParseType("BIGINT"));
+	input.SetBindData<ArgsBind>(std::move(bind));
+}
+
+// Emits one row per argument slot, in slot order, a batch at a time.
+void ArgsExec(TableFunction::ExecInput &input) {
+	const auto &bind = input.GetBindData<ArgsBind>();
+	auto &global = input.GetGlobalState<RangeGlobal>();
+
+	auto chunk = input.GetOutputChunk();
+	auto vec = chunk.GetVector(0);
+	auto *out = vec.GetDataMutable<int64_t>();
+
+	idx_t produced = 0;
+	while (produced < BATCH_ROWS && global.position < static_cast<int64_t>(bind.values.size())) {
+		out[produced++] = bind.values[static_cast<size_t>(global.position++)];
+	}
+	vec.SetSize(produced);
+}
+
+// ---------------------------------------------------------------------------
+// State plumbing and the optional hooks.
+// ---------------------------------------------------------------------------
+
+struct Seed {
+	int64_t tag = 0;
+};
+struct StateGlobal {
+	int64_t remaining = 0;
+};
+struct StateLocal {
+	int64_t tag = 0;
+};
+
+std::atomic<int> init_global_runs {0};
+std::atomic<int> init_local_runs {0};
+std::atomic<int> cardinality_runs {0};
+
+void StateBind(TableFunction::BindInput &input) {
+	input.AddResultColumn("v", input.GetContext().ParseType("BIGINT"));
+	input.SetBindData<RangeBind>(RangeBind {3});
+}
+
+void StateInitGlobal(TableFunction::InitGlobalInput &input) {
+	init_global_runs++;
+	const auto &bind = input.GetBindData<RangeBind>();
+	input.SetGlobalState<StateGlobal>(StateGlobal {bind.count});
+	input.SetMaxThreads(1);
+}
+
+void StateInitLocal(TableFunction::InitLocalInput &input) {
+	init_local_runs++;
+	// The local state derives its tag from the user data, reached through this phase's input.
+	const auto &seed = input.GetUserData<Seed>();
+	// Touching the global state here is what a real scan does to claim work.
+	(void)input.GetGlobalState<StateGlobal>();
+	input.SetLocalState<StateLocal>(StateLocal {seed.tag});
+}
+
+void StateExec(TableFunction::ExecInput &input) {
+	auto &global = input.GetGlobalState<StateGlobal>();
+	const auto &local = input.GetLocalState<StateLocal>();
+
+	auto chunk = input.GetOutputChunk();
+	auto vec = chunk.GetVector(0);
+	auto *out = vec.GetDataMutable<int64_t>();
+
+	idx_t produced = 0;
+	if (global.remaining > 0) {
+		global.remaining--;
+		out[0] = local.tag;
+		produced = 1;
+	}
+	vec.SetSize(produced);
+}
+
+void StateCardinality(TableFunction::CardinalityInput &input) {
+	cardinality_runs++;
+	input.SetCardinality(static_cast<idx_t>(input.GetBindData<RangeBind>().count), true);
+}
+
+// A bind callback that throws: the exception must surface as the query's error.
+void ThrowingBind(TableFunction::BindInput &) {
+	throw InvalidInputException("bind refused");
+}
+
+// An exec callback that throws once the scan is under way.
+void ThrowingExec(TableFunction::ExecInput &) {
+	throw InvalidInputException("exec refused");
+}
+
+} // namespace
+
+TEST_CASE("Stable C++API: table function registers and scans", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	RegisterRange(conn, "cpp_range");
+
+	REQUIRE(CollectBigints(conn.Execute("SELECT * FROM cpp_range(4)")) == std::vector<int64_t> {0, 1, 2, 3});
+	REQUIRE(CollectBigints(conn.Execute("SELECT sum(i) FROM cpp_range(10)")) == std::vector<int64_t> {45});
+	// A scan producing nothing at all, and one spanning several batches.
+	REQUIRE(CollectBigints(conn.Execute("SELECT * FROM cpp_range(0)")).empty());
+	REQUIRE(CollectBigints(conn.Execute("SELECT count(*) FROM cpp_range(5000)")) == std::vector<int64_t> {5000});
+}
+
+TEST_CASE("Stable C++API: table function with several result columns", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto function = TableFunction::Create(conn);
+	function.SetName("cpp_pairs");
+	function.GetSignature().AddParameter("n", conn.ParseType("BIGINT"));
+	function.SetBindCallback(PairsBind_).SetInitGlobalCallback(RangeInitGlobal).SetExecCallback(PairsExec);
+	function.Register();
+
+	// Both columns carry all rows: the count set on "a" reached "b".
+	REQUIRE(CollectBigints(conn.Execute("SELECT count(b) FROM cpp_pairs(5)")) == std::vector<int64_t> {5});
+	REQUIRE(CollectBigints(conn.Execute("SELECT sum(a) FROM cpp_pairs(5)")) == std::vector<int64_t> {10});
+	REQUIRE(CollectStrings(conn.Execute("SELECT string_agg(b, ',' ORDER BY a) FROM cpp_pairs(3)")) ==
+	        std::vector<std::string> {"row-payload-0,row-payload-1,row-payload-2"});
+}
+
+TEST_CASE("Stable C++API: table function parameter defaults, named arguments and varargs", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	const auto bigint = conn.ParseType("BIGINT");
+
+	auto function = TableFunction::Create(conn);
+	function.SetName("cpp_args");
+	function.WithSignature([&](FunctionSignature &sig) {
+		sig.AddParameter("a", bigint);
+		sig.AddParameter("b", bigint, Value::Create(conn, int64_t {7}));
+		sig.SetVarArgs(bigint);
+	});
+	function.SetBindCallback(ArgsBind_).SetInitGlobalCallback(RangeInitGlobal).SetExecCallback(ArgsExec);
+	function.Register();
+
+	// Only the required parameter: the defaulted one is still present, carrying its default.
+	REQUIRE(CollectBigints(conn.Execute("SELECT * FROM cpp_args(1)")) == std::vector<int64_t> {1, 7});
+	// A defaulted parameter passed by name.
+	REQUIRE(CollectBigints(conn.Execute("SELECT * FROM cpp_args(1, b => 5)")) == std::vector<int64_t> {1, 5});
+	// The variadic tail follows the fixed slots, in call order.
+	REQUIRE(CollectBigints(conn.Execute("SELECT * FROM cpp_args(1, 30, 40)")) == std::vector<int64_t> {1, 7, 30, 40});
+}
+
+TEST_CASE("Stable C++API: table function user data, global and local state", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	init_global_runs = 0;
+	init_local_runs = 0;
+	cardinality_runs = 0;
+
+	auto function = TableFunction::Create(conn);
+	function.SetName("cpp_state").SetUserData<Seed>(Seed {42});
+	function.SetBindCallback(StateBind)
+	    .SetInitGlobalCallback(StateInitGlobal)
+	    .SetInitLocalCallback(StateInitLocal)
+	    .SetExecCallback(StateExec)
+	    .SetCardinalityCallback(StateCardinality);
+	function.Register();
+
+	// The bind data seeded three rows, each carrying the local state's tag, which came from the user data.
+	REQUIRE(CollectBigints(conn.Execute("SELECT * FROM cpp_state()")) == std::vector<int64_t> {42, 42, 42});
+	REQUIRE(init_global_runs >= 1);
+	REQUIRE(init_local_runs >= 1);
+	REQUIRE(cardinality_runs >= 1);
+}
+
+TEST_CASE("Stable C++API: table function callbacks report failure by throwing", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	auto bad_bind = TableFunction::Create(conn);
+	bad_bind.SetName("cpp_bad_bind").SetBindCallback(ThrowingBind).SetExecCallback(StateExec);
+	bad_bind.Register();
+
+	auto bad_exec = TableFunction::Create(conn);
+	bad_exec.SetName("cpp_bad_exec")
+	    .SetBindCallback(StateBind)
+	    .SetInitGlobalCallback(StateInitGlobal)
+	    .SetInitLocalCallback(StateInitLocal)
+	    .SetExecCallback(ThrowingExec);
+	bad_exec.Register();
+
+	REQUIRE_THROWS_MATCHES(conn.Execute("SELECT * FROM cpp_bad_bind()").Drain(), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	REQUIRE_THROWS_MATCHES(conn.Execute("SELECT * FROM cpp_bad_exec()").Drain(), Exception,
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+}
+
+TEST_CASE("Stable C++API: table function registration refusals", "[cpp_api]") {
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	const auto bigint = conn.ParseType("BIGINT");
+
+	// No name.
+	{
+		auto function = TableFunction::Create(conn);
+		function.SetBindCallback(StateBind).SetExecCallback(StateExec);
+		REQUIRE_THROWS_MATCHES(function.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+	// No bind callback: a table function has no other way to declare its columns.
+	{
+		auto function = TableFunction::Create(conn);
+		function.SetName("cpp_no_bind").SetExecCallback(StateExec);
+		REQUIRE_THROWS_MATCHES(function.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+	// No exec callback.
+	{
+		auto function = TableFunction::Create(conn);
+		function.SetName("cpp_no_exec").SetBindCallback(StateBind);
+		REQUIRE_THROWS_MATCHES(function.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+	// A return type on the signature: the columns come from bind instead.
+	{
+		auto function = TableFunction::Create(conn);
+		function.SetName("cpp_return_type").SetBindCallback(StateBind).SetExecCallback(StateExec);
+		function.GetSignature().SetReturnType(bigint);
+		REQUIRE_THROWS_MATCHES(function.Register(), Exception, HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	}
+}

--- a/tools/cpp/tests/test_cpp_api_table_function.cpp
+++ b/tools/cpp/tests/test_cpp_api_table_function.cpp
@@ -193,10 +193,10 @@ struct StateLocal {
 
 std::atomic<int> init_global_runs {0};
 std::atomic<int> init_local_runs {0};
-std::atomic<int> cardinality_runs {0};
 
 void StateBind(TableFunction::BindInput &input) {
 	input.AddResultColumn("v", input.GetContext().ParseType("BIGINT"));
+	input.SetCardinality(3, true);
 	input.SetBindData<RangeBind>(RangeBind {3});
 }
 
@@ -231,11 +231,6 @@ void StateExec(TableFunction::ExecInput &input) {
 		produced = 1;
 	}
 	vec.SetSize(produced);
-}
-
-void StateCardinality(TableFunction::CardinalityInput &input) {
-	cardinality_runs++;
-	input.SetCardinality(static_cast<idx_t>(input.GetBindData<RangeBind>().count), true);
 }
 
 // A bind callback that throws: the exception must surface as the query's error.
@@ -313,22 +308,19 @@ TEST_CASE("Stable C++API: table function user data, global and local state", "[c
 
 	init_global_runs = 0;
 	init_local_runs = 0;
-	cardinality_runs = 0;
 
 	auto function = TableFunction::Create(conn);
 	function.SetName("cpp_state").SetUserData<Seed>(Seed {42});
 	function.SetBindCallback(StateBind)
 	    .SetInitGlobalCallback(StateInitGlobal)
 	    .SetInitLocalCallback(StateInitLocal)
-	    .SetExecCallback(StateExec)
-	    .SetCardinalityCallback(StateCardinality);
+	    .SetExecCallback(StateExec);
 	function.Register();
 
 	// The bind data seeded three rows, each carrying the local state's tag, which came from the user data.
 	REQUIRE(CollectBigints(conn.Execute("SELECT * FROM cpp_state()")) == std::vector<int64_t> {42, 42, 42});
 	REQUIRE(init_global_runs >= 1);
 	REQUIRE(init_local_runs >= 1);
-	REQUIRE(cardinality_runs >= 1);
 }
 
 TEST_CASE("Stable C++API: table function callbacks report failure by throwing", "[cpp_api]") {

--- a/tools/cpp/tests/test_cpp_api_vector.cpp
+++ b/tools/cpp/tests/test_cpp_api_vector.cpp
@@ -252,6 +252,7 @@ TEST_CASE("Stable C++API: VectorView CONSTANT without flatten", "[cpp_api]") {
 }
 #endif
 
+#if (STANDARD_VECTOR_SIZE > 3)
 TEST_CASE("Stable C++API: VectorView DICTIONARY resolves validity through sel", "[cpp_api]") {
 	using namespace duckdb::cxx;
 
@@ -297,6 +298,7 @@ TEST_CASE("Stable C++API: VectorView DICTIONARY resolves validity through sel", 
 	// The view did not flatten the parent.
 	REQUIRE(vec.GetVectorType() == VectorType::DICTIONARY);
 }
+#endif
 
 #if (STANDARD_VECTOR_SIZE > 3)
 TEST_CASE("Stable C++API: MakeSequence and MakeConstant round-trip", "[cpp_api]") {


### PR DESCRIPTION
This PR is the third (and final?) part of the new C-API-V2 push that adds basically everything else from the prototype-fork.
- Part 1: https://github.com/duckdb/duckdb/pull/24702
- Part 2: https://github.com/duckdb/duckdb/pull/25184

Again, nothing is set in stone - there will for sure be more follow-up PRs, polishes, and features added that are currently blocked on core-work - but they will most likely not be as massive as the 3 PRs so far have been.

I'll add more detailed descriptions tomorrow, but below you'll find a short "table of content"/summary of the interfaces added/changed here. Note that all of these are of course also exposed in the "stable c++ API", `duckdb_cpp.hpp`

## Summary

### Table Functions

 User-defined table functions: bind / init global / init local / exec / progress phases, named parameters with defaults via function-signature, bind-time cardinality, projection pushdown, and expression claim-based **filter pushdown**. Filter pushdown has been a long requested feature, and we will continue to refine this API to make it more powerful as we hopefully rework expressions more soon.
 
### Copy Functions

 User-defined `COPY TO` and `COPY FROM` formats. TO side: bind, batch size, init, batch (input ownership transferred via `take_input`), flush, finalize. FROM side: bind, init global / init local, exec, progress. Option lists arrive single-valued (automatically packed into `TUPLE`s).

### Cast Functions
 User-defined casts keyed by (source, target) type, with an implicit-cast cost and a `CAST_MODE` telling `TRY_CAST` apart.

### Replacement Scans

Replacement scans registered on a connection, database or extension: the callback resolves an unknown table name to a function call, a collection or a subquery, optionally aliased.

### Expressions

Read-only inspection of bound expressions handed out by filter pushdown: one `EXPRESSION_TYPE` enum mirroring the engine's values for the node types a filter can contain, children, return type, and type-prefixed accessors for constants, column references, functions (name and owned qualified name) and cast mode.

### File System

 The engine's virtual file system from a connection or context: open options with `FILE_FLAG`s, read / write / read-at / write-at, seek, tell, size, sync.

### Catalog

`connection_describe_table` returning a table description: qualified name, read-only flag, and per-column name, type, default and generated markers.

### Arrow

Arrow C Data Interface bridges: an importer turning Arrow arrays into chunks, an exporter turning chunks into arrays, and `result_to_arrow_stream` to turn streaming query result into arrow streams.

### Prepared Statements

 Create, execute with parameters, destroy, and check/guarantee if a statement will actually be re-used or re-bound with `reuses_plan`.

### Identifiers

`identifier_render_quoted`, the engine's quoting rules for embedding a name in SQL.

### Qualified Names

Parse, create from parts, part access, render, equality, hash. Also adopted by `create_type_from_name`, which now takes a qualified name instead of an identifier.

### Custom Types 

Registering a named alias over a base type on a connection or extension. Will hopefully support custom type "signatures" w/ modifiers/parameters soon.

### Column Data Collections

`column_data_collection_clear` added to the existing module to make it more efficient to re-use CDCs - making it possible to implement e.g. an `Appender` in user-space (like the C++ API wrapper)