### PR TITLE
Tidy snapshot handling in the transaction manager

### DIFF
--- a/src/include/duckdb/transaction/duck_transaction.hpp
+++ b/src/include/duckdb/transaction/duck_transaction.hpp
@@ -36,13 +36,13 @@ struct CommitInfo {
 class DuckTransaction : public Transaction {
 public:
 	DuckTransaction(DuckTransactionManager &manager, ClientContext &context, transaction_t start_time,
-	                transaction_t transaction_id, idx_t catalog_version);
+	                SnapshotView view, idx_t catalog_version);
 	~DuckTransaction() override;
 
 	//! The start timestamp of this transaction
 	transaction_t start_time;
-	//! The transaction id of this transaction
-	transaction_t transaction_id;
+	//! What this transaction sees: its own writes, and everything before its visibility bound
+	SnapshotView view;
 	//! The commit id of this transaction, if it has successfully been committed
 	transaction_t commit_id;
 
@@ -94,6 +94,9 @@ public:
 		return true;
 	}
 	SnapshotView GetSnapshotView() const override;
+	transaction_t GetTransactionId() const {
+		return view.transaction_id;
+	}
 
 	unique_ptr<StorageLockKey> TryGetCheckpointLock();
 

--- a/src/include/duckdb/transaction/duck_transaction_manager.hpp
+++ b/src/include/duckdb/transaction/duck_transaction_manager.hpp
@@ -48,9 +48,6 @@ public:
 
 	void Checkpoint(ClientContext &context, bool force = false) override;
 
-	transaction_t LowestActiveId() const {
-		return lowest_active_id;
-	}
 	VisibilityBound LowestVisibilityBound() const {
 		return lowest_visibility_bound;
 	}
@@ -111,6 +108,14 @@ private:
 	//! Remove the given transaction from the list of active transactions
 	unique_ptr<DuckCleanupInfo> RemoveTransaction(DuckTransaction &transaction, bool store_transaction,
 	                                              unique_ptr<DuckCleanupInfo> cleanup_info) noexcept;
