### PR TITLE
Bound the unselected prefix range key lookup by the filter count

### DIFF
--- a/src/planner/filter/table_filter_prefix_range_function.cpp
+++ b/src/planner/filter/table_filter_prefix_range_function.cpp
@@ -136,16 +136,24 @@ public:
 
 	template <typename T, typename CONVERTER>
 	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const {
+		UnifiedVectorFormat key_data;
+		keys.ToUnifiedFormat(key_data);
+
+		const auto keys_data = UnifiedVectorFormat::GetData<T>(key_data);
 		idx_t found_count = 0;
-		for (const auto &entry : keys.template ValidValues<T>()) {
-			const U comparable = CONVERTER::Convert(entry.GetValue());
+		for (idx_t i = 0; i < count; i++) {
+			const auto key_idx = key_data.sel->get_index(i);
+			if (!key_data.validity.RowIsValid(key_idx)) {
+				continue;
+			}
+			const U comparable = CONVERTER::Convert(keys_data[key_idx]);
 			const U y = comparable - min;
 			const U bit_idx = y >> shift;
 			const uint8_t in_range = y <= span;
 			const uint32_t word_idx = (bit_idx >> WORD_SHIFT) & (0U - in_range);
 			const uint8_t bit = (bitmap[word_idx] >> (bit_idx & WORD_MASK)) & 1ULL;
 
-			result_sel.set_index(found_count, entry.GetIndex());
+			result_sel.set_index(found_count, i);
 			found_count += bit & in_range;
 		}
 		return found_count;

--- a/src/planner/filter/table_filter_prefix_range_function.cpp
+++ b/src/planner/filter/table_filter_prefix_range_function.cpp
@@ -136,17 +136,15 @@ public:
 
 	template <typename T, typename CONVERTER>
 	idx_t LookupKeys(Vector &keys, SelectionVector &result_sel, idx_t count) const {
-		UnifiedVectorFormat key_data;
-		keys.ToUnifiedFormat(key_data);
-
-		const auto keys_data = UnifiedVectorFormat::GetData<T>(key_data);
+		D_ASSERT(count <= keys.size());
+		auto key_entries = keys.Values<T>();
 		idx_t found_count = 0;
 		for (idx_t i = 0; i < count; i++) {
-			const auto key_idx = key_data.sel->get_index(i);
-			if (!key_data.validity.RowIsValid(key_idx)) {
+			const auto key_entry = key_entries[i];
+			if (!key_entry.IsValid()) {
 				continue;
 			}
-			const U comparable = CONVERTER::Convert(keys_data[key_idx]);
+			const U comparable = CONVERTER::Convert(key_entry.GetValue());
 			const U y = comparable - min;
 			const U bit_idx = y >> shift;
 			const uint8_t in_range = y <= span;
@@ -161,18 +159,14 @@ public:
 
 	template <typename T, typename CONVERTER>
 	idx_t LookupKeys(Vector &keys, const SelectionVector &sel, SelectionVector &result_sel, idx_t count) const {
-		UnifiedVectorFormat key_data;
-		keys.ToUnifiedFormat(key_data);
-
-		const auto keys_data = UnifiedVectorFormat::GetData<T>(key_data);
+		auto key_entries = keys.Values<T>();
 		idx_t found_count = 0;
 		for (idx_t i = 0; i < count; i++) {
-			const auto idx = sel.get_index_unsafe(i);
-			const auto key_idx = key_data.sel->get_index(idx);
-			if (!key_data.validity.RowIsValid(key_idx)) {
+			const auto key_entry = key_entries[sel.get_index_unsafe(i)];
+			if (!key_entry.IsValid()) {
 				continue;
 			}
-			const U comparable = CONVERTER::Convert(keys_data[key_idx]);
+			const U comparable = CONVERTER::Convert(key_entry.GetValue());
 			const U y = comparable - min;
 			const U bit_idx = y >> shift;
 			const uint8_t in_range = y <= span;

--- a/test/sql/filter/CMakeLists.txt
+++ b/test/sql/filter/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library_unity(test_filter OBJECT filter_cache.cpp)
+add_library_unity(test_filter OBJECT filter_cache.cpp
+                  prefix_range_filter_lookup.cpp)
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_filter>
     PARENT_SCOPE)

--- a/test/sql/filter/prefix_range_filter_lookup.cpp
+++ b/test/sql/filter/prefix_range_filter_lookup.cpp
@@ -1,0 +1,77 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb/common/vector/flat_vector.hpp"
+#include "duckdb/planner/filter/table_filter_functions.hpp"
+
+using namespace duckdb;
+
+// A concurrent append can grow a scanned column past the row count captured at scan init, so the
+// filter can be handed a vector holding more rows than count. The caller sizes result_sel to count
+// only, so a lookup that runs to the end of the vector writes past the end of result_sel. That race
+// cannot be driven from SQL, so the bound is asserted directly here.
+TEST_CASE("Prefix range filter lookup is bounded by the filter count", "[filter][prefix_range]") {
+	constexpr idx_t VECTOR_ROWS = STANDARD_VECTOR_SIZE;
+	constexpr idx_t FILTER_ROWS = VECTOR_ROWS >= 64 ? VECTOR_ROWS / 64 : 1;
+	constexpr idx_t NULL_ROW = FILTER_ROWS - 1;
+	constexpr idx_t MAX_BITS = 1ULL << 26;
+
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &context = *con.context;
+
+	Vector keys(LogicalType::BIGINT, VECTOR_ROWS);
+	auto key_data = FlatVector::GetDataMutable<int64_t>(keys);
+	FlatVector::SetSize(keys, count_t(VECTOR_ROWS));
+
+	for (idx_t i = 0; i < VECTOR_ROWS; i++) {
+		key_data[i] = NumericCast<int64_t>(2 * i + 1);
+	}
+	auto filter = PrefixRangeFilter::CreatePrefixRangeFilter(LogicalType::BIGINT);
+	filter->Initialize(context, VECTOR_ROWS, Value::BIGINT(1), Value::BIGINT(NumericCast<int64_t>(2 * VECTOR_ROWS - 1)),
+	                   MAX_BITS);
+	auto build_state = filter->InitializeBuildState(context);
+	filter->InsertKeys(keys, *build_state);
+	filter->MergeBuildState(*build_state);
+
+	// only the odd keys are in the bitmap, key 0 sits below its lower bound, and NULLs never match
+	for (idx_t i = 0; i < VECTOR_ROWS; i++) {
+		key_data[i] = NumericCast<int64_t>(i);
+	}
+	FlatVector::SetNull(keys, NULL_ROW, true);
+
+	vector<idx_t> expected_rows;
+	for (idx_t i = 0; i < FILTER_ROWS; i++) {
+		if (i % 2 == 1 && i != NULL_ROW) {
+			expected_rows.push_back(i);
+		}
+	}
+	SelectionVector result_sel;
+	result_sel.Initialize(FILTER_ROWS);
+	auto found_count = filter->LookupKeys(keys, result_sel, FILTER_ROWS);
+	REQUIRE(found_count == expected_rows.size());
+	for (idx_t i = 0; i < found_count; i++) {
+		REQUIRE(result_sel.get_index(i) == expected_rows[i]);
+	}
+
+	// the selection overload reports positions in sel rather than the row ids it selected
+	SelectionVector input_sel;
+	input_sel.Initialize(FILTER_ROWS);
+	for (idx_t i = 0; i < FILTER_ROWS; i++) {
+		input_sel.set_index(i, FILTER_ROWS - i - 1);
+	}
+	vector<idx_t> expected_positions;
+	for (idx_t i = 0; i < FILTER_ROWS; i++) {
+		const auto row = FILTER_ROWS - i - 1;
+		if (row % 2 == 1 && row != NULL_ROW) {
+			expected_positions.push_back(i);
+		}
+	}
+	SelectionVector selected_sel;
+	selected_sel.Initialize(FILTER_ROWS);
+	auto selected_count = filter->LookupKeys(keys, input_sel, selected_sel, FILTER_ROWS);
+	REQUIRE(selected_count == expected_positions.size());
+	for (idx_t i = 0; i < selected_count; i++) {
+		REQUIRE(selected_sel.get_index(i) == expected_positions[i]);
+	}
+}


### PR DESCRIPTION
`PrefixRangeBitmap::LookupKeys` (no-selection overload) ignored its `count`
parameter and iterated `keys.ValidValues<T>()`, which spans the vector's
buffer capacity rather than the rows being filtered. The caller sizes
`result_sel` to `approved_tuple_count` via `PrepareCapacity`, so a vector
holding more valid values than that count overflows the selection buffer.

The write is unconditional per iteration (the cursor only advances on a
match), so it overflows even when nothing matches.

Fixed by bounding the loop by `count`, matching the selection overload
directly below it.

Found via AddressSanitizer debugging a flaky ducklake test:

```
WRITE of size 4 at 0x7767409efc78 thread T73
  #0 SelectionVector::set_index                          selection_vector.hpp:126
  #1 PrefixRangeBitmap<uint64_t>::LookupKeys<int64_t,..> table_filter_prefix_range_function.cpp:148
  #2 NumericPrefixRangeFilter<int64_t>::LookupKeys       :322
  #3 PrefixRangeFilterExecutor::FilterSelection          table_filter_state.cpp:386
0x7767409efc78 is located 0 bytes after 88-byte region
```

88 bytes = 22 `sel_t` entries; the write lands at index 22.

No test: existing prefix-range tests do not trip ASAN, and I could not
construct a deterministic DuckDB-level reproducer. Observed via a DuckLake
concurrency test on a musl build, where the corrupted chunk aborts in
`free()`; glibc tolerates it silently.

Made with AI help
