### PR TITLE
Fix chained function calls on case-insensitive column matches

### DIFF
--- a/src/planner/column_qualifier.cpp
+++ b/src/planner/column_qualifier.cpp
@@ -302,6 +302,7 @@ optional_ptr<CatalogEntry> ColumnQualifier::QualifyFunction(FunctionExpression &
 	if (!new_colref) {
 		new_colref = std::move(colref);
 	}
+	new_colref->ClearAlias();
 	// we can! transform this into a function call on the column
 	// i.e. "x.lower()" becomes "lower(x)"
 	function.GetArgumentsMutable().insert(function.GetArgumentsMutable().begin(), std::move(new_colref));

--- a/test/sql/parser/function_chaining.test
+++ b/test/sql/parser/function_chaining.test
@@ -106,3 +106,16 @@ query I
 EXECUTE v1('Hello World')
 ----
 hello
+
+# chaining on a column whose name differs in case from the reference
+query I
+SELECT strftime(ci.purchasedate.nullif('1899-12-30T00:00:00'), '%Y-%m-%d')
+FROM (VALUES (TIMESTAMP '2026-01-01')) AS ci("PurchaseDate")
+----
+2026-01-01
+
+query I
+SELECT strftime(ci.PURCHASEDATE.nullif('1899-12-30T00:00:00'), '%Y-%m-%d')
+FROM (VALUES (TIMESTAMP '2026-01-01')) AS ci("PurchaseDate")
+----
+2026-01-01


### PR DESCRIPTION
Chaining a macro onto a column referenced with a different letter case than it was declared with fails to bind. 

Spoiler: the letter case is not the actual problem.

Identifiers are case-preserving, so when the registered name and the column name differ the binder adds an alias carrying the original name to the qualified reference. That's fine until the function is rewritten and the alias lands in argument position, where it means a named parameter. This PR clears the alias before the reference becomes an argument.

Fixes: https://github.com/duckdb/duckdb/issues/25285