### PR TITLE
Update compression tests for extension runs

### DIFF
--- a/test/sql/storage/compression/alp/alp_corrupt_count.test
+++ b/test/sql/storage/compression/alp/alp_corrupt_count.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alp_corrupt_count.db.gz {TEST_DIR}/alp_corrupt_count.
 
 load {TEST_DIR}/alp_corrupt_count.db readonly
 
+statement ok
+USE alp_corrupt_count
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALP';
 ----

--- a/test/sql/storage/compression/alp/alp_corrupt_exponent.test
+++ b/test/sql/storage/compression/alp/alp_corrupt_exponent.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alp_corrupt_exponent.db.gz {TEST_DIR}/alp_corrupt_exp
 
 load {TEST_DIR}/alp_corrupt_exponent.db readonly
 
+statement ok
+USE alp_corrupt_exponent
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALP';
 ----

--- a/test/sql/storage/compression/alp/alp_corrupt_header_undercount.test
+++ b/test/sql/storage/compression/alp/alp_corrupt_header_undercount.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alp_corrupt_header_undercount.db.gz {TEST_DIR}/alp_co
 
 load {TEST_DIR}/alp_corrupt_header_undercount.db readonly
 
+statement ok
+USE alp_corrupt_header_undercount
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALP';
 ----

--- a/test/sql/storage/compression/alp/alp_corrupt_metadata_offset.test
+++ b/test/sql/storage/compression/alp/alp_corrupt_metadata_offset.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alp_corrupt_metadata_offset.db.gz {TEST_DIR}/alp_corr
 
 load {TEST_DIR}/alp_corrupt_metadata_offset.db readonly
 
+statement ok
+USE alp_corrupt_metadata_offset
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALP';
 ----

--- a/test/sql/storage/compression/alp/alp_corrupt_offset.test
+++ b/test/sql/storage/compression/alp/alp_corrupt_offset.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alp_corrupt_offset.db.gz {TEST_DIR}/alp_corrupt_offse
 
 load {TEST_DIR}/alp_corrupt_offset.db readonly
 
+statement ok
+USE alp_corrupt_offset
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='b' AND compression='ALP';
 ----

--- a/test/sql/storage/compression/alp/alp_corrupt_offset_unordered.test
+++ b/test/sql/storage/compression/alp/alp_corrupt_offset_unordered.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alp_corrupt_offset_unordered.db.gz {TEST_DIR}/alp_cor
 
 load {TEST_DIR}/alp_corrupt_offset_unordered.db readonly
 
+statement ok
+USE alp_corrupt_offset_unordered
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALP';
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_count.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_count.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_count.db.gz {TEST_DIR}/alprd_corrupt_co
 
 load {TEST_DIR}/alprd_corrupt_count.db readonly
 
+statement ok
+USE alprd_corrupt_count
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_dictionary_count.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_dictionary_count.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_dictionary_count.db.gz {TEST_DIR}/alprd
 
 load {TEST_DIR}/alprd_corrupt_dictionary_count.db readonly
 
+statement ok
+USE alprd_corrupt_dictionary_count
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_dictionary_count_zero.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_dictionary_count_zero.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_dictionary_count_zero.db.gz {TEST_DIR}/
 
 load {TEST_DIR}/alprd_corrupt_dictionary_count_zero.db readonly
 
+statement ok
+USE alprd_corrupt_dictionary_count_zero
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_exception_count.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_exception_count.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_exception_count.db.gz {TEST_DIR}/alprd_
 
 load {TEST_DIR}/alprd_corrupt_exception_count.db readonly
 
+statement ok
+USE alprd_corrupt_exception_count
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE segment_type = 'DOUBLE' AND compression != 'ALPRD';
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_exception_position.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_exception_position.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_exception_position.db.gz {TEST_DIR}/alp
 
 load {TEST_DIR}/alprd_corrupt_exception_position.db readonly
 
