### PR TITLE
Fix BETWEEN to follow SQL three-valued logic for NULL bounds

### DIFF
--- a/src/function/scalar/comparison/between.cpp
+++ b/src/function/scalar/comparison/between.cpp
@@ -214,6 +214,7 @@ unique_ptr<FunctionData> BetweenFunctionDeserialize(Deserializer &deserializer, 
 ScalarFunction BetweenFun::GetFunction() {
 	ScalarFunction between_fun("__between", {LogicalType::ANY, LogicalType::ANY, LogicalType::ANY},
 	                           LogicalType::BOOLEAN, BetweenFunction, BindBetweenFun);
+	between_fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	between_fun.SetToStringCallback(BetweenToString);
 	between_fun.SetGetExpressionTypeCallback(BetweenGetExpressionType);
 	between_fun.SetLegacySerializeCallback(BetweenLegacySerializeCallback);

--- a/src/optimizer/statistics/expression/propagate_between.cpp
+++ b/src/optimizer/statistics/expression/propagate_between.cpp
@@ -39,12 +39,17 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateBetween(BoundFunctionE
 		expr_ptr = make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
 	} else if (lower_prune == FilterPropagateResult::FILTER_FALSE_OR_NULL ||
 	           upper_prune == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
-		// either one of the filters is false or null: replace with a constant or null (false)
-		vector<unique_ptr<Expression>> children;
-		children.push_back(std::move(input));
-		children.push_back(std::move(lower_bound));
-		children.push_back(std::move(upper_bound));
-		expr_ptr = ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(false));
+		// one comparison is false or null: the result is false or null only if the other comparison cannot be false
+		// the result is null only when the input or the bound of the false-or-null comparison is null
+		auto &false_bound = lower_prune == FilterPropagateResult::FILTER_FALSE_OR_NULL ? lower_bound : upper_bound;
+		auto other_prune = lower_prune == FilterPropagateResult::FILTER_FALSE_OR_NULL ? upper_prune : lower_prune;
+		if (other_prune == FilterPropagateResult::FILTER_ALWAYS_TRUE ||
+		    other_prune == FilterPropagateResult::FILTER_TRUE_OR_NULL) {
+			vector<unique_ptr<Expression>> children;
+			children.push_back(std::move(input));
+			children.push_back(std::move(false_bound));
+			expr_ptr = ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(false));
+		}
 	} else if (lower_prune == FilterPropagateResult::FILTER_TRUE_OR_NULL &&
 	           upper_prune == FilterPropagateResult::FILTER_TRUE_OR_NULL) {
 		// both filters are true or null: replace with a true or null

--- a/test/sql/join/test_between_null_bound_join.test
+++ b/test/sql/join/test_between_null_bound_join.test
@@ -1,0 +1,93 @@
+# name: test/sql/join/test_between_null_bound_join.test
+# description: BETWEEN with a NULL bound must follow SQL three-valued logic regardless of vector representation
+# group: [join]
+
+# https://github.com/duckdb/duckdb/issues/25170
+
+statement ok
+CREATE TABLE t0(c0 BOOLEAN, c1 INT, c2 INT);
+
+statement ok
+INSERT INTO t0 SELECT false, r, NULL FROM range(1, 23) t(r);
+
+statement ok
+INSERT INTO t0 VALUES (false, 23, -1);
+
+# the RHS is larger than the LHS, so the LHS rows are fed to the condition as constant vectors
+query I
+SELECT count(*) FROM t0 RIGHT JOIN (SELECT 1 FROM range(100)) s
+  ON ((EXISTS (SELECT 1 FROM t0 WHERE t0.c2 < 0)) NOT BETWEEN (t0.c2 = t0.c1) AND t0.c0);
+----
+2300
+
+# the RHS is smaller than the LHS, so the LHS rows stay flat
+query I
+SELECT count(*) FROM t0 RIGHT JOIN (SELECT 1 FROM range(10)) s
+  ON ((EXISTS (SELECT 1 FROM t0 WHERE t0.c2 < 0)) NOT BETWEEN (t0.c2 = t0.c1) AND t0.c0);
+----
+230
+
+# constant NULL lower bound with a FALSE upper comparison is FALSE, not NULL
+query II
+SELECT ((EXISTS (SELECT 1)) BETWEEN NULL::BOOLEAN AND false) AS b, ((EXISTS (SELECT 1)) BETWEEN NULL::BOOLEAN AND false) IS NULL;
+----
+false	false
+
+query I
+SELECT ((EXISTS (SELECT 1)) NOT BETWEEN NULL::BOOLEAN AND false);
+----
+true
+
+# statistics propagation: one comparison false-or-null, the other unknown, must not fold to NULL
+statement ok
+CREATE TABLE tt(x INT, l INT, u INT);
+
+statement ok
+INSERT INTO tt VALUES (10, NULL, 5), (10, 20, 50), (NULL, 20, 50), (10, NULL, 50);
+
+query IIII
+SELECT x, l, u, (CASE WHEN random() < 2 THEN x ELSE x END) BETWEEN l AND u FROM tt ORDER BY ALL;
+----
+10	20	50	false
+10	NULL	5	false
+10	NULL	50	NULL
+NULL	20	50	NULL
+
+# the original issue: UNION ALL over identical RIGHT JOINs with a shared subplan
+statement ok
+CREATE TABLE t1(c0 BOOLEAN, c1 INT, c2 INT, PRIMARY KEY(c1));
+
+statement ok
+CREATE UNIQUE INDEX i0 ON t1 (c1);
+
+statement ok
+CREATE UNIQUE INDEX i1 ON t1 (c1);
+
+loop i 0 11
+
+statement ok
+INSERT INTO t1(c1, c0) VALUES (${i} * 2 + 1, false), (${i} * 2 + 2, false);
+
+endloop
+
+statement ok
+INSERT INTO t1(c1, c0, c2) VALUES (23, false, -1);
+
+query I
+SELECT count(*) FROM (
+  SELECT 1 FROM t1 RIGHT JOIN (SELECT 1 AS col0 FROM t1) AS sub0
+    ON ((EXISTS (SELECT 1 FROM t1 WHERE t1.c2 < 0)) NOT BETWEEN (t1.c2 = t1.c1) AND t1.c0)
+) x;
+----
+529
+
+query I
+SELECT count(*) FROM (
+  SELECT 1 FROM t1 RIGHT JOIN (SELECT 1 AS col0 FROM t1) AS sub0
+    ON ((EXISTS (SELECT 1 FROM t1 WHERE t1.c2 < 0)) NOT BETWEEN (t1.c2 = t1.c1) AND t1.c0)
+  UNION ALL
+  SELECT 1 FROM t1 RIGHT JOIN (SELECT 1 AS col0 FROM t1) AS sub0
+    ON ((EXISTS (SELECT 1 FROM t1 WHERE t1.c2 < 0)) NOT BETWEEN (t1.c2 = t1.c1) AND t1.c0)
+) x;
+----
+1058


### PR DESCRIPTION
## Summary
Fixes #25170.

- `__between` was registered with the default NULL handling, so the expression executor short-circuited to NULL whenever any argument reached it as a `CONSTANT` NULL vector. `BETWEEN` is `input >= lower AND input <= upper`, and Kleene AND can still be FALSE when one side is UNKNOWN and the other is FALSE, so the short-circuit made the result depend on vector representation instead of the logical value:
  ```sql
  SELECT ((EXISTS (SELECT 1)) BETWEEN NULL::BOOLEAN AND false);
  -- NULL (wrong: the upper comparison is FALSE, so the AND is FALSE)
  ```
  This is what #25170 hits: `PhysicalCrossProduct` references the smaller side's rows as `CONSTANT` vectors, so a `RIGHT JOIN` condition with a `BETWEEN ... NULL ...` bound only picks up the short-circuit once the build side happens to be the larger one, e.g. once a shared CTE subplan changes which side of a duplicated `UNION ALL` branch is scanned first. `SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING)` lets `__between`'s own three-valued logic decide the result for every representation.
- `StatisticsPropagator::PropagateBetween` had the same bug one layer up: whenever a comparison could statically be proven `FALSE_OR_NULL`, it folded the whole `BETWEEN` into `constant_or_null(false, input, lower, upper)` regardless of what the other comparison could produce, and fed that unrelated bound into the tuple. Both let a NULL mask a FALSE the other comparison already guaranteed, and let an unrelated NULL bound leak into the result. This PR only folds when the other comparison cannot be FALSE, and only guards on the bound that actually produced `FALSE_OR_NULL`.

## Test plan
- Added `test/sql/join/test_between_null_bound_join.test`, covering:
  - the reduced repro (no UNION ALL / no indexes needed): a `RIGHT JOIN` whose build side is referenced as `CONSTANT` vs `FLAT` vectors by the cross product, with a `BETWEEN` NULL bound in the condition
  - the constant-NULL-bound witness from the issue directly
  - the statistics-propagation FALSE_OR_NULL rewrite with one comparison FALSE and the other UNKNOWN
  - the original issue repro (`UNION ALL` over two identical `RIGHT JOIN`s sharing a common subplan)
- Verified the new test fails on `v2.0-cyanoptera` before this change and passes after
- `test/sql/join/*`, `test/sql/optimizer/*`, `test/optimizer/*`, `test/sql/filter/*`, `test/sql/subquery/*`, `test/sql/cte/*`, `test/sql/setops/*`, `test/sql/function/generic/*`, `test/sql/projection/*`, `test/sql/types/null/*` all pass
- Full `unittest` run: only unrelated pre-existing failure in a `[!mayfail]` timing-based C API test