### PR TITLE
Fix list_position statistics propagation for a NULL needle

### DIFF
--- a/src/function/scalar/list/contains_or_position.cpp
+++ b/src/function/scalar/list/contains_or_position.cpp
@@ -23,48 +23,66 @@ static void ListSearchFunction(DataChunk &input, ExpressionState &state, Vector 
 	ListSearchOp<RETURN_TYPE, FIND_NULLS>(input_list, list_child, target, result, target_count);
 }
 
-static FilterPropagateResult ListSearchFilterPruneImpl(optional_ptr<const BaseStatistics> list_stats,
-                                                       optional_ptr<const BaseStatistics> needle_stats) {
+//! Whether the statistics prove that no list element can ever match the needle.
+//! FIND_NULLS (list_position) also matches NULL elements against a NULL needle, whereas list_contains
+//! never matches a NULL needle at all.
+static bool ListSearchNeverMatches(optional_ptr<const BaseStatistics> list_stats,
+                                   optional_ptr<const BaseStatistics> needle_stats, const bool find_nulls) {
 	if (!list_stats || list_stats->GetStatsType() != StatisticsType::LIST_STATS) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		return false;
+	}
+	if (!list_stats->CanHaveNoNull()) {
+		// The list is always NULL, so there is nothing to search.
+		return true;
 	}
 
 	auto &child = ListStats::GetChildStats(*list_stats);
-	if (!list_stats->CanHaveNoNull() || !child.CanHaveNoNull()) {
-		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
-	}
+	// A NULL needle finds a NULL element - only list_position looks for those.
+	const bool null_needle_matches = find_nulls && child.CanHaveNull();
 
 	if (!needle_stats) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		// The needle is unknown, so it can only be ruled out if no element can match anything.
+		return !null_needle_matches && !child.CanHaveNoNull();
 	}
 	if (!needle_stats->CanHaveNoNull()) {
-		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
+		// The needle is always NULL.
+		return !null_needle_matches;
+	}
+	if (null_needle_matches && needle_stats->CanHaveNull()) {
+		// The needle can be NULL, in which case it matches any NULL element.
+		return false;
+	}
+	if (!child.CanHaveNoNull()) {
+		// Every element is NULL, and the needle we are searching for is not.
+		return true;
 	}
 	if (child.GetType() != needle_stats->GetType()) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		return false;
 	}
-	const bool can_have_null = list_stats->CanHaveNull() || needle_stats->CanHaveNull();
-	const auto filter_false =
-	    can_have_null ? FilterPropagateResult::FILTER_FALSE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_FALSE;
-
 	auto zonemap = StatisticsPropagator::PropagateComparison(child, *needle_stats, ExpressionType::COMPARE_EQUAL);
