### PR TITLE
fix crash casting a string to STRUCT with a VARIANT field

### DIFF
--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -36,6 +36,8 @@ string ShreddedVectorBuffer::ToString(const LogicalType &type, idx_t count) cons
 }
 
 void ShreddedVectorBuffer::SetVectorType(VectorType new_vector_type) {
+	// Callers must flatten first (see Vector::FlattenAndSetConstant); Vector::SetVectorType could do this
+	// automatically for all non-flat/constant buffers (dictionary, sequence, FSST, shredded) instead.
 	throw InternalException("ShreddedVectorBuffer::SetVectorType is not implemented and shouldn't be reached");
 }
 

--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -426,7 +426,7 @@ static bool StringToNestedTypeCast(Vector &source, Vector &result, idx_t count, 
 		auto &source_mask = ConstantVector::Validity(source);
 		auto &result_mask = FlatVector::ValidityMutable(result);
 		auto ret = T::StringToNestedTypeCastLoop(source_data, source_mask, result, result_mask, 1, parameters, nullptr);
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		result.FlattenAndSetConstant();
 		return ret;
 	}
 	default: {

--- a/test/sql/cast/string_to_struct_variant_cast.test
+++ b/test/sql/cast/string_to_struct_variant_cast.test
@@ -1,0 +1,70 @@
+# name: test/sql/cast/string_to_struct_variant_cast.test
+# description: cast strings into structs with VARIANT fields (issue #25298)
+# group: [cast]
+
+query I
+SELECT '{"v":"hello"}'::STRUCT(v VARIANT);
+----
+{'v': hello}
+
+query I
+SELECT '{"a":1, "b":{"c":2}}'::STRUCT(a VARIANT, b STRUCT(c VARIANT));
+----
+{'a': 1, 'b': {'c': 2}}
+
+statement ok
+CREATE TABLE variant_struct_tbl(col VARCHAR);
+
+statement ok
+INSERT INTO variant_struct_tbl (VALUES ('{"v":"hello"}'), ('{"v":"world"}'), (NULL));
+
+query I
+SELECT col::STRUCT(v VARIANT) FROM variant_struct_tbl;
+----
+{'v': hello}
+{'v': world}
+NULL
+
+query I
+SELECT '[{"v":1}, {"v":2}]'::STRUCT(v VARIANT)[];
+----
+[{'v': 1}, {'v': 2}]
+
+query I
+SELECT '[{v: 1}, {v: 2}]'::STRUCT(v VARIANT)[2];
+----
+[{'v': 1}, {'v': 2}]
+
+query I
+SELECT '{k={v: hello}}'::MAP(VARCHAR, STRUCT(v VARIANT));
+----
+{k={'v': hello}}
+
+query I
+SELECT '{v: NULL}'::STRUCT(v VARIANT);
+----
+{'v': NULL}
+
+query I
+SELECT TRY_CAST('{v: hello}' AS STRUCT(v VARIANT));
+----
+{'v': hello}
+
+query I
+SELECT TRY_CAST('not a struct' AS STRUCT(v VARIANT));
+----
+NULL
+
+statement error
+SELECT '{v: hello'::STRUCT(v VARIANT);
+----
+can't be cast to the destination type STRUCT(v VARIANT)
+
+# larger than a single vector, to exercise the batch (non-constant) cast path at scale
+statement ok
+CREATE TABLE big_variant_struct_tbl AS SELECT ('{v: ' || i || '}')::VARCHAR AS s FROM range(5000) t(i);
+
+query III
+SELECT count(*), min((s::STRUCT(v VARIANT)).v::INT), max((s::STRUCT(v VARIANT)).v::INT) FROM big_variant_struct_tbl;
+----
+5000	0	4999


### PR DESCRIPTION
## Summary
- `StringToNestedTypeCast()` in `string_cast.cpp` marks its constant struct result via a direct `SetVectorType()` call, which `VectorStructBuffer` propagates unconditionally to every child.
- A VARIANT struct field shredded during the cast doesn't support `SetVectorType()` and crashes (`INTERNAL Error: ShreddedVectorBuffer::SetVectorType is not implemented`), e.g. `'{"v":"hello"}'::STRUCT(v VARIANT)`.
- Now uses `Vector::FlattenAndSetConstant()` instead, which flattens non flat children first, matching the existing pattern in `execute_function.cpp`.

## Tests
- `test/sql/cast/string_to_struct_variant_cast.test` - struct/array/map casts with VARIANT fields, NULL handling, TRY_CAST, malformed input, and a 5000 row batch.

Fixes #25298 