### PR TITLE
json_serialize_sql serializes dynamic PIVOT instead of rejecting MultiStatement

### DIFF
--- a/extension/json/json_functions/json_serialize_sql.cpp
+++ b/extension/json/json_functions/json_serialize_sql.cpp
@@ -3,6 +3,8 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/parser/parsed_data/create_pragma_function_info.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/multi_statement.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 #include "json_deserializer.hpp"
 #include "json_functions.hpp"
 #include "json_serializer.hpp"
@@ -77,6 +79,20 @@ static unique_ptr<FunctionData> JsonSerializeBind(BindScalarFunctionInput &input
 	return make_uniq<JsonSerializeBindData>(skip_if_null, skip_if_empty, skip_if_default, format);
 }
 
+// Dynamic PIVOT is rewritten to a MultiStatement (CREATE TYPE + SELECT). Serialize the
+// SELECT children so json_serialize_sql can inspect a query that executes as SELECT.
+static void CollectSelectStatements(SQLStatement &statement, vector<reference<SelectStatement>> &selects) {
+	if (statement.type == StatementType::MULTI_STATEMENT) {
+		for (auto &child : statement.Cast<MultiStatement>().statements) {
+			CollectSelectStatements(*child, selects);
+		}
+		return;
+	}
+	if (statement.type == StatementType::SELECT_STATEMENT) {
+		selects.push_back(statement.Cast<SelectStatement>());
+	}
+}
+
 static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &local_state = JSONFunctionLocalState::ResetAndGet(state);
 	auto alc = local_state.json_allocator->GetYYAlc();
@@ -98,17 +114,19 @@ static void JsonSerializeFunction(DataChunk &args, ExpressionState &state, Vecto
 			auto statements_arr = yyjson_mut_arr(doc);
 
 			for (auto &statement : parser.statements) {
-				if (statement->type != StatementType::SELECT_STATEMENT) {
+				vector<reference<SelectStatement>> selects;
+				CollectSelectStatements(*statement, selects);
+				if (selects.empty()) {
 					throw NotImplementedException("Only SELECT statements can be serialized to json!");
 				}
-				auto &select = statement->Cast<SelectStatement>();
+				for (auto &select : selects) {
+					auto options = make_uniq<SerializationOptions>();
+					options->storage_compatibility = state.GetContext().db->config.options.storage_compatibility;
+					auto json = JsonSerializer::Serialize(select.get(), doc, info.skip_if_null, info.skip_if_empty,
+					                                      info.skip_if_default, *options);
 
-				auto options = make_uniq<SerializationOptions>();
-				options->storage_compatibility = state.GetContext().db->config.options.storage_compatibility;
-				auto json = JsonSerializer::Serialize(select, doc, info.skip_if_null, info.skip_if_empty,
-				                                      info.skip_if_default, *options);
-
-				yyjson_mut_arr_append(statements_arr, json);
+					yyjson_mut_arr_append(statements_arr, json);
+				}
 			}
 
 			yyjson_mut_obj_add_false(doc, result_obj, "error");

--- a/test/sql/json/test_json_serialize_sql.test
+++ b/test/sql/json/test_json_serialize_sql.test
@@ -172,6 +172,39 @@ SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM ms P
 ----
 1	10
 
+# Dynamic PIVOT is a MultiStatement (CREATE TYPE + SELECT). Serialize the SELECT (#25310).
+query I
+SELECT json_extract_string(json_serialize_sql($$
+PIVOT (VALUES ('a', 1), ('b', 2)) t(k, v)
+ON k
+USING sum(v)
+$$), '$.error');
+----
+false
+
+query I
+SELECT json_extract_string(json_serialize_sql($$
+PIVOT (VALUES ('a', 1), ('b', 2)) t(k, v)
+ON k
+USING sum(v)
+$$), '$.statements[0].node.from_table.type');
+----
+PIVOT
+
+query I
+SELECT json_deserialize_sql(json_serialize_sql($$
+PIVOT (VALUES ('a', 1), ('b', 2)) t(k, v)
+ON k
+USING sum(v)
+$$));
+----
+<REGEX>:.*PIVOT.*__pivot_enum_.*
+
+query I
+SELECT json_extract_string(json_serialize_sql('CREATE TABLE t(i INTEGER)'), '$.error_message');
+----
+Only SELECT statements can be serialized to json!
+
 statement error
 PRAGMA json_execute_serialized_sql(NULL);
 ----


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/25310

`json_serialize_sql` of a PIVOT with explicit `ON k IN (...)` works. The same query without the `IN` list executes, but serialize returned:

```
{"error":true,"error_type":"not implemented","error_message":"Only SELECT statements can be serialized to json!"}
```

Dynamic PIVOT is rewritten at parse time to a `MultiStatement`: a temporary `CREATE TYPE` enum plus the SELECT. `json_serialize_sql` rejected any non-SELECT top-level statement.

Walk `MultiStatement` children and serialize the SELECT nodes (skip the generated `CREATE TYPE`). `CREATE TABLE` and other non-SELECT statements still return the same error.

`./build/release/test/unittest test/sql/json/test_json_serialize_sql.test` — 59 assertions.