-	if (zonemap == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
-	    zonemap == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
-		return filter_false;
-	}
-	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	return zonemap == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
+	       zonemap == FilterPropagateResult::FILTER_FALSE_OR_NULL;
 }
 
 static FilterPropagateResult ListContainsFilterPrune(const FunctionStatisticsPruneInput &input) {
-	return ListSearchFilterPruneImpl(input.ChildStats(0), input.ChildStats(1));
+	auto list_stats = input.ChildStats(0);
+	auto needle_stats = input.ChildStats(1);
+	if (!ListSearchNeverMatches(list_stats, needle_stats, false)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	// list_contains is NULL if either side is NULL, and false otherwise.
+	const bool can_have_null = list_stats->CanHaveNull() || !needle_stats || needle_stats->CanHaveNull();
+	return can_have_null ? FilterPropagateResult::FILTER_FALSE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_FALSE;
 }
 
 static unique_ptr<BaseStatistics> ListPositionPropagateStats(ClientContext &, FunctionStatisticsInput &input) {
 	if (input.child_stats.size() != 2) {
 		return nullptr;
 	}
-	auto prune = ListSearchFilterPruneImpl(input.child_stats[0], input.child_stats[1]);
-	if (prune != FilterPropagateResult::FILTER_ALWAYS_FALSE && prune != FilterPropagateResult::FILTER_FALSE_OR_NULL) {
+	if (BaseStatistics::GetStatsType(input.expr.GetReturnType()) != StatisticsType::NUMERIC_STATS) {
+		return nullptr;
+	}
+	if (!ListSearchNeverMatches(input.child_stats[0], input.child_stats[1], true)) {
 		return nullptr;
 	}
 	// Needle cannot occur: list_position is NULL for every row.

--- a/test/sql/function/list/list_position_null_needle.test
+++ b/test/sql/function/list/list_position_null_needle.test
@@ -1,0 +1,103 @@
+# name: test/sql/function/list/list_position_null_needle.test
+# description: Test list_position with a NULL needle (issue #25355)
+# group: [list]
+
+# list_position finds NULL elements, so a NULL needle must not be folded away by statistics propagation
+
+query TT
+SELECT a, list_position(a, NULL) IS NOT NULL
+FROM VALUES ([2, 2, 3, NULL, NULL]), (NULL), ([]::INTEGER[]), ([NULL]) df(a)
+----
+[2, 2, 3, NULL, NULL]	true
+NULL	false
+[]	false
+[NULL]	true
+
+query TT
+SELECT a, list_position(a, NULL)
+FROM VALUES ([2, 2, 3, NULL, NULL]), (NULL), ([]::INTEGER[]), ([NULL]) df(a)
+----
+[2, 2, 3, NULL, NULL]	4
+NULL	NULL
+[]	NULL
+[NULL]	1
+
+# the same, but reading from a table so that the needle is compared against real column statistics
+
+statement ok
+CREATE TABLE lists AS
+SELECT a FROM VALUES ([2, 2, 3, NULL, NULL]), (NULL), ([]::INTEGER[]), ([NULL]) df(a);
+
+query TT
+SELECT a, list_position(a, NULL) FROM lists
+----
+[2, 2, 3, NULL, NULL]	4
+NULL	NULL
+[]	NULL
+[NULL]	1
+
+query I
+SELECT count(*) FROM lists WHERE list_position(a, NULL) IS NOT NULL
+----
+2
+
+# no list element is NULL: a NULL needle never matches
+
+statement ok
+CREATE TABLE no_null_elements AS SELECT [i, i + 1] AS a FROM range(3) tbl(i);
+
+query TT
+SELECT a, list_position(a, NULL) FROM no_null_elements
+----
+[0, 1]	NULL
+[1, 2]	NULL
+[2, 3]	NULL
+
+query I
+SELECT count(*) FROM no_null_elements WHERE list_position(a, NULL) IS NOT NULL
+----
+0
+
+# every list element is NULL
+
+statement ok
+CREATE TABLE only_null_elements AS SELECT [NULL::INTEGER, NULL] AS a FROM range(3);
+
+query TTT
+SELECT a, list_position(a, NULL), list_position(a, 42) FROM only_null_elements
+----
+[NULL, NULL]	1	NULL
+[NULL, NULL]	1	NULL
+[NULL, NULL]	1	NULL
+
+# the list itself is always NULL
+
+statement ok
+CREATE TABLE null_lists AS SELECT NULL::INTEGER[] AS a FROM range(3);
+
+query TT
+SELECT list_position(a, NULL), list_position(a, 42) FROM null_lists
+----
+NULL	NULL
+NULL	NULL
+NULL	NULL
+
+# list_contains never matches a NULL needle
+
+query TT
+SELECT a, list_contains(a, NULL) FROM lists
+----
+[2, 2, 3, NULL, NULL]	NULL
+NULL	NULL
+[]	NULL
+[NULL]	NULL
+
+# a non-constant NULL needle
+
+query TT
+SELECT a, list_position(a, b)
+FROM VALUES ([1, NULL], NULL), ([1, NULL], 1), ([1, 2], NULL) df(a, b)
+----
+[1, NULL]	2
+[1, NULL]	1
+[1, 2]	NULL


### PR DESCRIPTION
Fixes #25355.

```sql
FROM VALUES ([2, 2, 3, NULL, NULL]), (NULL), ([]::INTEGER[]), ([NULL]) df(a)
SELECT a, list_position(a, NULL) IS NOT NULL;
```

returns `false` for every row on `main`, but `true, false, false, true` in v1.5.5.

### Cause

`list_position` binds `ListSearchOp` with `FIND_NULLS`, so a NULL needle matches NULL list elements. `list_contains` never matches a NULL needle at all. The statistics callback for `list_position` reused the `list_contains` prune predicate, so a NULL needle produced `FILTER_FALSE_OR_NULL` and the callback published "no valid values, has null" statistics. `PropagateExpression` for `OPERATOR_IS_NOT_NULL` then folds that into constant `false`.

Two sibling branches were wrong the same way: a list whose elements are all NULL still contains a match for a NULL needle, and an unknown needle may be NULL.

### Fix

Split the predicate into `ListSearchNeverMatches`, taking a `find_nulls` flag. For `list_position`, a needle that can be NULL cannot be ruled out while the list child can contain NULLs.

`list_contains` pruning is unchanged, except that all-NULL elements combined with non-nullable inputs now yields `FILTER_ALWAYS_FALSE` rather than `FILTER_FALSE_OR_NULL` — `list_contains` returns `false`, not NULL, when no element matches.

### Tests

New `test/sql/function/list/list_position_null_needle.test` covers the reported query plus table-backed column statistics, all-NULL elements, an all-NULL list, a non-constant needle, and a `list_contains` NULL-needle guard. It fails on `main` and passes with this change. The existing `list_contains` row group pruning tests (`test/sql/optimizer/`, `test/sql/copy/parquet/`) still pass, so pruning is not weakened for the cases it covered.