### PR TITLE
Track I/O operation counts alongside byte counters

### DIFF
--- a/src/common/metrics.json
+++ b/src/common/metrics.json
@@ -68,10 +68,20 @@
 			"description": "The total amount of bytes read from storage",
 			"unit": "bytes"
 		},
+		"total_read_operations": {
+			"metric_type": "uint64",
+			"description": "The total number of read operations issued to storage",
+			"unit": "operations"
+		},
 		"total_bytes_written": {
 			"metric_type": "uint64",
 			"description": "The total amount of bytes written to storage",
 			"unit": "bytes"
+		},
+		"total_write_operations": {
+			"metric_type": "uint64",
+			"description": "The total number of write operations issued to storage",
+			"unit": "operations"
 		}
 	},
 	"storage": {

--- a/src/include/duckdb/main/profiler/metrics.hpp
+++ b/src/include/duckdb/main/profiler/metrics.hpp
@@ -117,6 +117,20 @@ struct MetricIOTotalBytesWritten {
 	static constexpr const char *Unit = "bytes";
 	static constexpr const char *TypeStr = "uint64";
 };
+struct MetricIOTotalReadOperations {
+	using METRIC_TYPE = uint64_t;
+	static constexpr const char *Name = "io.total_read_operations";
+	static constexpr const char *Description = "The total number of read operations issued to storage";
+	static constexpr const char *Unit = "operations";
+	static constexpr const char *TypeStr = "uint64";
+};
+struct MetricIOTotalWriteOperations {
+	using METRIC_TYPE = uint64_t;
+	static constexpr const char *Name = "io.total_write_operations";
+	static constexpr const char *Description = "The total number of write operations issued to storage";
+	static constexpr const char *Unit = "operations";
+	static constexpr const char *TypeStr = "uint64";
+};
 
 // Storage metrics
 struct MetricStorageAttachLoadStorageLatency {

--- a/src/include/duckdb/main/profiler/profiling_utils.hpp
+++ b/src/include/duckdb/main/profiler/profiling_utils.hpp
@@ -37,7 +37,9 @@ public:
 
 	// Always-tracked byte counters (used by progress bar even when profiling is disabled)
 	atomic<idx_t> bytes_read;
+	atomic<idx_t> read_operations;
 	atomic<idx_t> bytes_written;
+	atomic<idx_t> write_operations;
 	// Thread-safe memory allocation counter (updated from allocator callbacks on any thread)
 	atomic<idx_t> total_memory_allocated;
 
@@ -52,10 +54,12 @@ public:
 
 	void UpdateBytesRead(idx_t n) {
 		bytes_read += n;
+		read_operations++;
 	}
 
 	void UpdateBytesWritten(idx_t n) {
 		bytes_written += n;
+		write_operations++;
 	}
 
 	void UpdateTotalMemoryAllocated(idx_t n) {
@@ -82,8 +86,16 @@ public:
 		return bytes_read.load();
 	}
 
+	idx_t GetReadOperations() const {
+		return read_operations.load();
+	}
+
 	idx_t GetBytesWritten() const {
 		return bytes_written.load();
+	}
+
+	idx_t GetWriteOperations() const {
+		return write_operations.load();
 	}
 
 	idx_t GetTotalMemoryAllocated() const {
@@ -102,7 +114,9 @@ public:
 		string_timings.clear();
 		string_counters.clear();
 		bytes_read = 0;
+		read_operations = 0;
 		bytes_written = 0;
+		write_operations = 0;
 		total_memory_allocated = 0;
 
 		latency_timer.reset();
@@ -123,7 +137,9 @@ public:
 			string_counters[entry.first] += entry.second;
 		}
 		bytes_read += other.bytes_read.load();
+		read_operations += other.read_operations.load();
 		bytes_written += other.bytes_written.load();
+		write_operations += other.write_operations.load();
 		total_memory_allocated += other.total_memory_allocated.load();
 	}
 

--- a/src/main/profiler/metrics_manager.cpp
+++ b/src/main/profiler/metrics_manager.cpp
@@ -40,6 +40,8 @@ static const MetricDescriptor internal_metrics[] = {
 	DUCKDB_METRIC(MetricSystemTotalMemoryAllocated),
 	DUCKDB_METRIC(MetricIOTotalBytesRead),
 	DUCKDB_METRIC(MetricIOTotalBytesWritten),
+	DUCKDB_METRIC(MetricIOTotalReadOperations),
+	DUCKDB_METRIC(MetricIOTotalWriteOperations),
 	DUCKDB_METRIC(MetricStorageAttachLoadStorageLatency),
 	DUCKDB_METRIC(MetricStorageAttachReplayWALLatency),
 	DUCKDB_METRIC(MetricStorageCheckpointLatency),

--- a/src/main/profiler/profiling_utils.cpp
+++ b/src/main/profiler/profiling_utils.cpp
@@ -12,14 +12,17 @@ void QueryMetrics::FinalizeMetrics(GatheredMetrics &info) {
 		info.SetMetric(key, count);
 	}
 	info.SetMetric<MetricIOTotalBytesRead>(GetBytesRead());
+	info.SetMetric<MetricIOTotalReadOperations>(GetReadOperations());
 	info.SetMetric<MetricIOTotalBytesWritten>(GetBytesWritten());
+	info.SetMetric<MetricIOTotalWriteOperations>(GetWriteOperations());
 	info.SetMetric<MetricSystemBlockedThreadTime>(blocked_thread_time);
 	info.SetMetric<MetricSystemPeakBufferMemory>(system_peak_buffer_memory);
 	info.SetMetric<MetricSystemPeakTempDirSize>(system_peak_temp_dir_size);
 	info.SetMetric<MetricSystemTotalMemoryAllocated>(GetTotalMemoryAllocated());
 }
 
-QueryMetrics::QueryMetrics() : bytes_read(0), bytes_written(0), total_memory_allocated(0) {
+QueryMetrics::QueryMetrics()
+    : bytes_read(0), read_operations(0), bytes_written(0), write_operations(0), total_memory_allocated(0) {
 	Reset();
 }
 

--- a/src/main/query_profiler.cpp
+++ b/src/main/query_profiler.cpp
@@ -927,7 +927,9 @@ unique_ptr<QueryProfileResult> QueryProfiler::ToLegacyResultTree() const {
 
 	emit("total_memory_allocated", "system.total_memory_allocated");
 	emit("total_bytes_written", "io.total_bytes_written");
+	emit("total_write_operations", "io.total_write_operations");
 	emit("total_bytes_read", "io.total_bytes_read");
+	emit("total_read_operations", "io.total_read_operations");
 	emit("system_peak_temp_dir_size", "system.peak_temp_dir_size");
 	emit("system_peak_buffer_memory", "system.peak_buffer_memory");
 

--- a/test/sql/pragma/profiling/test_io_operation_metrics.test
+++ b/test/sql/pragma/profiling/test_io_operation_metrics.test
@@ -1,0 +1,57 @@
+# name: test/sql/pragma/profiling/test_io_operation_metrics.test
+# description: Test the io.total_read_operations and io.total_write_operations metrics
+# group: [profiling]
+
+require json
+
+# The metrics are registered and discoverable.
+query IIII
+SELECT metric_name, metric_type, description, unit
+FROM duckdb_available_metrics()
+WHERE metric_name = 'io.total_read_operations';
+----
+io.total_read_operations	uint64	The total number of read operations issued to storage	operations
+
+query IIII
+SELECT metric_name, metric_type, description, unit
+FROM duckdb_available_metrics()
+WHERE metric_name = 'io.total_write_operations';
+----
+io.total_write_operations	uint64	The total number of write operations issued to storage	operations
+
+# Write a source file so a later scan forces real reads from storage.
+statement ok
+COPY (SELECT i AS a, i * 2 AS b FROM range(100000) t(i)) TO '{TEST_DIR}/read_ops_src.csv';
+
+statement ok
+PRAGMA enable_profiling = 'json';
+
+statement ok
+PRAGMA profiling_output = '{TEST_DIR}/read_ops_profile.json';
+
+statement ok
+SET tracked_metrics = ['io.*'];
+
+# A single profiled query that both reads (source csv) and writes (dest csv).
+statement ok
+COPY (SELECT * FROM read_csv('{TEST_DIR}/read_ops_src.csv')) TO '{TEST_DIR}/read_ops_dst.csv';
+
+statement ok
+PRAGMA disable_profiling;
+
+statement ok
+CREATE OR REPLACE TABLE metrics_output AS SELECT * FROM '{TEST_DIR}/read_ops_profile.json';
+
+# Reading the CSV must have issued at least one read operation, writing at least one write operation.
+query I
+SELECT io.total_read_operations > 0 AND io.total_write_operations > 0 FROM metrics_output;
+----
+true
+
+# Operation counts are consistent with the byte counters: bytes moved implies operations issued.
+query I
+SELECT io.total_read_operations >= 1 AND io.total_bytes_read > 0
+   AND io.total_write_operations >= 1 AND io.total_bytes_written > 0
+FROM metrics_output;
+----
+true


### PR DESCRIPTION
Adds `io.total_read_operations` / `io.total_write_operations`, tracking the number of read/write operations issued to storage alongside the existing `io.total_bytes_read` / `io.total_bytes_written` counters. An "operation" is one file-system read/write call, so that I/O amplification can be calculated. 