### PR TITLE
Fix bind for summarize for stdin

### DIFF
--- a/src/planner/binder/statement/bind_summarize.cpp
+++ b/src/planner/binder/statement/bind_summarize.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/case_expression.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
+#include "duckdb/parser/tableref/bound_ref_wrapper.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/tableref/showref.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
@@ -90,11 +91,13 @@ BoundStatement Binder::BindSummarize(ShowRef &ref) {
 		node->from_table = std::move(basetableref);
 		query = std::move(node);
 	}
-	auto query_copy = query->Copy();
 
-	// we bind the plan once in a child-node to figure out the column names and column types
+	// Bind the source once to discover its columns and retain the plan for the summarize query.
+	auto source_select = make_uniq<SelectStatement>();
+	source_select->node = std::move(query);
+	auto source_ref = make_uniq<SubqueryRef>(std::move(source_select), "summarize_tbl");
 	auto child_binder = Binder::CreateBinder(context, this);
-	auto plan = child_binder->Bind(*query);
+	auto plan = child_binder->Bind(*source_ref);
 	D_ASSERT(plan.types.size() == plan.names.size());
 	vector<unique_ptr<ParsedExpression>> name_children;
 	vector<unique_ptr<ParsedExpression>> type_children;
@@ -108,8 +111,6 @@ BoundStatement Binder::BindSummarize(ShowRef &ref) {
 	vector<unique_ptr<ParsedExpression>> q75_children;
 	vector<unique_ptr<ParsedExpression>> count_children;
 	vector<unique_ptr<ParsedExpression>> null_percentage_children;
-	auto select = make_uniq<SelectStatement>();
-	select->node = std::move(query_copy);
 	for (idx_t i = 0; i < plan.names.size(); i++) {
 		name_children.push_back(make_uniq<ConstantExpression>(Value(plan.names[i])));
 		type_children.push_back(make_uniq<ConstantExpression>(Value(plan.types[i].ToString())));
@@ -139,8 +140,6 @@ BoundStatement Binder::BindSummarize(ShowRef &ref) {
 		count_children.push_back(SummarizeCreateCountStar());
 		null_percentage_children.push_back(SummarizeCreateNullPercentage(plan.names[i]));
 	}
-	auto subquery_ref = make_uniq<SubqueryRef>(std::move(select), "summarize_tbl");
-	subquery_ref->column_name_alias = plan.names;
 
 	auto select_node = make_uniq<SelectNode>();
 	select_node->select_list.push_back(SummarizeWrapUnnest(name_children, "column_name"));
@@ -155,7 +154,8 @@ BoundStatement Binder::BindSummarize(ShowRef &ref) {
 	select_node->select_list.push_back(SummarizeWrapUnnest(q75_children, "q75"));
 	select_node->select_list.push_back(SummarizeWrapUnnest(count_children, "count"));
 	select_node->select_list.push_back(SummarizeWrapUnnest(null_percentage_children, "null_percentage"));
-	select_node->from_table = std::move(subquery_ref);
+	MoveCorrelatedExpressions(*child_binder);
+	select_node->from_table = make_uniq<BoundRefWrapper>(std::move(plan), std::move(child_binder));
 
 	auto select_stmt = make_uniq<SelectStatement>();
 	select_stmt->node = std::move(select_node);

--- a/test/sql/show_select/summarize_subquery.test
+++ b/test/sql/show_select/summarize_subquery.test
@@ -13,3 +13,15 @@ query II
 SELECT column_name, min FROM (SUMMARIZE tbl);
 ----
 a	42
+
+# correlated summarize subquery
+query IIII
+SELECT i, column_name, min, max
+FROM range(2) t(i),
+LATERAL (
+	SUMMARIZE SELECT i + j AS x FROM range(2) u(j)
+)
+ORDER BY i;
+----
+0	x	0	1
+1	x	1	2

--- a/tools/shell/tests/test_read_from_stdin.py
+++ b/tools/shell/tests/test_read_from_stdin.py
@@ -89,6 +89,26 @@ class TestReadFromStdin(object):
         result.check_stdout("column0,column1,column2")
         result.check_stdout('0,0, test')
 
+    @pytest.mark.parametrize("reader,expected", [
+        ("read_csv('/dev/stdin', columns = {'time': 'DOUBLE'})", '2,1.0,2.0'),
+        ("read_csv_auto('/dev/stdin', header = false)", '2,1,2'),
+    ])
+    def test_summarize_stdin_csv(self, shell, tmp_path, reader, expected):
+        input_file = tmp_path / 'summarize.csv'
+        input_file.write_text('1\n2\n')
+        test = (
+            ShellTest(shell)
+            .input_file(input_file)
+            .statement(f"SELECT count, min, max FROM (SUMMARIZE (FROM {reader}))")
+            .add_argument(
+                '-csv',
+                ':memory:'
+            )
+        )
+        result = test.run()
+        result.check_stdout('count,min,max')
+        result.check_stdout(expected)
+
     def test_split_part_csv(self, shell):
         test = (
             ShellTest(shell)


### PR DESCRIPTION
Fix https://github.com/duckdblabs/duckdb-internal/issues/7725

`SUMMARIZE` was binding the input twice, which breaks for inputs such as `/dev/stdin`. During the first bind, csv schema detection read from the stdin, and then the second bind encountered an exhausted stream. 
Now we reuse the initially bound plan instead. 