### PR TITLE
Add a constant-pattern fast path for LIKE ... ESCAPE

### DIFF
--- a/benchmark/micro/string/like_escape_escaped_regular.benchmark
+++ b/benchmark/micro/string/like_escape_escaped_regular.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/string/like_escape_escaped_regular.benchmark
+# description: Contains word 'regular' in the l_comment (11.5%~), written with an escape sequence in the pattern
+# group: [string]
+
+name Like Escape ('%regula#r%' ESCAPE '#')
+group string
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT COUNT(*) FROM lineitem WHERE l_comment LIKE '%regula#r%' ESCAPE '#'
+
+result I
+687323

--- a/benchmark/micro/string/like_escape_regular.benchmark
+++ b/benchmark/micro/string/like_escape_regular.benchmark
@@ -1,0 +1,19 @@
+# name: benchmark/micro/string/like_escape_regular.benchmark
+# description: Contains word 'regular' in the l_comment (11.5%~), with an ESCAPE clause that the pattern never uses
+# group: [string]
+
+name Like Escape ('%regular%' ESCAPE '#')
+group string
+
+require tpch
+
+cache tpch_sf1.duckdb
+
+load
+CALL dbgen(sf=1);
+
+run
+SELECT COUNT(*) FROM lineitem WHERE l_comment LIKE '%regular%' ESCAPE '#'
+
+result I
+687323

