### PR TITLE
Prevent native stack overflow during join-order optimization

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library_unity(
   radix_partitioning.cpp
   re2_regex.cpp
   random_engine.cpp
+  stack_checker.cpp
   stacktrace.cpp
   string_util.cpp
   enum_util.cpp
@@ -87,6 +88,11 @@ add_library_unity(
   clustered_aggregate.cpp
   virtual_file_system.cpp
   windows_util.cpp)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_compile_definitions(duckdb_common PRIVATE _GNU_SOURCE)
+endif()
+
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_common>
     PARENT_SCOPE)

--- a/src/common/stack_checker.cpp
+++ b/src/common/stack_checker.cpp
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/stack_checker.cpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#include "duckdb/common/stack_checker.hpp"
+
+#include <cstdint>
+#include <limits>
+
+#if defined(__linux__) && !defined(DUCKDB_NO_THREADS) && !defined(DUCKDB_WASM_VERSION)
+#include <pthread.h>
+#endif
+
+namespace duckdb {
+
+#if defined(__linux__) && !defined(DUCKDB_NO_THREADS) && !defined(DUCKDB_WASM_VERSION)
+namespace {
+
+struct StackBounds {
+	uintptr_t lower;
+	uintptr_t upper;
+};
+
+// Reserve enough stack for another recursive operation, exception construction, stack unwinding, and cleanup.
+static constexpr idx_t STACK_CHECK_MARGIN = 128 * 1024;
+
+static bool SetStackBounds(StackBounds &bounds, uintptr_t lower, size_t size) {
+	if (size == 0 || size > std::numeric_limits<uintptr_t>::max() - lower) {
+		return false;
+	}
+
+	bounds.lower = lower;
+	bounds.upper = lower + size;
+	return true;
+}
+
+static StackBounds ReadCurrentThreadStackBounds() {
+	StackBounds bounds {0, 0};
+	pthread_attr_t attributes;
+	if (pthread_getattr_np(pthread_self(), &attributes) != 0) {
+		return bounds;
+	}
+
+	void *stack_address = nullptr;
+	size_t stack_size = 0;
+	const auto result = pthread_attr_getstack(&attributes, &stack_address, &stack_size);
+	pthread_attr_destroy(&attributes);
+	if (result != 0 || stack_address == nullptr || stack_size == 0) {
+		return bounds;
+	}
+
+	SetStackBounds(bounds, reinterpret_cast<uintptr_t>(stack_address), stack_size);
+	return bounds;
+}
+
+static const StackBounds &GetCurrentThreadStackBounds() {
+	// DuckDB can execute on threads created by embedding applications, so initialize
+	// the immutable pthread stack bounds lazily on first use in each thread.
+	static thread_local const StackBounds bounds = ReadCurrentThreadStackBounds();
+	return bounds;
+}
+
+} // namespace
+
+bool NativeStackChecker::IsStackNearLimit() {
+	// The marker value is irrelevant; its address approximates the current stack
+	// position. Each active call has its own stack-local marker, and volatile
+	// prevents the compiler from eliminating it.
+	volatile unsigned char stack_marker = 0;
+	const auto current = reinterpret_cast<uintptr_t>(&stack_marker);
+
+	const auto &bounds = GetCurrentThreadStackBounds();
+	if (bounds.lower == bounds.upper) {
+		return false;
+	}
+	if (current < bounds.lower || current > bounds.upper) {
+		// The current position is outside the reported bounds. Treat the bounds as
+		// unreliable and fail closed instead of silently disabling the check.
+		return true;
+	}
+
+	// The Linux native thread stack grows downwards, so the remaining stack
+	// space is the distance to the lower bound.
+	return current - bounds.lower <= STACK_CHECK_MARGIN;
+}
+
+#else
+
+bool NativeStackChecker::IsStackNearLimit() {
+	return false;
+}
+
+#endif
+
+} // namespace duckdb

