### PR TITLE
Speed up the PEG parser

### DIFF
--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
   cast.cpp
   executor.cpp
   in.cpp
+  parser.cpp
   storage.cpp
   string_serialize.cpp)
 

--- a/benchmark/micro/parser.cpp
+++ b/benchmark/micro/parser.cpp
@@ -1,0 +1,202 @@
+#include "benchmark_runner.hpp"
+#include "duckdb_benchmark_macro.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/parser.hpp"
+
+#include <algorithm>
+
+using namespace duckdb;
+
+namespace {
+
+struct ParserBenchmarkState : public DuckDBBenchmarkState {
+	explicit ParserBenchmarkState(string path) : DuckDBBenchmarkState(std::move(path)) {
+	}
+
+	vector<string> queries;
+};
+
+string ReadFile(FileSystem &fs, const string &path) {
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
+	string result(handle->GetFileSize(), '\0');
+	handle->Read(&result[0], result.size());
+	return result;
+}
+
+// reads every .sql file in the directory, sorted by name so the corpus order is stable across runs
+vector<string> ReadQueryDirectory(const string &directory) {
+	auto fs = FileSystem::CreateLocal();
+	vector<string> files;
+	fs->ListFiles(directory, [&](const string &name, bool is_directory) {
+		if (!is_directory && StringUtil::EndsWith(name, ".sql")) {
+			files.push_back(fs->JoinPath(directory, name));
+		}
+	});
+	if (files.empty()) {
+		throw IOException("Parser benchmark found no .sql files in \"%s\"", directory);
+	}
+	std::sort(files.begin(), files.end());
+	vector<string> queries;
+	for (auto &file : files) {
+		queries.push_back(ReadFile(*fs, file));
+	}
+	return queries;
+}
+
+void ParseCorpus(ParserBenchmarkState &state, idx_t iterations) {
+	// the connection's options carry the compiled grammar, so the grammar is shared across parses
+	auto options = state.conn.context->GetParserOptions();
+	for (idx_t i = 0; i < iterations; i++) {
+		for (auto &query : state.queries) {
+			Parser parser(options);
+			parser.ParseQuery(query);
+		}
+	}
+}
+
+// a single SELECT with a wide expression list, nested parentheses, a long IN list, CASE, chained function calls and
+// window functions
+string BuildExpressionQuery() {
+	string sql = "SELECT ";
+	for (idx_t i = 0; i < 40; i++) {
+		if (i > 0) {
+			sql += ", ";
+		}
+		sql += StringUtil::Format("(a%d + b%d * 3 - c%d / 2) %% 7 AS x%d", i, i, i, i);
+	}
+	sql += ", CASE WHEN a0 > 10 AND b0 < 20 THEN 'low' WHEN a0 BETWEEN 20 AND 30 OR c0 IS NULL THEN 'mid' ELSE "
+	       "'high' END AS bucket";
+	sql += ", ((((((((((a1 + 1) * 2) - 3) / 4) + 5) * 6) - 7) / 8) + 9) * 10) AS nested";
+	sql += ", upper(trim(concat(cast(a2 AS VARCHAR), '-', lower(coalesce(s2, 'none'))))) AS chained";
+	sql += ", row_number() OVER (PARTITION BY a3, b3 ORDER BY c3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT "
+	       "ROW) AS rn";
+	sql += ", sum(a4) FILTER (WHERE b4 > 0) OVER (ORDER BY c4 RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING) AS ws";
+	sql += " FROM t WHERE a0 IN (";
+	for (idx_t i = 0; i < 200; i++) {
+		if (i > 0) {
+			sql += ", ";
+		}
+		sql += std::to_string(i);
+	}
+	sql += ") AND (b0 LIKE 'abc%' OR b0 NOT SIMILAR TO 'x.*') AND c0::INTEGER = 1 AND d0 = DATE '2024-01-01' AND "
+	       "e0 IS NOT DISTINCT FROM f0 AND EXISTS (SELECT 1 FROM u WHERE u.id = t.id AND u.v > (SELECT avg(v) FROM u))";
+	sql += " ORDER BY 1, 2 DESC NULLS LAST LIMIT 100 OFFSET 10;";
+	return sql;
+}
+
+// DDL and DML statements with many columns, constraints and rows
+vector<string> BuildDDLQueries() {
+	vector<string> queries;
+	string create = "CREATE TABLE IF NOT EXISTS main.wide_table (";
+	for (idx_t i = 0; i < 200; i++) {
+		if (i > 0) {
+			create += ", ";
+		}
+		switch (i % 5) {
+		case 0:
+			create += StringUtil::Format("col%d INTEGER NOT NULL DEFAULT 0", i);
+			break;
+		case 1:
+			create += StringUtil::Format("col%d VARCHAR UNIQUE", i);
+			break;
+		case 2:
+			create += StringUtil::Format("col%d DECIMAL(18, 3) CHECK (col%d >= 0)", i, i);
+			break;
+		case 3:
+			create += StringUtil::Format("col%d TIMESTAMP WITH TIME ZONE", i);
+			break;
+		default:
+			create += StringUtil::Format("col%d STRUCT(a INTEGER, b MAP(VARCHAR, DOUBLE[]))", i);
+			break;
+		}
+	}
+	create += ", PRIMARY KEY (col0, col5), FOREIGN KEY (col10) REFERENCES other_table (id));";
+	queries.push_back(create);
+
+	string insert = "INSERT INTO wide_table (col0, col1, col2, col3) VALUES ";
+	for (idx_t i = 0; i < 500; i++) {
+		if (i > 0) {
+			insert += ", ";
+		}
+		insert += StringUtil::Format("(%d, 'value_%d', %d.5, '2024-01-01 00:00:00+00')", i, i, i);
+	}
+	insert += ";";
+	queries.push_back(insert);
+
+	queries.push_back("CREATE OR REPLACE VIEW v AS SELECT col0, col1, count(*) AS cnt FROM wide_table GROUP BY ALL "
+	                  "HAVING count(*) > 1 ORDER BY cnt DESC;");
+	queries.push_back("ALTER TABLE wide_table ADD COLUMN IF NOT EXISTS extra BIGINT DEFAULT 42;");
+	queries.push_back("ALTER TABLE wide_table ALTER COLUMN col1 SET DATA TYPE TEXT;");
+	queries.push_back("COPY wide_table TO 'out.parquet' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000);");
+	queries.push_back("CREATE INDEX idx ON wide_table USING ART (col0, col1) WITH (leaf_size = 4);");
+	queries.push_back("UPDATE wide_table SET col0 = col0 + 1, col1 = 'x' WHERE col2 > 10 AND col3 IS NOT NULL;");
+	queries.push_back("DELETE FROM wide_table USING other_table WHERE wide_table.col10 = other_table.id;");
+	queries.push_back("WITH RECURSIVE cte(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM cte WHERE n < 100) SELECT * "
+	                  "FROM cte;");
+	queries.push_back("PIVOT wide_table ON col1 USING sum(col0) GROUP BY col2;");
+	queries.push_back("SELECT * FROM read_csv('file.csv', header = true, delim = '|', columns = {'a': 'INTEGER', "
+	                  "'b': 'VARCHAR'});");
+	return queries;
+}
+
+} // namespace
+
+#define PARSER_BENCHMARK_BODY(LOAD, INFO)                                                                              \
+	duckdb::unique_ptr<DuckDBBenchmarkState> CreateBenchmarkState() override {                                         \
+		return make_uniq<ParserBenchmarkState>(GetDatabasePath());                                                     \
+	}                                                                                                                  \
+	void Load(DuckDBBenchmarkState *state_p) override {                                                                \
+		auto &state = static_cast<ParserBenchmarkState &>(*state_p);                                                   \
+		LOAD;                                                                                                          \
+	}                                                                                                                  \
+	string VerifyResult(QueryResult *result) override {                                                                \
+		return string();                                                                                               \
+	}                                                                                                                  \
+	string BenchmarkInfo() override {                                                                                  \
+		return INFO;                                                                                                   \
+	}
+
+DUCKDB_BENCHMARK(ParserTPCH, "[parser]")
+PARSER_BENCHMARK_BODY(state.queries = ReadQueryDirectory("extension/tpch/dbgen/queries"),
+                      "Parse the 22 TPC-H queries 200 times")
+void RunBenchmark(DuckDBBenchmarkState *state_p) override {
+	ParseCorpus(static_cast<ParserBenchmarkState &>(*state_p), 200);
+}
+FINISH_BENCHMARK(ParserTPCH)
+
+DUCKDB_BENCHMARK(ParserTPCDS, "[parser]")
+PARSER_BENCHMARK_BODY(state.queries = ReadQueryDirectory("extension/tpcds/dsdgen/queries"),
+                      "Parse the 99 TPC-DS queries 50 times")
+void RunBenchmark(DuckDBBenchmarkState *state_p) override {
+	ParseCorpus(static_cast<ParserBenchmarkState &>(*state_p), 50);
+}
+FINISH_BENCHMARK(ParserTPCDS)
+
+DUCKDB_BENCHMARK(ParserExpressions, "[parser]")
+PARSER_BENCHMARK_BODY(state.queries.push_back(BuildExpressionQuery()), "Parse an expression-heavy SELECT 500 times")
+void RunBenchmark(DuckDBBenchmarkState *state_p) override {
+	ParseCorpus(static_cast<ParserBenchmarkState &>(*state_p), 500);
+}
+FINISH_BENCHMARK(ParserExpressions)
+
+DUCKDB_BENCHMARK(ParserDDL, "[parser]")
+PARSER_BENCHMARK_BODY(state.queries = BuildDDLQueries(), "Parse a set of wide DDL and DML statements 200 times")
+void RunBenchmark(DuckDBBenchmarkState *state_p) override {
+	ParseCorpus(static_cast<ParserBenchmarkState &>(*state_p), 200);
+}
+FINISH_BENCHMARK(ParserDDL)
+
+DUCKDB_BENCHMARK(TokenizerTPCDS, "[parser]")
+PARSER_BENCHMARK_BODY(state.queries = ReadQueryDirectory("extension/tpcds/dsdgen/queries"),
+                      "Tokenize the 99 TPC-DS queries 200 times")
+void RunBenchmark(DuckDBBenchmarkState *state_p) override {
+	auto &state = static_cast<ParserBenchmarkState &>(*state_p);
+	for (idx_t i = 0; i < 200; i++) {
+		for (auto &query : state.queries) {
+			Parser::Tokenize(query);
+		}
+	}
+}
+FINISH_BENCHMARK(TokenizerTPCDS)

--- a/scripts/parser/grammar_types.yml
+++ b/scripts/parser/grammar_types.yml
@@ -1805,6 +1805,11 @@ packrat_memoized_rules:
   - ColId
   - ColumnReference
   - FunctionExpression
+  - CatalogQualification
+  - SchemaQualification
+  - ReservedSchemaQualification
+  - TableQualification
+  - ReservedTableQualification
 
 # ---------------------------------------------------------------------------
 # excluded_rules: no transformer stub generated, no semantic value extracted

--- a/src/include/duckdb/parser/peg/compiled_grammar.hpp
+++ b/src/include/duckdb/parser/peg/compiled_grammar.hpp
@@ -32,6 +32,10 @@ public:
 	bool HasGrammarChanges() const {
 		return has_grammar_changes;
 	}
+	//! Number of packrat-memoized matchers, the row width of a ParserPackratCache for this grammar
+	idx_t PackratSlotCount() const {
+		return packrat_slot_count;
+	}
 
 public:
 	static shared_ptr<CompiledGrammar> Get(ClientContext &context);
@@ -43,6 +47,7 @@ public:
 
 private:
 	MatcherAllocator allocator;