--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -245,9 +245,11 @@ struct LikeSegment {
 };
 
 struct LikeMatcher : public FunctionData {
-	LikeMatcher(string like_pattern_p, vector<LikeSegment> segments, bool has_start_percentage, bool has_end_percentage)
+	LikeMatcher(string like_pattern_p, vector<LikeSegment> segments, bool has_start_percentage, bool has_end_percentage,
+	            bool has_escape, char escape)
 	    : like_pattern(std::move(like_pattern_p)), segments(std::move(segments)),
-	      has_start_percentage(has_start_percentage), has_end_percentage(has_end_percentage) {
+	      has_start_percentage(has_start_percentage), has_end_percentage(has_end_percentage), has_escape(has_escape),
+	      escape(escape) {
 	}
 
 	bool Match(string_t &str) {
@@ -309,58 +311,81 @@ struct LikeMatcher : public FunctionData {
 		}
 	}
 
-	static unique_ptr<LikeMatcher> CreateLikeMatcher(string like_pattern, char escape = '\0') {
+	// build a matcher for LIKE without ESCAPE semantics
+	static unique_ptr<LikeMatcher> CreateLikeMatcher(string like_pattern) {
+		return CreateLikeMatcherInternal(std::move(like_pattern), false, '\0');
+	}
+
+	// build an escape-aware matcher - '\0' is a valid escape character, so escaping is signalled by the overload
+	static unique_ptr<LikeMatcher> CreateLikeMatcher(string like_pattern, char escape) {
+		return CreateLikeMatcherInternal(std::move(like_pattern), true, escape);
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<LikeMatcher>(like_pattern, segments, has_start_percentage, has_end_percentage, has_escape,
+		                              escape);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = other_p.Cast<LikeMatcher>();
+		// the same pattern produces different segments under a different escape character
+		return like_pattern == other.like_pattern && has_escape == other.has_escape &&
+		       (!has_escape || escape == other.escape);
+	}
+
+private:
+	// split the pattern into constant segments separated by unescaped '%', or return nullptr if that is not possible
+	static unique_ptr<LikeMatcher> CreateLikeMatcherInternal(string like_pattern, bool has_escape, char escape) {
 		vector<LikeSegment> segments;
-		idx_t last_non_pattern = 0;
+		string segment;
 		bool has_start_percentage = false;
 		bool has_end_percentage = false;
 		for (idx_t i = 0; i < like_pattern.size(); i++) {
 			auto ch = like_pattern[i];
-			if (ch == escape || ch == '%' || ch == '_') {
-				// special character, push a constant pattern
-				if (i > last_non_pattern) {
-					segments.emplace_back(like_pattern.substr(last_non_pattern, i - last_non_pattern));
-				}
-				last_non_pattern = i + 1;
-				if (ch == escape || ch == '_') {
-					// escape or underscore: could not create efficient like matcher
-					// FIXME: we could handle escaped percentages here
+			if (has_escape && ch == escape) {
+				if (i + 1 == like_pattern.size()) {
+					// dangling escape: leave the error to the generic matcher, which only raises it per row
 					return nullptr;
-				} else {
-					// sample_size
-					if (i == 0) {
-						has_start_percentage = true;
-					}
-					if (i + 1 == like_pattern.size()) {
-						has_end_percentage = true;
-					}
 				}
+				// an escaped character is matched literally, so it extends the current segment
+				segment += like_pattern[++i];
+				continue;
+			}
+			if (ch == '_') {
+				// segments are separated by variable-length gaps, not by the one-character gap '_' introduces
+				return nullptr;
+			}
+			if (ch != '%') {
+				segment += ch;
+				continue;
+			}
+			// wildcard: finish off the segment we were building
+			if (!segment.empty()) {
+				segments.emplace_back(std::move(segment));
+				segment.clear();
+			} else if (i == 0) {
+				has_start_percentage = true;
+			}
+			if (i + 1 == like_pattern.size()) {
+				has_end_percentage = true;
 			}
 		}
-		if (last_non_pattern < like_pattern.size()) {
-			segments.emplace_back(like_pattern.substr(last_non_pattern, like_pattern.size() - last_non_pattern));
+		if (!segment.empty()) {
+			segments.emplace_back(std::move(segment));
 		}
 		if (segments.empty()) {
 			return nullptr;
 		}
 		return make_uniq<LikeMatcher>(std::move(like_pattern), std::move(segments), has_start_percentage,
-		                              has_end_percentage);
+		                              has_end_percentage, has_escape, escape);
 	}
 
-	unique_ptr<FunctionData> Copy() const override {
-		return make_uniq<LikeMatcher>(like_pattern, segments, has_start_percentage, has_end_percentage);
-	}
-
-	bool Equals(const FunctionData &other_p) const override {
-		auto &other = other_p.Cast<LikeMatcher>();
-		return like_pattern == other.like_pattern;
-	}
-
-private:
 	string like_pattern;
 	vector<LikeSegment> segments;
 	bool has_start_percentage;
 	bool has_end_percentage;
+	bool has_escape;
+	char escape;
 };
 
 unique_ptr<FunctionData> LikeBindFunction(BindScalarFunctionInput &input) {
@@ -378,6 +403,34 @@ unique_ptr<FunctionData> LikeBindFunction(BindScalarFunctionInput &input) {
 		return LikeMatcher::CreateLikeMatcher(pattern_str->ToString());
 	}
 	return nullptr;
+}
+
+unique_ptr<FunctionData> LikeEscapeBindFunction(BindScalarFunctionInput &input) {
+	auto &arguments = input.GetArguments();
+	D_ASSERT(arguments.size() == 3);
+	for (auto &arg : arguments) {
+		if (arg->GetReturnType().id() == LogicalTypeId::VARCHAR &&
+		    !StringType::GetCollation(arg->GetReturnType()).empty()) {
+			return nullptr;
+		}
+	}
+	// the pattern and the escape character both have to be constant to resolve the escape sequences here
+	auto pattern_str = input.TryGetConstant(1);
+	auto escape_str = input.TryGetConstant(2);
+	if (!pattern_str || !escape_str || pattern_str->IsNull() || escape_str->IsNull()) {
+		return nullptr;
+	}
+	auto escape = escape_str->ToString();
+	if (escape.size() > 1) {
+		// invalid escape string - leave the error reporting to GetEscapeChar() in the generic matcher
+		return nullptr;
+	}
+	if (escape.empty()) {
+		// an empty ESCAPE clause disables escaping altogether
+		return LikeMatcher::CreateLikeMatcher(pattern_str->ToString());
+	}
+	// 'a#_b' ESCAPE '#' is the constant string "a_b", so a pattern holding the escape character still qualifies
+	return LikeMatcher::CreateLikeMatcher(pattern_str->ToString(), escape[0]);
 }
 
 bool LikeOperatorFunction(const char *s, idx_t slen, const char *pattern, idx_t plen, char escape) {
@@ -657,6 +710,21 @@ void RegularLikeFunction(DataChunk &input, ExpressionState &state, Vector &resul
 	}
 }
 
+template <class OP, bool INVERT>
+void RegularLikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	if (func_expr.BindInfo()) {
+		auto &matcher = func_expr.BindInfo()->Cast<LikeMatcher>();
+		// use fast like matcher
+		UnaryExecutor::Execute<string_t, bool>(args.data[0], result, [&](string_t input) {
+			return INVERT ? !matcher.Match(input) : matcher.Match(input);
+		});
+		return;
+	}
+	// use generic escape-aware like matcher
+	LikeEscapeFunction<OP>(args, state, result);
+}
+
 } // namespace
 
 ScalarFunction NotLikeFun::GetFunction() {
@@ -696,9 +764,9 @@ ScalarFunction LikeFun::GetFunction() {
 }
 
 ScalarFunction NotLikeEscapeFun::GetFunction() {
-	ScalarFunction not_like_escape("not_like_escape",
-	                               {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                               LogicalType::BOOLEAN, LikeEscapeFunction<NotLikeEscapeOperator>);
+	ScalarFunction not_like_escape(
+	    "not_like_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	    RegularLikeEscapeFunction<NotLikeEscapeOperator, true>, LikeEscapeBindFunction);
 	not_like_escape.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return not_like_escape;
 }
@@ -719,7 +787,8 @@ ScalarFunction NotIlikeEscapeFun::GetFunction() {
 }
 ScalarFunction LikeEscapeFun::GetFunction() {
 	ScalarFunction like_escape("like_escape", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
-	                           LogicalType::BOOLEAN, LikeEscapeFunction<LikeEscapeOperator>);
+	                           LogicalType::BOOLEAN, RegularLikeEscapeFunction<LikeEscapeOperator, false>,
+	                           LikeEscapeBindFunction);
 	like_escape.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
 	return like_escape;
 }

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_API_OBJECTS
     test_table_info.cpp
     test_appender_api.cpp
     test_lifecycle_hooks.cpp
+    test_like_matcher.cpp
     test_extension_schema_api.cpp
     test_pending_query.cpp
     test_plan_serialization.cpp

--- a/test/api/test_like_matcher.cpp
+++ b/test/api/test_like_matcher.cpp
@@ -1,0 +1,125 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+// like_escape stores its LikeMatcher in bind_info, which is the field the executor branches on to pick the fast path
+bool HasBindInfo(const Expression &expr, const string &function_name) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto &func = expr.Cast<BoundFunctionExpression>();
+		if (func.Function().GetName() == function_name) {
+			return func.BindInfo() != nullptr;
+		}
+	}
+	bool found = false;
+	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+		if (!found) {
+			found = HasBindInfo(child, function_name);
+		}
+	});
+	return found;
+}
+
+bool PlanHasBindInfo(const LogicalOperator &op, const string &function_name) {
+	for (auto &expr : op.expressions) {
+		if (HasBindInfo(*expr, function_name)) {
+			return true;
+		}
+	}
+	for (auto &child : op.children) {
+		if (PlanHasBindInfo(*child, function_name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool MatcherBuilt(Connection &con, const string &query) {
+	auto plan = con.ExtractPlan(query);
+	REQUIRE(plan);
+	return PlanHasBindInfo(*plan, "like_escape");
+}
+
+} // namespace
+
+TEST_CASE("LikeMatcher is built for constant patterns that contain the escape character", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t(s VARCHAR)"));
+
+	// Baseline: a constant pattern whose escape character is unused takes the fast path.
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE '%abc%' ESCAPE '#' FROM t"));
+
+	// Escaped wildcards are literals and can be included in constant segments.
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE 'a#_b' ESCAPE '#' FROM t"));
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE 'a#%b' ESCAPE '#' FROM t"));
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE '%a#_b%' ESCAPE '#' FROM t"));
+	// An escape can also quote an ordinary character.
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE 'a#b' ESCAPE '#' FROM t"));
+	// The escape character escaping itself.
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE 'a##b' ESCAPE '#' FROM t"));
+	// Escape characters can also be LIKE wildcard characters.
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE 'a%_b' ESCAPE '%' FROM t"));
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE 'a__b' ESCAPE '_' FROM t"));
+
+	// An empty ESCAPE clause disables escaping, and the pattern is constant without it.
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE 'a#b' ESCAPE '' FROM t"));
+
+	// NOT LIKE ... ESCAPE is planned as NOT like_escape(...), so it takes the same fast path.
+	REQUIRE(MatcherBuilt(con, "SELECT s NOT LIKE 'a#_b' ESCAPE '#' FROM t"));
+
+	// not_like_escape is only reachable by calling it by name, and is bound the same way.
+	auto plan = con.ExtractPlan("SELECT not_like_escape(s, 'a#_b', '#') FROM t");
+	REQUIRE(plan);
+	REQUIRE(PlanHasBindInfo(*plan, "not_like_escape"));
+}
+
+TEST_CASE("LikeMatcher is declined where the segment model cannot express the pattern", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t(s VARCHAR)"));
+
+	// The segment model cannot represent the one-character gap introduced by a real '_'.
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE 'a_b' ESCAPE '#' FROM t"));
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE '%a_b%' ESCAPE '#' FROM t"));
+
+	// A dangling escape is an invalid pattern, reported by the generic matcher per row.
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE 'abc#' ESCAPE '#' FROM t"));
+
+	// GetEscapeChar() remains responsible for rejecting multi-character escape strings.
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE 'abc' ESCAPE 'xy' FROM t"));
+
+	// A NULL pattern or escape has no pattern to prepare.
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE NULL ESCAPE '#' FROM t"));
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE 'abc' ESCAPE NULL FROM t"));
+
+	// A pattern that is not foldable cannot be prepared ahead of time at all.
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE s ESCAPE '#' FROM t"));
+
+	// A pattern that is entirely wildcards has no segment to anchor on.
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE '%%' ESCAPE '#' FROM t"));
+}
+
+TEST_CASE("LikeMatcher and collations", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	// the matcher compares bytes, so like LikeBindFunction it has to decline any collation
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE no_collation(s VARCHAR)"));
+	REQUIRE(MatcherBuilt(con, "SELECT s LIKE 'a#_b' ESCAPE '#' FROM no_collation"));
+
+	// POSIX does not transform the string, but it is still recorded on the type.
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE posix_collation(s VARCHAR COLLATE POSIX)"));
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE 'a#_b' ESCAPE '#' FROM posix_collation"));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE nocase_collation(s VARCHAR COLLATE NOCASE)"));
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE 'a#_b' ESCAPE '#' FROM nocase_collation"));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE ai_ci_collation(s VARCHAR COLLATE NOCASE.NOACCENT)"));
+	REQUIRE(!MatcherBuilt(con, "SELECT s LIKE 'a#_b' ESCAPE '#' FROM ai_ci_collation"));
+}

