### PR TITLE
Add comment and tags for table functions in bind callback.

### DIFF
--- a/src/function/table/system/pragma_table_info.cpp
+++ b/src/function/table/system/pragma_table_info.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/planner/binder.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/json_document.hpp"
 #include "duckdb/common/limits.hpp"
 
 #include <algorithm>
@@ -102,6 +103,26 @@ struct PragmaTableInfoHelper {
 };
 
 struct PragmaShowHelper {
+	static Value ColumnExtraInfo(const Value &comment, const InsertionOrderPreservingMap<string> &tags) {
+		if (comment.IsNull() && tags.empty()) {
+			return Value();
+		}
+		JSONWriter writer;
+		auto result = writer.CreateObject();
+		if (!comment.IsNull()) {
+			result.AddString("comment", comment.GetValue<string>());
+		}
+		if (!tags.empty()) {
+			auto tags_object = writer.CreateObject();
+			for (auto &tag : tags) {
+				tags_object.AddString(tag.first, tag.second);
+			}
+			result.Add("tags", tags_object);
+		}
+		writer.SetRoot(result);
+		return Value(writer.ToString(JSONWriteFlags::ALLOW_INVALID_UNICODE));
+	}
+
 	static void GetSchema(vector<LogicalType> &return_types, vector<Identifier> &names) {
 		names.emplace_back("column_name");
 		return_types.emplace_back(LogicalType::VARCHAR);
@@ -139,10 +160,11 @@ struct PragmaShowHelper {
 		// "default", VARCHAR
 		output.data[4].Append(DefaultValue(column));
 		// "extra", VARCHAR
-		output.data[5].Append(Value());
+		output.data[5].Append(ColumnExtraInfo(column.Comment(), column.Tags()));
 	}
 
-	static void GetViewColumns(idx_t i, const Identifier &name, const LogicalType &type, DataChunk &output) {
+	static void GetViewColumns(const Identifier &name, const LogicalType &type, const Value &comment,
+	                           const InsertionOrderPreservingMap<string> &tags, DataChunk &output) {
 		// "column_name", VARCHAR
 		output.data[0].Append(Value(name));
 		// "column_type", VARCHAR
@@ -154,7 +176,7 @@ struct PragmaShowHelper {
 		// "default", VARCHAR
 		output.data[4].Append(Value());
 		// "extra", VARCHAR
-		output.data[5].Append(Value());
+		output.data[5].Append(ColumnExtraInfo(comment, tags));
 	}
 };
 
@@ -220,6 +242,19 @@ void PragmaTableInfo::GetColumnInfo(TableCatalogEntry &table, const ColumnDefini
 	PragmaShowHelper::GetTableColumns(column, constraint_info, output);
 }
 
+void PragmaTableInfo::GetShowSchema(vector<LogicalType> &return_types, vector<Identifier> &names) {
+	PragmaShowHelper::GetSchema(return_types, names);
+}
+
+Value PragmaTableInfo::GetColumnExtraInfo(const Value &comment, const InsertionOrderPreservingMap<string> &tags) {
+	return PragmaShowHelper::ColumnExtraInfo(comment, tags);
+}
+
+void PragmaTableInfo::GetColumnInfo(const Identifier &name, const LogicalType &type, const Value &comment,
+                                    const InsertionOrderPreservingMap<string> &tags, DataChunk &output) {
+	PragmaShowHelper::GetViewColumns(name, type, comment, tags, output);
+}
+
 static void PragmaTableInfoTable(PragmaTableOperatorData &data, TableCatalogEntry &table, DataChunk &output,
                                  bool is_table_info) {
 	if (data.offset >= table.GetColumns().LogicalColumnCount()) {
@@ -266,7 +301,8 @@ static void PragmaTableInfoView(ClientContext &context, PragmaTableOperatorData 
 		if (is_table_info) {
 			PragmaTableInfoHelper::GetViewColumns(i, name, type, output);
 		} else {
-			PragmaShowHelper::GetViewColumns(i, name, type, output);
+			PragmaShowHelper::GetViewColumns(name, type, view.GetColumnComment(i),
+			                                 InsertionOrderPreservingMap<string>(), output);
 		}
 	}
 	data.offset = next;

--- a/src/function/table_function.cpp
+++ b/src/function/table_function.cpp
@@ -82,6 +82,33 @@ bool TableFunction::operator==(const TableFunction &rhs) const {
 	       global_initialization == rhs.global_initialization;
 }
 
+void TableFunctionBindInput::CheckBindResult(const vector<LogicalType> &return_types,
+                                             const vector<Identifier> &names) const {
+	if (return_types.size() != names.size()) {
+		throw InternalException("Failed to bind \"%s\": return_types/names must have same size", table_function.name);
+	}
+	if (return_types.empty()) {
+		throw InternalException("Failed to bind \"%s\": Table function must return at least one column",
+		                        table_function.name);
+	}
+	if (!column_comments.empty() && column_comments.size() != return_types.size()) {
+		throw InternalException(
+		    "Failed to bind \"%s\": column comments must be empty or have the same size as return_types",
+		    table_function.name);
+	}
+	if (!column_tags.empty() && column_tags.size() != return_types.size()) {
+		throw InternalException(
+		    "Failed to bind \"%s\": column tags must be empty or have the same size as return_types",
+		    table_function.name);
+	}
+	for (auto &comment : column_comments) {
+		if (!comment.IsNull() && comment.type() != LogicalType::VARCHAR) {
+			throw InternalException("Failed to bind \"%s\": column comments must be VARCHAR values",
+			                        table_function.name);
+		}
+	}
+}
+
 bool TableFunction::operator!=(const TableFunction &rhs) const {
 	return !(*this == rhs);
 }

--- a/src/include/duckdb/function/table/system_functions.hpp
+++ b/src/include/duckdb/function/table/system_functions.hpp
@@ -19,7 +19,15 @@ struct PragmaCollations {
 };
 
 struct PragmaTableInfo {
+	//! The schema returned by pragma_show / DESCRIBE
+	static void GetShowSchema(vector<LogicalType> &return_types, vector<Identifier> &names);
+	//! Formats optional column metadata for the DESCRIBE extra column
+	static Value GetColumnExtraInfo(const Value &comment, const InsertionOrderPreservingMap<string> &tags);
+	//! Appends a pragma_show / DESCRIBE row for a table column
 	static void GetColumnInfo(TableCatalogEntry &table, const ColumnDefinition &column, DataChunk &output);
+	//! Appends a pragma_show / DESCRIBE row for a column that is not backed by a table column
+	static void GetColumnInfo(const Identifier &name, const LogicalType &type, const Value &comment,
+	                          const InsertionOrderPreservingMap<string> &tags, DataChunk &output);
 
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/function/table_function.hpp
+++ b/src/include/duckdb/function/table_function.hpp
@@ -126,6 +126,12 @@ struct TableFunctionBindInput {
 	TableFunction &table_function;
 	const TableFunctionRef &ref;
 	optional_ptr<unique_ptr<LogicalOperator>> input_plan;
+	//! Optional comments for the columns produced by the table function
+	vector<Value> column_comments;
+	//! Optional tags for the columns produced by the table function
+	vector<InsertionOrderPreservingMap<string>> column_tags;
+
+	void CheckBindResult(const vector<LogicalType> &return_types, const vector<Identifier> &names) const;
 };
 
 struct TableFunctionInitInput {

--- a/src/include/duckdb/planner/operator/logical_get.hpp
+++ b/src/include/duckdb/planner/operator/logical_get.hpp
@@ -24,9 +24,12 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_GET;
 
 public:
-	LogicalGet(TableIndex table_index, TableFunction function, unique_ptr<FunctionData> bind_data,
-	           vector<LogicalType> returned_types, vector<Identifier> returned_names,
-	           virtual_column_map_t virtual_columns = virtual_column_map_t());
+	LogicalGet(
+	    TableIndex table_index, TableFunction function, unique_ptr<FunctionData> bind_data,
+	    vector<LogicalType> returned_types, vector<Identifier> returned_names,
+	    virtual_column_map_t virtual_columns = virtual_column_map_t(),
+	    vector<Value> returned_comments = vector<Value>(),
+	    vector<InsertionOrderPreservingMap<string>> returned_tags = vector<InsertionOrderPreservingMap<string>>());
 
 	//! The table index in the current bind context
 	TableIndex table_index;
@@ -38,6 +41,10 @@ public:
 	vector<LogicalType> returned_types;
 	//! The names of ALL columns that can be returned by the table function
 	vector<Identifier> names;
+	//! The comments of ALL columns that can be returned by the table function (empty if none were provided)
+	vector<Value> returned_comments;
+	//! The tags of ALL columns that can be returned by the table function (empty if none were provided)
+	vector<InsertionOrderPreservingMap<string>> returned_tags;
 	//! A mapping of column index -> type/name for all virtual columns
 	virtual_column_map_t virtual_columns;
 	//! Columns that are used outside the scan
@@ -71,6 +78,10 @@ public:
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 	//! Returns the underlying table that is being scanned, or nullptr if there is none
 	optional_ptr<TableCatalogEntry> GetTable() const;
+	//! Returns the comment of the column at the given index, or NULL if the column has no comment
+	Value GetColumnComment(idx_t column_index) const;
+	//! Returns the tags of the column at the given index, or an empty map if the column has no tags
+	InsertionOrderPreservingMap<string> GetColumnTags(idx_t column_index) const;
 	//! Returns any column to query - preferably the cheapest column
 	//! This is used when we are running e.g. a COUNT(*) and don't care about the contents of any columns in the table
 	column_t GetAnyColumn() const;

--- a/src/optimizer/late_materialization_helper.cpp
+++ b/src/optimizer/late_materialization_helper.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 unique_ptr<LogicalGet> LateMaterializationHelper::CreateLHSGet(const LogicalGet &rhs, Binder &binder) {
 	auto table_index = binder.GenerateTableIndex();
 	auto new_get = make_uniq<LogicalGet>(table_index, rhs.function, rhs.bind_data->Copy(), rhs.returned_types,
-	                                     rhs.names, rhs.virtual_columns);
+	                                     rhs.names, rhs.virtual_columns, rhs.returned_comments, rhs.returned_tags);
 	new_get->GetMutableColumnIds() = rhs.GetColumnIds();
 	new_get->projection_ids = rhs.projection_ids;
 	new_get->parameters = rhs.parameters;

--- a/src/planner/binder/tableref/bind_showref.cpp
+++ b/src/planner/binder/tableref/bind_showref.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/main/client_data.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -20,23 +21,55 @@
 
 namespace duckdb {
 
-struct BaseTableColumnInfo {
+struct DescribedColumnInfo {
 	optional_ptr<TableCatalogEntry> table = nullptr;
 	optional_ptr<const ColumnDefinition> column = nullptr;
+	Value comment;
+	InsertionOrderPreservingMap<string> tags;
+	bool found = false;
+	//! Whether the comment/tags come from a view instead of the traced table column
+	bool from_view = false;
 };
 
-BaseTableColumnInfo FindBaseTableColumn(LogicalOperator &op, ColumnBinding binding) {
-	BaseTableColumnInfo result;
+static DescribedColumnInfo FindDescribedColumn(BindContext &bind_context, LogicalOperator &op, ColumnBinding binding);
+
+static optional_ptr<ViewCatalogEntry> FindViewBinding(BindContext &bind_context, TableIndex table_index) {
+	for (auto &binding : bind_context.GetBindingsList()) {
+		if (binding->GetIndex() != table_index || binding->GetBindingType() != BindingType::CATALOG_ENTRY) {
+			continue;
+		}
+		auto entry = binding->GetStandardEntry();
+		if (entry && entry->type == CatalogType::VIEW_ENTRY) {
+			return entry->Cast<ViewCatalogEntry>();
+		}
+	}
+	return nullptr;
+}
+
+static DescribedColumnInfo FindDescribedColumnInternal(BindContext &bind_context, LogicalOperator &op,
+                                                       ColumnBinding binding) {
+	DescribedColumnInfo result;
+	auto table_indices = op.GetTableIndex();
+	bool owns_binding = false;
+	for (auto &table_index : table_indices) {
+		if (table_index == binding.table_index) {
+			owns_binding = true;
+			break;
+		}
+	}
+	if (!owns_binding) {
+		for (auto &child : op.children) {
+			result = FindDescribedColumn(bind_context, *child, binding);
+			if (result.found) {
+				return result;
+			}
+		}
+		return result;
+	}
 	switch (op.type) {
 	case LogicalOperatorType::LOGICAL_GET: {
 		auto &get = op.Cast<LogicalGet>();
-		if (get.table_index != binding.table_index) {
-			return result;
-		}
 		auto table = get.GetTable();
-		if (!table) {
-			break;
-		}
 		if (!get.projection_ids.empty()) {
 			throw InternalException("Projection ids should not exist here");
 		}
@@ -45,42 +78,27 @@ BaseTableColumnInfo FindBaseTableColumn(LogicalOperator &op, ColumnBinding bindi
 			//! Virtual column (like ROW_ID) does not have a ColumnDefinition entry in the TableCatalogEntry
 			return result;
 		}
-		result.table = table;
-		result.column = &table->GetColumn(LogicalIndex(base_column_id.GetPrimaryIndex()));
+		auto column_index = base_column_id.GetPrimaryIndex();
+		result.found = true;
+		if (table) {
+			result.table = table;
+			result.column = &table->GetColumn(LogicalIndex(column_index));
+		} else {
+			result.comment = get.GetColumnComment(column_index);
+			result.tags = get.GetColumnTags(column_index);
+		}
 		return result;
 	}
 	case LogicalOperatorType::LOGICAL_PROJECTION: {
 		auto &projection = op.Cast<LogicalProjection>();
-		if (binding.table_index != projection.table_index) {
-			break;
-		}
 		auto &expr = projection.GetExpression(binding);
 		if (expr.GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
 			// if the projection at this index only has a column reference we can directly trace it to the base table
 			auto &bound_colref = expr.Cast<BoundColumnRefExpression>();
-			return FindBaseTableColumn(*projection.children[0], bound_colref.Binding());
+			return FindDescribedColumn(bind_context, *projection.children[0], bound_colref.Binding());
 		}
 		break;
 	}
-	case LogicalOperatorType::LOGICAL_LIMIT:
-	case LogicalOperatorType::LOGICAL_ORDER_BY:
-	case LogicalOperatorType::LOGICAL_TOP_N:
-	case LogicalOperatorType::LOGICAL_SAMPLE:
-	case LogicalOperatorType::LOGICAL_DISTINCT:
-	case LogicalOperatorType::LOGICAL_FILTER:
-	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
-	case LogicalOperatorType::LOGICAL_JOIN:
-	case LogicalOperatorType::LOGICAL_ANY_JOIN:
-	case LogicalOperatorType::LOGICAL_ASOF_JOIN:
-	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
-		// for any "pass-through" operators - search in children directly
-		for (auto &child : op.children) {
-			result = FindBaseTableColumn(*child, binding);
-			if (result.table) {
-				return result;
-			}
-		}
-		break;
 	default:
 		// unsupported operator
 		break;
@@ -88,9 +106,21 @@ BaseTableColumnInfo FindBaseTableColumn(LogicalOperator &op, ColumnBinding bindi
 	return result;
 }
 
-BaseTableColumnInfo FindBaseTableColumn(LogicalOperator &op, idx_t column_index) {
+static DescribedColumnInfo FindDescribedColumn(BindContext &bind_context, LogicalOperator &op, ColumnBinding binding) {
+	auto result = FindDescribedColumnInternal(bind_context, op, binding);
+	auto view = FindViewBinding(bind_context, binding.table_index);
+	if (view) {
+		result.found = true;
+		result.from_view = true;
+		result.comment = view->GetColumnComment(binding.column_index);
+		result.tags.clear();
+	}
+	return result;
+}
+
+static DescribedColumnInfo FindDescribedColumn(BindContext &bind_context, LogicalOperator &op, idx_t column_index) {
 	auto bindings = op.GetColumnBindings();
-	return FindBaseTableColumn(op, bindings[column_index]);
+	return FindDescribedColumn(bind_context, op, bindings[column_index]);
 }
 
 BoundStatement Binder::BindDescribeQuery(ShowRef &ref) {
@@ -99,9 +129,9 @@ BoundStatement Binder::BindDescribeQuery(ShowRef &ref) {
 	auto plan = child_binder->Bind(*ref.query);
 
 	// construct a column data collection with the result
-	vector<Identifier> return_names = {"column_name", "column_type", "null", "key", "default", "extra"};
-	vector<LogicalType> return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
-	                                    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+	vector<Identifier> return_names;
+	vector<LogicalType> return_types;
+	PragmaTableInfo::GetShowSchema(return_types, return_names);
 	DataChunk output;
 	output.Initialize(Allocator::Get(context), return_types);
 
@@ -110,7 +140,7 @@ BoundStatement Binder::BindDescribeQuery(ShowRef &ref) {
 	collection->InitializeAppend(append_state);
 	for (idx_t column_idx = 0; column_idx < plan.types.size(); column_idx++) {
 		// check if we can trace the column to a base table so that we can figure out constraint information
-		auto result = FindBaseTableColumn(*plan.plan, column_idx);
+		auto result = FindDescribedColumn(child_binder->bind_context, *plan.plan, column_idx);
 		idx_t row_index = output.size();
 		auto &alias = plan.names[column_idx];
 		if (result.table) {
@@ -120,22 +150,12 @@ BoundStatement Binder::BindDescribeQuery(ShowRef &ref) {
 			if (alias != result.column->Name()) {
 				output.data[0].SetValue(row_index, Value(alias));
 			}
+			if (result.from_view) {
+				output.data[5].SetValue(row_index, PragmaTableInfo::GetColumnExtraInfo(result.comment, result.tags));
+			}
 		} else {
 			// we cannot - read the type/name from the plan instead
-			auto type = plan.types[column_idx];
-
-			// "name", VARCHAR
-			output.data[0].Append(Value(alias));
-			// "type", VARCHAR
-			output.data[1].Append(Value(type.ToString()));
-			// "null", VARCHAR
-			output.data[2].Append(Value("YES"));
-			// "pk", VARCHAR
-			output.data[3].Append(Value());
-			// "dflt_value", VARCHAR
-			output.data[4].Append(Value());
-			// "extra", VARCHAR
-			output.data[5].Append(Value());
+			PragmaTableInfo::GetColumnInfo(alias, plan.types[column_idx], result.comment, result.tags, output);
 		}
 
 		// both branches above append exactly one row to the child vectors, growing output.size() accordingly

--- a/src/planner/binder/tableref/bind_table_function.cpp
+++ b/src/planner/binder/tableref/bind_table_function.cpp
@@ -213,6 +213,8 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 	unique_ptr<FunctionData> bind_data;
 	vector<LogicalType> return_types;
 	vector<Identifier> return_names;
+	vector<Value> column_comments;
+	vector<InsertionOrderPreservingMap<string>> column_tags;
 	auto constexpr ordinality_name = "ordinality";
 	string ordinality_column_name = ordinality_name;
 	optional_idx ordinality_column_id;
@@ -261,6 +263,9 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 			                      table_function.name);
 		}
 		bind_data = table_function.bind(context, bind_input, return_types, return_names);
+		bind_input.CheckBindResult(return_types, return_names);
+		column_comments = std::move(bind_input.column_comments);
+		column_tags = std::move(bind_input.column_tags);
 		if (ref.with_ordinality == OrdinalityType::WITH_ORDINALITY) {
 			// check if column name 'ordinality' already exists and if so, replace it iteratively until free name is
 			// found
@@ -278,6 +283,12 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 			if (!correlated_columns.empty()) {
 				return_types.emplace_back(LogicalType::BIGINT);
 				return_names.emplace_back(ordinality_column_name);
+				if (!column_comments.empty()) {
+					column_comments.emplace_back();
+				}
+				if (!column_tags.empty()) {
+					column_tags.emplace_back();
+				}
 				D_ASSERT(return_names.size() == return_types.size());
 				ordinality_column_id = return_types.size() - 1;
 			}
@@ -288,13 +299,6 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 	}
 	if (bind_data && !bind_data->SupportStatementCache()) {
 		SetAlwaysRequireRebind();
-	}
-	if (return_types.size() != return_names.size()) {
-		throw InternalException("Failed to bind \"%s\": return_types/names must have same size", table_function.name);
-	}
-	if (return_types.empty()) {
-		throw InternalException("Failed to bind \"%s\": Table function must return at least one column",
-		                        table_function.name);
 	}
 	auto setof_column_name = ApplyPostgresSetofAliasCompatibility(table_function, ref, return_names);
 	// overwrite the names with any supplied aliases
@@ -312,7 +316,7 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 	}
 
 	auto get = make_uniq<LogicalGet>(bind_index, table_function, std::move(bind_data), return_types, return_names,
-	                                 virtual_columns);
+	                                 virtual_columns, std::move(column_comments), std::move(column_tags));
 	get->parameters = parameters;
 	get->named_parameters = named_parameters;
 	get->input_table_types = input_table_types;

--- a/src/planner/operator/logical_get.cpp
+++ b/src/planner/operator/logical_get.cpp
@@ -40,9 +40,11 @@ LogicalGet::LogicalGet() : LogicalOperator(LogicalOperatorType::LOGICAL_GET) {
 
 LogicalGet::LogicalGet(TableIndex table_index, TableFunction function, unique_ptr<FunctionData> bind_data,
                        vector<LogicalType> returned_types, vector<Identifier> returned_names,
-                       virtual_column_map_t virtual_columns_p)
+                       virtual_column_map_t virtual_columns_p, vector<Value> returned_comments_p,
+                       vector<InsertionOrderPreservingMap<string>> returned_tags_p)
     : LogicalOperator(LogicalOperatorType::LOGICAL_GET), table_index(table_index), function(std::move(function)),
       bind_data(std::move(bind_data)), returned_types(std::move(returned_types)), names(std::move(returned_names)),
+      returned_comments(std::move(returned_comments_p)), returned_tags(std::move(returned_tags_p)),
       virtual_columns(std::move(virtual_columns_p)), extra_info() {
 }
 
@@ -328,6 +330,9 @@ void LogicalGet::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<unique_ptr<RowGroupOrderOptions>>(214, "row_group_order_options",
 	                                                                      row_group_order_options);
 	serializer.WritePropertyWithDefault(215, "scan_partition_indices", scan_partition_indices, vector<idx_t>());
+	serializer.WritePropertyWithDefault(216, "returned_comments", returned_comments, vector<Value>());
+	serializer.WritePropertyWithDefault(217, "returned_tags", returned_tags,
+	                                    vector<InsertionOrderPreservingMap<string>>());
 }
 
 unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) {
@@ -362,6 +367,8 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 	    deserializer.ReadPropertyWithDefault<unique_ptr<RowGroupOrderOptions>>(214, "row_group_order_options");
 	auto scan_partition_indices =
 	    deserializer.ReadPropertyWithExplicitDefault<vector<idx_t>>(215, "scan_partition_indices", vector<idx_t>());
+	deserializer.ReadPropertyWithDefault(216, "returned_comments", result->returned_comments);
+	deserializer.ReadPropertyWithDefault(217, "returned_tags", result->returned_tags);
 	if (!legacy_column_ids.empty()) {
 		if (!result->column_ids.empty()) {
 			throw SerializationException(
@@ -385,9 +392,16 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 			throw InternalException("Table function \"%s\" has neither bind nor (de)serialize", function.name);
 		}
 		bind_data = function.bind(context, input, bind_return_types, bind_names);
+		input.CheckBindResult(bind_return_types, bind_names);
 		if (result->ordinality_idx.IsValid()) {
-			auto ordinality_pos = bind_return_types.begin() + NumericCast<int64_t>(result->ordinality_idx.GetIndex());
-			bind_return_types.emplace(ordinality_pos, LogicalType::BIGINT);
+			auto ordinality_offset = NumericCast<int64_t>(result->ordinality_idx.GetIndex());
+			bind_return_types.emplace(bind_return_types.begin() + ordinality_offset, LogicalType::BIGINT);
+			if (!input.column_comments.empty()) {
+				input.column_comments.emplace(input.column_comments.begin() + ordinality_offset);
+			}
+			if (!input.column_tags.empty()) {
+				input.column_tags.emplace(input.column_tags.begin() + ordinality_offset);
+			}
 		}
 		if (function.get_virtual_columns) {
 			virtual_columns = function.get_virtual_columns(context, bind_data.get());
@@ -412,6 +426,8 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 			}
 		}
 		result->returned_types = std::move(bind_return_types);
+		result->returned_comments = std::move(input.column_comments);
+		result->returned_tags = std::move(input.column_tags);
 	} else if (function.get_virtual_columns) {
 		virtual_columns = function.get_virtual_columns(context, bind_data.get());
 	}
@@ -425,6 +441,22 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 		result->SetPartitionsToScan(std::move(scan_partition_indices));
 	}
 	return std::move(result);
+}
+
+Value LogicalGet::GetColumnComment(idx_t column_index) const {
+	D_ASSERT(returned_comments.empty() || returned_comments.size() == returned_types.size());
+	if (column_index >= returned_comments.size()) {
+		return Value();
+	}
+	return returned_comments[column_index];
+}
+
+InsertionOrderPreservingMap<string> LogicalGet::GetColumnTags(idx_t column_index) const {
+	D_ASSERT(returned_tags.empty() || returned_tags.size() == returned_types.size());
+	if (column_index >= returned_tags.size()) {
+		return InsertionOrderPreservingMap<string>();
+	}
+	return returned_tags[column_index];
 }
 
 vector<TableIndex> LogicalGet::GetTableIndex() const {

--- a/test/extension/loadable_extension_demo.cpp
+++ b/test/extension/loadable_extension_demo.cpp
@@ -157,6 +157,11 @@ public:
 	                                                  vector<LogicalType> &return_types, vector<Identifier> &names) {
 		names.emplace_back("quack");
 		return_types.emplace_back(LogicalType::VARCHAR);
+		input.column_comments.emplace_back("A single duck utterance");
+		InsertionOrderPreservingMap<string> tags;
+		tags["ext:name"] = "loadable_extension_demo";
+		tags["ext:column_type"] = "sound";
+		input.column_tags.push_back(std::move(tags));
 		return make_uniq<QuackBindData>(BigIntValue::Get(input.inputs[0]));
 	}
 
@@ -168,6 +173,9 @@ public:
 	static void QuackFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 		auto &bind_data = data_p.bind_data->Cast<QuackBindData>();
 		auto &data = data_p.global_state->Cast<QuackGlobalData>();
+		if (bind_data.number_of_quacks == 999) {
+			throw InvalidInputException("quack scan must not execute");
+		}
 		if (data.offset >= bind_data.number_of_quacks) {
 			// finished returning values
 			return;
@@ -1217,6 +1225,7 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 		tagged_table_info->internal = true;
 
 		ColumnDefinition col_a("a", LogicalType::INTEGER);
+		col_a.SetComment(Value("Primary tagged column"));
 		InsertionOrderPreservingMap<string> col_a_tags;
 		col_a_tags["ext:name"] = "loadable_extension_demo";
 		col_a_tags["ext:column_type"] = "primary";
@@ -1224,6 +1233,7 @@ DUCKDB_CPP_EXTENSION_ENTRY(loadable_extension_demo, loader) {
 		tagged_table_info->columns.AddColumn(std::move(col_a));
 
 		ColumnDefinition col_b("b", LogicalType::VARCHAR);
+		col_b.SetComment(Value("Dimension tagged column"));
 		InsertionOrderPreservingMap<string> col_b_tags;
 		col_b_tags["ext:name"] = "loadable_extension_demo";
 		col_b_tags["ext:column_type"] = "dimension";

--- a/test/extension/test_tags.test
+++ b/test/extension/test_tags.test
@@ -27,3 +27,34 @@ SELECT column_name, tags['ext:name'], tags['ext:column_type'] FROM duckdb_column
 ----
 a	loadable_extension_demo	primary
 b	loadable_extension_demo	dimension
+
+query TT
+SELECT column_name, extra FROM (DESCRIBE tagged_table) ORDER BY column_name;
+----
+a	{"comment":"Primary tagged column","tags":{"ext:name":"loadable_extension_demo","ext:column_type":"primary"}}
+b	{"comment":"Dimension tagged column","tags":{"ext:name":"loadable_extension_demo","ext:column_type":"dimension"}}
+
+# DESCRIBE binds a table function without executing its scan and exposes bind-time column metadata
+query TT
+SELECT column_name, extra FROM (DESCRIBE FROM quack(999));
+----
+quack	{"comment":"A single duck utterance","tags":{"ext:name":"loadable_extension_demo","ext:column_type":"sound"}}
+
+statement error
+FROM quack(999);
+----
+quack scan must not execute
+
+# Metadata follows simple column references and is dropped for computed expressions
+query TT
+SELECT column_name, extra
+FROM (DESCRIBE SELECT quack AS utterance, quack || '!' AS expression FROM quack(1));
+----
+utterance	{"comment":"A single duck utterance","tags":{"ext:name":"loadable_extension_demo","ext:column_type":"sound"}}
+expression	NULL
+
+query TT
+SELECT column_name, extra FROM (DESCRIBE FROM quack(1) WITH ORDINALITY);
+----
+quack	{"comment":"A single duck utterance","tags":{"ext:name":"loadable_extension_demo","ext:column_type":"sound"}}
+ordinality	NULL

--- a/test/sql/show_select/describe_metadata.test
+++ b/test/sql/show_select/describe_metadata.test
@@ -1,0 +1,78 @@
+# name: test/sql/show_select/describe_metadata.test
+# description: Test comments and tags returned in the DESCRIBE extra column
+# group: [show_select]
+
+statement ok
+CREATE TABLE described_table(i INTEGER, j INTEGER);
+
+statement ok
+COMMENT ON COLUMN described_table.i IS 'identifier "column"';
+
+query TT
+SELECT column_name, extra FROM (DESCRIBE described_table) ORDER BY column_name;
+----
+i	{"comment":"identifier \"column\""}
+j	NULL
+
+statement ok
+CREATE VIEW described_view AS SELECT i FROM described_table;
+
+statement ok
+COMMENT ON COLUMN described_view.i IS 'view identifier column';
+
+query TT
+SELECT column_name, extra FROM pragma_show('described_view');
+----
+i	{"comment":"view identifier column"}
+
+# Metadata follows column references through aliases, but not computed expressions
+query TT
+SELECT column_name, extra
+FROM (DESCRIBE SELECT i AS aliased_i, i + 1 AS expression FROM described_table);
+----
+aliased_i	{"comment":"identifier \"column\""}
+expression	NULL
+
+# Legacy table functions return no column metadata
+query TT
+SELECT column_name, extra FROM (DESCRIBE FROM range(1));
+----
+range	NULL
+
+# DESCRIBE reports the view's own column comment, not the underlying table column comment
+query TT
+SELECT column_name, extra FROM (DESCRIBE described_view);
+----
+i	{"comment":"view identifier column"}
+
+statement ok
+CREATE VIEW uncommented_view AS SELECT i AS x, j FROM described_table;
+
+query TT
+SELECT column_name, extra FROM (DESCRIBE uncommented_view);
+----
+x	NULL
+j	NULL
+
+query TT
+SELECT column_name, extra FROM (DESCRIBE SELECT i AS aliased_i FROM described_view);
+----
+aliased_i	{"comment":"view identifier column"}
+
+# Metadata passes through operators that forward their children's columns
+query TT
+SELECT column_name, extra FROM (DESCRIBE SELECT i FROM described_table ORDER BY i LIMIT 1);
+----
+i	{"comment":"identifier \"column\""}
+
+query TT
+SELECT column_name, extra FROM (DESCRIBE SELECT i, row_number() OVER () AS rn FROM described_table);
+----
+i	{"comment":"identifier \"column\""}
+rn	NULL
+
+query TT
+SELECT column_name, extra FROM (DESCRIBE SELECT i, u FROM described_table, UNNEST([1]) t(u));
+----
+i	{"comment":"identifier \"column\""}
+u	NULL


### PR DESCRIPTION
Table functions can optionally supply per-column comments and tags through `TableFunctionBindInput` in their existing bind callback. The metadata is carried by `LogicalGet` and exposed as JSON in the existing `extra` column of `DESCRIBE`, `SHOW`, and `pragma_show`, preserving the six-column result schema.

Metadata follows simple column references and aliases; computed expressions have no metadata. Views report their own column comments. Regression tests cover table and view comments, tagged extension columns, table-function metadata without scan execution, aliases, computed expressions, and ordinality.

Resolves the merge conflict with `main` while preserving the expected-schema fields used by multi-file readers.

Related discussion: #25381.

Validation on the branch merged with current `main`:

- `make reldebug` with JSON, ICU, TPC-H, and TPC-DS extensions: passed.
- 16 focused metadata, DESCRIBE, and multi-file regression tests: passed normally and with `debug_verify_serializer=true`.
- `make allunit` against the reldebug build: 7,240 passed, 110 skipped, 0 failures.
- Formatting and whitespace checks against `origin/main`: passed.
