### PR TITLE
Fix OOB vector access in PIVOT map() constant folding

### DIFF
--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -319,6 +319,10 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 			value = Value::LIST(child_type, values);
 			return true;
 		} else if (function.FunctionName() == "map") {
+			if (function.GetArguments().size() != 2) {
+				return false;
+			}
+
 			Value keys;
 			if (!ConstructConstantFromExpression(function.GetArguments()[0].GetExpression(), keys)) {
 				return false;

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -179,6 +179,10 @@ static bool TryFoldConstantForBackwardsCompatibility(const ParsedExpression &exp
 			value = Value::LIST(child_type, values);
 			return true;
 		} else if (function.FunctionName() == "map") {
+			if (function.GetArguments().size() != 2) {
+				return false;
+			}
+
 			Value keys;
 			if (!TryFoldConstantForBackwardsCompatibility(function.GetArguments()[0].GetExpression(), keys)) {
 				return false;

--- a/test/sql/pivot/pivot_map_no_args.test
+++ b/test/sql/pivot/pivot_map_no_args.test
@@ -1,0 +1,55 @@
+# name: test/sql/pivot/pivot_map_no_args.test
+# description: Test PIVOT IN-list with a map() call whose argument count is not 2 (issue #25276, #25278, #25279)
+# group: [pivot]
+
+statement ok
+CREATE TABLE t(col VARCHAR);
+
+query I
+SELECT * FROM t PIVOT (count(*) FOR col IN (CAST(map() AS VARCHAR)));
+----
+0
+
+statement error
+SELECT * FROM t PIVOT (count(*) FOR col IN (CAST(map(['a']) AS VARCHAR)));
+----
+No function matches the given name and argument types 'map(VARCHAR[])'
+
+statement error
+SELECT * FROM t PIVOT (count(*) FOR col IN (CAST(map(['a'],[1],[2]) AS VARCHAR)));
+----
+No function matches the given name and argument types 'map(VARCHAR[], INTEGER[], INTEGER[])'
+
+query I
+SELECT CAST(map() AS VARCHAR);
+----
+{}
+
+# issue #25278: same bug via an aggregate PIVOT with a different cast target type
+statement error
+SELECT * FROM (SELECT 1 AS a, 'x' AS b) t PIVOT (sum(a) FOR b IN (CAST(map() AS INTEGER)));
+----
+Conversion Error: Unimplemented type for cast (MAP("NULL", "NULL") -> INTEGER)
+
+# issue #25279: same pattern in a second location - the legacy pre-v1.5.0 PIVOT
+# backwards-compat constant-folding path used when serializing PIVOT views.
+# Only reachable once the #25276 fix above lets parsing fall back instead of crashing.
+statement ok
+SET storage_compatibility_version='v1.4.0';
+
+statement ok
+CREATE TABLE t2(year INT, jan INT, feb INT);
+
+statement ok
+INSERT INTO t2 VALUES (2024, 100, 200);
+
+statement ok
+CREATE VIEW v AS PIVOT t2 ON year IN (CAST(map() AS MAP(INT,INT)));
+
+query III
+SELECT * FROM v;
+----
+100	200	0
+
+statement ok
+RESET storage_compatibility_version;

--- a/test/sql/pivot/pivot_map_no_args.test
+++ b/test/sql/pivot/pivot_map_no_args.test
@@ -34,8 +34,13 @@ Conversion Error: Unimplemented type for cast (MAP("NULL", "NULL") -> INTEGER)
 # issue #25279: same pattern in a second location - the legacy pre-v1.5.0 PIVOT
 # backwards-compat constant-folding path used when serializing PIVOT views.
 # Only reachable once the #25276 fix above lets parsing fall back instead of crashing.
+# debug_verify_serializer is forced on explicitly so this reproduces deterministically
+# across every test config, instead of only under verify_serializer.json.
 statement ok
 SET storage_compatibility_version='v1.4.0';
+
+statement ok
+SET debug_verify_serializer=true;
 
 statement ok
 CREATE TABLE t2(year INT, jan INT, feb INT);
@@ -43,13 +48,13 @@ CREATE TABLE t2(year INT, jan INT, feb INT);
 statement ok
 INSERT INTO t2 VALUES (2024, 100, 200);
 
-statement ok
+statement error
 CREATE VIEW v AS PIVOT t2 ON year IN (CAST(map() AS MAP(INT,INT)));
-
-query III
-SELECT * FROM v;
 ----
-100	200	0
+Serialization Error: Cannot serialize non-constant expression 'CAST("map"() AS MAP(INTEGER, INTEGER))' in pivot list when targeting database storage version 'v1.4.0'
 
 statement ok
 RESET storage_compatibility_version;
+
+statement ok
+RESET debug_verify_serializer;


### PR DESCRIPTION
## Summary
- `ConstructConstantFromExpression()` in `peg_transformer_factory.cpp` and `TryFoldConstantForBackwardsCompatibility()` in `pivotref.cpp` both have a `map` branch that indexes `GetArguments()[0]`/`[1]` without first checking there are 2 arguments.
- A zero-argument `map()` inside a PIVOT IN-list (`CAST(map() AS VARCHAR)`, or `CAST(map() AS MAP(INT,INT))` under `storage_compatibility_version='v1.4.0'`) triggers an OOB vector access and crashes the engine (`INTERNAL Error: Attempted to access index 0 within vector of size 0`).

- Both now return `false` when the argument count isn't exactly 2, falling back to normal expression binding / raw-expression storage instead of indexing blindly.

## Why 1 PR
- fixing #25279 in isolation isn't independently testable without also fixing #25276.

## Tests
- `test/sql/pivot/pivot_map_no_args.test` — added regression tests using the same repro cases from 25276, 25278, and 25279.

Fixes #25276, #25278, #25279.