--- a/src/include/duckdb/common/stack_checker.hpp
+++ b/src/include/duckdb/common/stack_checker.hpp
@@ -8,13 +8,26 @@
 
 #pragma once
 
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/typedefs.hpp"
+
 namespace duckdb {
+
+class NativeStackChecker {
+public:
+	//! On Linux, returns whether the current thread has less than the reserved stack space remaining.
+	//! Returns false on unsupported platforms.
+	static bool IsStackNearLimit();
+};
 
 template <class RECURSIVE_CLASS>
 class StackChecker {
 public:
 	StackChecker(RECURSIVE_CLASS &recursive_class_p, idx_t stack_usage_p)
 	    : recursive_class(recursive_class_p), stack_usage(stack_usage_p) {
+		if (NativeStackChecker::IsStackNearLimit()) {
+			throw InvalidInputException("Insufficient stack space to process the query");
+		}
 		recursive_class.stack_depth += stack_usage;
 	}
 	~StackChecker() {

--- a/src/optimizer/join_order/join_order_optimizer.cpp
+++ b/src/optimizer/join_order/join_order_optimizer.cpp
@@ -1,8 +1,10 @@
 #include "duckdb/optimizer/join_order/join_order_optimizer.hpp"
 
 #include "duckdb/common/enums/join_type.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/stack_checker.hpp"
 #include "duckdb/optimizer/join_order/cardinality_estimator.hpp"
 #include "duckdb/optimizer/join_order/cost_model.hpp"
 #include "duckdb/optimizer/join_order/plan_enumerator.hpp"
@@ -59,6 +61,15 @@ JoinOrderOptimizer JoinOrderOptimizer::CreateChildOptimizer() {
 
 unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOperator> plan,
                                                          optional_ptr<RelationStats> stats) {
+	// Correlated subqueries are represented as delim joins and can cause the
+	// join-order optimizer to recurse deeply without using StackChecker. On Linux,
+	// check the native stack before touching the plan or reading optimizer settings.
+#if defined(__linux__) && !defined(DUCKDB_NO_THREADS) && !defined(DUCKDB_WASM_VERSION)
+	if (NativeStackChecker::IsStackNearLimit()) {
+		throw InvalidInputException("Insufficient stack space to process the query");
+	}
+#endif
+
 	auto max_expression_depth = Settings::Get<MaxExpressionDepthSetting>(query_graph_manager.context);
 	if (depth > max_expression_depth) {
 		// Very deep plans will eventually consume quite some stack space

--- a/test/optimizer/CMakeLists.txt
+++ b/test/optimizer/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library_unity(
   common_subplan_nonserializable.cpp
   filter_pushdown_alias.cpp
   join_order_conflict_detector.cpp
+  join_order_stack_check.cpp
   logical_plan_verification.cpp
   relation_statistics.cpp
   remove_unused_columns.cpp

--- a/test/optimizer/join_order_stack_check.cpp
+++ b/test/optimizer/join_order_stack_check.cpp
@@ -1,0 +1,198 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+#include "duckdb/optimizer/join_order/join_order_optimizer.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/planner.hpp"
+
+#if defined(__linux__) && !defined(DUCKDB_NO_THREADS) && !defined(DUCKDB_WASM_VERSION)
+#include <pthread.h>
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace {
+
+using namespace duckdb;
+using std::exception;
+using std::move;
+using std::runtime_error;
+using std::string;
+using std::stringstream;
+
+constexpr size_t TEST_STACK_SIZE = 256 * 1024;
+
+struct ThreadState {
+	ThreadState(ClientContext &context_p, duckdb::unique_ptr<LogicalOperator> plan_p)
+	    : context(context_p), plan(std::move(plan_p)) {
+	}
+
+	ClientContext &context;
+	duckdb::unique_ptr<LogicalOperator> plan;
+	string error;
+	bool optimizer_entered = false;
+};
+
+static void ExecuteQuery(Connection &con, const string &sql) {
+	auto result = con.Query(sql);
+	if (result->HasError()) {
+		throw runtime_error(result->GetError());
+	}
+}
+
+static string BuildQuery() {
+	std::stringstream query;
+	query << R"SQL(
+WITH latest_config AS (
+	SELECT c.*
+	FROM configs c
+	WHERE (c.store_id, c.mobile_upload_date) IN (
+		SELECT store_id, max(mobile_upload_date)
+		FROM configs
+		WHERE logic_state = 1 AND is_temp = 0
+		GROUP BY store_id
+	)
+),
+base AS (
+	SELECT s.store_id, s.store_code, s.store_name, c.data_id,
+	       c.mobile_upload_date, o.pi4, o.pi5, o.pi6
+	FROM stores s
+	LEFT JOIN latest_config c ON c.store_id = s.store_id
+	LEFT JOIN store_organizations so ON so.store_id = s.store_id
+	LEFT JOIN organizations o ON o.org_id = so.org_id
+	LEFT JOIN distributor_stores ds ON ds.store_id = s.store_id
+	LEFT JOIN stores distributor ON distributor.store_id = ds.dist_id
+	WHERE s.store_type_id = 1
+	  AND s.state = 1
+	  AND o.pi4 = 100
+	GROUP BY s.store_id, s.store_code, s.store_name, c.data_id,
+	         c.mobile_upload_date, o.pi4, o.pi5, o.pi6
+),
+total AS (
+	SELECT b.store_id,
+		(SELECT org_name FROM organizations bo1 WHERE bo1.org_id = b.pi5) AS pi5_name,
+		(SELECT org_name FROM organizations bo1 WHERE bo1.org_id = b.pi6) AS pi6_name
+)SQL";
+
+	for (idx_t i = 1; i <= 72; i++) {
+		query << ",\n\t\t(SELECT max(iv.value) FROM item_values iv WHERE iv.data_id = b.data_id AND iv.item_id = "
+		      << i << ") AS item_" << i;
+	}
+
+	query << "\n\tFROM base b\n)\nSELECT count(*)\nFROM total";
+	return query.str();
+}
+
+static void *RunJoinOrderStackCheck(void *arg) {
+	auto &state = *static_cast<ThreadState *>(arg);
+	try {
+		JoinOrderOptimizer optimizer(state.context);
+		state.optimizer_entered = true;
+		state.plan = optimizer.Optimize(std::move(state.plan));
+		state.error = "query unexpectedly succeeded";
+	} catch (const exception &ex) {
+		state.error = ex.what();
+	} catch (...) {
+		state.error = "unknown error";
+	}
+	return nullptr;
+}
+
+TEST_CASE("Join-order optimizer checks the native stack", "[optimizer]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	ExecuteQuery(con, "SET max_expression_depth = 1000");
+	ExecuteQuery(con, R"SQL(
+CREATE TABLE stores (
+	store_id INTEGER,
+	store_code VARCHAR,
+	store_name VARCHAR,
+	store_type_id INTEGER,
+	state INTEGER
+))SQL");
+	ExecuteQuery(con, R"SQL(
+CREATE TABLE configs (
+	data_id INTEGER,
+	store_id INTEGER,
+	mobile_upload_date TIMESTAMP,
+	logic_state INTEGER,
+	is_temp INTEGER
+))SQL");
+	ExecuteQuery(con, R"SQL(
+CREATE TABLE organizations (
+	org_id INTEGER,
+	org_name VARCHAR,
+	pi4 INTEGER,
+	pi5 INTEGER,
+	pi6 INTEGER
+))SQL");
+	ExecuteQuery(con, R"SQL(
+CREATE TABLE store_organizations (
+	id INTEGER,
+	store_id INTEGER,
+	org_id INTEGER
+))SQL");
+	ExecuteQuery(con, R"SQL(
+CREATE TABLE distributor_stores (
+	store_id INTEGER,
+	dist_id INTEGER
+))SQL");
+	ExecuteQuery(con, R"SQL(
+CREATE TABLE item_values (
+	data_id INTEGER,
+	item_id INTEGER,
+	value INTEGER
+))SQL");
+
+	ExecuteQuery(con, R"SQL(
+INSERT INTO stores VALUES
+	(1, 'S0001', 'demo store', 1, 1),
+	(2, 'D0001', 'distributor', 2, 1)
+)SQL");
+	ExecuteQuery(con, R"SQL(
+INSERT INTO configs VALUES
+	(10, 1, TIMESTAMP '2025-01-01 00:00:00', 1, 0),
+	(11, 1, TIMESTAMP '2024-01-01 00:00:00', 1, 0)
+)SQL");
+	ExecuteQuery(con, R"SQL(
+INSERT INTO organizations VALUES
+	(200, 'main org', 100, 1000, 1001),
+	(1000, 'pi5 org', 0, 0, 0),
+	(1001, 'pi6 org', 0, 0, 0)
+)SQL");
+	ExecuteQuery(con, "INSERT INTO store_organizations VALUES (1, 1, 200)");
+	ExecuteQuery(con, "INSERT INTO distributor_stores VALUES (1, 2)");
+	ExecuteQuery(con, "INSERT INTO item_values SELECT 10, item_id, item_id FROM range(1, 73) AS items(item_id)");
+
+	con.BeginTransaction();
+	Parser parser(con.context->GetParserOptions());
+	parser.ParseQuery(BuildQuery());
+	REQUIRE(parser.statements.size() == 1);
+	Planner planner(*con.context);
+	planner.CreatePlan(std::move(parser.statements[0]));
+	REQUIRE(planner.plan);
+
+	ThreadState state(*con.context, std::move(planner.plan));
+	pthread_attr_t attributes;
+	REQUIRE(pthread_attr_init(&attributes) == 0);
+	REQUIRE(pthread_attr_setstacksize(&attributes, TEST_STACK_SIZE) == 0);
+
+	pthread_t thread;
+	const auto create_result = pthread_create(&thread, &attributes, RunJoinOrderStackCheck, &state);
+	REQUIRE(pthread_attr_destroy(&attributes) == 0);
+	REQUIRE(create_result == 0);
+	if (create_result != 0) {
+		return;
+	}
+
+	REQUIRE(pthread_join(thread, nullptr) == 0);
+	REQUIRE(state.optimizer_entered);
+	INFO(state.error);
+	REQUIRE(state.error.find("Insufficient stack space to process the query") != string::npos);
+	con.Rollback();
+}
+
+} // namespace
+#endif


### PR DESCRIPTION
Problem:
Correlated subqueries can make join-order optimization recurse deeply and exhaust the native thread stack before max_expression_depth can stop it.

Fix:
Add a Linux NativeStackChecker with native stack-bound lookup. Invoke it from the generic StackChecker constructor to cover recursive parser and expression binding paths, and directly at each join-order optimizer entry. Raise an input error before the native stack safety margin is exhausted.