### PR TITLE
Increase stack size on Linux with musl libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ endif()
 
 if (MUSL_ENABLED)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__MUSL_ENABLED__")
+  add_link_options(-Wl,-z,stack-size=8388608)
 endif()
 
 set(M32_FLAG "")

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -33,7 +33,8 @@ add_library_unity(
   test_utf8_codepoint_oob.cpp
   test_temporary_memory_manager.cpp
   test_versioning_utils.cpp
-  test_value_to_sql_string.cpp)
+  test_value_to_sql_string.cpp
+  test_musl_stack_size.cpp)
 
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_common>

--- a/test/common/test_musl_stack_size.cpp
+++ b/test/common/test_musl_stack_size.cpp
@@ -1,0 +1,21 @@
+#include "catch.hpp"
+
+#include <array>
+#include <thread>
+
+TEST_CASE("Check that 7MB can be allocated on stack with musl libc", "[musl_stack_size]") {
+#ifndef __MUSL_ENABLED__
+	return;
+#endif
+
+	std::thread th([] {
+		std::array<char, 7 * (1 << 20)> arr;
+		volatile char *ptr = arr.data();
+
+		for (size_t i = 0; i < arr.size(); i += (1 << 10)) {
+			ptr[i] = 42;
+		}
+	});
+
+	th.join();
+}


### PR DESCRIPTION
I was investigating a musl-specific test failure, that appeared to be a [stack overflow](https://github.com/duckdb/ducklake/pull/1430#issuecomment-5550167044).

Default stack size with musl libc is 128KB, while on glibc it is 8MB.

This PR increases default stack size for musl libc to 8MB to have it closer in behaviour to glibc.

Testing: new musl-specific test is added that tries to allocate 7MB on stack.