### PR TITLE
Add shared SWAR word primitives

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -1766,10 +1766,10 @@ bool StringValueScanner::SkipUntilState(CSVState initial_state, CSVState until_s
 			while (current_iterator.pos.buffer_pos + 8 < to_pos) {
 				uint64_t value = Load<uint64_t>(
 				    reinterpret_cast<const_data_ptr_t>(&buffer_handle_ptr[current_iterator.pos.buffer_pos]));
-				if (ContainsZeroByte((value ^ state_machine_strict->transition_array.delimiter) &
-				                     (value ^ state_machine_strict->transition_array.new_line) &
-				                     (value ^ state_machine_strict->transition_array.carriage_return) &
-				                     (value ^ state_machine_strict->transition_array.comment))) {
+				if (SwarWord::MaybeZeroBytes((value ^ state_machine_strict->transition_array.delimiter) &
+				                             (value ^ state_machine_strict->transition_array.new_line) &
+				                             (value ^ state_machine_strict->transition_array.carriage_return) &
+				                             (value ^ state_machine_strict->transition_array.comment))) {
 					break;
 				}
 				current_iterator.pos.buffer_pos += 8;
@@ -1784,8 +1784,8 @@ bool StringValueScanner::SkipUntilState(CSVState initial_state, CSVState until_s
 			while (current_iterator.pos.buffer_pos + 8 < to_pos) {
 				uint64_t value = Load<uint64_t>(
 				    reinterpret_cast<const_data_ptr_t>(&buffer_handle_ptr[current_iterator.pos.buffer_pos]));
-				if (ContainsZeroByte((value ^ state_machine_strict->transition_array.quote) &
-				                     (value ^ state_machine_strict->transition_array.escape))) {
+				if (SwarWord::MaybeZeroBytes((value ^ state_machine_strict->transition_array.quote) &
+				                             (value ^ state_machine_strict->transition_array.escape))) {
 					break;
 				}
 				current_iterator.pos.buffer_pos += 8;

--- a/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
+++ b/src/execution/operator/csv_scanner/state_machine/csv_state_machine_cache.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/csv_scanner/csv_state_machine.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_state_machine_cache.hpp"
 #include "duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp"
+#include "duckdb/common/swar.hpp"
 
 namespace duckdb {
 
@@ -10,12 +11,6 @@ void InitializeTransitionArray(StateMachine &transition_array, const CSVState cu
 	}
 }
 
-// Shift and OR to replicate across all bytes
-void ShiftAndReplicateBits(uint64_t &value) {
-	value |= value << 8;
-	value |= value << 16;
-	value |= value << 32;
-}
 void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_options) {
 	D_ASSERT(state_machine_cache.find(state_machine_options) == state_machine_cache.end());
 	// Initialize transition array with default values to the Standard option
@@ -448,19 +443,11 @@ void CSVStateMachineCache::Insert(const CSVStateMachineOptions &state_machine_op
 	transition_array.skip_comment[static_cast<uint8_t>('\r')] = false;
 	transition_array.skip_comment[static_cast<uint8_t>('\n')] = false;
 
-	transition_array.delimiter = delimiter_first_byte;
-	transition_array.new_line = static_cast<uint8_t>('\n');
-	transition_array.carriage_return = static_cast<uint8_t>('\r');
-	transition_array.quote = quote;
-	transition_array.escape = escape;
-
-	// Shift and OR to replicate across all bytes
-	ShiftAndReplicateBits(transition_array.delimiter);
-	ShiftAndReplicateBits(transition_array.new_line);
-	ShiftAndReplicateBits(transition_array.carriage_return);
-	ShiftAndReplicateBits(transition_array.quote);
-	ShiftAndReplicateBits(transition_array.escape);
-	ShiftAndReplicateBits(transition_array.comment);
+	transition_array.delimiter = SwarWord::Repeat(delimiter_first_byte);
+	transition_array.new_line = SwarWord::Repeat('\n');
+	transition_array.carriage_return = SwarWord::Repeat('\r');
+	transition_array.quote = SwarWord::Repeat(quote);
+	transition_array.escape = SwarWord::Repeat(escape);
 }
 
 CSVStateMachineCache::CSVStateMachineCache() {

--- a/src/function/scalar/create_sort_key.cpp
+++ b/src/function/scalar/create_sort_key.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/bswap.hpp"
 #include "duckdb/common/enums/order_type.hpp"
 #include "duckdb/common/radix.hpp"
+#include "duckdb/common/swar.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -144,47 +145,17 @@ struct SortKeyVectorData {
 	data_t valid_byte;
 };
 
-//! Word-at-a-time (SWAR) primitives used to encode string/blob payloads
+//! Word at a time primitives specific to encoding string and blob payloads, on top of SwarWord
 struct SortKeyWord {
-	static constexpr idx_t SIZE = sizeof(uint64_t);
-	static constexpr uint64_t LSB = 0x0101010101010101ULL;
-	static constexpr uint64_t MSB = 0x8080808080808080ULL;
-	static constexpr uint64_t LOW7 = 0x7F7F7F7F7F7F7F7FULL;
-
-	//! Sets the high bit of every byte of `word` that is zero
-	static inline uint64_t ZeroBytes(uint64_t word) {
-		return ~(((word & LOW7) + LOW7) | word) & MSB;
-	}
-
-	//! Sets the high bit of every byte of `word` that has to be escaped (\x00 or \x01)
+	//! Flags every byte of `word` that has to be escaped (\x00 or \x01)
 	static inline uint64_t EscapedBytes(uint64_t word) {
 		// clearing the lowest bit maps both \x00 and \x01 - and nothing else - onto \x00
-		return ZeroBytes(word & ~LSB);
+		return SwarWord::ZeroBytes(word & ~SwarWord::LSB);
 	}
 
 	//! Adds one to every byte of `word`, wrapping around within each byte
 	static inline uint64_t IncrementBytes(uint64_t word) {
-		return ((word & LOW7) + LSB) ^ (word & MSB);
-	}
-
-	//! Sums up the individual bytes of `word` - only valid if the sum does not exceed 255
-	static inline idx_t SumBytes(uint64_t word) {
-		return static_cast<idx_t>((word * LSB) >> 56);
-	}
-
-	//! The number of bytes flagged in a mask returned by ZeroBytes/EscapedBytes
-	static inline idx_t CountFlagged(uint64_t mask) {
-		// every flagged byte has its high bit set - shift it down so each byte is a zero or a one
-		return SumBytes(mask >> 7);
-	}
-
-	//! The index of the first byte flagged in a mask returned by ZeroBytes/EscapedBytes
-	static inline idx_t FirstFlagged(uint64_t mask) {
-#if DUCKDB_IS_BIG_ENDIAN
-		return CountZeros<uint64_t>::Leading(mask) / 8;
-#else
-		return CountZeros<uint64_t>::Trailing(mask) / 8;
-#endif
+		return ((word & SwarWord::LOW7) + SwarWord::LSB) ^ (word & SwarWord::MSB);
 	}
 
 	template <bool FLIP_BYTES>
@@ -212,7 +183,7 @@ struct SortKeyConstantOperator {
 		if (FLIP_BYTES) {
 			// flip word-at-a-time - the encoded size is a compile-time constant, so this fully unrolls
 			idx_t b = 0;
-			for (; b + SortKeyWord::SIZE <= sizeof(T); b += SortKeyWord::SIZE) {
+			for (; b + SwarWord::SIZE <= sizeof(T); b += SwarWord::SIZE) {
 				Store<uint64_t>(~Load<uint64_t>(result + b), result + b);
 			}
 			for (; b < sizeof(T); b++) {
@@ -253,7 +224,7 @@ struct SortKeyVarcharOperator {
 		auto input_data = const_data_ptr_cast(input.GetDataUnsafe());
 		auto input_size = input.GetSize();
 		idx_t pos = 0;
-		for (; pos + SortKeyWord::SIZE <= input_size; pos += SortKeyWord::SIZE) {
+		for (; pos + SwarWord::SIZE <= input_size; pos += SwarWord::SIZE) {
 			auto encoded = SortKeyWord::IncrementBytes(Load<uint64_t>(input_data + pos));
 			Store<uint64_t>(SortKeyWord::FlipWord<FLIP_BYTES>(encoded), result + pos);
 		}
@@ -296,7 +267,7 @@ struct SortKeyBlobOperator {
 
 	//! Number of words processed per iteration of the bulk loops
 	static constexpr idx_t BLOCK = 4;
-	static constexpr idx_t BLOCK_SIZE = BLOCK * SortKeyWord::SIZE;
+	static constexpr idx_t BLOCK_SIZE = BLOCK * SwarWord::SIZE;
 
 	static idx_t GetEncodeLength(TYPE input) {
 		auto input_data = const_data_ptr_cast(input.GetDataUnsafe());
@@ -307,13 +278,12 @@ struct SortKeyBlobOperator {
 			// the per-byte counts of an entire block fit in a single word, so we only sum them up once
 			uint64_t flagged = 0;
 			for (idx_t w = 0; w < BLOCK; w++) {
-				flagged += SortKeyWord::EscapedBytes(Load<uint64_t>(input_data + pos + w * SortKeyWord::SIZE)) >> 7;
+				flagged += SortKeyWord::EscapedBytes(Load<uint64_t>(input_data + pos + w * SwarWord::SIZE)) >> 7;
 			}
-			escaped_characters += SortKeyWord::SumBytes(flagged);
+			escaped_characters += SwarWord::SumBytes(flagged);
 		}
-		for (; pos + SortKeyWord::SIZE <= input_size; pos += SortKeyWord::SIZE) {
-			escaped_characters +=
-			    SortKeyWord::CountFlagged(SortKeyWord::EscapedBytes(Load<uint64_t>(input_data + pos)));
+		for (; pos + SwarWord::SIZE <= input_size; pos += SwarWord::SIZE) {
+			escaped_characters += SwarWord::CountFlagged(SortKeyWord::EscapedBytes(Load<uint64_t>(input_data + pos)));
 		}
 		for (; pos < input_size; pos++) {
 			// we escape both \x00 and \x01
@@ -330,13 +300,13 @@ struct SortKeyBlobOperator {
 		auto input_size = input.GetSize();
 		idx_t result_offset = 0;
 		idx_t pos = 0;
-		while (pos + SortKeyWord::SIZE <= input_size) {
+		while (pos + SwarWord::SIZE <= input_size) {
 			// bulk-copy BLOCK words at a time for as long as none of them contain a byte to escape
 			while (pos + BLOCK_SIZE <= input_size) {
 				uint64_t words[BLOCK];
 				uint64_t escapes = 0;
 				for (idx_t w = 0; w < BLOCK; w++) {
-					words[w] = Load<uint64_t>(input_data + pos + w * SortKeyWord::SIZE);
+					words[w] = Load<uint64_t>(input_data + pos + w * SwarWord::SIZE);
 					escapes |= SortKeyWord::EscapedBytes(words[w]);
 				}
 				if (escapes) {
@@ -344,12 +314,12 @@ struct SortKeyBlobOperator {
 				}
 				for (idx_t w = 0; w < BLOCK; w++) {
 					Store<uint64_t>(SortKeyWord::FlipWord<FLIP_BYTES>(words[w]),
-					                result + result_offset + w * SortKeyWord::SIZE);
+					                result + result_offset + w * SwarWord::SIZE);
 				}
 				pos += BLOCK_SIZE;
 				result_offset += BLOCK_SIZE;
 			}
-			if (pos + SortKeyWord::SIZE > input_size) {
+			if (pos + SwarWord::SIZE > input_size) {
 				break;
 			}
 			// we have at least one full word of input left, and hence at least SIZE + 1 bytes of result space,
@@ -358,12 +328,12 @@ struct SortKeyBlobOperator {
 			Store<uint64_t>(SortKeyWord::FlipWord<FLIP_BYTES>(word), result + result_offset);
 			const auto escapes = SortKeyWord::EscapedBytes(word);
 			if (!escapes) {
-				pos += SortKeyWord::SIZE;
-				result_offset += SortKeyWord::SIZE;
+				pos += SwarWord::SIZE;
+				result_offset += SwarWord::SIZE;
 				continue;
 			}
 			// escape the first flagged byte - the remainder of the word is re-processed in the next iteration
-			const auto escape_pos = SortKeyWord::FirstFlagged(escapes);
+			const auto escape_pos = SwarWord::FirstFlagged(escapes);
 			result_offset += escape_pos;
 			result[result_offset++] = SortKeyWord::FlipByte<FLIP_BYTES>(SortKeyVectorData::BLOB_ESCAPE_CHARACTER);
 			result[result_offset++] = SortKeyWord::FlipByte<FLIP_BYTES>(input_data[pos + escape_pos]);

--- a/src/function/scalar/string/strip_accents.cpp
+++ b/src/function/scalar/string/strip_accents.cpp
@@ -1,17 +1,16 @@
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/common/swar.hpp"
 
 #include "utf8proc.hpp"
 
 namespace duckdb {
 
 bool IsAscii(const char *input, idx_t n) {
-	static constexpr uint64_t MASK = 0x8080808080808080U;
-
 	// Check 8 bytes at a time
 	idx_t i = 0;
-	for (; i + sizeof(uint64_t) <= n; i += sizeof(uint64_t)) {
-		if ((Load<uint64_t>(const_data_ptr_cast(input + i)) & MASK)) {
+	for (; i + SwarWord::SIZE <= n; i += SwarWord::SIZE) {
+		if (!SwarWord::IsAscii(Load<uint64_t>(const_data_ptr_cast(input + i)))) {
 			// non-ascii character in the next 8 bytes
 			return false;
 		}

--- a/src/include/duckdb/common/swar.hpp
+++ b/src/include/duckdb/common/swar.hpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/swar.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/bit_utils.hpp"
+#include "duckdb/common/typedefs.hpp"
+
+namespace duckdb {
+
+//! SWAR primitives over the eight bytes of a uint64_t, the masks flag a byte by setting its high bit
+struct SwarWord {
+	static constexpr idx_t SIZE = sizeof(uint64_t);
+	static constexpr uint64_t LSB = 0x0101010101010101ULL;
+	static constexpr uint64_t MSB = 0x8080808080808080ULL;
+	static constexpr uint64_t LOW7 = 0x7F7F7F7F7F7F7F7FULL;
+
+	//! A word with every byte set to `byte`
+	static inline uint64_t Repeat(uint8_t byte) {
+		return LSB * byte;
+	}
+
+	//! Flags every byte of `word` that is zero, exact for all byte values
+	static inline uint64_t ZeroBytes(uint64_t word) {
+		return ~(((word & LOW7) + LOW7) | word) & MSB;
+	}
+
+	//! Flags every zero byte of `word` and possibly bytes above one, cheaper than ZeroBytes for callers that verify
+	static inline uint64_t MaybeZeroBytes(uint64_t word) {
+		return (word - LSB) & ~word & MSB;
+	}
+
+	//! Whether no byte of `word` has its high bit set
+	static inline bool IsAscii(uint64_t word) {
+		return (word & MSB) == 0;
+	}
+
+	//! Sums up the individual bytes of `word`, only valid if the sum does not exceed 255
+	static inline idx_t SumBytes(uint64_t word) {
+		return static_cast<idx_t>((word * LSB) >> 56);
+	}
+
+	//! The number of flagged bytes in a mask
+	static inline idx_t CountFlagged(uint64_t mask) {
+		// every flagged byte has its high bit set, shifted down each byte is a zero or a one
+		return SumBytes(mask >> 7);
+	}
+
+	//! The index (in memory order) of the first flagged byte in a mask
+	static inline idx_t FirstFlagged(uint64_t mask) {
+#if DUCKDB_IS_BIG_ENDIAN
+		return CountZeros<uint64_t>::Leading(mask) / 8;
+#else
+		return CountZeros<uint64_t>::Trailing(mask) / 8;
+#endif
+	}
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/base_scanner.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/execution/operator/csv_scanner/csv_state_machine.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_error.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/swar.hpp"
 
 namespace duckdb {
 
@@ -183,10 +184,6 @@ public:
 	static CSVIterator SkipCSVRows(shared_ptr<CSVBufferManager> buffer_manager,
 	                               const shared_ptr<CSVStateMachine> &state_machine, idx_t rows_to_skip);
 
-	inline static bool ContainsZeroByte(uint64_t v) {
-		return (v - UINT64_C(0x0101010101010101)) & ~(v)&UINT64_C(0x8080808080808080);
-	}
-
 protected:
 	//! Boundaries of this scanner
 	CSVIterator iterator;
@@ -319,8 +316,8 @@ protected:
 				while (iterator.pos.buffer_pos + 8 < to_pos) {
 					const uint64_t value =
 					    Load<uint64_t>(reinterpret_cast<const_data_ptr_t>(&buffer_handle_ptr[iterator.pos.buffer_pos]));
-					if (ContainsZeroByte((value ^ state_machine->transition_array.quote) &
-					                     (value ^ state_machine->transition_array.escape))) {
+					if (SwarWord::MaybeZeroBytes((value ^ state_machine->transition_array.quote) &
+					                             (value ^ state_machine->transition_array.escape))) {
 						break;
 					}
 					iterator.pos.buffer_pos += 8;
@@ -356,11 +353,11 @@ protected:
 				while (iterator.pos.buffer_pos + 8 < to_pos) {
 					uint64_t value =
 					    Load<uint64_t>(reinterpret_cast<const_data_ptr_t>(&buffer_handle_ptr[iterator.pos.buffer_pos]));
-					if (ContainsZeroByte((value ^ state_machine->transition_array.delimiter) &
-					                     (value ^ state_machine->transition_array.new_line) &
-					                     (value ^ state_machine->transition_array.carriage_return) &
-					                     (value ^ state_machine->transition_array.escape) &
-					                     (value ^ state_machine->transition_array.comment))) {
+					if (SwarWord::MaybeZeroBytes((value ^ state_machine->transition_array.delimiter) &
+					                             (value ^ state_machine->transition_array.new_line) &
+					                             (value ^ state_machine->transition_array.carriage_return) &
+					                             (value ^ state_machine->transition_array.escape) &
+					                             (value ^ state_machine->transition_array.comment))) {
 						break;
 					}
 					iterator.pos.buffer_pos += 8;
@@ -382,8 +379,8 @@ protected:
 				while (iterator.pos.buffer_pos + 8 < to_pos) {
 					const uint64_t value =
 					    Load<uint64_t>(reinterpret_cast<const_data_ptr_t>(&buffer_handle_ptr[iterator.pos.buffer_pos]));
-					if (ContainsZeroByte((value ^ state_machine->transition_array.new_line) &
-					                     (value ^ state_machine->transition_array.carriage_return))) {
+					if (SwarWord::MaybeZeroBytes((value ^ state_machine->transition_array.new_line) &
+					                             (value ^ state_machine->transition_array.carriage_return))) {
 						break;
 					}
 					iterator.pos.buffer_pos += 8;

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library_unity(
   test_strftime.cpp
   test_string_util.cpp
   test_substring_oob.cpp
+  test_swar.cpp
   test_utf8_codepoint_oob.cpp
   test_temporary_memory_manager.cpp
   test_versioning_utils.cpp

--- a/test/common/test_swar.cpp
+++ b/test/common/test_swar.cpp
@@ -1,0 +1,64 @@
+#include "catch.hpp"
+#include "duckdb/common/swar.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+uint64_t WordOf(const uint8_t *bytes) {
+	return Load<uint64_t>(bytes);
+}
+
+uint64_t ReferenceZeroBytes(const uint8_t *bytes) {
+	// flags in memory order, as a word
+	uint8_t flags[SwarWord::SIZE];
+	for (idx_t i = 0; i < SwarWord::SIZE; i++) {
+		flags[i] = bytes[i] == 0 ? 0x80 : 0;
+	}
+	return WordOf(flags);
+}
+
+} // namespace
+
+TEST_CASE("SWAR word flags", "[swar]") {
+	// every pair of byte values, in the first two lanes, with a third distinct lane
+	for (idx_t a = 0; a < 256; a++) {
+		for (idx_t b = 0; b < 256; b++) {
+			uint8_t bytes[SwarWord::SIZE] = {
+			    static_cast<uint8_t>(a), static_cast<uint8_t>(b), 0x42, 0x42, 0x42, 0x42, 0x42, 0x42};
+			const auto word = WordOf(bytes);
+			const auto exact = SwarWord::ZeroBytes(word);
+			REQUIRE(exact == ReferenceZeroBytes(bytes));
+			REQUIRE(SwarWord::IsAscii(word) == (a < 0x80 && b < 0x80));
+			// the inexact test flags every zero byte and nothing when there is none
+			const auto maybe = SwarWord::MaybeZeroBytes(word);
+			REQUIRE((exact & ~maybe) == 0);
+			if (!exact) {
+				REQUIRE(maybe == 0);
+			}
+		}
+	}
+	// flag counting and the first flagged byte on every subset of lanes
+	for (idx_t subset = 0; subset < 256; subset++) {
+		uint8_t bytes[SwarWord::SIZE];
+		idx_t expected_count = 0;
+		idx_t expected_first = SwarWord::SIZE;
+		for (idx_t i = 0; i < SwarWord::SIZE; i++) {
+			const bool flagged = (subset >> i) & 1;
+			bytes[i] = flagged ? 0 : 1;
+			expected_count += flagged;
+			if (flagged && expected_first == SwarWord::SIZE) {
+				expected_first = i;
+			}
+		}
+		const auto mask = SwarWord::ZeroBytes(WordOf(bytes));
+		REQUIRE(SwarWord::CountFlagged(mask) == expected_count);
+		if (subset) {
+			REQUIRE(SwarWord::FirstFlagged(mask) == expected_first);
+		}
+	}
+	uint8_t bytes[SwarWord::SIZE] = {1, 2, 3, 4, 5, 6, 7, 8};
+	REQUIRE(SwarWord::SumBytes(WordOf(bytes)) == 36);
+	REQUIRE(SwarWord::SumBytes(SwarWord::Repeat(31)) == 248);
+	REQUIRE(SwarWord::Repeat(0x2c) == 0x2c2c2c2c2c2c2c2cULL);
+}


### PR DESCRIPTION
This PR adds duckdb/common/swar.hpp, a header with the word-at-a-time byte primitives (SWAR, "SIMD within a register").