### PR TITLE
Fix INTERNAL bind error for UNNEST comma join with CAST filter

### DIFF
--- a/src/optimizer/unnest_rewriter.cpp
+++ b/src/optimizer/unnest_rewriter.cpp
@@ -454,8 +454,10 @@ bool UnnestRewriter::RewriteInlineCTEDedupCandidate(unique_ptr<LogicalOperator> 
 		return false;
 	}
 
-	// After replacing the CTE refs by the shared domain producer, expressions in the join subtree must read
-	// directly from the producer bindings. The dedup bindings are retargeted to their original delimiter columns.
+	// After replacing the CTE refs by the shared domain producer, expressions in the continuation must
+	// read directly from the producer bindings. Projection pullup can leave projections above a pushed
+	// filter/join; those still reference the domain CTE scan and must be rewritten with the join subtree.
+	// The dedup bindings are retargeted to their original delimiter columns.
 	ColumnBindingReplacer domain_ref_replacer;
 	for (idx_t binding_idx = 0; binding_idx < lhs_bindings.size(); binding_idx++) {
 		domain_ref_replacer.replacement_bindings.emplace_back(
@@ -464,7 +466,7 @@ bool UnnestRewriter::RewriteInlineCTEDedupCandidate(unique_ptr<LogicalOperator> 
 	for (idx_t binding_idx = 0; binding_idx < dedup_bindings.size(); binding_idx++) {
 		domain_ref_replacer.replacement_bindings.emplace_back(dedup_bindings[binding_idx], delim_columns[binding_idx]);
 	}
-	domain_ref_replacer.VisitOperator(topmost_op);
+	domain_ref_replacer.VisitOperator(*domain_cte.children[1]);
 	overwritten_tbl_idx = dedup_bindings[0].table_index;
 	// Inline CTE dedup inputs can contain repeated source columns, e.g. table-in-out UNNEST can project an input
 	// column and carry it again as a delimiter column. The RHS projection path only has the unique delimiter

--- a/test/issues/general/test_25167.test
+++ b/test/issues/general/test_25167.test
@@ -1,0 +1,43 @@
+# name: test/issues/general/test_25167.test
+# description: Issue 25167 - INTERNAL Error binding a base column through comma-join UNNEST with a failing CAST filter
+# group: [general]
+
+statement ok
+CREATE TABLE t0(c1 INTEGER[]);
+
+statement ok
+INSERT INTO t0 VALUES ([1]);
+
+statement ok
+SET debug_verify_column_bindings = true;
+
+# Projecting the outer list through lateral UNNEST must raise Conversion Error, not INTERNAL.
+statement error
+SELECT t0.c1 FROM t0, unnest(t0.c1) AS x(c0) WHERE CAST('x' AS BOOLEAN);
+----
+Conversion Error: Could not convert string 'x' to BOOL
+
+statement error
+SELECT t0.c1, x.c0 FROM t0, unnest(t0.c1) AS x(c0) WHERE CAST('x' AS BOOLEAN);
+----
+Conversion Error: Could not convert string 'x' to BOOL
+
+statement error
+SELECT 1 FROM t0, unnest(t0.c1) AS x(c0) WHERE CAST('x' AS BOOLEAN);
+----
+Conversion Error: Could not convert string 'x' to BOOL
+
+statement error
+SELECT t0.c1 FROM t0 WHERE CAST('x' AS BOOLEAN);
+----
+Conversion Error: Could not convert string 'x' to BOOL
+
+query I
+SELECT t0.c1 FROM t0, unnest(t0.c1) AS x(c0);
+----
+[1]
+
+query I
+SELECT t0.c1 FROM t0, unnest(t0.c1) AS x(c0) WHERE CAST('true' AS BOOLEAN);
+----
+[1]


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/25167

`SELECT t0.c1 FROM t0, unnest(t0.c1) AS x(c0) WHERE CAST('x' AS BOOLEAN)` raised `INTERNAL Error: Failed to bind column reference "" [20.0]` instead of the Conversion Error the same CAST produces without UNNEST or without the base column in the SELECT list.

Introduced when delim joins became CTEs by default (#23333). The unnest rewriter inlined the domain CTE but only remapped CTE refs in the join subtree (`topmost_op`). Projection pullup can leave a projection *above* a pushed constant filter, so that projection still pointed at the removed CTE scan.

Visit `domain_cte.children[1]` (the whole continuation) so those pulled-up projections are rewritten too.

Verified on the v2.0-cyanoptera binary:

- issue SQL → Conversion Error: Could not convert string 'x' to BOOL
- `test/issues/general/test_25167.test` — 9 assertions
- `test/optimizer/unnest*` — 181 assertions
- `test/sql/types/list/unnest*` — 599 assertions