+	//! Recompute lowest_visibility_bound over the active transactions, leaving out `exclude`, and
+	//! return its index among them (their count when absent). Caller holds the transaction lock
+	idx_t UpdateLowestVisibilityBound(optional_ptr<DuckTransaction> exclude) noexcept;
+	//! Move the committed transactions below the cleanup info's lowest visibility bound into it.
+	//! Caller holds the transaction lock; must not allocate (see CreateCleanupInfo)
+	void SweepCommittedTransactions(DuckCleanupInfo &cleanup_info) noexcept;
+	//! Hand a cleanup to the background cleanup thread, if it has anything to do
+	void QueueCleanup(unique_ptr<DuckCleanupInfo> cleanup_info);
 
 	//! Whether or not we can checkpoint
 	CheckpointDecision CanCheckpoint(DuckTransaction &transaction, unique_ptr<StorageLockKey> &checkpoint_lock,
@@ -126,8 +131,6 @@ private:
 	transaction_t current_start_timestamp;
 	//! The current transaction ID used by transactions
 	transaction_t current_transaction_id;
-	//! The lowest active transaction id
-	atomic<transaction_t> lowest_active_id;
 	//! The lowest bound any active transaction reads at. A version preceding it is visible to
 	//! every active transaction, so whatever it supersedes can be cleaned up or compacted
 	atomic<VisibilityBound> lowest_visibility_bound;

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -69,7 +69,7 @@ void ActiveCheckpointWrapper::GetCheckpointTransaction(CheckpointOptions &option
 	transaction.SetIsCheckpointTransaction();
 	checkpoint_transaction = &transaction;
 	options.checkpoint_id = transaction_manager.NextCheckpointId();
-	options.visibility_bound = VisibilityBound::Before(transaction.start_time);
+	options.visibility_bound = transaction.view.visibility_bound;
 	transaction_manager.SetActiveCheckpoint(options.checkpoint_id.GetIndex());
 }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -211,7 +211,7 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_id
 	try {
 		// read at the commits seen so far, not at this transaction's older snapshot
 		auto &transaction_manager = DuckTransactionManager::Get(db);
-		TransactionData rewrite_visibility(transaction.transaction_id,
+		TransactionData rewrite_visibility(transaction.GetTransactionId(),
 		                                   VisibilityBound::Through(transaction_manager.GetLastCommit()));
 		row_groups = parent.row_groups->AlterType(context, changed_idx, target_type, bound_columns, cast_expr,
 		                                          rewrite_visibility);

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1072,15 +1072,13 @@ void RowGroup::Scan(CollectionScanState &state, DataChunk &result, TableScanType
 	auto &transaction_manager = DuckTransactionManager::Get(GetCollection().GetAttached());
 
 	VisibilityBound visibility_bound;
-	transaction_t transaction_id;
 	if (type == TableScanType::TABLE_SCAN_COMMITTED_ROWS) {
 		visibility_bound = VisibilityBound::Through(transaction_manager.GetLastCommit());
-		transaction_id = MAX_TRANSACTION_ID;
 	} else {
 		visibility_bound = transaction_manager.LowestVisibilityBound();
-		transaction_id = transaction_manager.LowestActiveId();
 	}
-	TransactionData transaction(transaction_id, visibility_bound);
+	// a scan on behalf of no transaction: there are no writes of its own to see
+	TransactionData transaction(MAX_TRANSACTION_ID, visibility_bound);
 
 	ScanOptions options(transaction);
 	options.insert_type = InsertedScanType::ALL_ROWS;

--- a/src/transaction/commit_state.cpp
+++ b/src/transaction/commit_state.cpp
@@ -295,7 +295,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 				new_entry.set->VerifyExistenceOfDependency(commit_id, new_entry);
 			}
 		} else if (new_entry.type == CatalogType::DELETED_ENTRY && old_entry.set) {
-			old_entry.set->CommitDrop(commit_id, VisibilityBound::Before(transaction.start_time), old_entry);
+			old_entry.set->CommitDrop(commit_id, transaction.view.visibility_bound, old_entry);
 		}
 		// Grab a write lock on the catalog
 		auto &duck_catalog = catalog.Cast<DuckCatalog>();
@@ -318,8 +318,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 				// Transaction view at bind time (what the trigger saw when it was created).
 				// Use commit_id as the transaction_id so that earlier catalog changes in this
 				// same transaction (already stamped with commit_id) are visible here.
-				CatalogTransaction bind_txn(duck_catalog.GetDatabase(), commit_id,
-				                            VisibilityBound::Before(transaction.start_time));
+				CatalogTransaction bind_txn(duck_catalog.GetDatabase(), commit_id, transaction.view.visibility_bound);
 				// Transaction view at commit time (all changes committed before this commit)
 				CatalogTransaction commit_txn(duck_catalog.GetDatabase(), MAX_TRANSACTION_ID,
 				                              VisibilityBound::Through(commit_id));
@@ -357,7 +356,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 	case UndoFlags::INSERT_TUPLE: {
 		// append:
 		auto info = reinterpret_cast<AppendInfo *>(data);
-		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
+		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.GetTransactionId()) {
 			auto &storage = info->table->GetStorage();
 			auto table_name = storage.GetTableName();
 			auto table_modification = storage.TableModification();
@@ -371,7 +370,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 	case UndoFlags::DELETE_TUPLE: {
 		// deletion:
 		auto info = reinterpret_cast<DeleteInfo *>(data);
-		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
+		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.GetTransactionId()) {
 			auto &storage = info->table->GetStorage();
 			auto table_name = storage.GetTableName();
 			auto table_modification = storage.TableModification();
@@ -384,7 +383,7 @@ void CommitState::CommitEntry(UndoFlags type, data_ptr_t data, CommitInfo &info)
 	case UndoFlags::UPDATE_TUPLE: {
 		// update:
 		auto info = reinterpret_cast<UpdateInfo *>(data);
-		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.transaction_id) {
+		if (info->table->HasParent() && info->table->Parent().timestamp != transaction.GetTransactionId()) {
 			auto &storage = info->table->GetStorage();
 			auto table_name = storage.GetTableName();
 			auto table_modification = storage.TableModification();

--- a/src/transaction/duck_transaction.cpp
+++ b/src/transaction/duck_transaction.cpp
@@ -36,15 +36,15 @@ TransactionData::TransactionData(transaction_t transaction_id_p, VisibilityBound
 }
 
 DuckTransaction::DuckTransaction(DuckTransactionManager &manager, ClientContext &context_p, transaction_t start_time,
-                                 transaction_t transaction_id, idx_t catalog_version_p)
-    : Transaction(manager, context_p), start_time(start_time), transaction_id(transaction_id), commit_id(0),
+                                 SnapshotView view_p, idx_t catalog_version_p)
+    : Transaction(manager, context_p), start_time(start_time), view(view_p), commit_id(0),
       catalog_version(catalog_version_p), awaiting_cleanup(false), undo_buffer(*this, context_p),
       storage(make_uniq<LocalStorage>(context_p, *this)) {
-	D_ASSERT(IsCommitted(start_time) && !IsCommitted(transaction_id));
+	D_ASSERT(IsCommitted(start_time) && !IsCommitted(view.transaction_id));
 }
 
 SnapshotView DuckTransaction::GetSnapshotView() const {
-	return SnapshotView(transaction_id, VisibilityBound::Before(start_time));
+	return view;
 }
 
 DuckTransaction::~DuckTransaction() {
@@ -144,7 +144,7 @@ UndoBufferReference DuckTransaction::CreateUpdateInfo(DuckTableEntry &table_entr
 	idx_t alloc_size = UpdateInfo::GetAllocSize(type_size);
 	auto undo_entry = undo_buffer.CreateEntry(UndoFlags::UPDATE_TUPLE, alloc_size);
 	auto &update_info = UpdateInfo::Get(undo_entry);
-	UpdateInfo::Initialize(update_info, table_entry, transaction_id, row_group_start);
+	UpdateInfo::Initialize(update_info, table_entry, GetTransactionId(), row_group_start);
 	return undo_entry;
 }
 
@@ -304,7 +304,7 @@ ErrorData DuckTransaction::Commit(AttachedDatabase &db, CommitInfo &commit_info,
 	}
 
 	try {
-		undo_buffer.RevertCommit(iterator_state, this->transaction_id);
+		undo_buffer.RevertCommit(iterator_state, GetTransactionId());
 		if (!db.IsSystem() && !db.IsTemporary() &&
 		    Settings::Get<DebugForceCommitRevertFailureSetting>(db.GetDatabase())) {
 			throw IOException("Forced RevertCommit failure (debug_force_commit_revert_failure)");

--- a/src/transaction/duck_transaction_manager.cpp
+++ b/src/transaction/duck_transaction_manager.cpp
@@ -54,7 +54,6 @@ DuckTransactionManager::DuckTransactionManager(AttachedDatabase &db) : Transacti
 	// if transaction_id < start_timestamp for any set of active transactions
 	// uncommitted data could be read by
 	current_transaction_id = TRANSACTION_ID_START;
-	lowest_active_id = TRANSACTION_ID_START;
 	lowest_visibility_bound = VisibilityBound::IncludingUncommitted();
 	active_checkpoint = 0;
 	if (!db.GetCatalog().IsDuckCatalog()) {
@@ -90,13 +89,14 @@ Transaction &DuckTransactionManager::StartTransaction(ClientContext &context) {
 	// obtain the start time and transaction ID of this transaction
 	transaction_t start_time = current_start_timestamp++;
 	transaction_t transaction_id = current_transaction_id++;
+	// the transaction sees its own writes, and every commit before its start time
+	SnapshotView view(transaction_id, VisibilityBound::Before(start_time));
 	if (active_transactions.empty()) {
-		lowest_visibility_bound = VisibilityBound::Before(start_time);
-		lowest_active_id = transaction_id;
+		lowest_visibility_bound = view.visibility_bound;
 	}
 
 	// create the actual transaction
-	auto transaction = make_uniq<DuckTransaction>(*this, context, start_time, transaction_id, last_committed_version);
+	auto transaction = make_uniq<DuckTransaction>(*this, context, start_time, view, last_committed_version);
 	auto &transaction_ref = *transaction;
 
 	// store it in the set of active transactions
@@ -174,7 +174,7 @@ DuckTransactionManager::GetCheckpointType(DuckTransaction &transaction, const Un
 					if (!other_transactions.empty()) {
 						other_transactions += ", ";
 					}
-					other_transactions += "[" + to_string(active_transaction->transaction_id) + "]";
+					other_transactions += "[" + to_string(active_transaction->GetTransactionId()) + "]";
 				}
 			}
 			if (!other_transactions.empty()) {
@@ -428,11 +428,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 	                         undo_properties.has_catalog_changes || error.HasError();
 
 	// Remove the transaction from the list of active transactions and gather cleanup information.
-	auto cleanup_info = RemoveTransaction(transaction, store_transaction, CreateCleanupInfo());
-	if (cleanup_info->ScheduleCleanup()) {
-		lock_guard<mutex> q_lock(cleanup_queue_lock);
-		cleanup_queue.emplace(std::move(cleanup_info));
-	}
+	QueueCleanup(RemoveTransaction(transaction, store_transaction, CreateCleanupInfo()));
 
 	// We do not need to hold the transaction lock during cleanup of transactions,
 	// as they (1) have been removed, or (2) enter cleanup_info.
@@ -475,7 +471,7 @@ ErrorData DuckTransactionManager::CommitTransaction(ClientContext &context, Tran
 void DuckTransactionManager::RollbackTransaction(Transaction &transaction_p) {
 	auto &transaction = transaction_p.Cast<DuckTransaction>();
 
-	DUCKDB_LOG(db.GetDatabase(), TransactionLogType, db, "Rollback", transaction.transaction_id);
+	DUCKDB_LOG(db.GetDatabase(), TransactionLogType, db, "Rollback", transaction.GetTransactionId());
 
 	ErrorData error;
 	{
@@ -484,11 +480,7 @@ void DuckTransactionManager::RollbackTransaction(Transaction &transaction_p) {
 		error = transaction.Rollback();
 
 		// Remove the transaction from the list of active transactions and gather cleanup information.
-		auto cleanup_info = RemoveTransaction(transaction, CreateCleanupInfo());
-		if (cleanup_info->ScheduleCleanup()) {
-			lock_guard<mutex> q_lock(cleanup_queue_lock);
-			cleanup_queue.emplace(std::move(cleanup_info));
-		}
+		QueueCleanup(RemoveTransaction(transaction, CreateCleanupInfo()));
 	}
 
 	CleanupTransactions();
@@ -519,22 +511,8 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
                                           unique_ptr<DuckCleanupInfo> cleanup_info) noexcept {
 	// Nothing here may allocate: CreateCleanupInfo has reserved everything this needs (see its comment).
 
-	// Find the transaction in the active transactions,
-	// as well as the lowest start time, transaction id, and active query.
-	idx_t t_index = active_transactions.size();
-	auto computed_lowest_visibility_bound = VisibilityBound::AllCommitted();
-	auto lowest_transaction_id = MAX_TRANSACTION_ID;
-	for (idx_t i = 0; i < active_transactions.size(); i++) {
-		if (active_transactions[i].get() == &transaction) {
-			t_index = i;
-			continue;
-		}
-		computed_lowest_visibility_bound = VisibilityBound::Min(
-		    computed_lowest_visibility_bound, VisibilityBound::Before(active_transactions[i]->start_time));
-		lowest_transaction_id = MinValue(lowest_transaction_id, active_transactions[i]->transaction_id);
-	}
-	lowest_visibility_bound = computed_lowest_visibility_bound;
-	lowest_active_id = lowest_transaction_id;
+	// Find the transaction in the active transactions and recompute the lowest bound without it.
+	auto t_index = UpdateLowestVisibilityBound(&transaction);
 	D_ASSERT(t_index != active_transactions.size());
 
 	// Decide if we need to store the transaction, or if we can schedule it for cleanup.
@@ -554,17 +532,37 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 		current_transaction->awaiting_cleanup = true;
 		cleanup_info->transactions.push_back(std::move(current_transaction));
 	}
-	cleanup_info->lowest_visibility_bound = computed_lowest_visibility_bound;
+	cleanup_info->lowest_visibility_bound = LowestVisibilityBound();
 
 	// Remove the transaction from the list of active transactions.
 	active_transactions.unsafe_erase_at(t_index);
 
-	// Traverse the recently_committed transactions to see if we can move any
-	// to the list of transactions awaiting GC.
+	// Move the committed transactions that no snapshot can still see to the cleanup info.
+	SweepCommittedTransactions(*cleanup_info);
+
+	return cleanup_info;
+}
+
+idx_t DuckTransactionManager::UpdateLowestVisibilityBound(optional_ptr<DuckTransaction> exclude) noexcept {
+	idx_t exclude_index = active_transactions.size();
+	auto computed_lowest_visibility_bound = VisibilityBound::AllCommitted();
+	for (idx_t i = 0; i < active_transactions.size(); i++) {
+		if (exclude && active_transactions[i].get() == exclude.get()) {
+			exclude_index = i;
+			continue;
+		}
+		computed_lowest_visibility_bound =
+		    VisibilityBound::Min(computed_lowest_visibility_bound, active_transactions[i]->view.visibility_bound);
+	}
+	lowest_visibility_bound = computed_lowest_visibility_bound;
+	return exclude_index;
+}
+
+void DuckTransactionManager::SweepCommittedTransactions(DuckCleanupInfo &cleanup_info) noexcept {
 	idx_t i = 0;
 	for (; i < recently_committed_transactions.size(); i++) {
 		D_ASSERT(recently_committed_transactions[i]);
-		if (recently_committed_transactions[i]->commit_id >= computed_lowest_visibility_bound) {
+		if (recently_committed_transactions[i]->commit_id >= cleanup_info.lowest_visibility_bound) {
 			// recently_committed_transactions is ordered on commit_id.
 			// Thus, if the current commit_id is greater than
 			// lowest_visibility_bound, any subsequent commit IDs are also greater.
@@ -572,7 +570,7 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 		}
 
 		recently_committed_transactions[i]->awaiting_cleanup = true;
-		cleanup_info->transactions.push_back(std::move(recently_committed_transactions[i]));
+		cleanup_info.transactions.push_back(std::move(recently_committed_transactions[i]));
 	}
 
 	if (i > 0) {
@@ -581,8 +579,13 @@ DuckTransactionManager::RemoveTransaction(DuckTransaction &transaction, bool sto
 		auto end = recently_committed_transactions.begin() + static_cast<int64_t>(i);
 		recently_committed_transactions.erase(start, end);
 	}
+}
 
-	return cleanup_info;
+void DuckTransactionManager::QueueCleanup(unique_ptr<DuckCleanupInfo> cleanup_info) {
+	if (cleanup_info->ScheduleCleanup()) {
+		lock_guard<mutex> q_lock(cleanup_queue_lock);
+		cleanup_queue.emplace(std::move(cleanup_info));
+	}
 }
 
 idx_t DuckTransactionManager::GetCatalogVersion(Transaction &transaction_p) {


### PR DESCRIPTION
This is a PR making a couple of cosmetic (but no behavioral) changes on the v2.0-cyanoptera branch in order to allow #23631 (group commit), which is targeting the main branch, to have a smaller diff and be easier to review. As the v2.0-cyanoptera branch is still under active development and will be for a while, it also makes merging fixes back into the main branch easier.

The PR consists of the following three changes:
- It embeds SnapshotView fully into DuckTransaction, leaving a single place where the VisibilityBound is determined by the transaction's start_time. #23631 will change that.
- It factors out two functions UpdateLowestVisibilityBound and SweepCommittedTransactions, which are currently used in a single place, but will be called by multiple places in #23631 (as cleanups can also trigger after fsync). It also creates a new QueueCleanup method that is called in two places already.
- It removes lowest_active_id, which wasn't really of use. Its only reader, the checkpoint scan in RowGroup::Scan, was never consulting it (inserts are all rows, deletes are decided by the bound alone, updates are disallowed), so the scan now passes MAX_TRANSACTION_ID there, as its committed-rows branch already did.