### PR TITLE
Print failed test name correctly and stack trace for crashing tests

### DIFF
--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -996,6 +996,10 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
             if detail_lines:
                 detail_lines.append("")
             detail_lines.extend(preferred_assertion.detail_lines)
+    if not snippet_lines and test_name is not None and line_number is not None:
+        snippet_lines = render_test_snippet(test_name, line_number)
+    if not detail_lines and stderr_info.failing_summary_block:
+        detail_lines.extend(stderr_info.failing_summary_block)
     if not detail_lines:
         if stdout_info.fallback_failure_block:
             stdout_failure_test_name, stdout_failure_block = stdout_info.fallback_failure_block
@@ -1004,10 +1008,6 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
             )
             reproduce_batch = [test_name] if test_name else list(batch)
             detail_lines.extend(stdout_failure_block)
-    if not snippet_lines and test_name is not None and line_number is not None:
-        snippet_lines = render_test_snippet(test_name, line_number)
-    if not detail_lines and stderr_info.failing_summary_block:
-        detail_lines.extend(stderr_info.failing_summary_block)
     if not detail_lines:
         detail_lines.extend(extract_interesting_failure_block(stderr_lines))
     if not detail_lines:

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -117,6 +117,7 @@ class StdoutParse:
     last_unfinished_test: str | None
     preferred_assertion: StdoutAssertionFailure | None
     fallback_failure_block: tuple[str | None, list[str]] | None
+    fatal_error_lines: list[str]
     failed_reason_line: str | None
 
 
@@ -602,6 +603,32 @@ def infer_timed_out_test_from_stdout(stdout_lines: list[str], batch):
     return None
 
 
+def extract_fatal_error_lines(stdout_lines: list[str]):
+    for idx, line in enumerate(stdout_lines):
+        if not FATAL_ERROR_PATTERN.match(line):
+            continue
+
+        lines = []
+        for next_line in stdout_lines[idx + 1 :]:
+            stripped = next_line.strip()
+            if PROGRESS_TEST_START_PATTERN.match(stripped):
+                break
+            if stripped.startswith("test cases:") or stripped.startswith("assertions:"):
+                break
+            if stripped.startswith("==============================================================================="):
+                break
+            if stripped.startswith("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"):
+                break
+            lines.append(stripped)
+
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        while lines and not lines[-1].strip():
+            lines.pop()
+        return lines
+    return []
+
+
 def extract_failed_reason_line(stdout_lines: list[str]):
     for idx, line in enumerate(stdout_lines):
         if not FAILED_HEADER_PATTERN.match(line):
@@ -755,6 +782,7 @@ def parse_stdout_failure_info(stdout_lines: list[str]):
         last_unfinished_test=last_unfinished_test,
         preferred_assertion=preferred_assertion,
         fallback_failure_block=fallback_failure_block,
+        fatal_error_lines=extract_fatal_error_lines(stdout_lines),
         failed_reason_line=extract_failed_reason_line(stdout_lines),
     )
 
@@ -948,6 +976,8 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
 
     test_name = stderr_info.test_name
     line_number = stderr_info.line_number
+    if stdout_info.fatal_error_lines and stdout_info.last_started_test:
+        test_name, line_number = retarget_failing_test(stdout_info.last_started_test, test_name, line_number)
     if test_name is None and returncode is not None and returncode < 0:
         test_name = stdout_info.last_unfinished_test or infer_timed_out_test_from_stdout(stdout_lines, batch)
     reproduce_batch = [test_name] if test_name else list(batch)
@@ -983,6 +1013,8 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
     snippet_lines = []
     if stderr_info.query_failure_lines:
         detail_lines.extend(stderr_info.query_failure_lines)
+    elif stdout_info.fatal_error_lines:
+        detail_lines.extend(stdout_info.fatal_error_lines)
 
     preferred_assertion = stdout_info.preferred_assertion
     if preferred_assertion is not None:

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -1276,6 +1276,34 @@ Replacing deprecated string __TEST_DIR__ in path "__TEST_DIR__/hnsw_reclaim_spac
             ["/duckdb_build_dir/build/release/_deps/vss_extension_fc-src/test/sql/hnsw/hnsw_lateral_join_group.test"],
         )
 