+	idx_t packrat_slot_count = 0;
 	optional_ptr<const Matcher> program_matcher;
 	optional_ptr<const Matcher> top_level_statement_matcher;
 

--- a/src/include/duckdb/parser/peg/keyword_helper.hpp
+++ b/src/include/duckdb/parser/peg/keyword_helper.hpp
@@ -30,6 +30,13 @@ public:
 	virtual bool KeywordCategoryType(const string &text, PEGKeywordCategory type) const = 0;
 	virtual bool IsKeyword(const string &text) const = 0;
 	virtual vector<ParserKeyword> KeywordList() const = 0;
+
+	//! Bit of a category in the bit set returned by KeywordCategories
+	static uint8_t CategoryBit(PEGKeywordCategory category) {
+		return static_cast<uint8_t>(1 << static_cast<uint8_t>(category));
+	}
+	//! Bit set over the categories the text belongs to, 0 if the text is not a keyword
+	virtual uint8_t KeywordCategories(const string &text) const = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/keyword_helper/default_keyword_maps.hpp
+++ b/src/include/duckdb/parser/peg/keyword_helper/default_keyword_maps.hpp
@@ -10,7 +10,11 @@ class DefaultKeywordMaps {
 public:
 	bool IsKeywordOfCategory(const string &text, PEGKeywordCategory type) const;
 	bool IsKeyword(const string &text) const;
+	//! Bit set (see PEGKeywordHelper::CategoryBit) of the categories the text belongs to, 0 if it is not a keyword
+	uint8_t KeywordCategories(const string &text) const;
 	vector<ParserKeyword> ToList() const;
+	//! Builds the combined lookup map from the category sets; must be called once the sets are populated
+	void Finalize();
 
 public:
 	case_insensitive_set_t reserved_keyword_map;
@@ -18,6 +22,13 @@ public:
 	case_insensitive_set_t colname_keyword_map;
 	case_insensitive_set_t typefunc_keyword_map;
 	case_insensitive_set_t typename_keyword_map;
+
+private:
+	void AddCategory(const case_insensitive_set_t &keywords, PEGKeywordCategory category);
+
+	//! Every keyword mapped to the bit set of categories it belongs to, so that a lookup hashes the text once
+	//! instead of once per category set
+	case_insensitive_map_t<uint8_t> keyword_categories;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/keyword_helper/duckdb_keyword_helper.hpp
+++ b/src/include/duckdb/parser/peg/keyword_helper/duckdb_keyword_helper.hpp
@@ -15,6 +15,7 @@ public:
 public:
 	bool KeywordCategoryType(const std::string &text, const PEGKeywordCategory type) const override;
 	bool IsKeyword(const string &text) const override;
+	uint8_t KeywordCategories(const string &text) const override;
 	vector<ParserKeyword> KeywordList() const override;
 
 private:

--- a/src/include/duckdb/parser/peg/keyword_helper/parsed_grammar_keyword_helper.hpp
+++ b/src/include/duckdb/parser/peg/keyword_helper/parsed_grammar_keyword_helper.hpp
@@ -14,6 +14,7 @@ public:
 public:
 	bool KeywordCategoryType(const string &text, PEGKeywordCategory type) const override;
 	bool IsKeyword(const string &text) const override;
+	uint8_t KeywordCategories(const string &text) const override;
 	vector<ParserKeyword> KeywordList() const override;
 
 private:

--- a/src/include/duckdb/parser/peg/keyword_table.hpp
+++ b/src/include/duckdb/parser/peg/keyword_table.hpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/parser/peg/keyword_table.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/constants.hpp"
+
+namespace duckdb {
+
+//! Interns every literal of a compiled grammar ('SELECT', '(', ',', ...) as a dense integer id, so that keyword
+//! matching and first-set pruning compare integers instead of strings
+class KeywordTable {
+public:
+	//! Returns the id of the keyword, registering it if it has not been seen before. Matching is case-insensitive.
+	idx_t Register(const string &keyword) {
+		auto entry = ids.find(keyword);
+		if (entry != ids.end()) {
+			return entry->second;
+		}
+		auto id = ids.size();
+		ids.emplace(keyword, id);
+		return id;
+	}
+
+	//! Returns the id of the keyword the text refers to, or DConstants::INVALID_INDEX if it is not a keyword
+	idx_t Lookup(const string &text) const {
+		auto entry = ids.find(text);
+		if (entry == ids.end()) {
+			return DConstants::INVALID_INDEX;
+		}
+		return entry->second;
+	}
+
+private:
+	case_insensitive_map_t<idx_t> ids;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -20,6 +20,10 @@
 #include "duckdb/parser/peg/tokenizer/tokenizer.hpp"
 #include "duckdb/parser/peg/parsed_grammar.hpp"
 #include "duckdb/parser/peg/transformer/parse_result.hpp"
+#include "duckdb/parser/peg/keyword_table.hpp"
+#include "duckdb/storage/arena_allocator.hpp"
+
+#include <new>
 
 namespace duckdb {
 class ClientContext;
@@ -161,7 +165,8 @@ struct MatchState {
 
 	TokenIterator token_iterator;
 	vector<MatcherSuggestion> &suggestions;
-	reference_set_t<const Matcher> added_suggestions;
+	//! The matchers that already contributed a suggestion through this state, created on first use
+	unique_ptr<reference_set_t<const Matcher>> added_suggestions;
 	ParseResultAllocator &allocator;
 	idx_t &max_token_index;
 	IdentifierCaseMode identifier_case_mode = IdentifierCaseMode::PRESERVE_CASE;
@@ -204,6 +209,51 @@ struct MatchState {
 	void AddSuggestion(MatcherSuggestion suggestion);
 };
 
+//! Describes which tokens can begin a successful match of a matcher. Computed once per compiled grammar by the
+//! MatcherFactory and used to skip matchers that cannot possibly match the current token (see Matcher::CanStartAt).
+struct MatcherFirstSet {
+	//! Whether the matcher can succeed without consuming any token
+	bool nullable = false;
+	//! Whether the matcher can begin with a token that is not a grammar literal (identifier, string, number, ...)
+	bool any_token = false;
+	//! Bitmap over KeywordTable ids of the literals the matcher can begin with
+	unsafe_vector<uint64_t> keywords;
+	//! Whether the set is restrictive, i.e. a match must begin with one of the literals in `keywords`
+	bool prunable = false;
+
+	void AddKeyword(idx_t keyword_id) {
+		auto word = keyword_id / 64;
+		if (word >= keywords.size()) {
+			keywords.resize(word + 1, 0);
+		}
+		keywords[word] |= uint64_t(1) << (keyword_id % 64);
+	}
+	bool HasKeyword(idx_t keyword_id) const {
+		auto word = keyword_id / 64;
+		return word < keywords.size() && (keywords[word] >> (keyword_id % 64)) & 1;
+	}
+	//! Merge the tokens another matcher can begin with (does not touch nullable)
+	void MergeStart(const MatcherFirstSet &other) {
+		any_token = any_token || other.any_token;
+		if (other.keywords.size() > keywords.size()) {
+			keywords.resize(other.keywords.size(), 0);
+		}
+		for (idx_t i = 0; i < other.keywords.size(); i++) {
+			keywords[i] |= other.keywords[i];
+		}
+	}
+	bool operator==(const MatcherFirstSet &other) const {
+		return nullable == other.nullable && any_token == other.any_token && keywords == other.keywords;
+	}
+	//! Called once the set is complete: only a restrictive set needs to keep its bitmap
+	void Finalize() {
+		prunable = !nullable && !any_token;
+		if (!prunable) {
+			keywords.clear();
+		}
+	}
+};
+
 enum class MatcherType {
 	KEYWORD,
 	LIST,
@@ -223,8 +273,35 @@ public:
 	}
 	virtual ~Matcher() = default;
 
+	//! Whether a match can begin at the current token according to the first set. A matcher that cannot start here
+	//! would fail without consuming input, so skipping it changes neither the outcome, the error position nor the
+	//! suggestions; at the autocomplete cursor every matcher runs.
+	bool CanStartAt(MatchState &state) const {
+		if (!first_set.prunable) {
+			return true;
+		}
+		auto token = state.token_iterator.Current();
+		if (!token || token->type == TokenType::END_OF_INPUT_AUTOCOMPLETE) {
+			return true;
+		}
+		auto keyword_id = state.token_iterator.CurrentKeywordId(*keyword_table);
+		return keyword_id != DConstants::INVALID_INDEX && first_set.HasKeyword(keyword_id);
+	}
+
 	//! Match and construct the parse result
-	MatcherResult MatchParseResult(MatchState &state) const;
+	MatcherResult MatchParseResult(MatchState &state) const {
+		if (!CanStartAt(state)) {
+			return MatcherResult::Failure();
+		}
+		state.rule = rule;
+		if (state.use_heap_based_parser) {
+			return MatchHeapBased(state);
+		}
+		if (packrat_memoized && state.packrat_cache) {
+			return MatchMemoized(state);
+		}
+		return MatchParseResultInternal(state);
+	}
 	virtual MatcherResult MatchParseResultInternal(MatchState &state) const = 0;
 	virtual SuggestionType AddSuggestion(MatchState &state) const;
 	virtual SuggestionType AddSuggestionInternal(MatchState &state) const = 0;
@@ -251,11 +328,19 @@ public:
 	optional_idx GetPackratId() const {
 		return packrat_id;
 	}
-	void SetPackratMemoized() {
+	//! Marks the matcher as packrat-memoized; `slot` is its column in the ParserPackratCache
+	void SetPackratMemoized(idx_t slot) {
 		packrat_memoized = true;
+		packrat_slot = slot;
 	}
 	bool IsPackratMemoized() const {
 		return packrat_memoized;
+	}
+	void SetFirstSet(MatcherFirstSet first_set_p) {
+		first_set = std::move(first_set_p);
+	}
+	idx_t GetPackratSlot() const {
+		return packrat_slot;
 	}
 
 public:
@@ -275,13 +360,24 @@ public:
 		return reinterpret_cast<const TARGET &>(*this);
 	}
 
+private:
+	//! Runs the matcher on the heap-based matcher stack instead of the native stack
+	MatcherResult MatchHeapBased(MatchState &state) const;
+	//! Runs the matcher through the packrat cache, memoizing the result per token position
+	MatcherResult MatchMemoized(MatchState &state) const;
+
 protected:
 	friend class MatcherAllocator;
 	MatcherType type;
 	string name;
 	optional_idx packrat_id;
 	bool packrat_memoized = false;
+	idx_t packrat_slot = 0;
 	optional_ptr<const CompiledGrammarRule> rule;
+	//! The tokens a match can begin with, computed once the grammar is fully constructed
+	MatcherFirstSet first_set;
+	//! The literals of the grammar this matcher belongs to, set by the MatcherAllocator
+	optional_ptr<const KeywordTable> keyword_table;
 };
 
 class KeywordInfo {
@@ -301,16 +397,50 @@ class MatcherAllocator {
 public:
 	Matcher &Allocate(unique_ptr<Matcher> matcher);
 
+	//! All matchers allocated so far, indexed by their packrat id
+	const vector<unique_ptr<Matcher>> &GetMatchers() const {
+		return matchers;
+	}
+
 private:
 	vector<unique_ptr<Matcher>> matchers;
+	//! The literals of the grammar; owned here because the matchers reference it
+	KeywordTable keyword_table;
 };
 
+//! Owns the parse results of a single parse; they are placed in an arena and released together
 class ParseResultAllocator {
 public:
-	optional_ptr<ParseResult> Allocate(unique_ptr<ParseResult> parse_result);
+	ParseResultAllocator();
+	~ParseResultAllocator();
+
+	template <class RESULT, class... ARGS>
+	RESULT &Allocate(ARGS &&... args) {
+		auto result = arena.Make<RESULT>(std::forward<ARGS>(args)...);
+		parse_results.push_back(*result);
+		return *result;
+	}
+
+	//! The children of a sequence or repetition are gathered on a scratch stack while it matches. Matchers nest, so
+	//! the stack is strictly LIFO; once the composite succeeds its children are copied into the arena.
+	idx_t ChildrenBegin() const {
+		return child_scratch.size();
+	}
+	void PushChild(ParseResult &child) {
+		child_scratch.push_back(child);
+	}
+	void DiscardChildren(idx_t begin) {
+		while (child_scratch.size() > begin) {
+			child_scratch.pop_back();
+		}
+	}
+	//! Moves the children pushed since `begin` into the arena and returns them (nullptr if there are none)
+	reference<ParseResult> *TakeChildren(idx_t begin, idx_t &count);
 
 private:
-	vector<unique_ptr<ParseResult>> parse_results;
+	ArenaAllocator arena;
+	unsafe_vector<reference<ParseResult>> parse_results;
+	unsafe_vector<reference<ParseResult>> child_scratch;
 };
 
 template <class RESULT, class... ARGS>
@@ -318,10 +448,10 @@ MatcherResult MatchState::AllocateParseResult(ARGS &&... args) {
 	if (!BuildParseResult()) {
 		return MatcherResult::Success();
 	}
-	auto result = allocator.Allocate(make_uniq<RESULT>(std::forward<ARGS>(args)...));
+	auto &result = allocator.Allocate<RESULT>(std::forward<ARGS>(args)...);
 	if (rule) {
-		result->SetRule(*rule);
-		result->name = rule->name;
+		result.SetRule(*rule);
+		result.name = rule->name;
 	}
 	return MatcherResult::Success(result);
 }

--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -156,7 +156,7 @@ struct MatchState {
 	      max_token_index(max_token_index), identifier_case_mode(identifier_case_mode_p),
 	      packrat_cache(packrat_cache_p), mode(mode_p), use_heap_based_parser(use_heap_based_parser_p) {
 	}
-	MatchState(MatchState &state)
+	MatchState(const MatchState &state)
 	    : token_iterator(state.token_iterator), suggestions(state.suggestions), allocator(state.allocator),
 	      max_token_index(state.max_token_index), identifier_case_mode(state.identifier_case_mode),
 	      packrat_cache(state.packrat_cache), mode(state.mode), use_heap_based_parser(state.use_heap_based_parser),

--- a/src/include/duckdb/parser/peg/matcher/choice_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/choice_matcher.hpp
@@ -21,6 +21,9 @@ public:
 			start_offset = optional_idx(current->offset);
 		}
 		for (idx_t i = 0; i < matchers.size(); i++) {
+			if (!matchers[i].get().CanStartAt(state)) {
+				continue;
+			}
 			MatchState choice_state(state);
 			auto child_result = matchers[i].get().MatchParseResult(choice_state);
 			if (child_result.IsSuccess()) {

--- a/src/include/duckdb/parser/peg/matcher/identifier_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/identifier_matcher.hpp
@@ -159,14 +159,16 @@ public:
 	}
 
 private:
-	bool IsAllowedKeyword(const string &token_text) const {
-		if (!keyword_helper.IsKeyword(token_text)) {
+	//! Whether the current token is not a keyword, or a keyword that may be used as this kind of identifier
+	bool IsAllowedKeyword(MatchState &state) const {
+		auto categories = state.token_iterator.CurrentKeywordCategories(keyword_helper);
+		if (categories == 0) {
 			return true;
 		}
-		if (keyword_helper.KeywordCategoryType(token_text, PEGKeywordCategory::KEYWORD_UNRESERVED)) {
+		if (categories & PEGKeywordHelper::CategoryBit(PEGKeywordCategory::KEYWORD_UNRESERVED)) {
 			return true;
 		}
-		return keyword_helper.KeywordCategoryType(token_text, GetAllowedCategory());
+		return (categories & PEGKeywordHelper::CategoryBit(GetAllowedCategory())) != 0;
 	}
 
 	bool MatchIdentifier(MatchState &state) const {
@@ -175,7 +177,7 @@ private:
 			return false;
 		}
 		auto &token_text = token->text;
-		if (!IsAllowedKeyword(token_text) || !IsIdentifier(token_text)) {
+		if (!IsAllowedKeyword(state) || !IsIdentifier(token_text)) {
 			return false;
 		}
 		state.token_iterator.Advance();

--- a/src/include/duckdb/parser/peg/matcher/keyword_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/keyword_matcher.hpp
@@ -43,6 +43,9 @@ public:
 	string ToString() const override {
 		return "'" + keyword + "'";
 	}
+	idx_t GetKeywordId() const {
+		return keyword_id;
+	}
 
 private:
 	bool MatchKeyword(MatchState &state) const {
@@ -50,7 +53,8 @@ private:
 		if (!token) {
 			return false;
 		}
-		if (StringUtil::CIEquals(keyword, token->text)) {
+		// literals are interned case-insensitively, so comparing ids is a case-insensitive comparison
+		if (state.token_iterator.CurrentKeywordId(*keyword_table) == keyword_id) {
 			// move to the next token
 			state.token_iterator.Advance();
 			state.UpdateMaxTokenIndex();
@@ -60,8 +64,11 @@ private:
 	}
 
 private:
+	friend class MatcherAllocator;
 	const string keyword;
 	const KeywordInfo info;
+	//! Id of the keyword in the grammar's keyword table, assigned by the MatcherAllocator
+	idx_t keyword_id = DConstants::INVALID_INDEX;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/matcher/list_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/list_matcher.hpp
@@ -16,7 +16,8 @@ public:
 
 	MatcherResult MatchParseResultInternal(MatchState &state) const override {
 		MatchState list_state(state);
-		vector<reference<ParseResult>> results;
+		auto &allocator = state.allocator;
+		auto children_begin = allocator.ChildrenBegin();
 		// when suppress_suggestions is set, we discard any suggestions added by child matchers
 		auto saved_suggestion_size = suppress_suggestions ? list_state.suggestions.size() : 0;
 
@@ -31,27 +32,31 @@ public:
 				auto child_result = child_matcher.get().MatchParseResult(list_state);
 				if (!child_result.IsSuccess()) {
 					DiscardSuggestions(list_state, saved_suggestion_size);
+					allocator.DiscardChildren(children_begin);
 					return MatcherResult::Failure();
 				}
 				if (child_result.HasParseResult()) {
-					results.push_back(*child_result.GetParseResult());
+					allocator.PushChild(*child_result.GetParseResult());
 				}
 				continue;
 			}
 			if (suppress_suggestions) {
 				DiscardSuggestions(list_state, saved_suggestion_size);
+				allocator.DiscardChildren(children_begin);
 				return MatcherResult::Failure();
 			}
 			if (child_matcher.get().AddSuggestion(list_state) == SuggestionType::OPTIONAL) {
 				continue;
 			}
 			state.token_iterator.SetPosition(list_state.token_iterator);
+			allocator.DiscardChildren(children_begin);
 			return MatcherResult::Failure();
 		}
 		state.token_iterator.SetPosition(list_state.token_iterator);
 		DiscardSuggestions(list_state, saved_suggestion_size);
-		// Empty name implies it's a subrule, e.g. 'SET'i (StandardAssignment / SetTimeZone)
-		return state.AllocateParseResult<ListParseResult>(std::move(results), name, start_offset);
+		idx_t child_count;
+		auto children = allocator.TakeChildren(children_begin, child_count);
+		return state.AllocateParseResult<ListParseResult>(children, child_count, start_offset);
 	}
 
 	SuggestionType AddSuggestionInternal(MatchState &state) const override {

--- a/src/include/duckdb/parser/peg/matcher/optional_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/optional_matcher.hpp
@@ -14,6 +14,9 @@ public:
 	}
 
 	MatcherResult MatchParseResultInternal(MatchState &state) const override {
+		if (!matcher.CanStartAt(state)) {
+			return state.AllocateParseResult<OptionalParseResult>();
+		}
 		MatchState child_state(state);
 		optional_idx start_offset;
 		if (auto current = child_state.token_iterator.Current()) {

--- a/src/include/duckdb/parser/peg/matcher/repeat_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/repeat_matcher.hpp
@@ -14,7 +14,8 @@ public:
 
 	MatcherResult MatchParseResultInternal(MatchState &state) const override {
 		MatchState repeat_state(state);
-		vector<reference<ParseResult>> results;
+		auto &allocator = state.allocator;
+		auto children_begin = allocator.ChildrenBegin();
 
 		optional_idx start_offset;
 		if (auto current = repeat_state.token_iterator.Current()) {
@@ -28,7 +29,7 @@ public:
 			return MatcherResult::Failure();
 		}
 		if (first_result.HasParseResult()) {
-			results.push_back(*first_result.GetParseResult());
+			allocator.PushChild(*first_result.GetParseResult());
 		}
 
 		// After the first success, the overall result is a success.
@@ -49,12 +50,14 @@ public:
 				break;
 			}
 			if (next_result.HasParseResult()) {
-				results.push_back(*next_result.GetParseResult());
+				allocator.PushChild(*next_result.GetParseResult());
 			}
 		}
 
 		// Return all collected results in a RepeatParseResult.
-		return state.AllocateParseResult<RepeatParseResult>(std::move(results), start_offset);
+		idx_t child_count;
+		auto children = allocator.TakeChildren(children_begin, child_count);
+		return state.AllocateParseResult<RepeatParseResult>(children, child_count, start_offset);
 	}
 
 	SuggestionType AddSuggestionInternal(MatchState &state) const override {

--- a/src/include/duckdb/parser/peg/matcher_factory.hpp
+++ b/src/include/duckdb/parser/peg/matcher_factory.hpp
@@ -36,6 +36,10 @@ public:
 	Matcher &CreateRootMatcher(const string &root_rule);
 	//! Look up a matcher for a rule that was built by CreateRootMatcher. Throws if the rule has not been built.
 	Matcher &GetMatcher(const string &rule_name);
+	//! Number of packrat-memoized rules, the row width of a ParserPackratCache
+	idx_t PackratSlotCount() const {
+		return packrat_memoized_rules.size();
+	}
 
 private:
 	// Base primitives
@@ -53,6 +57,9 @@ private:
 	virtual unique_ptr<RepeatMatcher> CreateRepeat(Matcher &matcher) const;
 
 	void SetRuleOverrides();
+
+	//! Computes the first set of every matcher, see Matcher::CanStartAt
+	void ComputeFirstSets();
 
 	void AddKeywordOverride(const char *name, KeywordInfo keyword_info);
 	void AddRuleOverride(const char *name, unique_ptr<Matcher> &&matcher_p);
@@ -74,7 +81,8 @@ private:
 	mutable case_insensitive_map_t<reference<KeywordMatcher>> keywords;
 	case_insensitive_map_t<KeywordInfo> keyword_overrides;
 	string_set_t no_suggestion_rules;
-	string_set_t packrat_memoized_rules;
+	//! The packrat-memoized rules, mapped to their dense slot in the packrat cache
+	string_map_t<idx_t> packrat_memoized_rules;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/matcher_stack.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "duckdb/common/allocator.hpp"
 #include "duckdb/common/optional.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/parser/peg/matcher.hpp"
@@ -58,6 +59,8 @@ struct MatchStackFrame {
 
 class MatchStack {
 public:
+	~MatchStack();
+
 	MatcherResult Execute(const Matcher &matcher, MatchState &state);
 	void PushChildFrame(MatchStackFrame &parent, const Matcher &matcher, MatchState &state);
 
@@ -65,13 +68,30 @@ private:
 	static bool IsTerminalMatcher(const Matcher &matcher);
 	MatcherResult ExecuteTerminalMatcher(const Matcher &matcher, MatchState &state);
 	void PushFrame(const Matcher &matcher, MatchState &state);
+	template <class FRAME, class... ARGS>
+	void AllocateFrame(ARGS &&... args);
+	data_ptr_t AllocateFrameMemory(idx_t size);
+	void PopFrame();
 	void InitializeFrame(MatchStackFrame &frame);
 	void ExecuteFrame(MatchStackFrame &frame);
 	MatcherResult FinalizeFrame(MatchStackFrame &frame);
 	MatcherResult ExecuteInternal(const Matcher &matcher, MatchState &state);
 
 private:
-	vector<unique_ptr<MatchStackFrame>> frames;
+	//! Frames are pushed and popped strictly LIFO, so they are placed in fixed-size blocks that are reused as frames
+	//! pop instead of being allocated one by one. An entry records where the block cursor stood before its frame,
+	//! which is where the cursor returns when the frame pops.
+	struct FrameEntry {
+		reference<MatchStackFrame> frame;
+		idx_t block_index;
+		idx_t block_offset;
+	};
+	static constexpr idx_t FRAME_BLOCK_SIZE = 16384;
+
+	unsafe_vector<FrameEntry> frames;
+	unsafe_vector<AllocatedData> blocks;
+	idx_t block_index = 0;
+	idx_t block_offset = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/matcher_stack/choice_match_stack_frame.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack/choice_match_stack_frame.hpp
@@ -31,6 +31,10 @@ public:
 			child_index++;
 			child_state.reset();
 		}
+		while (child_index < choice_matcher.matchers.size() &&
+		       !choice_matcher.matchers[child_index].get().CanStartAt(match_state)) {
+			child_index++;
+		}
 		if (child_index >= choice_matcher.matchers.size()) {
 			SetResult(MatcherResult::Failure());
 			return;

--- a/src/include/duckdb/parser/peg/matcher_stack/choice_match_stack_frame.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack/choice_match_stack_frame.hpp
@@ -17,7 +17,9 @@ public:
 	void Execute(MatchStack &stack) override {
 		if (HasChildResult()) {
 			auto child_result = TakeChildResult();
-			D_ASSERT(child_state);
+			if (!child_state) {
+				throw InternalException("Choice frame has a child result but no child state");
+			}
 			if (child_result.IsSuccess()) {
 				match_state.token_iterator.SetPosition(child_state->token_iterator);
 				if (!child_result.HasParseResult()) {
@@ -39,13 +41,13 @@ public:
 			SetResult(MatcherResult::Failure());
 			return;
 		}
-		child_state = make_uniq<MatchState>(match_state);
+		child_state.emplace(match_state);
 		stack.PushChildFrame(*this, choice_matcher.matchers[child_index].get(), *child_state);
 	}
 
 private:
 	const ChoiceMatcher &choice_matcher;
-	unique_ptr<MatchState> child_state;
+	optional<MatchState> child_state;
 	idx_t child_index = 0;
 	optional_idx start_offset;
 };

--- a/src/include/duckdb/parser/peg/matcher_stack/list_match_stack_frame.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack/list_match_stack_frame.hpp
@@ -9,6 +9,7 @@ class ListMatchStackFrame : public MatchStackFrame {
 public:
 	ListMatchStackFrame(match_frame_index_t frame_index, const ListMatcher &matcher, MatchState &state)
 	    : MatchStackFrame(frame_index, matcher, state), list_matcher(matcher), list_state(state) {
+		children_begin = state.allocator.ChildrenBegin();
 		saved_suggestion_size = matcher.suppress_suggestions ? list_state.suggestions.size() : 0;
 		if (auto current = list_state.token_iterator.Current()) {
 			start_offset = optional_idx(current->offset);
@@ -20,11 +21,12 @@ public:
 			auto child_result = TakeChildResult();
 			if (!child_result.IsSuccess()) {
 				DiscardSuggestions();
+				match_state.allocator.DiscardChildren(children_begin);
 				SetResult(MatcherResult::Failure());
 				return;
 			}
 			if (child_result.HasParseResult()) {
-				results.push_back(*child_result.GetParseResult());
+				match_state.allocator.PushChild(*child_result.GetParseResult());
 			}
 			child_index++;
 		}
@@ -37,6 +39,7 @@ public:
 			}
 			if (list_matcher.suppress_suggestions) {
 				DiscardSuggestions();
+				match_state.allocator.DiscardChildren(children_begin);
 				SetResult(MatcherResult::Failure());
 				return;
 			}
@@ -45,14 +48,15 @@ public:
 				continue;
 			}
 			match_state.token_iterator.SetPosition(list_state.token_iterator);
+			match_state.allocator.DiscardChildren(children_begin);
 			SetResult(MatcherResult::Failure());
 			return;
 		}
 		match_state.token_iterator.SetPosition(list_state.token_iterator);
 		DiscardSuggestions();
-		auto list_name = list_matcher.HasName() ? list_matcher.GetName() : string();
-		SetResult(
-		    match_state.AllocateParseResult<ListParseResult>(std::move(results), std::move(list_name), start_offset));
+		idx_t child_count;
+		auto children = match_state.allocator.TakeChildren(children_begin, child_count);
+		SetResult(match_state.AllocateParseResult<ListParseResult>(children, child_count, start_offset));
 	}
 
 private:
@@ -67,7 +71,7 @@ private:
 private:
 	const ListMatcher &list_matcher;
 	MatchState list_state;
-	vector<reference<ParseResult>> results;
+	idx_t children_begin;
 	idx_t child_index = 0;
 	idx_t saved_suggestion_size = 0;
 	optional_idx start_offset;

--- a/src/include/duckdb/parser/peg/matcher_stack/optional_match_stack_frame.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack/optional_match_stack_frame.hpp
@@ -16,6 +16,10 @@ public:
 
 	void Execute(MatchStack &stack) override {
 		if (!HasChildResult()) {
+			if (!optional_matcher.GetChildMatcher().CanStartAt(child_state)) {
+				SetResult(match_state.AllocateParseResult<OptionalParseResult>());
+				return;
+			}
 			stack.PushChildFrame(*this, optional_matcher.GetChildMatcher(), child_state);
 			return;
 		}

--- a/src/include/duckdb/parser/peg/matcher_stack/repeat_match_stack_frame.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack/repeat_match_stack_frame.hpp
@@ -9,6 +9,7 @@ class RepeatMatchStackFrame : public MatchStackFrame {
 public:
 	RepeatMatchStackFrame(match_frame_index_t frame_index, const RepeatMatcher &matcher, MatchState &state)
 	    : MatchStackFrame(frame_index, matcher, state), repeat_matcher(matcher), repeat_state(state) {
+		children_begin = state.allocator.ChildrenBegin();
 		if (auto current = repeat_state.token_iterator.Current()) {
 			start_offset = optional_idx(current->offset);
 		}
@@ -19,6 +20,7 @@ public:
 			auto child_result = TakeChildResult();
 			if (!child_result.IsSuccess()) {
 				if (!matched_once) {
+					match_state.allocator.DiscardChildren(children_begin);
 					SetResult(MatcherResult::Failure());
 				} else {
 					SetRepeatResult();
@@ -27,7 +29,7 @@ public:
 			}
 			matched_once = true;
 			if (child_result.HasParseResult()) {
-				results.push_back(*child_result.GetParseResult());
+				match_state.allocator.PushChild(*child_result.GetParseResult());
 			}
 			match_state.token_iterator.SetPosition(repeat_state.token_iterator);
 			auto current = repeat_state.token_iterator.Current();
@@ -42,13 +44,15 @@ public:
 
 private:
 	void SetRepeatResult() {
-		SetResult(match_state.AllocateParseResult<RepeatParseResult>(std::move(results), start_offset));
+		idx_t child_count;
+		auto children = match_state.allocator.TakeChildren(children_begin, child_count);
+		SetResult(match_state.AllocateParseResult<RepeatParseResult>(children, child_count, start_offset));
 	}
 
 private:
 	const RepeatMatcher &repeat_matcher;
 	MatchState repeat_state;
-	vector<reference<ParseResult>> results;
+	idx_t children_begin;
 	bool matched_once = false;
 	optional_idx start_offset;
 };

--- a/src/include/duckdb/parser/peg/matcher_token.hpp
+++ b/src/include/duckdb/parser/peg/matcher_token.hpp
@@ -8,10 +8,14 @@
 
 #pragma once
 
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/parser/peg/token_type.hpp"
 
 namespace duckdb {
+class KeywordTable;
+class PEGKeywordHelper;
 
 struct MatcherToken {
 	// NOLINTNEXTLINE: allow implicit conversion from text
@@ -27,6 +31,13 @@ struct MatcherToken {
 	bool unterminated = false;
 	bool preceded_by_newline = false;
 	bool preceded_by_block_comment = false;
+	//! Id of the token in the grammar's KeywordTable (INVALID_INDEX if it is not a literal), resolved on first use
+	//! and cached here; `keyword_table` records which table the id belongs to
+	optional_ptr<const KeywordTable> keyword_table;
+	idx_t keyword_id = DConstants::INVALID_INDEX;
+	//! Keyword categories of the token (see PEGKeywordHelper::KeywordCategories), cached in the same way
+	optional_ptr<const PEGKeywordHelper> keyword_helper;
+	uint8_t keyword_categories = 0;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/parser_packrat.hpp
+++ b/src/include/duckdb/parser/peg/parser_packrat.hpp
@@ -9,42 +9,38 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/optional_ptr.hpp"
-#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 class Matcher;
 class ParseResult;
 
-struct ParserPackratKey {
-	idx_t matcher_id;
-	idx_t token_index;
-
-	bool operator==(const ParserPackratKey &other) const {
-		return matcher_id == other.matcher_id && token_index == other.token_index;
-	}
-};
-
-struct ParserPackratKeyHash {
-	size_t operator()(const ParserPackratKey &key) const;
-};
-
 struct ParserPackratEntry {
+	//! Whether this entry holds a memoized result
+	bool valid = false;
 	bool success = false;
 	idx_t token_index_after = 0;
 	idx_t max_token_index_seen = 0;
 	optional_ptr<ParseResult> result;
 };
 
+//! Memoizes the outcome of the packrat-memoized matchers for a single parse: a dense table with one row per token
+//! position, starting at the position the parse starts at, and one column per memoized matcher
 class ParserPackratCache {
 public:
-	ParserPackratCache();
+	ParserPackratCache(idx_t start_token_index, idx_t slot_count);
 	~ParserPackratCache();
 
 	optional_ptr<const ParserPackratEntry> Lookup(const Matcher &matcher, idx_t token_index) const;
 	void Store(const Matcher &matcher, idx_t token_index, ParserPackratEntry entry);
 
 private:
-	unordered_map<ParserPackratKey, ParserPackratEntry, ParserPackratKeyHash> entries;
+	idx_t GetEntryIndex(const Matcher &matcher, idx_t token_index) const;
+
+private:
+	idx_t start_token_index;
+	idx_t slot_count;
+	unsafe_vector<ParserPackratEntry> entries;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -231,20 +231,20 @@ struct ListParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::LIST;
 
 public:
-	explicit ListParseResult(vector<reference<ParseResult>> results_p, string name_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), children(std::move(results_p)) {
-		name = std::move(name_p);
-		for (auto &child : children) {
-			EncloseChild(child.get());
+	//! `children_p` lives in the parse arena and stays valid for as long as this result does
+	ListParseResult(reference<ParseResult> *children_p, idx_t child_count_p, optional_idx offset)
+	    : ParseResult(TYPE, offset), children(children_p), child_count(child_count_p) {
+		for (idx_t i = 0; i < child_count; i++) {
+			EncloseChild(children[i].get());
 		}
 	}
 
 	vector<reference<ParseResult>> GetChildren() const {
-		return children;
+		return vector<reference<ParseResult>>(children, children + child_count);
 	}
 
 	ParseResult &GetChild(idx_t index) {
-		if (index >= children.size()) {
+		if (index >= child_count) {
 			throw InternalException("Child index out of bounds");
 		}
 		return children[index].get();
@@ -269,35 +269,37 @@ public:
 		if (!name.empty()) {
 			ss << " (" << name << ")";
 		}
-		ss << " [" << children.size() << " children]\n";
+		ss << " [" << child_count << " children]\n";
 
 		std::string child_indent = indent + (is_last ? "   " : "│  ");
-		for (size_t i = 0; i < children.size(); ++i) {
-			children[i].get().ToStringInternal(ss, visited, child_indent, i == children.size() - 1);
+		for (idx_t i = 0; i < child_count; ++i) {
+			children[i].get().ToStringInternal(ss, visited, child_indent, i == child_count - 1);
 		}
 	}
 
 private:
-	vector<reference<ParseResult>> children;
+	reference<ParseResult> *children;
+	idx_t child_count;
 };
 
 struct RepeatParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::REPEAT;
 
-	explicit RepeatParseResult(vector<reference<ParseResult>> results_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), children(std::move(results_p)) {
-		for (auto &child : children) {
-			EncloseChild(child.get());
+	//! `children_p` lives in the parse arena and stays valid for as long as this result does
+	RepeatParseResult(reference<ParseResult> *children_p, idx_t child_count_p, optional_idx offset)
+	    : ParseResult(TYPE, offset), children(children_p), child_count(child_count_p) {
+		for (idx_t i = 0; i < child_count; i++) {
+			EncloseChild(children[i].get());
 		}
 	}
 
 	vector<reference<ParseResult>> GetChildren() const {
-		return children;
+		return vector<reference<ParseResult>>(children, children + child_count);
 	}
 
 	template <class T>
 	T &Child(idx_t index) {
-		if (index >= children.size()) {
+		if (index >= child_count) {
 			throw InternalException("Child index out of bounds");
 		}
 		return children[index].get().Cast<T>();
@@ -317,16 +319,17 @@ struct RepeatParseResult : ParseResult {
 		if (!name.empty()) {
 			ss << " (" << name << ")";
 		}
-		ss << " [" << children.size() << " children]\n";
+		ss << " [" << child_count << " children]\n";
 
 		std::string child_indent = indent + (is_last ? "   " : "│  ");
-		for (size_t i = 0; i < children.size(); ++i) {
-			children[i].get().ToStringInternal(ss, visited, child_indent, i == children.size() - 1);
+		for (idx_t i = 0; i < child_count; ++i) {
+			children[i].get().ToStringInternal(ss, visited, child_indent, i == child_count - 1);
 		}
 	}
 
 private:
-	vector<reference<ParseResult>> children;
+	reference<ParseResult> *children;
+	idx_t child_count;
 };
 
 struct OptionalParseResult : ParseResult {

--- a/src/include/duckdb/parser/token_iterator.hpp
+++ b/src/include/duckdb/parser/token_iterator.hpp
@@ -24,7 +24,7 @@ class TokenIterator {
 public:
 	DUCKDB_API explicit TokenIterator(unique_ptr<vector<MatcherToken>> owned_tokens);
 	DUCKDB_API explicit TokenIterator(vector<MatcherToken> &tokens);
-	TokenIterator(TokenIterator &other) : tokens(other.tokens), position(other.position) {
+	TokenIterator(const TokenIterator &other) : tokens(other.tokens), position(other.position) {
 	}
 	DUCKDB_API TokenIterator(TokenIterator &&other) noexcept;
 	TokenIterator &operator=(const TokenIterator &) = delete;

--- a/src/include/duckdb/parser/token_iterator.hpp
+++ b/src/include/duckdb/parser/token_iterator.hpp
@@ -15,6 +15,8 @@
 
 namespace duckdb {
 struct SimpleToken;
+class KeywordTable;
+class PEGKeywordHelper;
 
 //! Iterates over an already-tokenized query. A root iterator can own its tokens; child iterators
 //! reference the same tokens and carry an independent position for speculative parsing.
@@ -22,28 +24,78 @@ class TokenIterator {
 public:
 	DUCKDB_API explicit TokenIterator(unique_ptr<vector<MatcherToken>> owned_tokens);
 	DUCKDB_API explicit TokenIterator(vector<MatcherToken> &tokens);
-	DUCKDB_API TokenIterator(TokenIterator &other);
+	TokenIterator(TokenIterator &other) : tokens(other.tokens), position(other.position) {
+	}
 	DUCKDB_API TokenIterator(TokenIterator &&other) noexcept;
 	TokenIterator &operator=(const TokenIterator &) = delete;
 	TokenIterator &operator=(TokenIterator &&) = delete;
 
 	DUCKDB_API bool AtEnd() const;
 	DUCKDB_API bool HasMoreStatements() const;
-	DUCKDB_API idx_t Position() const;
 	DUCKDB_API idx_t Size() const;
 	DUCKDB_API idx_t EndOffset() const;
 
-	DUCKDB_API optional_ptr<const MatcherToken> Current() const;
 	DUCKDB_API const MatcherToken &Previous() const;
 	DUCKDB_API const MatcherToken &GetToken(idx_t index) const;
 
-	DUCKDB_API void Advance(idx_t count = 1);
-	DUCKDB_API void SetPosition(idx_t position);
-	DUCKDB_API void SetPosition(const TokenIterator &other);
 	DUCKDB_API void SetPreviousTokenType(TokenType type);
+
+	idx_t Position() const {
+		return position;
+	}
+	optional_ptr<const MatcherToken> Current() const {
+		if (position >= tokens.size()) {
+			return nullptr;
+		}
+		return tokens[position];
+	}
+	void Advance(idx_t count = 1) {
+		if (count > tokens.size() - position) {
+			ThrowAdvanceOutOfRange(count);
+		}
+		position += count;
+	}
+	void SetPosition(idx_t position_p) {
+		if (position_p > tokens.size()) {
+			ThrowPositionOutOfRange(position_p);
+		}
+		position = position_p;
+	}
+	//! Returns the keyword id of the current token in the given table (INVALID_INDEX if it is not a keyword).
+	//! The id is resolved on first use and cached in the token. Requires a current token.
+	idx_t CurrentKeywordId(const KeywordTable &table) {
+		auto &token = tokens[position];
+		if (token.keyword_table.get() != &table) {
+			ResolveKeyword(token, table);
+		}
+		return token.keyword_id;
+	}
+	//! Returns the keyword categories of the current token according to the given helper, cached in the token
+	//! after the first lookup. Requires a current token.
+	uint8_t CurrentKeywordCategories(const PEGKeywordHelper &helper) {
+		auto &token = tokens[position];
+		if (token.keyword_helper.get() != &helper) {
+			ResolveKeywordCategories(token, helper);
+		}
+		return token.keyword_categories;
+	}
+	//! Moves this iterator to the position of `other`, which must iterate over the same tokens
+	void SetPosition(const TokenIterator &other) {
+		if (&tokens != &other.tokens) {
+			ThrowDifferentTokens();
+		}
+		position = other.position;
+	}
 
 	DUCKDB_API vector<SimpleToken> RemainingTokens() const;
 	DUCKDB_API string ToString() const;
+
+private:
+	DUCKDB_API static void ResolveKeyword(MatcherToken &token, const KeywordTable &table);
+	DUCKDB_API static void ResolveKeywordCategories(MatcherToken &token, const PEGKeywordHelper &helper);
+	[[noreturn]] DUCKDB_API void ThrowAdvanceOutOfRange(idx_t count) const;
+	[[noreturn]] DUCKDB_API void ThrowDifferentTokens() const;
+	[[noreturn]] DUCKDB_API void ThrowPositionOutOfRange(idx_t position_p) const;
 
 private:
 	unique_ptr<vector<MatcherToken>> owned_tokens;

--- a/src/parser/peg/compiled_grammar.cpp
+++ b/src/parser/peg/compiled_grammar.cpp
@@ -142,6 +142,7 @@ CompiledGrammar::Create(const case_insensitive_map_t<reference<GrammarExtension>
 	auto terminal_rule_overrides = grammar.BuildTerminalRuleOverrides(new_matcher->GetKeywordHelper());
 	MatcherFactory factory(new_matcher->allocator, grammar, *new_matcher, std::move(terminal_rule_overrides));
 	new_matcher->program_matcher = factory.CreateRootMatcher("Program");
+	new_matcher->packrat_slot_count = factory.PackratSlotCount();
 	new_matcher->top_level_statement_matcher = factory.GetMatcher("TopLevelStatement");
 	return new_matcher;
 }

--- a/src/parser/peg/keyword_helper/default_keyword_maps.cpp
+++ b/src/parser/peg/keyword_helper/default_keyword_maps.cpp
@@ -2,27 +2,34 @@
 
 namespace duckdb {
 
-bool DefaultKeywordMaps::IsKeywordOfCategory(const string &text, PEGKeywordCategory category) const {
-	switch (category) {
-	case PEGKeywordCategory::KEYWORD_RESERVED:
-		return reserved_keyword_map.count(text) != 0;
-	case PEGKeywordCategory::KEYWORD_UNRESERVED:
-		return unreserved_keyword_map.count(text) != 0;
-	case PEGKeywordCategory::KEYWORD_TYPE_FUNC:
-		return typefunc_keyword_map.count(text) != 0;
-	case PEGKeywordCategory::KEYWORD_COL_NAME:
-		return colname_keyword_map.count(text) != 0;
-	case PEGKeywordCategory::KEYWORD_TYPE_NAME:
-		return typename_keyword_map.count(text) != 0;
-	default:
-		return false;
+void DefaultKeywordMaps::AddCategory(const case_insensitive_set_t &keywords, PEGKeywordCategory category) {
+	for (auto &keyword : keywords) {
+		keyword_categories[keyword] |= PEGKeywordHelper::CategoryBit(category);
 	}
 }
 
+void DefaultKeywordMaps::Finalize() {
+	AddCategory(reserved_keyword_map, PEGKeywordCategory::KEYWORD_RESERVED);
+	AddCategory(unreserved_keyword_map, PEGKeywordCategory::KEYWORD_UNRESERVED);
+	AddCategory(typefunc_keyword_map, PEGKeywordCategory::KEYWORD_TYPE_FUNC);
+	AddCategory(colname_keyword_map, PEGKeywordCategory::KEYWORD_COL_NAME);
+	AddCategory(typename_keyword_map, PEGKeywordCategory::KEYWORD_TYPE_NAME);
+}
+
+bool DefaultKeywordMaps::IsKeywordOfCategory(const string &text, PEGKeywordCategory category) const {
+	return (KeywordCategories(text) & PEGKeywordHelper::CategoryBit(category)) != 0;
+}
+
 bool DefaultKeywordMaps::IsKeyword(const string &text) const {
-	return reserved_keyword_map.count(text) != 0 || unreserved_keyword_map.count(text) != 0 ||
-	       colname_keyword_map.count(text) != 0 || typefunc_keyword_map.count(text) != 0 ||
-	       typename_keyword_map.count(text) != 0;
+	return keyword_categories.find(text) != keyword_categories.end();
+}
+
+uint8_t DefaultKeywordMaps::KeywordCategories(const string &text) const {
+	auto entry = keyword_categories.find(text);
+	if (entry == keyword_categories.end()) {
+		return 0;
+	}
+	return entry->second;
 }
 
 vector<ParserKeyword> DefaultKeywordMaps::ToList() const {

--- a/src/parser/peg/keyword_helper/duckdb_keyword_helper.cpp
+++ b/src/parser/peg/keyword_helper/duckdb_keyword_helper.cpp
@@ -4,6 +4,7 @@ namespace duckdb {
 
 DuckDBKeywordHelper::DuckDBKeywordHelper() : initialized(false) {
 	InitializeKeywordMaps();
+	keyword_maps.Finalize();
 }
 
 const DuckDBKeywordHelper &DuckDBKeywordHelper::Instance() {
@@ -18,6 +19,10 @@ bool DuckDBKeywordHelper::KeywordCategoryType(const std::string &text, const PEG
 bool DuckDBKeywordHelper::IsKeyword(const string &text) const {
 	return keyword_maps.IsKeyword(text);
 };
+
+uint8_t DuckDBKeywordHelper::KeywordCategories(const string &text) const {
+	return keyword_maps.KeywordCategories(text);
+}
 
 vector<ParserKeyword> DuckDBKeywordHelper::KeywordList() const {
 	return keyword_maps.ToList();

--- a/src/parser/peg/keyword_helper/parsed_grammar_keyword_helper.cpp
+++ b/src/parser/peg/keyword_helper/parsed_grammar_keyword_helper.cpp
@@ -58,6 +58,7 @@ ParsedGrammarKeywordHelper::ParsedGrammarKeywordHelper(const ParsedGrammar &gram
 		case_insensitive_set_t active_rules;
 		PopulateKeywordMap(grammar, entry.first, entry.first, entry.second.get(), active_rules);
 	}
+	keyword_maps.Finalize();
 }
 
 bool ParsedGrammarKeywordHelper::KeywordCategoryType(const string &text, PEGKeywordCategory category) const {
@@ -66,6 +67,10 @@ bool ParsedGrammarKeywordHelper::KeywordCategoryType(const string &text, PEGKeyw
 
 bool ParsedGrammarKeywordHelper::IsKeyword(const string &text) const {
 	return keyword_maps.IsKeyword(text);
+}
+
+uint8_t ParsedGrammarKeywordHelper::KeywordCategories(const string &text) const {
+	return keyword_maps.KeywordCategories(text);
 }
 
 vector<ParserKeyword> ParsedGrammarKeywordHelper::KeywordList() const {

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/parser/peg/matcher.hpp"
+#include "duckdb/parser/peg/matcher/keyword_matcher.hpp"
 #include "duckdb/parser/peg/matcher_stack.hpp"
 #include "duckdb/parser/peg/compiled_grammar.hpp"
 #include "duckdb/parser/peg/matcher_factory.hpp"
@@ -18,44 +19,44 @@
 
 namespace duckdb {
 
-MatcherResult Matcher::MatchParseResult(MatchState &state) const {
-	state.rule = rule;
-	if (state.use_heap_based_parser) {
-		MatchStack stack;
-		return stack.Execute(*this, state);
-	}
-	auto result = MatcherResult::Failure();
-	if (!state.packrat_cache || !IsPackratMemoized() || !GetPackratId().IsValid()) {
-		result = MatchParseResultInternal(state);
-	} else {
-		auto token_index = state.token_iterator.Position();
-		auto cached_result = state.packrat_cache->Lookup(*this, token_index);
-		if (cached_result) {
-			state.token_iterator.SetPosition(cached_result->token_index_after);
-			state.max_token_index = MaxValue(state.max_token_index, cached_result->max_token_index_seen);
-			if (cached_result->success) {
-				result = MatcherResult::Success(cached_result->result);
-			}
-		} else {
-			auto max_token_index_before = state.GetMaxTokenIndex();
-			result = MatchParseResultInternal(state);
-			ParserPackratEntry cache_entry;
-			cache_entry.success = result.IsSuccess();
-			cache_entry.token_index_after = state.token_iterator.Position();
-			cache_entry.max_token_index_seen = MaxValue(max_token_index_before, state.GetMaxTokenIndex());
-			cache_entry.result = result.GetParseResult();
-			state.packrat_cache->Store(*this, token_index, cache_entry);
+MatcherResult Matcher::MatchHeapBased(MatchState &state) const {
+	MatchStack stack;
+	return stack.Execute(*this, state);
+}
+
+MatcherResult Matcher::MatchMemoized(MatchState &state) const {
+	D_ASSERT(IsPackratMemoized() && GetPackratId().IsValid());
+	auto token_index = state.token_iterator.Position();
+	auto cached_result = state.packrat_cache->Lookup(*this, token_index);
+	if (cached_result) {
+		state.token_iterator.SetPosition(cached_result->token_index_after);
+		state.max_token_index = MaxValue(state.max_token_index, cached_result->max_token_index_seen);
+		if (cached_result->success) {
+			return MatcherResult::Success(cached_result->result);
 		}
+		return MatcherResult::Failure();
 	}
+	auto max_token_index_before = state.GetMaxTokenIndex();
+	auto result = MatchParseResultInternal(state);
+	ParserPackratEntry cache_entry;
+	cache_entry.success = result.IsSuccess();
+	cache_entry.token_index_after = state.token_iterator.Position();
+	cache_entry.max_token_index_seen = MaxValue(max_token_index_before, state.GetMaxTokenIndex());
+	cache_entry.result = result.GetParseResult();
+	state.packrat_cache->Store(*this, token_index, cache_entry);
 	return result;
 }
 
 SuggestionType Matcher::AddSuggestion(MatchState &state) const {
-	auto entry = state.added_suggestions.find(*this);
-	if (entry != state.added_suggestions.end()) {
+	if (!state.added_suggestions) {
+		state.added_suggestions = make_uniq<reference_set_t<const Matcher>>();
+	}
+	auto &added_suggestions = *state.added_suggestions;
+	auto entry = added_suggestions.find(*this);
+	if (entry != added_suggestions.end()) {
 		return SuggestionType::MANDATORY;
 	}
-	state.added_suggestions.insert(*this);
+	added_suggestions.insert(*this);
 	return AddSuggestionInternal(state);
 }
 
@@ -77,14 +78,37 @@ void MatchState::AddSuggestion(MatcherSuggestion suggestion) {
 Matcher &MatcherAllocator::Allocate(unique_ptr<Matcher> matcher) {
 	auto &result = *matcher;
 	result.packrat_id = optional_idx(matchers.size());
+	result.keyword_table = keyword_table;
+	if (result.Type() == MatcherType::KEYWORD) {
+		auto &keyword_matcher = result.Cast<KeywordMatcher>();
+		keyword_matcher.keyword_id = keyword_table.Register(keyword_matcher.keyword);
+	}
 	matchers.push_back(std::move(matcher));
 	return result;
 }
 
-optional_ptr<ParseResult> ParseResultAllocator::Allocate(unique_ptr<ParseResult> parse_result) {
-	auto result_ptr = parse_result.get();
-	parse_results.push_back(std::move(parse_result));
-	return optional_ptr<ParseResult>(result_ptr);
+ParseResultAllocator::ParseResultAllocator() : arena(Allocator::DefaultAllocator()) {
+}
+
+ParseResultAllocator::~ParseResultAllocator() {
+	for (auto &parse_result : parse_results) {
+		parse_result.get().~ParseResult();
+	}
+}
+
+reference<ParseResult> *ParseResultAllocator::TakeChildren(idx_t begin, idx_t &count) {
+	D_ASSERT(begin <= child_scratch.size());
+	count = child_scratch.size() - begin;
+	if (count == 0) {
+		return nullptr;
+	}
+	auto memory = arena.AllocateAligned(count * sizeof(reference<ParseResult>));
+	auto children = reinterpret_cast<reference<ParseResult> *>(memory);
+	for (idx_t i = 0; i < count; i++) {
+		new (children + i) reference<ParseResult>(child_scratch[begin + i]);
+	}
+	DiscardChildren(begin);
+	return children;
 }
 
 } // namespace duckdb

--- a/src/parser/peg/matcher_factory.cpp
+++ b/src/parser/peg/matcher_factory.cpp
@@ -140,8 +140,9 @@ Matcher &MatcherFactory::CreateMatcher(string_t rule_name, vector<reference<Matc
 	auto &compiled_rule = *rule_p;
 
 	matcher.SetRule(compiled_rule);
-	if (packrat_memoized_rules.count(rule_name)) {
-		matcher.SetPackratMemoized();
+	auto memoized_entry = packrat_memoized_rules.find(rule_name);
+	if (memoized_entry != packrat_memoized_rules.end()) {
+		matcher.SetPackratMemoized(memoized_entry->second);
 	}
 	if (no_suggestion_rules.count(rule_name)) {
 		matcher.Cast<ListMatcher>().suppress_suggestions = true;
@@ -155,8 +156,9 @@ void MatcherFactory::AddKeywordOverride(const char *name, KeywordInfo info) {
 
 void MatcherFactory::AddRuleOverride(const char *name, unique_ptr<Matcher> &&matcher_p) {
 	auto &matcher = allocator.Allocate(std::move(matcher_p));
-	if (packrat_memoized_rules.count(name)) {
-		matcher.SetPackratMemoized();
+	auto memoized_entry = packrat_memoized_rules.find(name);
+	if (memoized_entry != packrat_memoized_rules.end()) {
+		matcher.SetPackratMemoized(memoized_entry->second);
 	}
 	if (grammar.GetRule(name)) {
 		auto rule_p = compiled.GetRule(name);
@@ -170,7 +172,7 @@ void MatcherFactory::AddRuleOverride(const char *name, unique_ptr<Matcher> &&mat
 }
 
 void MatcherFactory::AddPackratMemoizedRule(const char *name) {
-	packrat_memoized_rules.insert(name);
+	packrat_memoized_rules.emplace(name, packrat_memoized_rules.size());
 }
 
 void MatcherFactory::SuppressSuggestions(const char *name) {
@@ -253,7 +255,74 @@ Matcher &MatcherFactory::CreateRootMatcher(const string &root_rule) {
 	while (construction_state.HasScheduled()) {
 		CreateMatcher(construction_state.TakeNext());
 	}
+	ComputeFirstSets();
 	return GetMatcher(root_rule);
+}
+
+void MatcherFactory::ComputeFirstSets() {
+	auto &matchers = allocator.GetMatchers();
+	// the first sets are computed as a fixpoint: every matcher's set is derived from its children's sets, which
+	// only ever grow, so iterating until nothing changes handles the recursion in the grammar
+	vector<MatcherFirstSet> first_sets(matchers.size());
+	auto first_set_of = [&](const Matcher &matcher) -> const MatcherFirstSet & {
+		return first_sets[matcher.GetPackratId().GetIndex()];
+	};
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		for (idx_t i = 0; i < matchers.size(); i++) {
+			auto &matcher = *matchers[i];
+			MatcherFirstSet updated;
+			switch (matcher.Type()) {
+			case MatcherType::KEYWORD:
+				updated.AddKeyword(matcher.Cast<KeywordMatcher>().GetKeywordId());
+				break;
+			case MatcherType::LIST: {
+				// a sequence can start with anything its leading nullable children can start with, plus the first
+				// child that must consume a token
+				updated.nullable = true;
+				for (auto &child : matcher.Cast<ListMatcher>().matchers) {
+					auto &child_set = first_set_of(child.get());
+					updated.MergeStart(child_set);
+					if (!child_set.nullable) {
+						updated.nullable = false;
+						break;
+					}
+				}
+				break;
+			}
+			case MatcherType::CHOICE:
+				for (auto &child : matcher.Cast<ChoiceMatcher>().matchers) {
+					auto &child_set = first_set_of(child.get());
+					updated.MergeStart(child_set);
+					updated.nullable = updated.nullable || child_set.nullable;
+				}
+				break;
+			case MatcherType::OPTIONAL:
+				updated.MergeStart(first_set_of(matcher.Cast<OptionalMatcher>().GetChildMatcher()));
+				updated.nullable = true;
+				break;
+			case MatcherType::REPEAT: {
+				auto &child_set = first_set_of(matcher.Cast<RepeatMatcher>().GetChildMatcher());
+				updated.MergeStart(child_set);
+				updated.nullable = child_set.nullable;
+				break;
+			}
+			default:
+				// identifiers, literals, operators and end-of-input are not described by grammar literals
+				updated.any_token = true;
+				break;
+			}
+			if (!(updated == first_sets[i])) {
+				first_sets[i] = std::move(updated);
+				changed = true;
+			}
+		}
+	}
+	for (idx_t i = 0; i < matchers.size(); i++) {
+		first_sets[i].Finalize();
+		matchers[i]->SetFirstSet(std::move(first_sets[i]));
+	}
 }
 
 unique_ptr<KeywordMatcher> MatcherFactory::CreateKeyword(const string &keyword, const KeywordInfo &info) const {

--- a/src/parser/peg/matcher_factory.cpp
+++ b/src/parser/peg/matcher_factory.cpp
@@ -216,6 +216,11 @@ Matcher &MatcherFactory::CreateRootMatcher(const string &root_rule) {
 	AddPackratMemoizedRule("ColId");
 	AddPackratMemoizedRule("ColumnReference");
 	AddPackratMemoizedRule("FunctionExpression");
+	AddPackratMemoizedRule("CatalogQualification");
+	AddPackratMemoizedRule("SchemaQualification");
+	AddPackratMemoizedRule("ReservedSchemaQualification");
+	AddPackratMemoizedRule("TableQualification");
+	AddPackratMemoizedRule("ReservedTableQualification");
 	//===--------------------------------------------------------------------===//
 	// END GENERATED PACKRAT MEMOIZED RULES
 	//===--------------------------------------------------------------------===//

--- a/src/parser/peg/matcher_stack.cpp
+++ b/src/parser/peg/matcher_stack.cpp
@@ -36,6 +36,12 @@ void PackratMatchState::StoreResult(const Matcher &matcher, MatchState &state, c
 	state.packrat_cache->Store(matcher, token_index_before.GetIndex(), cache_entry);
 }
 
+MatchStack::~MatchStack() {
+	while (!frames.empty()) {
+		PopFrame();
+	}
+}
+
 MatchStackFrame::MatchStackFrame(match_frame_index_t frame_index_p, const Matcher &matcher_p, MatchState &state_p)
     : frame_index(frame_index_p), matcher(matcher_p), match_state(state_p) {
 }
@@ -117,21 +123,53 @@ MatcherResult MatchStack::ExecuteTerminalMatcher(const Matcher &matcher, MatchSt
 	return result;
 }
 
+data_ptr_t MatchStack::AllocateFrameMemory(idx_t size) {
+	size = AlignValue<idx_t>(size);
+	if (block_index < blocks.size() && block_offset + size > blocks[block_index].GetSize()) {
+		block_index++;
+		block_offset = 0;
+	}
+	if (block_index == blocks.size()) {
+		blocks.push_back(Allocator::DefaultAllocator().Allocate(MaxValue<idx_t>(size, FRAME_BLOCK_SIZE)));
+	}
+	auto memory = blocks[block_index].get() + block_offset;
+	block_offset += size;
+	return memory;
+}
+
+template <class FRAME, class... ARGS>
+void MatchStack::AllocateFrame(ARGS &&... args) {
+	static_assert(sizeof(FRAME) <= FRAME_BLOCK_SIZE, "match frames must fit in a frame block");
+	auto previous_block_index = block_index;
+	auto previous_block_offset = block_offset;
+	auto memory = AllocateFrameMemory(sizeof(FRAME));
+	auto &frame = *new (memory) FRAME(std::forward<ARGS>(args)...);
+	frames.push_back(FrameEntry {frame, previous_block_index, previous_block_offset});
+}
+
+void MatchStack::PopFrame() {
+	auto &entry = frames.back();
+	block_index = entry.block_index;
+	block_offset = entry.block_offset;
+	entry.frame.get().~MatchStackFrame();
+	frames.pop_back();
+}
+
 void MatchStack::PushFrame(const Matcher &matcher, MatchState &state) {
 	state.rule = matcher.GetRule();
 	auto frame_index = frames.size();
 	switch (matcher.Type()) {
 	case MatcherType::OPTIONAL:
-		frames.push_back(make_uniq<OptionalMatchStackFrame>(frame_index, matcher.Cast<OptionalMatcher>(), state));
+		AllocateFrame<OptionalMatchStackFrame>(frame_index, matcher.Cast<OptionalMatcher>(), state);
 		break;
 	case MatcherType::CHOICE:
-		frames.push_back(make_uniq<ChoiceMatchStackFrame>(frame_index, matcher.Cast<ChoiceMatcher>(), state));
+		AllocateFrame<ChoiceMatchStackFrame>(frame_index, matcher.Cast<ChoiceMatcher>(), state);
 		break;
 	case MatcherType::LIST:
-		frames.push_back(make_uniq<ListMatchStackFrame>(frame_index, matcher.Cast<ListMatcher>(), state));
+		AllocateFrame<ListMatchStackFrame>(frame_index, matcher.Cast<ListMatcher>(), state);
 		break;
 	case MatcherType::REPEAT:
-		frames.push_back(make_uniq<RepeatMatchStackFrame>(frame_index, matcher.Cast<RepeatMatcher>(), state));
+		AllocateFrame<RepeatMatchStackFrame>(frame_index, matcher.Cast<RepeatMatcher>(), state);
 		break;
 	case MatcherType::KEYWORD:
 	case MatcherType::VARIABLE:
@@ -147,7 +185,7 @@ void MatchStack::PushFrame(const Matcher &matcher, MatchState &state) {
 
 void MatchStack::PushChildFrame(MatchStackFrame &parent, const Matcher &matcher, MatchState &state) {
 	D_ASSERT(!frames.empty());
-	D_ASSERT(frames.back()->frame_index == parent.frame_index);
+	D_ASSERT(frames.back().frame.get().frame_index == parent.frame_index);
 	D_ASSERT(!parent.HasChildResult());
 	if (IsTerminalMatcher(matcher)) {
 		parent.SetChildResult(ExecuteTerminalMatcher(matcher, state));
@@ -197,7 +235,7 @@ MatcherResult MatchStack::ExecuteInternal(const Matcher &matcher, MatchState &st
 	}
 	PushFrame(matcher, state);
 	while (!frames.empty()) {
-		auto &frame = *frames.back();
+		auto &frame = frames.back().frame.get();
 		auto frame_count = frames.size();
 		ExecuteFrame(frame);
 		if (!frame.HasResult()) {
@@ -205,11 +243,11 @@ MatcherResult MatchStack::ExecuteInternal(const Matcher &matcher, MatchState &st
 			continue;
 		}
 		auto result = FinalizeFrame(frame);
-		frames.pop_back();
+		PopFrame();
 		if (frames.empty()) {
 			return result;
 		}
-		auto &parent = *frames.back();
+		auto &parent = frames.back().frame.get();
 		parent.SetChildResult(result);
 	}
 	throw InternalException("Matcher stack completed without a result");

--- a/src/parser/peg/matcher_stack.cpp
+++ b/src/parser/peg/matcher_stack.cpp
@@ -159,6 +159,10 @@ void MatchStack::PushChildFrame(MatchStackFrame &parent, const Matcher &matcher,
 void MatchStack::InitializeFrame(MatchStackFrame &frame) {
 	auto &matcher = frame.matcher;
 	auto &state = frame.match_state;
+	if (!matcher.CanStartAt(state)) {
+		frame.SetResult(MatcherResult::Failure());
+		return;
+	}
 	if (!PackratMatchState::IsEnabled(matcher, state)) {
 		return;
 	}

--- a/src/parser/peg/parser_packrat.cpp
+++ b/src/parser/peg/parser_packrat.cpp
@@ -4,34 +4,41 @@
 
 namespace duckdb {
 
-size_t ParserPackratKeyHash::operator()(const ParserPackratKey &key) const {
-	return std::hash<idx_t>()(key.matcher_id) ^ (std::hash<idx_t>()(key.token_index) << 1);
+ParserPackratCache::ParserPackratCache(idx_t start_token_index_p, idx_t slot_count_p)
+    : start_token_index(start_token_index_p), slot_count(slot_count_p) {
 }
-
-ParserPackratCache::ParserPackratCache() = default;
 
 ParserPackratCache::~ParserPackratCache() = default;
 
-optional_ptr<const ParserPackratEntry> ParserPackratCache::Lookup(const Matcher &matcher, idx_t token_index) const {
+idx_t ParserPackratCache::GetEntryIndex(const Matcher &matcher, idx_t token_index) const {
 	D_ASSERT(matcher.IsPackratMemoized());
-	auto packrat_id = matcher.GetPackratId();
-	D_ASSERT(packrat_id.IsValid());
-	auto matcher_id = packrat_id.GetIndex();
-	ParserPackratKey key {matcher_id, token_index};
-	auto entry = entries.find(key);
-	if (entry == entries.end()) {
+	D_ASSERT(matcher.GetPackratSlot() < slot_count);
+	D_ASSERT(token_index >= start_token_index);
+	return (token_index - start_token_index) * slot_count + matcher.GetPackratSlot();
+}
+
+optional_ptr<const ParserPackratEntry> ParserPackratCache::Lookup(const Matcher &matcher, idx_t token_index) const {
+	auto entry_index = GetEntryIndex(matcher, token_index);
+	if (entry_index >= entries.size() || !entries[entry_index].valid) {
 		return nullptr;
 	}
-	return optional_ptr<const ParserPackratEntry>(&entry->second);
+	return optional_ptr<const ParserPackratEntry>(&entries[entry_index]);
 }
 
 void ParserPackratCache::Store(const Matcher &matcher, idx_t token_index, ParserPackratEntry entry) {
-	D_ASSERT(matcher.IsPackratMemoized());
-	auto packrat_id = matcher.GetPackratId();
-	D_ASSERT(packrat_id.IsValid());
-	auto matcher_id = packrat_id.GetIndex();
-	ParserPackratKey key {matcher_id, token_index};
-	entries.insert(make_pair(key, entry));
+	auto entry_index = GetEntryIndex(matcher, token_index);
+	if (entry_index >= entries.size()) {
+		// grow geometrically so that a parse that keeps advancing does not re-allocate at every token
+		auto new_size = MaxValue<idx_t>(entry_index + 1, entries.size() * 2);
+		entries.resize(new_size);
+	}
+	auto &stored = entries[entry_index];
+	if (stored.valid) {
+		// keep the first result that was memoized for this position
+		return;
+	}
+	stored = entry;
+	stored.valid = true;
 }
 
 } // namespace duckdb

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -89,7 +89,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(Token
 	}
 	vector<MatcherSuggestion> suggestions;
 	ParseResultAllocator parse_result_allocator;
-	ParserPackratCache packrat_cache;
+	ParserPackratCache packrat_cache(token_iterator.Position(), grammar.PackratSlotCount());
 	idx_t max_token_index = token_iterator.Position();
 	const bool use_heap_based_parser = options.heap_based_parser && !grammar.HasGrammarChanges();
 	MatchState state(token_iterator, suggestions, parse_result_allocator, max_token_index,

--- a/src/parser/token_iterator.cpp
+++ b/src/parser/token_iterator.cpp
@@ -2,6 +2,8 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/parser/parser_extension.hpp"
+#include "duckdb/parser/peg/keyword_helper.hpp"
+#include "duckdb/parser/peg/keyword_table.hpp"
 
 namespace duckdb {
 
@@ -13,9 +15,6 @@ TokenIterator::TokenIterator(unique_ptr<vector<MatcherToken>> owned_tokens_p)
 }
 
 TokenIterator::TokenIterator(vector<MatcherToken> &tokens_p) : tokens(tokens_p) {
-}
-
-TokenIterator::TokenIterator(TokenIterator &other) : tokens(other.tokens), position(other.position) {
 }
 
 TokenIterator::TokenIterator(TokenIterator &&other) noexcept
@@ -40,10 +39,6 @@ bool TokenIterator::HasMoreStatements() const {
 	return false;
 }
 
-idx_t TokenIterator::Position() const {
-	return position;
-}
-
 idx_t TokenIterator::Size() const {
 	return tokens.size();
 }
@@ -54,13 +49,6 @@ idx_t TokenIterator::EndOffset() const {
 	}
 	auto &last_token = tokens.back();
 	return last_token.offset + last_token.length;
-}
-
-optional_ptr<const MatcherToken> TokenIterator::Current() const {
-	if (position >= tokens.size()) {
-		return nullptr;
-	}
-	return tokens[position];
 }
 
 const MatcherToken &TokenIterator::Previous() const {
@@ -77,26 +65,27 @@ const MatcherToken &TokenIterator::GetToken(idx_t index) const {
 	return tokens[index];
 }
 
-void TokenIterator::Advance(idx_t count) {
-	if (count > tokens.size() - position) {
-		throw InternalException("Cannot advance TokenIterator by %llu tokens from position %llu (size %llu)", count,
-		                        position, tokens.size());
-	}
-	position += count;
+void TokenIterator::ResolveKeyword(MatcherToken &token, const KeywordTable &table) {
+	token.keyword_id = table.Lookup(token.text);
+	token.keyword_table = table;
 }
 
-void TokenIterator::SetPosition(idx_t position_p) {
-	if (position_p > tokens.size()) {
-		throw InternalException("Token position %llu is out of range (size %llu)", position_p, tokens.size());
-	}
-	position = position_p;
+void TokenIterator::ResolveKeywordCategories(MatcherToken &token, const PEGKeywordHelper &helper) {
+	token.keyword_categories = helper.KeywordCategories(token.text);
+	token.keyword_helper = helper;
 }
 
-void TokenIterator::SetPosition(const TokenIterator &other) {
-	if (&tokens != &other.tokens) {
-		throw InternalException("Cannot set TokenIterator position from a different token collection");
-	}
-	SetPosition(other.position);
+void TokenIterator::ThrowDifferentTokens() const {
+	throw InternalException("Cannot set TokenIterator position from a different token collection");
+}
+
+void TokenIterator::ThrowAdvanceOutOfRange(idx_t count) const {
+	throw InternalException("Cannot advance TokenIterator by %llu tokens from position %llu (size %llu)", count,
+	                        position, tokens.size());
+}
+
+void TokenIterator::ThrowPositionOutOfRange(idx_t position_p) const {
+	throw InternalException("Token position %llu is out of range (size %llu)", position_p, tokens.size());
 }
 
 void TokenIterator::SetPreviousTokenType(TokenType type) {


### PR DESCRIPTION
# Speed up the PEG parser

This PR optimizes the hand-written PEG matcher in `src/parser/peg` without changing what it accepts, the parse results it produces, or the error positions and autocomplete suggestions it reports. Both the heap-based matcher (the default on this branch) and the recursive matcher are updated in lockstep.

## Results

Measured with the new `benchmark/micro/parser.cpp` micro-benchmarks against the `v2.0-cyanoptera` tip (release build, Apple Silicon, `heap_based_parser` at its default of `true`, medians of 15 timed runs, before/after binaries interleaved):

| Benchmark | Before | After | Speedup |
|---|---:|---:|---:|
| ParserTPCH (22 queries x 200) | 4.102 s | 0.706 s | 5.8x |
| ParserTPCDS (99 queries x 50) | 11.499 s | 1.958 s | 5.9x |
| ParserExpressions (500 iterations) | 4.282 s | 0.851 s | 5.0x |
| ParserDDL (200 iterations) | 6.535 s | 1.663 s | 3.9x |
| TokenizerTPCDS (99 queries x 200) | 0.258 s | 0.192 s | 1.3x |

Parsing the full TPC-DS query set goes from 2.3 ms to 0.40 ms per query.

Speedup of the same binaries by platform and toolchain (Linux x86_64 is a Core Ultra 9 185H, both builds against libstdc++):

| Benchmark | macOS arm64, Apple clang | Linux, clang 21 | Linux, gcc 15 |
|---|---:|---:|---:|
| ParserTPCH | 5.8x | 3.5x | 3.7x |
| ParserTPCDS | 5.9x | 3.7x | 4.0x |
| ParserExpressions | 5.0x | 3.3x | 3.5x |
| ParserDDL | 3.9x | 2.8x | 3.0x |
| TokenizerTPCDS | 1.3x | 1.3x | 1.3x |

The smaller Linux ratio is explained under "What remains" below.

## Changes

Four commits, 36 files, +884/-192 lines, on top of the `v2.0-cyanoptera` tip:

| Commit | Files | Lines |
|---|---:|---:|
| Add parser micro-benchmarks | 2 | +203 |
| Speed up the PEG matcher | 32 | +598 / -179 |
| Memoize the qualification rules of the PEG grammar | 2 | +10 |
| Reuse frame storage in the heap-based parser | 5 | +74 / -14 |

**Add parser micro-benchmarks** (`benchmark/micro/parser.cpp`). Parse the TPC-H and TPC-DS query sets, a generated expression-heavy query, and a set of DDL statements through `Parser::ParseQuery`, plus a tokenizer-only benchmark. These are what the table above was measured with.

**Speed up the PEG matcher.** Profiling showed the time going to three places: comparing keyword strings at every `KeywordMatcher`, trying alternatives that could never match the current token, and allocating parse results and their child vectors. The commit addresses each:

- *Intern literals.* `MatcherAllocator` owns a `KeywordTable` that assigns every literal in the grammar an id when the matcher is allocated. `TokenIterator` resolves the id of the current token once and caches it, so a keyword match is an integer compare instead of a case-insensitive string compare.
- *First-set pruning.* `MatcherFactory::ComputeFirstSets` computes, for every matcher, the set of literal ids that can start it (a fixpoint over the matcher graph). `ChoiceMatcher`, `OptionalMatcher` and their stack-frame counterparts skip children whose first set does not contain the current token, and `Matcher::MatchParseResult` / `MatchStack::InitializeFrame` check the same thing before doing any work. Matchers that are nullable or can start with a non-literal token are never pruned, and nothing is pruned at the autocomplete cursor, so error positions and suggestions are unchanged.
- *Dense packrat cache.* `ParserPackratCache` is indexed by `(token offset, memoized rule slot)` into a flat vector instead of a hash map keyed by `(rule id, position)`.
- *Arena parse results.* `ParseResultAllocator` places parse results in an `ArenaAllocator` and gives list/repeat matchers a LIFO scratch stack for collecting children, so `ListParseResult`/`RepeatParseResult` no longer own a `vector` each and a discarded speculative match costs only a pointer reset.
- *Keyword categories as a bitmask.* `PEGKeywordHelper::KeywordCategories` returns all categories of a token in one lookup, cached on the token; the identifier matchers mask against it instead of doing one map lookup per category, and the tokenizer's keyword check becomes a single lookup.
- *Small hot-path cleanups.* `TokenIterator` accessors are inline, and `MatchState::added_suggestions` is allocated only when autocomplete actually adds a suggestion.

**Memoize the qualification rules of the PEG grammar.** `CatalogQualification`, `SchemaQualification`, `ReservedSchemaQualification`, `TableQualification` and `ReservedTableQualification` are retried at the same position by every alternative of `ColumnReference`, `FunctionIdentifier` and the qualified table and type names. Adding them to `packrat_memoized_rules` in `grammar_types.yml` removes those retries.

**Reuse frame storage in the heap-based parser.** After the above, profiling the heap-based parser showed about 40% of its time in allocating and freeing a `MatchStackFrame` per non-terminal step plus a `MatchState` per alternative tried by `ChoiceMatchStackFrame`. Frames are pushed and popped strictly LIFO, so `MatchStack` now places them in fixed-size blocks that are reused as frames pop, and the choice frame keeps the state of the alternative it is trying in an `optional` (which is why the `MatchState` and `TokenIterator` copy constructors now take a const reference).

What remains in the profile is mostly the transformer building the statement tree; its `TransformStack` frames could use the same block storage, but that is a separate change. On Linux there is one more matcher cost worth noting: `ParseResult::name` is a `string` copied from the rule for every parse result, and with libstdc++'s 15-byte small-string buffer most rule names heap-allocate (libc++ keeps up to 22 bytes inline, which is why the Apple Silicon speedups are higher). The name duplicates the `rule` pointer the result already carries, but replacing it touches every reader of `name`, so that is also left for a follow-up.

## Testing

- The full unit test suite (`test/run '*'`) passes on the final build on macOS (Apple clang, libc++) and on Linux x86_64 (clang 21, libstdc++), with the autocomplete, tpch, tpcds and json extensions loaded. A handful of memory-limit and out-of-core `test_slow` tests fail under parallel workers on both machines and pass when run alone; `memory_limit_batch_load.test_slow` fails on the Linux box on the baseline build as well.
- `test/sql/peg_parser/*`, `test/sql/parser/*` and `test/sql/function/autocomplete/*` pass with both `heap_based_parser = true` (default) and `heap_based_parser = false`.
- `make format-check` is clean for the changed files, and `make parser-grammar` followed by the formatter leaves no diff, so the generated `matcher_factory.cpp` matches `grammar_types.yml`.
- The full CI matrix ran on my fork for this exact commit (https://github.com/shreeve/duckdb/actions/runs/34007691125). Every build, test and tidy job passed, with three exceptions that I checked individually: the Thread Sanitizer job reports a race in the t-digest arena of `approx_quantile` during `test/sql/show_select/summarize_subquery.test`, which a sanitizer build of the base commit without this change reports at the same rate (10 of 15 runs), so it is pre-existing; the Relassert and No String Inline jobs both hit the 600 s batch timeout in `Interrupted QueryAppender flow`, which passes in the other test jobs of the same run and in repeated local relassert runs; and the two regression benchmark jobs compared against `main` instead of `v2.0-cyanoptera` because the workflow falls back to `main` on a branch push.

## How this was written

I want to be upfront that I used Claude as a pair programmer on this change: it did much of the profiling and drafted most of the code. I did my best to review every line individually and to hold it to the quality this codebase expects: I read the full diff, checked each optimization against the matcher semantics (in particular that first-set pruning cannot change the error position or the autocomplete suggestions), and ran the tests, the format check, the generated-file check and the benchmarks on both the baseline and the patched build, on macOS and Linux. I am aware of the generative AI note in CONTRIBUTING.md; I am submitting this because I have reviewed it to the point where I can answer for every line, and I am happy to rework anything that does not fit.