+statement ok
+USE alprd_corrupt_exception_position
+
 query I
 SELECT compression FROM pragma_storage_info('two_alp') WHERE compression='ALPRD';
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_header_undercount.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_header_undercount.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_header_undercount.db.gz {TEST_DIR}/alpr
 
 load {TEST_DIR}/alprd_corrupt_header_undercount.db readonly
 
+statement ok
+USE alprd_corrupt_header_undercount
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_left_bit_width.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_left_bit_width.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_left_bit_width.db.gz {TEST_DIR}/alprd_c
 
 load {TEST_DIR}/alprd_corrupt_left_bit_width.db readonly
 
+statement ok
+USE alprd_corrupt_left_bit_width
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_metadata_underflow.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_metadata_underflow.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_metadata_underflow.db.gz {TEST_DIR}/alp
 
 load {TEST_DIR}/alprd_corrupt_metadata_underflow.db readonly
 
+statement ok
+USE alprd_corrupt_metadata_underflow
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_offset.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_offset.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_offset.db.gz {TEST_DIR}/alprd_corrupt_o
 
 load {TEST_DIR}/alprd_corrupt_offset.db readonly
 
+statement ok
+USE alprd_corrupt_offset
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='b' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_offset_unordered.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_offset_unordered.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_offset_unordered.db.gz {TEST_DIR}/alprd
 
 load {TEST_DIR}/alprd_corrupt_offset_unordered.db readonly
 
+statement ok
+USE alprd_corrupt_offset_unordered
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/alprd/alprd_corrupt_right_bit_width.test
+++ b/test/sql/storage/compression/alprd/alprd_corrupt_right_bit_width.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/alprd_corrupt_right_bit_width.db.gz {TEST_DIR}/alprd_
 
 load {TEST_DIR}/alprd_corrupt_right_bit_width.db readonly
 
+statement ok
+USE alprd_corrupt_right_bit_width
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='ALPRD' LIMIT 1;
 ----

--- a/test/sql/storage/compression/bitpacking/bitpacking_corrupt_count.test
+++ b/test/sql/storage/compression/bitpacking/bitpacking_corrupt_count.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/bitpacking_corrupt_count.db.gz {TEST_DIR}/bitpacking_
 
 load {TEST_DIR}/bitpacking_corrupt_count.db readonly
 
+statement ok
+USE bitpacking_corrupt_count
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='BitPacking';
 ----

--- a/test/sql/storage/compression/bitpacking/bitpacking_corrupt_group_offset.test
+++ b/test/sql/storage/compression/bitpacking/bitpacking_corrupt_group_offset.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/bitpacking_corrupt_group_offset.db.gz {TEST_DIR}/bitp
 
 load {TEST_DIR}/bitpacking_corrupt_group_offset.db readonly
 
+statement ok
+USE bitpacking_corrupt_group_offset
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='BitPacking';
 ----

