### PR TITLE
Fix stale column_count in LateMaterialization for stacked filters

### DIFF
--- a/src/optimizer/late_materialization.cpp
+++ b/src/optimizer/late_materialization.cpp
@@ -67,6 +67,7 @@ vector<ColumnBinding> LateMaterialization::ConstructRHS(unique_ptr<LogicalOperat
 			if (filter.HasProjectionMap()) {
 				// if the filter has a projection map, we need to project the new column
 				filter.projection_map.emplace_back(column_count - 1);
+				column_count = filter.projection_map.size();
 			}
 			break;
 		}


### PR DESCRIPTION
When two `LogicalFilter` with a projection map are stacked directly above a `LogicalGet`, the outer filter appends `column_count - 1` (the number of columns the `LogicalGet` produces) even though its child now produces `projection_map.size()` columns.

Fixes: https://github.com/duckdb/duckdb/issues/25274