+    def test_fatal_stdout_failure_preserves_stacktrace(self):
+        batch = ["test/sql/crash.test"]
+        stdout = """
+[0/1] (0%): test/sql/crash.test
+/duckdb/test/sqlite/test_sqllogictest.cpp:41: FAILED:
+  {Unknown expression after the reported line}
+due to a fatal error condition:
+  SIGSEGV - Segmentation violation signal
+
+/duckdb/build/release/test/unittest(duckdb::CrashHere()+0x12) [0x1234]
+/duckdb/build/release/src/libduckdb.so(duckdb::Execute()+0x34) [0x5678]
+===============================================================================
+test cases: 1 | 1 failed
+"""
+        lines, reproduce_batch = run_tests.summarize_failure_output(None, stdout, "", batch, returncode=-11)
+        self.assertEqual(
+            strip_ansi_lines(lines)[1:],
+            [
+                "error: FAIL test/sql/crash.test",
+                "",
+                "SIGSEGV - Segmentation violation signal",
+                "",
+                "/duckdb/build/release/test/unittest(duckdb::CrashHere()+0x12) [0x1234]",
+                "/duckdb/build/release/src/libduckdb.so(duckdb::Execute()+0x34) [0x5678]",
+            ],
+        )
+        self.assertEqual(reproduce_batch, batch)
+
     def test_signal_only_failure_prefers_returncode_over_unrelated_stdout(self):
         batch = ["test/sql/crash.test"]
         lines, reproduce_batch = run_tests.summarize_failure_output(

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -1196,6 +1196,54 @@ unittest is a Catch v2.13.7 host application.
             ],
         )
 
+    def test_empty_stdout_assertion_uses_sqllogictest_stderr_diagnostics(self):
+        batch = ["/tmp/fail.test"]
+        stdout = """
+Filters: /tmp/fail.test
+
+[0/1] (0%): /tmp/fail.test
+-------------------------------------------------------------------------------
+/tmp/fail.test
+-------------------------------------------------------------------------------
+/duckdb/test/sqlite/test_sqllogictest.cpp:47
+...............................................................................
+
+/tmp/fail.test:314: FAILED:
+
+
+[1/1] (100%): /tmp/fail.test took 0.015s
+===============================================================================
+test cases:  1 |  0 passed | 1 failed
+assertions: 28 | 27 passed | 1 failed
+"""
+        stderr = """
+1. /tmp/fail.test:314
+================================================================================
+Query unexpectedly failed (/tmp/fail.test:314)
+ (/tmp/fail.test:314)!
+================================================================================
+SELECT x'303132' IN (SELECT * FROM t1);
+================================================================================
+Actual result:
+================================================================================
+Binder Error: Cannot compare values of type BLOB and INTEGER in IN/ANY/ALL clause - an explicit cast is required
+
+LINE 1: SELECT x'303132' IN (SELECT * FROM t1)
+                            ^^^^^^^^^^^^^^^^^^
+"""
+        lines, reproduce_batch = run_tests.summarize_failure_output(None, stdout, stderr, batch)
+        stripped_lines = strip_ansi_lines(lines)
+
+        self.assertEqual(reproduce_batch, batch)
+        self.assertIn("error: FAIL /tmp/fail.test", stripped_lines)
+        self.assertIn(
+            "Binder Error: Cannot compare values of type BLOB and INTEGER in IN/ANY/ALL clause - "
+            "an explicit cast is required",
+            stripped_lines,
+        )
+        self.assertIn("LINE 1: SELECT x'303132' IN (SELECT * FROM t1)", stripped_lines)
+        self.assertIn("                            ^^^^^^^^^^^^^^^^^^", stripped_lines)
+
     def test_fatal_stdout_failure_uses_last_started_test_and_signal(self):
         batch = [
             "/duckdb_build_dir/build/release/_deps/vss_extension_fc-src/test/sql/slow/hnsw_reclaim_storage.test_slow",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,16 @@ endif()
 
 add_executable(unittest unittest.cpp ${UNITTEST_OBJECT_FILES})
 
+# Enable best-effort stack traces for fatal signals in the test runner without
+# enabling stack traces for every DuckDB exception.
+if((CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT MUSL_ENABLED) OR APPLE)
+  target_compile_definitions(unittest PRIVATE DUCKDB_UNITTEST_CRASH_STACKTRACE)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT MUSL_ENABLED)
+  set_target_properties(unittest PROPERTIES ENABLE_EXPORTS ON)
+endif()
+
 set(RUN_WRAPPER_UNITTEST_NAME "unittest")
 if(WIN32)
   set(RUN_WRAPPER_UNITTEST_NAME "unittest.exe")

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -24,9 +24,9 @@ namespace duckdb_base_std {
 } // namespace duckdb_base_std
 #endif
 // optional support for printing stacktraces on a crash -- using the backtrace support in DuckDB
