### PR TITLE
Fix compiler warnings (variable unused or method)

### DIFF
--- a/extension/core_functions/scalar/date/date_part.cpp
+++ b/extension/core_functions/scalar/date/date_part.cpp
@@ -2047,6 +2047,7 @@ static scalar_function_t DatePartUnaryCallback(DatePartSpecifier part_code, Logi
 	case DatePartSpecifier::INVALID:
 		throw NotImplementedException("Specifier type not implemented for DATEPART");
 	}
+	throw InternalException("Unrecognized DatePartSpecifier in DatePartUnaryCallback");
 }
 
 template <typename OP>
@@ -2126,6 +2127,7 @@ static function_statistics_t DatePartUnaryStatistics(DatePartSpecifier part_code
 	case DatePartSpecifier::INVALID:
 		throw NotImplementedException("Specifier type not implemented for DATEPART");
 	}
+	throw InternalException("Unrecognized DatePartSpecifier in DatePartUnaryStatistics");
 }
 
 unique_ptr<FunctionData> DatePartBind(BindScalarFunctionInput &input) {

--- a/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -512,11 +512,9 @@ unique_ptr<FunctionData> ListAggregatesBind(BindScalarFunctionInput &input) {
 }
 
 unique_ptr<FunctionData> ListAggregateBind(BindScalarFunctionInput &input) {
-	auto &bound_function = input.GetBoundFunction();
-	auto &arguments = input.GetArguments();
 	// the list column and the name of the aggregate function
-	D_ASSERT(bound_function.GetArguments().size() >= 2);
-	D_ASSERT(arguments.size() >= 2);
+	D_ASSERT(input.GetBoundFunction().GetArguments().size() >= 2);
+	D_ASSERT(input.GetArguments().size() >= 2);
 
 	return ListAggregatesBind<true>(input);
 }

--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1062,14 +1062,17 @@ struct DecimalRoundNegativePrecisionOperator {
 		T divide_power_of_ten =
 		    UnsafeNumericCast<T>(POWERS_OF_TEN_CLASS::POWERS_OF_TEN[-info.target_scale + source_scale]);
 		T multiply_power_of_ten = UnsafeNumericCast<T>(POWERS_OF_TEN_CLASS::POWERS_OF_TEN[-info.target_scale]);
+		const bool check_overflow = info.check_overflow;
 
 		UnaryExecutor::Execute<T, T>(input.data[0], result, [&](T input) {
 			auto rounded =
 			    UnsafeNumericCast<T>(RoundDivide<T, ROUND_POLICY>(input, divide_power_of_ten) * multiply_power_of_ten);
-			if constexpr (std::is_same_v<T, hugeint_t>) {
-				if (info.check_overflow && (rounded <= -Hugeint::POWERS_OF_TEN[Decimal::MAX_WIDTH_DECIMAL] ||
-				                            rounded >= Hugeint::POWERS_OF_TEN[Decimal::MAX_WIDTH_DECIMAL])) {
-					throw OutOfRangeException("Overflow in %s of DECIMAL(38)", ROUND_POLICY::Name);
+			if (check_overflow) {
+				if constexpr (std::is_same_v<T, hugeint_t>) {
+					if (rounded <= -Hugeint::POWERS_OF_TEN[Decimal::MAX_WIDTH_DECIMAL] ||
+					    rounded >= Hugeint::POWERS_OF_TEN[Decimal::MAX_WIDTH_DECIMAL]) {
+						throw OutOfRangeException("Overflow in %s of DECIMAL(38)", ROUND_POLICY::Name);
+					}
 				}
 			}
 			return rounded;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1275,13 +1275,19 @@ optional_ptr<CatalogEntry> Catalog::GetEntry(CatalogEntryRetriever &retriever, c
                                              const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found) {
 	// Instance lookup: search within this catalog only (do not resolve the catalog by name)
 	EntryLookupInfo qualified(lookup_info, QualifiedName(GetName(), schema_name, lookup_info.GetEntryIdentifier()));
-	auto result = TryLookupEntry(retriever, qualified, if_not_found);
+	return GetEntryInCatalog(retriever, qualified, if_not_found);
+}
+
+optional_ptr<CatalogEntry> Catalog::GetEntryInCatalog(CatalogEntryRetriever &retriever,
+                                                      const EntryLookupInfo &lookup_info,
+                                                      OnEntryNotFound if_not_found) {
+	auto result = TryLookupEntry(retriever, lookup_info, if_not_found);
 
 	// Try autoloading extension to resolve lookup
 	if (!result.Found()) {
 		if (AutoLoadExtensionByCatalogEntry(*retriever.GetContext().db, lookup_info.GetCatalogType(),
 		                                    lookup_info.GetEntryIdentifier())) {
-			result = TryLookupEntry(retriever, qualified, if_not_found);
+			result = TryLookupEntry(retriever, lookup_info, if_not_found);
 		}
 	}
 
@@ -1295,11 +1301,17 @@ optional_ptr<CatalogEntry> Catalog::GetEntry(CatalogEntryRetriever &retriever, c
 optional_ptr<CatalogEntry> Catalog::GetEntry(ClientContext &context, const Identifier &schema_name,
                                              const EntryLookupInfo &lookup_info, OnEntryNotFound if_not_found) {
 	CatalogEntryRetriever retriever(context);
-	return GetEntry(retriever, schema_name, lookup_info, if_not_found);
+	return GetEntryInCatalog(
+	    retriever,
+	    EntryLookupInfo(lookup_info, QualifiedName(GetName(), schema_name, lookup_info.GetEntryIdentifier())),
+	    if_not_found);
 }
 
 CatalogEntry &Catalog::GetEntry(ClientContext &context, const Identifier &schema, const EntryLookupInfo &lookup_info) {
-	return *GetEntry(context, schema, lookup_info, OnEntryNotFound::THROW_EXCEPTION);
+	CatalogEntryRetriever retriever(context);
+	return *GetEntryInCatalog(
+	    retriever, EntryLookupInfo(lookup_info, QualifiedName(GetName(), schema, lookup_info.GetEntryIdentifier())),
+	    OnEntryNotFound::THROW_EXCEPTION);
 }
 
 optional_ptr<CatalogEntry> Catalog::GetEntry(CatalogEntryRetriever &retriever, const Identifier &catalog,
@@ -1314,12 +1326,16 @@ optional_ptr<CatalogEntry> Catalog::GetEntry(ClientContext &context, const Ident
                                              const Identifier &schema, const EntryLookupInfo &lookup_info,
                                              OnEntryNotFound if_not_found) {
 	CatalogEntryRetriever retriever(context);
-	return GetEntry(retriever, catalog, schema, lookup_info, if_not_found);
+	return GetEntry(retriever,
+	                EntryLookupInfo(lookup_info, QualifiedName(catalog, schema, lookup_info.GetEntryIdentifier())),
+	                if_not_found);
 }
 
 CatalogEntry &Catalog::GetEntry(ClientContext &context, const Identifier &catalog, const Identifier &schema,
                                 const EntryLookupInfo &lookup_info) {
-	return *GetEntry(context, catalog, schema, lookup_info, OnEntryNotFound::THROW_EXCEPTION);
+	return *GetEntry(context,
+	                 EntryLookupInfo(lookup_info, QualifiedName(catalog, schema, lookup_info.GetEntryIdentifier())),
+	                 OnEntryNotFound::THROW_EXCEPTION);
 }
 
 optional_ptr<SchemaCatalogEntry> Catalog::GetSchema(CatalogEntryRetriever &retriever,

--- a/src/common/serializer/async_task_queue.cpp
+++ b/src/common/serializer/async_task_queue.cpp
@@ -92,10 +92,12 @@ AsyncTaskQueue::AsyncTaskQueue(ClientContext &client_context_p, idx_t max_active
 
 AsyncTaskQueue::~AsyncTaskQueue() {
 	lock_guard<mutex> guard(lock);
+#ifdef D_ASSERT_IS_ENABLED
 	auto drained = pending_requests.empty() && pending_bytes == 0 && in_flight_bytes == 0 && active_tasks == 0 &&
 	               pending_tasks == 0;
 	D_ASSERT(closed || drained);
 	D_ASSERT(!closed || drained);
+#endif
 }
 
 bool AsyncTaskQueue::IsAsync() const {
@@ -273,8 +275,12 @@ void AsyncTaskQueue::WorkOnPendingTask() {
 		TaskScheduler::YieldThread();
 		return;
 	}
+#ifdef D_ASSERT_IS_ENABLED
 	auto result = task->Execute(TaskExecutionMode::PROCESS_ALL);
 	D_ASSERT(result != TaskExecutionResult::TASK_BLOCKED);
+#else
+	task->Execute(TaskExecutionMode::PROCESS_ALL);
+#endif
 	task.reset();
 }
 
@@ -383,9 +389,11 @@ ManagedAsyncTaskQueue::ManagedAsyncTaskQueue(ClientContext &client_context_p, id
 
 ManagedAsyncTaskQueue::~ManagedAsyncTaskQueue() {
 	lock_guard<mutex> guard(lock);
+#ifdef D_ASSERT_IS_ENABLED
 	auto drained = pending_requests.empty() && pending_bytes == 0 && submitted_bytes == 0 && submitted_requests == 0;
 	D_ASSERT(closed || drained);
 	D_ASSERT(!closed || drained);
+#endif
 }
 
 bool ManagedAsyncTaskQueue::IsAsync() const {

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -102,10 +102,12 @@ AsyncWriteQueue::AsyncWriteQueue(ClientContext &client_context_p, AsyncWriteTarg
 
 AsyncWriteQueue::~AsyncWriteQueue() {
 	lock_guard<mutex> guard(lock);
+#ifdef D_ASSERT_IS_ENABLED
 	auto drained = pending_requests.empty() && pending_bytes == 0 && in_flight_bytes == 0 && active_tasks == 0 &&
 	               pending_tasks == 0 && scheduled_pending_bytes == 0 && pending_task_bytes.empty();
 	D_ASSERT(closed || drained);
 	D_ASSERT(!closed || drained);
+#endif
 }
 
 bool AsyncWriteQueue::IsAsync() const {
@@ -393,8 +395,12 @@ void AsyncWriteQueue::WorkOnPendingTask() {
 		TaskScheduler::YieldThread();
 		return;
 	}
+#ifdef D_ASSERT_IS_ENABLED
 	auto result = task->Execute(TaskExecutionMode::PROCESS_ALL);
 	D_ASSERT(result != TaskExecutionResult::TASK_BLOCKED);
+#else
+	task->Execute(TaskExecutionMode::PROCESS_ALL);
+#endif
 	task.reset();
 }
 
@@ -531,10 +537,12 @@ ManagedAsyncWriteQueue::ManagedAsyncWriteQueue(ClientContext &client_context_p, 
 
 ManagedAsyncWriteQueue::~ManagedAsyncWriteQueue() {
 	lock_guard<mutex> guard(lock);
+#ifdef D_ASSERT_IS_ENABLED
 	auto drained = pending_writes.empty() && pending_bytes == 0 && external_pending_bytes == 0 &&
 	               submitted_bytes == 0 && submitted_requests == 0;
 	D_ASSERT(closed || drained);
 	D_ASSERT(!closed || drained);
+#endif
 }
 
 bool ManagedAsyncWriteQueue::IsAsync() const {
@@ -1059,10 +1067,12 @@ ManagedAsyncWriteStreamQueue::ManagedAsyncWriteStreamQueue(ClientContext &client
 
 ManagedAsyncWriteStreamQueue::~ManagedAsyncWriteStreamQueue() {
 	annotated_lock_guard<annotated_mutex> guard(lock);
+#ifdef D_ASSERT_IS_ENABLED
 	auto drained = batch_depth == 0 && pending_writes.empty() && pending_bytes == 0 && submitted_bytes == 0 &&
 	               submitted_requests == 0;
 	D_ASSERT(closed || drained);
 	D_ASSERT(!closed || drained);
+#endif
 }
 
 bool ManagedAsyncWriteStreamQueue::IsAsync() const {

--- a/src/common/sort/hashed_sort.cpp
+++ b/src/common/sort/hashed_sort.cpp
@@ -511,9 +511,11 @@ static void BuildDirectColumnData(ClientContext &client, const vector<LogicalTyp
 	}
 }
 
+#ifdef D_ASSERT_IS_ENABLED
 static idx_t ExpectedChunkCount(idx_t count) {
 	return (count + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE;
 }
+#endif
 
 static void PackDirectColumnData(HashedSortGroup &hash_group) {
 	lock_guard<mutex> direct_guard(hash_group.scan_lock);

--- a/src/execution/operator/join/physical_iejoin.cpp
+++ b/src/execution/operator/join/physical_iejoin.cpp
@@ -1417,8 +1417,7 @@ void IEJoinLocalSourceState::SplitPayloads(DataChunk &chunk) {
 
 const SelectionVector *IEJoinLocalSourceState::ApplyArbitraryPredicate(DataChunk &chunk) {
 	//	Apply any arbitrary predicate
-	auto &op = gsource.op;
-	D_ASSERT(op.predicate);
+	D_ASSERT(gsource.op.predicate);
 
 	const auto result_count = pred_executor.SelectExpression(chunk, pred_matches);
 	chunk.Slice(pred_matches, result_count);

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -1547,8 +1547,12 @@ bool CopyFileLifecycleExecutor::WorkOnTask(bool throw_error) {
 	if (!executor.GetTask(task)) {
 		return false;
 	}
+#ifdef D_ASSERT_IS_ENABLED
 	const auto result = task->Execute(TaskExecutionMode::PROCESS_ALL);
 	D_ASSERT(result != TaskExecutionResult::TASK_BLOCKED);
+#else
+	task->Execute(TaskExecutionMode::PROCESS_ALL);
+#endif
 	task.reset();
 	if (throw_error) {
 		ThrowError();
@@ -1586,14 +1590,18 @@ void CopyFileLifecycleExecutor::ThrowError() {
 // Copy File State Helpers
 //===--------------------------------------------------------------------===//
 bool CopyDirectoryManager::EnsureDirectory(FileSystem &fs, const string &dir_path) {
+#ifdef D_ASSERT_IS_ENABLED
 	bool created_entry = false;
+#endif
 	{
 		std::unique_lock<mutex> guard(lock);
 		while (true) {
 			auto entry = directories.find(dir_path);
 			if (entry == directories.end()) {
 				directories.emplace(dir_path, DirectoryEntry());
+#ifdef D_ASSERT_IS_ENABLED
 				created_entry = true;
+#endif
 				break;
 			}
 
@@ -1619,7 +1627,9 @@ bool CopyDirectoryManager::EnsureDirectory(FileSystem &fs, const string &dir_pat
 		lock_guard<mutex> guard(lock);
 		auto entry = directories.find(dir_path);
 		D_ASSERT(entry != directories.end());
+#ifdef D_ASSERT_IS_ENABLED
 		D_ASSERT(created_entry);
+#endif
 		entry->second.state = error ? CopyDirectoryState::FAILED : CopyDirectoryState::COMPLETE;
 		entry->second.error = error;
 		entry->second.created = created;
@@ -2001,9 +2011,13 @@ optional<PartitionedCopyTask> PartitionedCopyHashGroup::TryNextBatchTask() {
 	task.end_idx = batch_row_idx;
 
 	// Update partition/batch counters
+#ifdef D_ASSERT_IS_ENABLED
 	const auto batch_idx =
 	    batch_state.AddCollectionSlot(partitioned_copy.GetPartitionCollectionSchema(), task.end_idx - task.begin_idx);
 	D_ASSERT(batch_idx == task.batch_idx);
+#else
+	batch_state.AddCollectionSlot(partitioned_copy.GetPartitionCollectionSchema(), task.end_idx - task.begin_idx);
+#endif
 
 	return task;
 }

--- a/src/execution/physical_plan/plan_recursive_cte.cpp
+++ b/src/execution/physical_plan/plan_recursive_cte.cpp
@@ -119,8 +119,12 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
 			unique_ptr<Expression> current =
 			    make_uniq<BoundReferenceExpression>(payload_types[i], payload_types.size() + i);
 			const auto normalize_previous = ExpressionBinder::PushCollation(context, previous, payload_types[i]);
+#ifdef D_ASSERT_IS_ENABLED
 			const auto normalize_current = ExpressionBinder::PushCollation(context, current, payload_types[i]);
 			D_ASSERT(normalize_previous == normalize_current);
+#else
+			ExpressionBinder::PushCollation(context, current, payload_types[i]);
+#endif
 			if (normalize_previous) {
 				payload_comparisons.push_back(BoundComparisonExpression::Create(
 				    ExpressionType::COMPARE_DISTINCT_FROM, std::move(previous), std::move(current)));

--- a/src/function/scalar/list/list_extract.cpp
+++ b/src/function/scalar/list/list_extract.cpp
@@ -124,9 +124,8 @@ static void ListExtractFunction(DataChunk &args, ExpressionState &state, Vector 
 
 static unique_ptr<FunctionData> ListExtractBind(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
-	auto &bound_function = input.GetBoundFunction();
 	auto &arguments = input.GetArguments();
-	D_ASSERT(bound_function.GetArguments().size() == 2);
+	D_ASSERT(input.GetBoundFunction().GetArguments().size() == 2);
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 	return nullptr;
 }

--- a/src/function/variant/variant_shredding.cpp
+++ b/src/function/variant/variant_shredding.cpp
@@ -43,6 +43,7 @@ static void WriteShreddedDecimal(UnifiedVariantVectorData &variant, Vector &resu
 	}
 }
 
+#ifdef D_ASSERT_IS_ENABLED
 static bool IsVariantStringType(VariantLogicalType type_id) {
 	switch (type_id) {
 	case VariantLogicalType::GEOMETRY:
@@ -55,6 +56,7 @@ static bool IsVariantStringType(VariantLogicalType type_id) {
 		return false;
 	}
 }
+#endif
 
 static void WriteShreddedString(UnifiedVariantVectorData &variant, Vector &result, const SelectionVector &sel,
                                 const SelectionVector &value_index_sel, const SelectionVector &result_sel,

--- a/src/include/duckdb/catalog/catalog.hpp
+++ b/src/include/duckdb/catalog/catalog.hpp
@@ -511,6 +511,9 @@ public:
 	                OnEntryNotFound if_not_found);
 
 private:
+	//! Look up an entry within this catalog and handle autoloading and errors
+	optional_ptr<CatalogEntry> GetEntryInCatalog(CatalogEntryRetriever &retriever, const EntryLookupInfo &lookup_info,
+	                                             OnEntryNotFound if_not_found);
 	//! Lookup an entry in the schema (taken from the lookup_info), returning the entry and schema if they exist
 	virtual CatalogEntryLookup TryLookupEntryInternal(CatalogTransaction transaction,
 	                                                  const EntryLookupInfo &lookup_info);

--- a/src/optimizer/common_subplan_optimizer.cpp
+++ b/src/optimizer/common_subplan_optimizer.cpp
@@ -1017,8 +1017,12 @@ public:
 				D_ASSERT(subplan.canonical_bindings.size() == new_bindings.size());
 				for (idx_t i = 0; i < old_bindings[subplan_idx].size(); i++) {
 					replacer.replacement_bindings.emplace_back(old_bindings[subplan_idx][i], new_bindings[i]);
+#ifdef D_ASSERT_IS_ENABLED
 					const auto inserted = generated_binding_map.emplace(new_bindings[i], subplan.canonical_bindings[i]);
 					D_ASSERT(inserted.second);
+#else
+					generated_binding_map.emplace(new_bindings[i], subplan.canonical_bindings[i]);
+#endif
 				}
 			}
 

--- a/src/optimizer/join_order/join_order_operator.cpp
+++ b/src/optimizer/join_order/join_order_operator.cpp
@@ -268,10 +268,12 @@ void JoinOrderConflictDetector::Build(vector<unique_ptr<JoinOrderOperator>> &ope
 		                             (op->type != JoinOrderOperatorType::INNER || !op->conflict_rules.empty());
 		SimplifyConflictRules(*op, set_manager);
 		D_ASSERT(ContainedInUnion(op->total_set, op->left_relations, op->right_relations));
+#ifdef D_ASSERT_IS_ENABLED
 		for (auto &rule : op->conflict_rules) {
 			D_ASSERT(ContainedInUnion(rule.trigger, op->left_relations, op->right_relations));
 			D_ASSERT(ContainedInUnion(rule.requirement, op->left_relations, op->right_relations));
 		}
+#endif
 		if (op->type != JoinOrderOperatorType::CROSS_PRODUCT) {
 			D_ASSERT(!op->left_total_set.get().Empty());
 			D_ASSERT(!op->right_total_set.get().Empty());

--- a/src/optimizer/partial_aggregate_pushdown.cpp
+++ b/src/optimizer/partial_aggregate_pushdown.cpp
@@ -804,8 +804,12 @@ static unique_ptr<LogicalAggregate> DECreateUpperAggregate(Optimizer &optimizer,
 	for (auto &group : aggr.groups) {
 		auto &ref = group->Cast<BoundColumnRefExpression>();
 		idx_t gs;
+#ifdef D_ASSERT_IS_ENABLED
 		auto has_side = GetExpressionSide(*group, side_bindings, gs);
 		D_ASSERT(has_side);
+#else
+		GetExpressionSide(*group, side_bindings, gs);
+#endif
 		auto binding = sides[gs].group_map.at(ref.Binding());
 		upper_aggr->groups.push_back(make_uniq<BoundColumnRefExpression>(ref.GetReturnType(), binding));
 	}

--- a/src/parallel/pipeline_broadcast_exchange.cpp
+++ b/src/parallel/pipeline_broadcast_exchange.cpp
@@ -1504,8 +1504,12 @@ SourceResultType PipelineBroadcastExchange::ReserveScanLocked(
 		auto position = consumer.position++;
 		buffer->ReserveRead(position, scan_state.spool_reader, next_chunk, batch_index, spool_read);
 		if (spool_read.IsSet()) {
+#ifdef D_ASSERT_IS_ENABLED
 			auto inserted = consumer.in_flight_reads.insert(position);
 			D_ASSERT(inserted.second);
+#else
+			consumer.in_flight_reads.insert(position);
+#endif
 		} else {
 			consumer.rows_read += next_chunk->size();
 			RetireChunksLocked();
@@ -1552,8 +1556,12 @@ SourceResultType PipelineBroadcastExchange::ReserveBatchScanLocked(
 				scan_state.reported_batch_index = batch_range.batch_index;
 				if (spool_read.IsSet()) {
 					spool_read.batch_sequence = batch_sequence;
+#ifdef D_ASSERT_IS_ENABLED
 					auto inserted = consumer.in_flight_reads.insert(position);
 					D_ASSERT(inserted.second);
+#else
+					consumer.in_flight_reads.insert(position);
+#endif
 				} else {
 					position_entry->second++;
 					consumer.rows_read += next_chunk->size();
@@ -1612,8 +1620,12 @@ SourceResultType PipelineBroadcastExchange::ReserveBatchScanLocked(
 		if (consumer.next_batch_sequence < buffer->NextBatchSequence()) {
 			auto batch_sequence = consumer.next_batch_sequence++;
 			auto &batch_range = buffer->GetBatchRange(batch_sequence);
+#ifdef D_ASSERT_IS_ENABLED
 			auto inserted = consumer.active_batch_positions.emplace(batch_sequence, batch_range.begin_position);
 			D_ASSERT(inserted.second);
+#else
+			consumer.active_batch_positions.emplace(batch_sequence, batch_range.begin_position);
+#endif
 			scan_state.batch_sequence = batch_sequence;
 			continue;
 		}

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -71,6 +71,7 @@ static void CheckTreeDepth(const LogicalOperator &op, idx_t max_depth, idx_t dep
 	}
 }
 
+#ifdef D_ASSERT_IS_ENABLED
 static bool ContainsDependentJoin(const LogicalOperator &op) {
 	if (op.type == LogicalOperatorType::LOGICAL_DEPENDENT_JOIN) {
 		return true;
@@ -132,6 +133,7 @@ static bool VerifyPlannedExpressions(const LogicalOperator &plan) {
 	}
 	return true;
 }
+#endif
 
 static void RunPostBindExtensions(ClientContext &context, Binder &binder, BoundStatement &statement) {
 	for (auto &planner_extension : PlannerExtension::Iterate(context)) {

--- a/src/storage/buffer/buffer_pool.cpp
+++ b/src/storage/buffer/buffer_pool.cpp
@@ -246,6 +246,9 @@ void EvictionQueue::PurgeIteration(const idx_t purge_size) {
 	// Re-enqueue alive nodes via producer token — goes into a dedicated sub-queue
 	// that the consumer token has already passed
 	if (alive_count > 0) {
+		if (!purge_producer_token.valid()) {
+			throw OutOfMemoryException("Failed to allocate eviction queue producer");
+		}
 		q.enqueue_bulk(purge_producer_token, purge_nodes.begin(), alive_count);
 	}
 }

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1431,8 +1431,8 @@ vector<RowGroupWriteData> RowGroup::WriteToDisk(RowGroupWriteInfo &info,
 	}
 
 	idx_t column_count = row_groups[0].get().GetColumnCount();
-	for (auto &row_group : row_groups) {
-		D_ASSERT(column_count == row_group.get().GetColumnCount());
+	for (idx_t row_group_idx = 0; row_group_idx < row_groups.size(); row_group_idx++) {
+		D_ASSERT(column_count == row_groups[row_group_idx].get().GetColumnCount());
 		RowGroupWriteData write_data;
 		write_data.states.reserve(column_count);
 		write_data.statistics.reserve(column_count);

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -220,9 +220,8 @@ void RowGroupCollection::FinalizeCheckpoint(MetaBlockPointer pointer,
 void RowGroupCollection::Initialize(PersistentCollectionData &data) {
 	stats.InitializeEmpty(types);
 	auto l = owned_row_groups->Lock();
-	auto base_row_id = owned_row_groups->GetBaseRowId();
 	for (auto &row_group_data : data.row_group_data) {
-		D_ASSERT(row_group_data.start == base_row_id + total_rows.load());
+		D_ASSERT(row_group_data.start == owned_row_groups->GetBaseRowId() + total_rows.load());
 		auto row_group = make_uniq<RowGroup>(*this, row_group_data);
 		row_group->MergeIntoStatistics(stats);
 		total_rows += row_group->count;
@@ -885,10 +884,14 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 	}
 	bool is_persistent = segments.back()->GetNode().IsPersistent();
 	idx_t merged_count = 0;
+#ifdef D_ASSERT_IS_ENABLED
 	idx_t source_offset = 0;
+#endif
 	idx_t target_row_start = start_index;
 	for (auto &entry : segments) {
+#ifdef D_ASSERT_IS_ENABLED
 		D_ASSERT(entry->GetRowStart() == source_row_groups->GetBaseRowId() + source_offset);
+#endif
 		auto row_group = entry->MoveNode();
 		row_group->MoveToCollection(*this);
 		idx_t row_group_count = row_group->count;
@@ -900,7 +903,9 @@ void RowGroupCollection::MergeStorage(RowGroupCollection &data, optional_ptr<Dat
 			row_group_data->row_group_data.push_back(std::move(persistent_data));
 		}
 		merged_count += row_group_count;
+#ifdef D_ASSERT_IS_ENABLED
 		source_offset += row_group_count;
+#endif
 		row_groups->AppendSegment(std::move(row_group), target_row_start);
 		target_row_start += row_group_count;
 	}


### PR DESCRIPTION
Different compilers show many warnings CI jobs:
- https://github.com/duckdb/duckdb/actions/runs/33839747683/job/100958659658 (gcc 13)
- https://github.com/duckdb/duckdb/actions/runs/33839747683/job/100919594728 (clang 20)
- https://github.com/duckdb/duckdb/actions/runs/33839747683/job/100921488698 (gcc 14)
- https://github.com/duckdb/duckdb/actions/runs/33839747683/job/100919594730 (clang 21, LTO)

Summary of the solved warnings:

| Jobs | Warning groups |
|---|---|
| GCC 13 / GCC 14 | `numeric.cpp`: anonymous-namespace bind data captured by a lambda (`-Wsubobject-linkage`); `date_part.cpp`: two non-void switch functions missing a final return/throw (`-Wreturn-type`); `catalog.cpp`: four deprecated internal `GetEntry` calls; `buffer_pool.cpp`: possible null producer-token dereference reported as `-Wstringop-overflow` inside concurrentqueue. |
| Clang 20 / Clang 21 LTO | 30 assertion-related warnings in release builds: 23 unused variables, 2 variables set but unused, 2 unused helper functions, and 3 assertion-only planner helpers with unnecessary internal linkage. |

The Clang warnings occur because `D_ASSERT` compiles out in release mode.