### PR TITLE
Fix crash casting a UNION to a UNION with a VARIANT member

### DIFF
--- a/src/function/cast/union_casts.cpp
+++ b/src/function/cast/union_casts.cpp
@@ -266,7 +266,8 @@ static bool UnionMemberToMemberCast(Vector &source, Vector &result, idx_t count,
 
 	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
 		// Constant vector case optimization
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		// member casts can emit non-flat vectors (e.g. a shredded VARIANT) - flatten before marking constant
+		result.FlattenAndSetConstant();
 		if (ConstantVector::IsNull(source)) {
 			ConstantVector::SetNull(result, count_t(count));
 		} else {

--- a/test/sql/cast/union_member_variant_cast.test
+++ b/test/sql/cast/union_member_variant_cast.test
@@ -1,0 +1,58 @@
+# name: test/sql/cast/union_member_variant_cast.test
+# description: cast unions into unions with VARIANT members
+# group: [cast]
+
+query I
+SELECT union_value(a := 42)::UNION(a VARIANT);
+----
+42
+
+query I
+SELECT union_value(a := 'hello')::UNION(a VARIANT);
+----
+hello
+
+# the target union has members the source does not
+query I
+SELECT union_value(a := 42)::UNION(a VARIANT, b INTEGER);
+----
+42
+
+query I
+SELECT union_tag(union_value(a := 42)::UNION(a VARIANT, b INTEGER));
+----
+a
+
+query I
+SELECT union_value(a := NULL::INTEGER)::UNION(a VARIANT);
+----
+NULL
+
+# nested: a struct member carrying a VARIANT field
+query I
+SELECT union_value(a := {'v': 42})::UNION(a STRUCT(v VARIANT));
+----
+{'v': 42}
+
+# several members shredded in the same cast
+query I
+SELECT union_value(a := 42)::UNION(a VARIANT, b VARIANT);
+----
+42
+
+statement ok
+CREATE TABLE union_tbl AS SELECT * FROM (VALUES (union_value(a := 42)), (union_value(a := 7)), (NULL)) t(u);
+
+query I
+SELECT u::UNION(a VARIANT) FROM union_tbl;
+----
+42
+7
+NULL
+
+query I
+SELECT variant_typeof((u::UNION(a VARIANT)).a) FROM union_tbl;
+----
+INT32
+INT32
+VARIANT_NULL


### PR DESCRIPTION
Fixes #25368

`UnionMemberToMemberCast()` casts the members (the `INTEGER` -> `VARIANT` one comes back shredded), then marks the constant result with a direct `SetVectorType()`. A `UNION` is a `STRUCT` underneath, so that propagates straight into the shredded member and throws.

Swapped it for `FlattenAndSetConstant()`, which flattens non-flat children first - same thing `execute_function.cpp` and `union/from_struct.cpp` already do.

## Tests

Added `test/sql/cast/union_member_variant_cast.test`