--- a/test/sql/storage/compression/bitpacking/bitpacking_corrupt_metadata_underflow.test
+++ b/test/sql/storage/compression/bitpacking/bitpacking_corrupt_metadata_underflow.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/bitpacking_corrupt_metadata_underflow.db.gz {TEST_DIR
 
 load {TEST_DIR}/bitpacking_corrupt_metadata_underflow.db readonly
 
+statement ok
+USE bitpacking_corrupt_metadata_underflow
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='BitPacking';
 ----

--- a/test/sql/storage/compression/bitpacking/bitpacking_corrupt_width.test
+++ b/test/sql/storage/compression/bitpacking/bitpacking_corrupt_width.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/bitpacking_corrupt_width.db.gz {TEST_DIR}/bitpacking_
 
 load {TEST_DIR}/bitpacking_corrupt_width.db readonly
 
+statement ok
+USE bitpacking_corrupt_width
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='BitPacking';
 ----

--- a/test/sql/storage/compression/rle/rle_corrupt_run_undercount.test
+++ b/test/sql/storage/compression/rle/rle_corrupt_run_undercount.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/rle_corrupt_run_undercount.db.gz {TEST_DIR}/rle_corru
 
 load {TEST_DIR}/rle_corrupt_run_undercount.db readonly
 
+statement ok
+USE rle_corrupt_run_undercount
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='RLE';
 ----

--- a/test/sql/storage/compression/rle/rle_corrupt_value_capacity.test
+++ b/test/sql/storage/compression/rle/rle_corrupt_value_capacity.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/rle_corrupt_value_capacity.db.gz {TEST_DIR}/rle_corru
 
 load {TEST_DIR}/rle_corrupt_value_capacity.db readonly
 
+statement ok
+USE rle_corrupt_value_capacity
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE column_name='a' AND compression='RLE';
 ----

--- a/test/sql/storage/compression/uncompressed/validity_corrupt_count.test
+++ b/test/sql/storage/compression/uncompressed/validity_corrupt_count.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/validity_corrupt_count.db.gz {TEST_DIR}/validity_corr
 
 load {TEST_DIR}/validity_corrupt_count.db readonly
 
+statement ok
+USE validity_corrupt_count
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE segment_type='VALIDITY' AND compression='Uncompressed';
 ----

--- a/test/sql/storage/compression/uncompressed/validity_corrupt_count_boundary.test
+++ b/test/sql/storage/compression/uncompressed/validity_corrupt_count_boundary.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/validity_corrupt_count_boundary.db.gz {TEST_DIR}/vali
 
 load {TEST_DIR}/validity_corrupt_count_boundary.db readonly
 
+statement ok
+USE validity_corrupt_count_boundary
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE segment_type='VALIDITY' AND compression='Uncompressed';
 ----

--- a/test/sql/storage/compression/uncompressed/validity_corrupt_offset.test
+++ b/test/sql/storage/compression/uncompressed/validity_corrupt_offset.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/validity_corrupt_offset.db.gz {TEST_DIR}/validity_cor
 
 load {TEST_DIR}/validity_corrupt_offset.db readonly
 
+statement ok
+USE validity_corrupt_offset
+
 query I
 SELECT compression FROM pragma_storage_info('t') WHERE segment_type='VALIDITY' AND compression='Uncompressed';
 ----

--- a/test/sql/storage/types/list/list_corrupt_offset_order.test
+++ b/test/sql/storage/types/list/list_corrupt_offset_order.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/list_corrupt_offset_order.db.gz {TEST_DIR}/list_corru
 
 load {TEST_DIR}/list_corrupt_offset_order.db readonly
 
+statement ok
+USE list_corrupt_offset_order
+
 statement error
 SELECT len(a) FROM t LIMIT 5 OFFSET 98;
 ----

--- a/test/sql/storage/types/list/list_corrupt_offset_range.test
+++ b/test/sql/storage/types/list/list_corrupt_offset_range.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/list_corrupt_offset_range.db.gz {TEST_DIR}/list_corru
 
 load {TEST_DIR}/list_corrupt_offset_range.db readonly
 
+statement ok
+USE list_corrupt_offset_range
+
 statement error
 SELECT count(*) FROM (SELECT unnest(a) FROM t);
 ----

--- a/test/sql/storage/types/list/list_corrupt_offset_skip.test
+++ b/test/sql/storage/types/list/list_corrupt_offset_skip.test
@@ -8,6 +8,9 @@ unzip data/storage/corrupt/list_corrupt_offset_skip.db.gz {TEST_DIR}/list_corrup
 
 load {TEST_DIR}/list_corrupt_offset_skip.db readonly
 
+statement ok
+USE list_corrupt_offset_skip
+
 # id filter rejects whole vectors, forcing the Skip path
 statement error
 SELECT a FROM t WHERE id = 7000;


### PR DESCRIPTION
A few of recently added compression tests use:

```sql
load {TEST_DIR}/path_to_db_file.db
```

And expect the loaded DB to be available as a default catalog.

This is not the case in DuckLake test runs that use an atached DuckLake catalog as a default one using `--test-config test/configs/attach_ducklake.json` ([link](https://github.com/duckdb/ducklake/blob/0f569a6bba3028637c5020ccd31af24739e3fb42/test/configs/attach_ducklake.json)).

This PR adds `USE <catalog_name>` calls at the beginnings of problematic tests.

CC: @pdet, @HendrikLambert 