### PR TITLE
aggregate: widen FirstStringStateBase::alloc_size to idx_t to stop the 2GB integer truncation

### DIFF
--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -87,7 +87,7 @@ struct FirstStringStateBase {
 	//! Whether the state has been set (i.e. we have seen a row)
 	bool is_set;
 	//! The size of the arena allocation for a non-inlined string value - not part of the exported state
-	uint32_t alloc_size;
+	idx_t alloc_size;
 
 	void Assign(string_t input, AggregateInputData &input_data) {
 		if (input.IsInlined()) {
@@ -99,7 +99,7 @@ struct FirstStringStateBase {
 			if (alloc_size >= len) {
 				ptr = value.GetDataWriteable();
 			} else {
-				alloc_size = UnsafeNumericCast<uint32_t>(NextPowerOfTwo(len));
+				alloc_size = NextPowerOfTwo(len);
 				ptr = char_ptr_cast(input_data.allocator.Allocate(alloc_size));
 			}
 			memcpy(ptr, input.GetData(), len);


### PR DESCRIPTION
Fixes #25269.

`FirstStringStateBase::Assign()` stored the arena allocation size in a `uint32_t` after casting `NextPowerOfTwo(len)`. For any input string with `len` in `(2^31, 2^32-1]` — a size DuckDB's own `string_t` cap permits — `NextPowerOfTwo(len)` returns `2^32`, and the outer `UnsafeNumericCast<uint32_t>` truncates that to `0`. Release builds then call `ArenaAllocator::Allocate(0)`, get back a stub, and `memcpy` gigabytes of attacker content past it — an attacker-controlled heap buffer overflow reachable through any `first()`, `last()`, or `any_value()` over a `VARCHAR` or `BLOB` column. Debug builds crash at the checked cast.

Widening `alloc_size` to `idx_t` lets `NextPowerOfTwo`'s `uint64_t` result survive without truncation. The doc comment on the field already notes it's not part of the exported state, so the four extra bytes only touch the aggregate's internal state layout. The `alloc_size >= len` reuse check keeps working because `len` is promoted to `idx_t` at the comparison.

## Verified

`main` at `154c2c8d`, debug build (`make debug` with `-j2` and shell target; the parquet+other loadable-extension link steps OOM at `-j4` on a 15 GB box).

- The reporter's own ASan trace in the issue is the primary evidence for the pre-fix crash; on a debug build the 2 GB scalar string generation dominates wall-time before the aggregate path is even entered, so I didn't independently re-crash it. The truncation itself is arithmetically inevitable for any `len` in that range — `NextPowerOfTwo` returns `2^32`, `uint32_t` cast returns `0`, `memcpy` then writes `len` bytes past the stub.
- Post-fix smoke checks all pass on the same debug build: `last`, `first`, `any_value` over short and 1 MB `VARCHAR` values return the expected lengths; multi-row `first(x ORDER BY i)` and `last(x ORDER BY i)` return the expected boundary rows.

## Notes

Reported and root-caused by @ylwango613; the fix follows directly from the analysis in the issue.

I used an AI coding assistant while working on this. Every hunk was reviewed by a human before commit, the fix and smoke tests were run on real hardware, and the diff is two lines with no logic change beyond the width of `alloc_size`.