### PR TITLE
Avoid rebuilding sorted aggregate sort specifications during execution

### DIFF
--- a/benchmark/micro/aggregate/recursive_sorted_aggregate_copy.benchmark
+++ b/benchmark/micro/aggregate/recursive_sorted_aggregate_copy.benchmark
@@ -1,0 +1,26 @@
+# name: benchmark/micro/aggregate/recursive_sorted_aggregate_copy.benchmark
+# description: Repeated sorted aggregate bind data copies in a recursive CTE
+# group: [aggregate]
+
+name Recursive Sorted Aggregate Copy
+group aggregate
+
+init
+PREPARE recursive_sorted_aggregate_copy AS
+WITH RECURSIVE r(iter, asc_value, desc_value) AS (
+	VALUES (0, 'seed'::VARCHAR, 'seed'::VARCHAR)
+	UNION ALL
+	SELECT iter + 1,
+	       string_agg(v, ',' ORDER BY ord ASC NULLS FIRST),
+	       string_agg(v, ',' ORDER BY ord DESC NULLS LAST)
+	FROM r, (VALUES ('a', 2), ('b', 1), ('n', NULL)) t(v, ord)
+	WHERE iter < 1000
+	GROUP BY iter
+)
+SELECT * FROM r WHERE iter = 1000;
+
+run
+EXECUTE recursive_sorted_aggregate_copy;
+
+result III
+1000	n,b,a	a,b,n

--- a/src/function/aggregate/sorted_aggregate_function.cpp
+++ b/src/function/aggregate/sorted_aggregate_function.cpp
@@ -131,22 +131,20 @@ struct SortedAggregateBindData : public FunctionData {
 			                    make_uniq<BoundReferenceExpression>(buffered_types[entry.column],
 			                                                        UnsafeNumericCast<idx_t>(entry.column + 1)));
 		}
-		sort = make_uniq<Sort>(context, orders, sort_types, scan_cols);
+		sort = make_shared_ptr<Sort>(context, orders, sort_types, scan_cols);
 	}
 
 	SortedAggregateBindData(const SortedAggregateBindData &other)
 	    : context(other.context), function(other.function), sort_types(other.sort_types), scan_cols(other.scan_cols),
