### PR TITLE
Fix primary key update to NOT NULL

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -1150,6 +1150,14 @@ unique_ptr<CatalogEntry> DuckTableEntry::SetNotNull(ClientContext &context, SetN
 
 unique_ptr<CatalogEntry> DuckTableEntry::DropNotNull(ClientContext &context, DropNotNullInfo &info) {
 	auto not_null_idx = GetColumnIndex(info.column_name);
+	if (const auto pk = GetPrimaryKey()) {
+		auto &unique = pk->Cast<UniqueConstraint>();
+		for (const auto &pk_index : unique.GetLogicalIndexes(columns)) {
+			if (pk_index == not_null_idx) {
+				throw CatalogException("column %s is in a primary key", info.column_name);
+			}
+		}
+	}
 
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();

--- a/test/sql/alter/alter_col/test_drop_not_null_primary_key.test
+++ b/test/sql/alter/alter_col/test_drop_not_null_primary_key.test
@@ -1,0 +1,11 @@
+# name: test/sql/alter/alter_col/test_drop_not_null_primary_key.test
+# description: DROP NOT NULL on a PRIMARY KEY column should fail because the column is in a primary key
+# group: [alter_col]
+
+statement ok
+CREATE TABLE pk_col(i INTEGER PRIMARY KEY, j INTEGER);
+
+statement error
+ALTER TABLE pk_col ALTER COLUMN i DROP NOT NULL
+----
+<REGEX>:Catalog Error.*column "i" is in a primary key.*


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25396

I checked the postgres behavior: it doesn't allow primary key to be not null.
```sql
CREATE TABLE pk_col (
    i INTEGER PRIMARY KEY,
    j INTEGER
);
ALTER TABLE pk_col ALTER COLUMN i DROP NOT NULL;
```
gets error message
```sh
CREATE TABLE
psql:commands.sql:6: ERROR:  column "i" is in a primary key
```
In this PR, I stick to PG's behavior to disable certain behavior.