### PR TITLE
Properly transform qualified columns in rename/exclude

### DIFF
--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -394,6 +394,7 @@ public:
 	static vector<reference<ParseResult>> ExtractParseResultsFromList(ParseResult &parse_result);
 	static bool ExpressionIsEmptyStar(const ParsedExpression &expr);
 	static QualifiedName StringToQualifiedName(vector<string> input);
+	static QualifiedColumnName StringToQualifiedColumnName(const vector<string> &input);
 	static LogicalType GetIntervalTargetType(DatePartSpecifier date_part);
 	static bool ConstructConstantFromExpression(const ParsedExpression &expr, Value &value);
 	static unique_ptr<ParsedExpression> TryNegateValue(const ConstantExpression &expr);

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/parser/peg/transformer/peg_transformer.hpp"
 #include "duckdb/common/enums/trigger_type.hpp"
 #include "duckdb/common/query_location.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/peg/matcher.hpp"
 #include "duckdb/common/to_string.hpp"
 #include "duckdb/parser/sql_statement.hpp"
@@ -252,6 +253,33 @@ QualifiedName PEGTransformerFactory::StringToQualifiedName(vector<string> input)
 	} else {
 		throw ParserException("Too many qualifications found - expected [catalog.schema.name] or [schema.name]");
 	}
+}
+
+QualifiedColumnName PEGTransformerFactory::StringToQualifiedColumnName(const vector<string> &input) {
+	if (input.empty()) {
+		throw InternalException("QualifiedColumnName cannot be made with an empty input.");
+	}
+	auto identifiers = StringsToIdentifiers(input);
+	if (identifiers.size() == 1) {
+		return QualifiedColumnName(std::move(identifiers[0]));
+	} else if (identifiers.size() == 2) {
+		return QualifiedColumnName(std::move(identifiers[0]), std::move(identifiers[1]));
+	} else if (identifiers.size() == 3) {
+		QualifiedColumnName result;
+		result.schema = std::move(identifiers[0]);
+		result.table = std::move(identifiers[1]);
+		result.column = std::move(identifiers[2]);
+		return result;
+	} else if (identifiers.size() == 4) {
+		QualifiedColumnName result;
+		result.catalog = std::move(identifiers[0]);
+		result.schema = std::move(identifiers[1]);
+		result.table = std::move(identifiers[2]);
+		result.column = std::move(identifiers[3]);
+		return result;
+	}
+	throw ParserException("Expected at most 4 entries (catalog.schema.table.column), but found %zu entries (input: %s)",
+	                      input.size(), StringUtil::Join(input, "."));
 }
 
 LogicalType PEGTransformerFactory::GetIntervalTargetType(DatePartSpecifier date_part) {

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -2082,8 +2082,7 @@ qualified_column_set_t PEGTransformerFactory::TransformExcludeNameSingle(PEGTran
 
 QualifiedColumnName PEGTransformerFactory::TransformExcludeDottedName(PEGTransformer &transformer,
                                                                       const vector<string> &dotted_identifier) {
-	auto result_string = StringUtil::Join(dotted_identifier, ".");
-	return QualifiedColumnName::Parse(result_string);
+	return StringToQualifiedColumnName(dotted_identifier);
 }
 
 QualifiedColumnName PEGTransformerFactory::TransformExcludeColumnName(PEGTransformer &transformer,

--- a/test/sql/projection/select_star_exclude.test
+++ b/test/sql/projection/select_star_exclude.test
@@ -111,6 +111,22 @@ SELECT * EXCLUDE (INTEGERS.i, integers.J) FROM integers
 ----
 3
 
+# dots in quoted identifiers are not qualification separators
+query I
+SELECT * EXCLUDE ("a.b") FROM (SELECT 1 AS "a.b", 2 AS c)
+----
+2
+
+query I
+SELECT * EXCLUDE ("table.with.dot"."column.with.dot") FROM (SELECT 1 AS "column.with.dot", 2 AS c) AS "table.with.dot"
+----
+2
+
+statement error
+SELECT * EXCLUDE (a.b.c.d.e) FROM (SELECT 1 AS e)
+----
+<REGEX>:Parser Error: Expected at most 4 entries.*
+
 statement error
 SELECT * EXCLUDE (integers.i, integers.j, integers2.i) FROM integers
 ----

--- a/test/sql/projection/select_star_rename.test
+++ b/test/sql/projection/select_star_rename.test
@@ -32,6 +32,17 @@ SELECT renamed_col FROM (SELECT integers.* RENAME integers.i AS renamed_col FROM
 ----
 1
 
+# dots in quoted identifiers are not qualification separators
+query II
+SELECT d, c FROM (SELECT * RENAME ("a.b" AS d) FROM (SELECT 1 AS "a.b", 2 AS c))
+----
+1	2
+
+query II
+SELECT d, c FROM (SELECT * RENAME ("table.with.dot"."column.with.dot" AS d) FROM (SELECT 1 AS "column.with.dot", 2 AS c) AS "table.with.dot")
+----
+1	2
+
 # multiple renames
 query II
 SELECT r1, r2 FROM (SELECT * RENAME (integers.i AS r1, j AS r2) FROM integers)


### PR DESCRIPTION
cc @evertlammerts 

The previous implementation for parsing columns in `SELECT * EXCLUDE()` and `RENAME` was a bit too simplistic and lost the context of whether columns were wrapped with `""` or not. This caused the following queries to have incorrect results compared to v1.5.5, but are now fixed: 
```sql
memory D SELECT * RENAME ("a.b" AS d) FROM (SELECT 1 AS "a.b", 2 AS c);
┌───────┬───────┐
│   d   │   c   │
│ int32 │ int32 │
├───────┼───────┤
│     1 │     2 │
└───────┴───────┘
memory D  SELECT * EXCLUDE ("a.b") FROM (SELECT 1 AS "a.b", 2 AS c);
┌───────┐
│   c   │
│ int32 │
├───────┤
│     2 │
└───────┘
```

I only handle up to 4 components and not an arbitrary amount, is that something worth adding as well? 