--- a/test/sql/function/string/test_like_escape_constant_pattern.test
+++ b/test/sql/function/string/test_like_escape_constant_pattern.test
@@ -1,0 +1,317 @@
+# name: test/sql/function/string/test_like_escape_constant_pattern.test
+# description: LIKE / NOT LIKE ... ESCAPE with a constant pattern - exercises the matcher fast path built by LikeEscapeBindFunction
+# group: [string]
+
+statement ok
+CREATE TABLE t(id INTEGER, s VARCHAR);
+
+statement ok
+INSERT INTO t VALUES
+    (1, 'a_b'),
+    (2, 'aXb'),
+    (3, 'a%b'),
+    (4, 'a#b'),
+    (5, 'ab'),
+    (6, 'xxa_byy'),
+    (7, NULL),
+    (8, ''),
+    (9, 'a_b_c'),
+    (10, 'A_B');
+
+# A constant pattern is resolved into a matcher at bind time, a column pattern is not. Both must agree, so every
+# pattern below is also run through this single-row table to force the generic per-row matcher.
+statement ok
+CREATE TABLE p(pat VARCHAR);
+
+# === escaped wildcards are literal characters, so the pattern is still a constant string ===
+
+# 'a#_b' is the constant string "a_b"
+query I
+SELECT id FROM t WHERE s LIKE 'a#_b' ESCAPE '#' ORDER BY id
+----
+1
+
+statement ok
+DELETE FROM p; INSERT INTO p VALUES ('a#_b');
+
+query I
+SELECT id FROM t, p WHERE s LIKE pat ESCAPE '#' ORDER BY id
+----
+1
+
+# same, surrounded by wildcards
+query I
+SELECT id FROM t WHERE s LIKE '%a#_b%' ESCAPE '#' ORDER BY id
+----
+1
+6
+9
+
+statement ok
+DELETE FROM p; INSERT INTO p VALUES ('%a#_b%');
+
+query I
+SELECT id FROM t, p WHERE s LIKE pat ESCAPE '#' ORDER BY id
+----
+1
+6
+9
+
+# 'a#%b' is the constant string "a%b"
+query I
+SELECT id FROM t WHERE s LIKE 'a#%b' ESCAPE '#' ORDER BY id
+----
+3
+
+# the escape character escaping itself
+query I
+SELECT id FROM t WHERE s LIKE 'a##b' ESCAPE '#' ORDER BY id
+----
+4
+
+# an escape may also quote an ordinary character
+query I
+SELECT id FROM t WHERE s LIKE 'a#Xb' ESCAPE '#' ORDER BY id
+----
+2
+
+# === an unescaped '_' is a wildcard and keeps using the generic matcher ===
+
+query I
+SELECT id FROM t WHERE s LIKE 'a_b' ESCAPE '#' ORDER BY id
+----
+1
+2
+3
+4
+
+statement ok
+DELETE FROM p; INSERT INTO p VALUES ('a_b');
+
+query I
+SELECT id FROM t, p WHERE s LIKE pat ESCAPE '#' ORDER BY id
+----
+1
+2
+3
+4
+
+# === the escape character may itself be a wildcard character ===
+
+# with ESCAPE '%', '%%' is a literal percent sign
+query I
+SELECT id FROM t WHERE s LIKE 'a%%b' ESCAPE '%' ORDER BY id
+----
+3
+
+statement ok
+DELETE FROM p; INSERT INTO p VALUES ('a%%b');
+
+query I
+SELECT id FROM t, p WHERE s LIKE pat ESCAPE '%' ORDER BY id
+----
+3
+
+# ... and '%_' is a literal underscore
+query I
+SELECT id FROM t WHERE s LIKE 'a%_b' ESCAPE '%' ORDER BY id
+----
+1
+
+# a trailing escaped '%' is a literal percent sign, not a wildcard: it must not match "ab"
+query I
+SELECT id FROM t WHERE s LIKE 'ab%%' ESCAPE '%' ORDER BY id
+----
+
+statement ok
+DELETE FROM p; INSERT INTO p VALUES ('ab%%');
+
+query I
+SELECT id FROM t, p WHERE s LIKE pat ESCAPE '%' ORDER BY id
+----
+
+# with ESCAPE '_', '__' is a literal underscore
+query I
+SELECT id FROM t WHERE s LIKE 'a__b' ESCAPE '_' ORDER BY id
+----
+1
+
+# the same pattern text means different things under different escape characters, so the two must not be conflated
+query TT
+SELECT 'ab' LIKE 'a#b' ESCAPE '#', 'ab' LIKE 'a#b' ESCAPE '@'
+----
+true	false
+
+query TT
+SELECT 'a#b' LIKE 'a#b' ESCAPE '#', 'a#b' LIKE 'a#b' ESCAPE '@'
+----
+false	true
+
+# === NOT LIKE ... ESCAPE ===
+
+query I
+SELECT id FROM t WHERE s NOT LIKE 'a#_b' ESCAPE '#' ORDER BY id
+----
+2
+3
+4
+5
+6
+8
+9
+10
+
+query I
+SELECT id FROM t WHERE s NOT LIKE '%a#_b%' ESCAPE '#' ORDER BY id
+----
+2
+3
+4
+5
+8
+10
+
+# NOT LIKE ... ESCAPE is planned as NOT like_escape(...); not_like_escape is reachable by calling it by name
+query I
+SELECT id FROM t WHERE not_like_escape(s, 'a#_b', '#') ORDER BY id
+----
+2
+3
+4
+5
+6
+8
+9
+10
+
+query TT
+SELECT not_like_escape('a_b', 'a#_b', '#'), not_like_escape('aXb', 'a#_b', '#')
+----
+false	true
+
+# === edge cases ===
+
+# an only-percent pattern has no constant segment to anchor on
+query I
+SELECT id FROM t WHERE s LIKE '%' ESCAPE '#' ORDER BY id
+----
+1
+2
+3
+4
+5
+6
+8
+9
+10
+
+# an empty pattern matches only the empty string
+query I
+SELECT id FROM t WHERE s LIKE '' ESCAPE '#' ORDER BY id
+----
+8
+
+# an empty escape string disables escaping, so '_' goes back to being a wildcard
+query I
+SELECT id FROM t WHERE s LIKE 'a_b' ESCAPE '' ORDER BY id
+----
+1
+2
+3
+4
+
+# ... and the escape character is then matched literally
+query I
+SELECT id FROM t WHERE s LIKE 'a#b' ESCAPE '' ORDER BY id
+----
+4
+
+# a NULL pattern or escape yields NULL, never a match
+query I
+SELECT id FROM t WHERE s LIKE NULL ESCAPE '#' ORDER BY id
+----
+
+query I
+SELECT id FROM t WHERE s LIKE 'a#_b' ESCAPE NULL ORDER BY id
+----
+
+query T
+SELECT 'a_b' LIKE 'a#_b' ESCAPE NULL
+----
+NULL
+
+# a multi-character escape string is rejected
+statement error
+SELECT id FROM t WHERE s LIKE 'a#_b' ESCAPE '##'
+----
+Escape string must be empty or one character
+
+# A dangling escape character is an invalid pattern, so no matcher is built for it. The generic matcher validates
+# the pattern while it walks it, which means the error surfaces once a row gets far enough to reach the trailing
+# escape - a row that mismatches earlier never sees it.
+statement error
+SELECT 'abc' LIKE 'abc#' ESCAPE '#'
+----
+Like pattern must not end with escape character
+
+query T
+SELECT 'xyz' LIKE 'abc#' ESCAPE '#'
+----
+false
+
+# the same holds when the escape character is a wildcard character, where the pattern is fully consumed
+statement error
+SELECT 'ab' LIKE 'ab%' ESCAPE '%'
+----
+Like pattern must not end with escape character
+
+statement error
+SELECT '' LIKE '%' ESCAPE '%'
+----
+Like pattern must not end with escape character
+
+# === a runtime-constant pattern is folded at bind time as well ===
+
+statement ok
+PREPARE prep AS SELECT id FROM t WHERE s LIKE '%' || ? || '%' ESCAPE '#' ORDER BY id
+
+# an escaped underscore is a literal underscore
+query I
+EXECUTE prep('a#_b')
+----
+1
+6
+9
+
+# ... while a bare one is still a wildcard
+query I
+EXECUTE prep('a_b')
+----
+1
+2
+3
+4
+6
+9
+
+query I
+EXECUTE prep('zznotfound')
+----
+
+# === a per-row escape column keeps using the generic ternary path ===
+
+statement ok
+CREATE TABLE esc_t(id INTEGER, s VARCHAR, pat VARCHAR, esc VARCHAR);
+
+statement ok
+INSERT INTO esc_t VALUES
+    (1, 'a_b', 'a#_b', '#'),
+    (2, 'a%b', 'a%%b', '%'),
+    (3, 'aXb', 'a#_b', '#'),
+    (4, 'ab', 'ab%%', '%');
+
+query I
+SELECT id FROM esc_t WHERE s LIKE pat ESCAPE esc ORDER BY id
+----
+1
+2


### PR DESCRIPTION
LIKE / NOT LIKE ... ESCAPE has no bind function, so like_escape always runs the generic character-by-character matcher - even when the escape character never occurs in the pattern. For example, LIKE 'a#_b' ESCAPE '#' should take the same  SIMD contains path a plain LIKE does.

This PR binds a LikeMatcher when the pattern and the escape character are both  constant, and resolve escape sequences while building it instead of bailing out on them: an escaped character is matched literally, so it just extends the current constant segment.

Moreover, this PR fixes a bug: the loop consuming trailing '%' wildcards did not check  for the escape character. Under ESCAPE '%', 'abc' LIKE 'abc%%' ESCAPE '%' returned true even though that pattern denotes the constant "abc%", and a pattern ending in a dangling escape was accepted as a match instead of raising the syntax error the main loop raises for it.