### PR TITLE
Fix trailing '%' wildcards ignoring the ESCAPE character

### DIFF
--- a/src/function/scalar/string/like.cpp
+++ b/src/function/scalar/string/like.cpp
@@ -220,7 +220,18 @@ bool TemplatedLikeOperator(const char *sdata, idx_t slen, const char *pdata, idx
 			return false;
 		}
 	}
-	while (pidx < plen && pdata[pidx] == PERCENTAGE) {
+	// a trailing '%' only matches an empty suffix when it is not escaped
+	while (pidx < plen) {
+		if (HAS_ESCAPE && pdata[pidx] == escape) {
+			if (pidx + 1 == plen) {
+				throw SyntaxException("Like pattern must not end with escape character!");
+			}
+			// the escape sequence needs a character to match against, and there is none left
+			break;
+		}
+		if (pdata[pidx] != PERCENTAGE) {
+			break;
+		}
 		pidx++;
 	}
 	return pidx == plen && sidx == slen;

--- a/test/sql/function/string/test_like_escape.test
+++ b/test/sql/function/string/test_like_escape.test
@@ -119,3 +119,37 @@ SELECT '%' LIKE (chr(0) || '%') ESCAPE chr(0),
        (chr(0) || 'abc') LIKE (chr(0) || '%') ESCAPE ''
 ----
 true	false	true
+
+# A trailing '%' only acts as a wildcard when it is not escaped: with ESCAPE '%', 'abc%%' is the constant "abc%".
+query TT
+SELECT 'abc' LIKE 'abc%%' ESCAPE '%', 'abc%' LIKE 'abc%%' ESCAPE '%'
+----
+false	true
+
+# A pattern ending in an escape character is invalid whether or not the string still has characters left to match.
+statement error
+SELECT 'abcd' LIKE 'abc#' ESCAPE '#';
+----
+Like pattern must not end with escape character
+
+statement error
+SELECT 'abc' LIKE 'abc#' ESCAPE '#';
+----
+Like pattern must not end with escape character
+
+# ... but a string that mismatches earlier never reaches the escape, so it is simply not a match.
+query T
+SELECT 'xyz' LIKE 'abc#' ESCAPE '#'
+----
+false
+
+# The same holds when the escape character is a wildcard, where the pattern is consumed by the trailing '%' loop.
+statement error
+SELECT 'ab' LIKE 'ab%' ESCAPE '%';
+----
+Like pattern must not end with escape character
+
+statement error
+SELECT '' LIKE '%' ESCAPE '%';
+----
+Like pattern must not end with escape character


### PR DESCRIPTION
The loop that consumes trailing '%' wildcards at the end of a LIKE pattern did not check whether a '%' was escaped, so it treated an escaped one as a wildcard. Under ESCAPE '%', 'abc' LIKE 'abc%%' ESCAPE '%' returned true even though that pattern denotes the constant string "abc%".

A pattern ending in a dangling escape character is invalid, and the same loop determined whether that got reported. The main matching loop raises a syntax error for such a pattern, but only reaches the escape while the string still has characters left to match; once the string runs out, control falls through to this loop, which stopped at the escape and reported "no match" instead. The error therefore depended on the data: 'abcd' LIKE 'abc#' ESCAPE '#' raised it, while 'abc' LIKE 'abc#' ESCAPE '#' silently returned false.

The loop now recognises the escape character, so the first pattern no longer matches "abc" and the second raises the error whatever the string is.