-	      scan_types(other.scan_types), buffered_cols(other.buffered_cols), buffered_types(other.buffered_types),
-	      buffered_struct_type(other.buffered_struct_type), buffered_funcs(other.buffered_funcs),
-	      sorted_on_args(other.sorted_on_args), threshold(other.threshold) {
+	      scan_types(other.scan_types), sort(other.sort), buffered_cols(other.buffered_cols),
+	      buffered_types(other.buffered_types), buffered_struct_type(other.buffered_struct_type),
+	      buffered_funcs(other.buffered_funcs), sorted_on_args(other.sorted_on_args), threshold(other.threshold) {
 		if (other.bind_info) {
 			bind_info = other.bind_info->Copy();
 		}
 		for (auto &order : other.orders) {
 			orders.emplace_back(order.Copy());
 		}
-
-		sort = make_uniq<Sort>(context, orders, sort_types, scan_cols);
 	}
 
 	unique_ptr<FunctionData> Copy() const override {
@@ -188,8 +186,8 @@ struct SortedAggregateBindData : public FunctionData {
 	vector<column_t> scan_cols;
 	//! The types of the sunk columns
 	vector<LogicalType> scan_types;
-	//! The shared sort specification
-	unique_ptr<Sort> sort;
+	//! The immutable shared sort specification
+	shared_ptr<const Sort> sort;
 
 	//! The mapping from inputs to buffered columns
 	vector<column_t> buffered_cols;

--- a/test/sql/cte/recursive_cte_ordered_aggregate.test
+++ b/test/sql/cte/recursive_cte_ordered_aggregate.test
@@ -1,0 +1,38 @@
+# name: test/sql/cte/recursive_cte_ordered_aggregate.test
+# description: Test ordered aggregates in recursive CTEs
+# group: [cte]
+
+foreach threads 1 8
+
+statement ok
+SET threads={threads};
+
+statement ok
+PREPARE recursive_sorted_aggregate AS
+WITH RECURSIVE r(iter, asc_value, desc_value) AS (
+	VALUES (0, 'seed'::VARCHAR, 'seed'::VARCHAR)
+	UNION ALL
+	SELECT iter + 1,
+	       string_agg(v, ',' ORDER BY ord ASC NULLS FIRST),
+	       string_agg(v, ',' ORDER BY ord DESC NULLS LAST)
+	FROM r, (VALUES ('a', 2), ('b', 1), ('n', NULL)) t(v, ord)
+	WHERE iter < 3
+	GROUP BY iter
+)
+SELECT * FROM r WHERE iter = 3;
+
+query ITT
+EXECUTE recursive_sorted_aggregate;
+----
+3	n,b,a	a,b,n
+
+# Reuse the prepared plan and its sorted aggregate specifications.
+query ITT
+EXECUTE recursive_sorted_aggregate;
+----
+3	n,b,a	a,b,n
+
+statement ok
+DEALLOCATE recursive_sorted_aggregate;
+
+endloop


### PR DESCRIPTION
After #25262 made the heap parser the default, recursive CTE workloads with ordered aggregates became much more sensitive to work that was already happening during execution. I reduced this to a recursive CTE containing two ordered `string_agg` calls and found the following path in the flamegraph:

`PhysicalRecursiveCTE` → `AggregateObject` → `SortedAggregateBindData::Copy` → `Sort::Sort` → `DecodeSortKeyBind` → `Parser::ParseColumnList`

Recursive execution recreates aggregate state for each epoch. This copies the aggregate function data, and the `SortedAggregateBindData` copy constructor was rebuilding its `Sort` object every time. Constructing that object binds the sort-key encoder and decoder, with the latter parsing a synthesized type declaration. An immutable piece of the physical specification was therefore repeatedly reconstructed during execution.

I changed the sorted aggregate bind data to retain a `shared_ptr<const Sort>`. The original binding or state reconstruction still creates the sort specification once. Subsequent bind-data copies continue to deep-copy the inner aggregate bind data and order nodes, but share the immutable sort specification.

I added a microbenchmark that prepares a recursive CTE outside the timed section and executes 1,000 recursive epochs with two differently ordered aggregates. In a 12-run Hyperfine comparison, the benchmark went from 764.8 ± 56.7 ms to 366.4 ± 26.2 ms, a 2.09× improvement. Sampling attributed 3,329 of 7,480 baseline samples to `SortedAggregateBindData::Copy`, including 3,318 samples in `Parser::ParseColumnList`. In the changed build, the copy appeared in 1 of 7,114 samples and `Parser::ParseColumnList` disappeared from execution.

----

CI:

```
FASTER
benchmark  base median                   PR median                     delta median        runs
---------  ----------------------------  ----------------------------  ------------------  ----
day12      586.6 ms [574.2 ms…614.1 ms]  568.4 ms [556.8 ms…604.1 ms]   -18.2 ms ( -3.1%)    40
day13       46.1 ms [ 41.2 ms… 52.5 ms]   41.7 ms [ 40.2 ms… 49.3 ms]    -4.4 ms ( -9.7%)    85
day23      208.4 ms [202.5 ms…249.0 ms]  139.7 ms [136.5 ms…146.6 ms]   -68.7 ms (-33.0%)    40
day24      190.1 ms [185.6 ms…260.4 ms]   59.7 ms [ 58.3 ms… 62.0 ms]  -130.3 ms (-68.6%)    65
day17      361.3 ms [355.4 ms…397.4 ms]   52.1 ms [ 50.7 ms… 54.7 ms]  -309.2 ms (-85.6%)    70

geomean: 168.1 ms -> 144.5 ms  -23.6 ms (-14.1%)  (initial 10 samples)
```

```
FASTER
benchmark                base median                   PR median                     delta median        runs
-----------------------  ----------------------------  ----------------------------  ------------------  ----
flummi_ray                 2.2 s  [  2.2 s …  2.3 s ]    2.1 s  [  2.1 s …  2.2 s ]  -107.6 ms ( -4.8%)    40
aoc2022_day09            642.7 ms [636.5 ms…659.2 ms]  611.2 ms [605.5 ms…627.9 ms]   -31.5 ms ( -4.9%)    40
aoc2022_day20            411.1 ms [402.4 ms…418.2 ms]  381.7 ms [371.8 ms…404.2 ms]   -29.4 ms ( -7.2%)    40
aoc2022_day20_using_key  434.1 ms [420.4 ms…438.6 ms]  401.6 ms [394.4 ms…406.9 ms]   -32.6 ms ( -7.5%)    40
aoc2022_day23            640.5 ms [627.3 ms…654.4 ms]  583.3 ms [569.8 ms…602.4 ms]   -57.2 ms ( -8.9%)    40
aoc2022_day23_using_key  654.7 ms [641.9 ms…667.3 ms]  591.8 ms [576.3 ms…615.7 ms]   -62.8 ms ( -9.6%)    40
asql_fluid_using_key     401.3 ms [391.1 ms…404.8 ms]  357.7 ms [352.5 ms…375.2 ms]   -43.6 ms (-10.9%)    40
asql_fluid               427.5 ms [418.4 ms…434.8 ms]  357.3 ms [351.7 ms…367.9 ms]   -70.2 ms (-16.4%)    40
aoc2024_day20            204.2 ms [202.3 ms…209.6 ms]  161.3 ms [158.8 ms…168.1 ms]   -42.9 ms (-21.0%)    40
aoc2022_day05            185.0 ms [177.7 ms…189.8 ms]  138.5 ms [135.4 ms…151.6 ms]   -46.5 ms (-25.1%)    40
asql_cyk                 219.9 ms [214.0 ms…242.2 ms]  160.4 ms [156.0 ms…181.1 ms]   -59.5 ms (-27.1%)    40
asql_cyk_using_key       158.1 ms [155.9 ms…180.9 ms]   92.7 ms [ 87.7 ms…149.9 ms]   -65.4 ms (-41.3%)    40
flummi_generations       533.3 ms [527.5 ms…575.1 ms]  309.4 ms [304.0 ms…352.9 ms]  -223.9 ms (-42.0%)    40
asql_marching_squares    120.4 ms [118.0 ms…126.2 ms]   67.8 ms [ 66.3 ms… 70.8 ms]   -52.7 ms (-43.7%)    55
flummi_life              322.9 ms [317.2 ms…338.3 ms]  165.2 ms [162.2 ms…169.4 ms]  -157.7 ms (-48.8%)    40
asql_sudoku               94.5 ms [ 91.1 ms…100.8 ms]   45.1 ms [ 44.3 ms… 47.9 ms]   -49.4 ms (-52.3%)    80
aoc2024_day20_using_key   97.7 ms [ 96.2 ms…109.7 ms]   37.8 ms [ 37.4 ms… 41.8 ms]   -59.9 ms (-61.3%)    90
aoc2022_day07             63.9 ms [ 63.4 ms… 67.1 ms]   24.4 ms [ 23.6 ms… 65.1 ms]   -39.5 ms (-61.7%)   110
aoc2022_day21             64.5 ms [ 63.6 ms… 71.8 ms]   24.5 ms [ 24.0 ms… 25.9 ms]   -40.0 ms (-62.0%)   110
bfs                       61.3 ms [ 60.7 ms… 64.4 ms]   18.6 ms [ 18.3 ms… 23.0 ms]   -42.7 ms (-69.7%)   110

geomean: 135.3 ms -> 119.0 ms  -16.3 ms (-12.1%)  (initial 10 samples)
```