### PR TITLE
Return an input error for invalid regex split patterns

### DIFF
--- a/src/function/scalar/string/string_split.cpp
+++ b/src/function/scalar/string/string_split.cpp
@@ -155,6 +155,7 @@ ScalarFunctionSet StringSplitRegexFun::GetFunctions() {
 	// regexp options
 	regex_fun.GetSignature().AddParameter(LogicalType::VARCHAR);
 	regexp_split.AddFunction(regex_fun);
+	regexp_split.SetFallible();
 	return regexp_split;
 }
 

--- a/test/sql/function/string/test_string_split.test
+++ b/test/sql/function/string/test_string_split.test
@@ -355,3 +355,20 @@ statement error
 SELECT string_split_regex(a, '[') FROM test ORDER BY a;
 ----
 <REGEX>:.*Catalog Error.*does not exist.*
+
+# error in non-constant regex
+statement ok
+CREATE TABLE split_patterns (s VARCHAR, p VARCHAR)
+
+statement ok
+INSERT INTO split_patterns VALUES ('asdf', '(')
+
+statement error
+SELECT string_split_regex(s, p) FROM split_patterns
+----
+<REGEX>:.*Invalid Input Error.*missing.*
+
+statement error
+SELECT string_split_regex(s, p, 'c') FROM split_patterns
+----
+<REGEX>:.*Invalid Input Error.*missing.*


### PR DESCRIPTION
Invalid dynamic regex patterns currently raise an internal error in the regex split functions.

Mark these functions as fallible so they return an `Invalid Input Error`, matching constant patterns.
