### PR TITLE
Fix foreign key constrain check

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -691,8 +691,7 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 	auto sibling_storage = local_storage.GetStorage(data_table);
 	auto sibling_delete_indexes = sibling_storage ? &sibling_storage->delete_indexes : nullptr;
 
-	data_table.info->indexes.VerifyForeignKey(sibling_delete_indexes, dst_keys_ptr, dst_chunk,
-	                                          global_conflict_manager);
+	data_table.info->indexes.VerifyForeignKey(sibling_delete_indexes, dst_keys_ptr, dst_chunk, global_conflict_manager);
 
 	// Check if we can insert the chunk into the local storage.
 	bool local_error = false;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -687,19 +687,21 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 
 	// Global constraint verification.
 	auto &data_table = table_entry.GetStorage();
-	data_table.info->indexes.VerifyForeignKey(storage ? &storage->delete_indexes : nullptr, dst_keys_ptr, dst_chunk,
+	auto &local_storage = LocalStorage::Get(context, db);
+	auto sibling_storage = local_storage.GetStorage(data_table);
+	auto sibling_delete_indexes = sibling_storage ? &sibling_storage->delete_indexes : nullptr;
+
+	data_table.info->indexes.VerifyForeignKey(sibling_delete_indexes, dst_keys_ptr, dst_chunk,
 	                                          global_conflict_manager);
 
 	// Check if we can insert the chunk into the local storage.
-	auto &local_storage = LocalStorage::Get(context, db);
 	bool local_error = false;
-	auto local_verification = local_storage.Find(data_table);
+	auto local_verification = sibling_storage != nullptr;
 
 	// Local constraint verification.
 	if (local_verification) {
 		auto &local_indexes = local_storage.GetIndexes(context, data_table);
-		local_indexes.VerifyForeignKey(storage ? &storage->delete_indexes : nullptr, dst_keys_ptr, dst_chunk,
-		                               local_conflict_manager);
+		local_indexes.VerifyForeignKey(sibling_delete_indexes, dst_keys_ptr, dst_chunk, local_conflict_manager);
 		local_error = IsForeignKeyConstraintError(local_conflict_manager, is_append, count);
 	}
 	// Global constraint verification.

--- a/test/sql/constraints/foreignkey/test_fk_transaction.test
+++ b/test/sql/constraints/foreignkey/test_fk_transaction.test
@@ -61,8 +61,10 @@ BEGIN TRANSACTION
 statement ok
 DELETE FROM pkt WHERE i = 1
 
-statement ok
+statement error
 INSERT INTO fkt VALUES (1)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
 
 statement ok
 ROLLBACK
@@ -108,8 +110,10 @@ BEGIN TRANSACTION
 statement ok
 DELETE FROM pkt WHERE i = 3
 
-statement ok
+statement error
 INSERT INTO fkt VALUES (3)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
 
 statement ok
 ROLLBACK

--- a/test/sql/constraints/foreignkey/test_fk_transaction.test
+++ b/test/sql/constraints/foreignkey/test_fk_transaction.test
@@ -147,3 +147,48 @@ DELETE FROM b
 
 statement ok
 DELETE FROM a
+
+statement ok
+COMMIT
+
+# Cross-table check: a parent DELETE followed by a child INSERT in the same
+# transaction must not commit a dangling foreign key reference.
+
+statement ok
+CREATE TABLE cross_fk_parent(id INTEGER PRIMARY KEY)
+
+statement ok
+CREATE TABLE cross_fk_child(pid INTEGER, FOREIGN KEY (pid) REFERENCES cross_fk_parent(id))
+
+statement ok
+INSERT INTO cross_fk_parent VALUES (1)
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+DELETE FROM cross_fk_parent WHERE id = 1
+
+statement error
+INSERT INTO cross_fk_child VALUES (1)
+----
+<REGEX>:Constraint Error.*Violates foreign key constraint.*
+
+statement ok
+ROLLBACK
+
+query I
+SELECT count(*) FROM cross_fk_parent
+----
+1
+
+query I
+SELECT count(*) FROM cross_fk_child
+----
+0
+
+statement ok
+DROP TABLE cross_fk_child
+
+statement ok
+DROP TABLE cross_fk_parent


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25388

Copy the repro SQL here for easier review
```sql
memory D CREATE TABLE p(id INT PRIMARY KEY);
memory D CREATE TABLE c(pid INT REFERENCES p(id));
memory D INSERT INTO p VALUES (1);
memory D BEGIN;
memory D DELETE FROM p WHERE id=1;
memory D INSERT INTO c VALUES (1);
memory D COMMIT; <-- pass through, incorrect behavior
```

The issue is, 
- During the transaction, deletes for the parent table is stored in [`delete_indexes`](https://github.com/duckdb/duckdb/blob/e3946f2327a3cc622e1ec7fe71d51de49f93e61d/src/include/duckdb/transaction/local_storage.hpp#L68-L69) in the parent table
- When inserting rows into child table, we should check whether parent table's index allows child table's new insert
- But [here](https://github.com/duckdb/duckdb/blob/e3946f2327a3cc622e1ec7fe71d51de49f93e61d/src/storage/data_table.cpp#L691) we're passing child table's