### PR TITLE
Fix task executor regression

### DIFF
--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -187,7 +187,7 @@ private:
 	//! Currently alive executor tasks
 	atomic<idx_t> executor_tasks;
 
-	//! Total time blocked while waiting on tasks. In ticks. One tick corresponds to WAIT_TIME.
+	//! Total time blocked while waiting on tasks, in microseconds
 	atomic<idx_t> blocked_thread_time;
 };
 } // namespace duckdb

--- a/src/include/duckdb/execution/executor.hpp
+++ b/src/include/duckdb/execution/executor.hpp
@@ -55,6 +55,11 @@ public:
 	void Initialize(unique_ptr<PhysicalOperator> physical_plan);
 
 	void CancelTasks();
+	//! Whether the thread driving ExecuteTask holds a partially processed task.
+	//! `task` is owned by that thread alone, so only it may call this.
+	bool HasTaskInProgress() const {
+		return task != nullptr;
+	}
 	PendingExecutionResult ExecuteTask(bool dry_run = false);
 	void WaitForTask();
 	void SignalTaskRescheduled(lock_guard<mutex> &);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -686,7 +686,12 @@ ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
 }
 
 void ClientContext::WaitForTask(ClientContextLock &lock, BaseQueryResult &result) {
-	active_query->executor->WaitForTask();
+	auto &executor = *active_query->executor;
+	if (executor.HasTaskInProgress()) {
+		// This thread is holding a partially processed task, the next step resumes it without waiting.
+		return;
+	}
+	executor.WaitForTask();
 }
 
 bool ClientContext::ErrorInvalidatesTransaction(ExceptionType type) {

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -388,8 +388,10 @@ void Executor::WaitForTask() {
 	}
 	// Nothing to run on this thread, all remaining tasks are either running on other threads or descheduled.
 	// Wait (bounded), but wake up on task completion or reschedule.
-	blocked_thread_time += blocked_micros + WAIT_TIME_MS.count();
+	const auto wait_begin = TimePoint::Tick();
 	task_reschedule.wait_for(l, WAIT_TIME_MS);
+	const auto wait_micros = NumericCast<idx_t>(TimePoint::ElapsedMicros(wait_begin, TimePoint::Tick()));
+	blocked_thread_time += blocked_micros + wait_micros;
 #endif
 }
 

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -376,11 +376,6 @@ void Executor::WaitForTask() {
 		blocked_thread_time += blocked_micros;
 		return;
 	}
-	if (task) {
-		// This thread is holding a partially processed task, the next step will make progress without waiting
-		blocked_thread_time += blocked_micros;
-		return;
-	}
 	if (TaskScheduler::GetScheduler(context).GetTaskCountForProducer(*producer) > 0) {
 		// A new task is available for the calling thread, the next step will make progress without waiting
 		blocked_thread_time += blocked_micros;

--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -376,9 +376,13 @@ void Executor::WaitForTask() {
 		blocked_thread_time += blocked_micros;
 		return;
 	}
-	auto &scheduler = TaskScheduler::GetScheduler(context);
-	if (scheduler.GetTaskCountForProducer(*producer) > 0) {
-		// A task is available for the calling thread, the next step will make progress without waiting
+	if (task) {
+		// This thread is holding a partially processed task, the next step will make progress without waiting
+		blocked_thread_time += blocked_micros;
+		return;
+	}
+	if (TaskScheduler::GetScheduler(context).GetTaskCountForProducer(*producer) > 0) {
+		// A new task is available for the calling thread, the next step will make progress without waiting
 		blocked_thread_time += blocked_micros;
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb/issues/25282

Basically, don't just check if there are new tasks, also check if we  _currently_ hold a partially processed task.

Also fix the `blocked_thread_time` to increment by the actual time waited, not just a fixed `WAIT_TIME_NS` even when the thread wakes up earlier.