-#ifdef DUCKDB_DEBUG_STACKTRACE
+#if defined(DUCKDB_DEBUG_STACKTRACE) || defined(DUCKDB_UNITTEST_CRASH_STACKTRACE)
 #include "duckdb/common/exception.hpp"
-#define CATCH_STACKTRACE(X) duckdb::Exception::FormatStackTrace(X).c_str()
+#define CATCH_STACKTRACE(X) duckdb::Exception::FormatStackTrace(X)
 #endif
 
 #define CATCH_VERSION_MAJOR 2
@@ -10878,7 +10878,8 @@ namespace {
     //! Signals fatal error message to the run context
     void reportFatal( char const * message ) {
 #ifdef CATCH_STACKTRACE
-        message = (const char*) CATCH_STACKTRACE(message); //enrich error message with a stacktrace
+        auto messageWithStacktrace = CATCH_STACKTRACE(message);
+        message = messageWithStacktrace.c_str();
 #endif
         Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition( message );
     }
@@ -11001,7 +11002,7 @@ namespace Catch {
             sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
         }
         // Return the old stack
-#ifndef CATCH_STACKTRACE
+#if !defined(CATCH_STACKTRACE) || !defined(__APPLE__)
         sigaltstack(&oldSigStack, nullptr); // sigaltstack prevents catch-stacktrace to work (on MacOS)
 #endif
     }
@@ -11042,7 +11043,7 @@ namespace Catch {
         sigStack.ss_sp = altStackMem;
         sigStack.ss_size = altStackSize;
         sigStack.ss_flags = 0;
-#ifndef CATCH_STACKTRACE
+#if !defined(CATCH_STACKTRACE) || !defined(__APPLE__)
         sigaltstack(&sigStack, &oldSigStack); // sigaltstack prevents catch-stacktrace to work (on MacOS)
 #endif
         struct sigaction sa = { };


### PR DESCRIPTION
### Print correct filename of failing test

Some CI test failures are difficult to read/lack information:
```sql
================================================================
error: FAIL /__w/duckdb/duckdb/build/release/_deps/ducklake_extension_fc-src/test/sql/
  
      135  4   1
      136  5   1
      137  
    > 138  statement error
      139  CALL ducklake_merge_adjacent_files('ducklake', 'example_2', schema=>'bogus');
      140  ----
      141  Did you mean "main.example_2 or s1.example_2"?
  
-------------------------------------------------------------------------------
/__w/duckdb/duckdb/build/release/_deps/ducklake_extension_fc-src/test/sql/compaction/merge_adjacent_options.test
-------------------------------------------------------------------------------
/__w/duckdb/duckdb/build/release/test/sqlite/../../../../duckdb/test/sqlite/test_sqllogictest.cpp:47
...............................................................................
  
/__w/duckdb/duckdb/build/release/_deps/ducklake_extension_fc-src/test/sql/compaction/merge_adjacent_options.test:138: FAILED:
  
reproduce:
./build/release/test/unittest /__w/duckdb/duckdb/build/release/_deps/ducklake_extension_fc-src/test/sql/
```

The test runner should print:
```
error: FAIL /__w/duckdb/duckdb/build/release/_deps/ducklake_extension_fc-src/test/sql/compaction/merge_adjacent_options.test
```
so it's clear _what_ test is failing instead of printing the sqllogictest C++ wrapper path.

### Show stack trace for segfault

A test that segfaults does not print any stack trace:
```sql
================================================================
error: FAIL test/sql/window/test_constant_orderby.test

SIGSEGV - Segmentation fault

reproduce:
build/release/test/unittest --thread-stack-size 131072 test/sql/window/test_constant_orderby.test
```

We're not enabling stack traces for all exceptions because that can slow down internally thrown C++ exceptions. This PR only prints a stack trace when Catch2 crashes.