### PR TITLE
Remove `LogicalType` from parsed `CastExpression`

### DIFF
--- a/.github/patches/extensions/mysql_scanner/0002-cast-expression-target-type.patch
+++ b/.github/patches/extensions/mysql_scanner/0002-cast-expression-target-type.patch
@@ -1,0 +1,53 @@
+diff --git a/src/mysql_sql_writer.cpp b/src/mysql_sql_writer.cpp
+index a610c64..e04be0c 100644
+--- a/src/mysql_sql_writer.cpp
++++ b/src/mysql_sql_writer.cpp
+@@ -479,10 +479,8 @@ string MySQLSQLWriter::WriteExpression(const ParsedExpression &expr) {
+ 			// instead of errors), numeric strings ('1e2', '5.7') and time zone offsets
+ 			// (SupportsPushdown verifies that the cast succeeds)
+ 			auto &value = cast_expr.Child().Cast<ConstantExpression>().GetValue();
+-			auto target_type = cast_expr.TargetType();
+-			if (target_type.id() == LogicalTypeId::UNBOUND) {
+-				target_type = UnboundType::TryDefaultBind(target_type);
+-			}
++			// the cast target is an unbound type expression - resolve it against the built-in types
++			auto target_type = UnboundType::TryDefaultBind(cast_expr.TargetType());
+ 			auto cast_result = value.DefaultTryCastAs(target_type);
+ 			if (!cast_result) {
+ 				throw InternalException("MySQLSQLWriter: cast of literal failed - should have been blocked by "
+@@ -490,7 +488,8 @@ string MySQLSQLWriter::WriteExpression(const ParsedExpression &expr) {
+ 			}
+ 			return WriteConstant(*cast_result);
+ 		}
+-		return "CAST(" + WriteExpression(cast_expr.Child()) + " AS " + WriteCastType(cast_expr.TargetType()) + ")";
++		return "CAST(" + WriteExpression(cast_expr.Child()) + " AS " +
++		       WriteCastType(UnboundType::TryDefaultBind(cast_expr.TargetType())) + ")";
+ 	}
+ 	case ExpressionClass::BETWEEN: {
+ 		auto &between = expr.Cast<BetweenExpression>();
+diff --git a/src/storage/mysql_catalog.cpp b/src/storage/mysql_catalog.cpp
+index d8a2dde..7210afd 100644
+--- a/src/storage/mysql_catalog.cpp
++++ b/src/storage/mysql_catalog.cpp
+@@ -1271,7 +1271,9 @@ bool MySQLCatalog::SupportsPushdown(const ParsedExpression &expr) {
+ 			// MySQL has no TRY_CAST
+ 			return false;
+ 		}
+-		if (!MySQLSupportsType(cast_expr.TargetType(), true)) {
++		// the cast target is an unbound type expression - resolve it against the built-in types
++		auto target_type = UnboundType::TryDefaultBind(cast_expr.TargetType());
++		if (!MySQLSupportsType(target_type, true)) {
+ 			return false;
+ 		}
+ 		// MySQL's CAST semantics differ from DuckDB's in several ways: malformed input returns
+@@ -1284,10 +1286,6 @@ bool MySQLCatalog::SupportsPushdown(const ParsedExpression &expr) {
+ 		// non-literal expressions over malformed data remain a documented limitation.
+ 		if (cast_expr.Child().GetExpressionClass() == ExpressionClass::CONSTANT) {
+ 			auto &value = cast_expr.Child().Cast<ConstantExpression>().GetValue();
+-			auto target_type = cast_expr.TargetType();
+-			if (target_type.id() == LogicalTypeId::UNBOUND) {
+-				target_type = UnboundType::TryDefaultBind(target_type);
+-			}
+ 			auto cast_result = value.DefaultTryCastAs(target_type);
+ 			if (!cast_result) {
+ 				return false;

--- a/scripts/generate_util.py
+++ b/scripts/generate_util.py
@@ -193,6 +193,15 @@ def generate_member_comparison(member, indent='\t'):
             f'{indent}\treturn false;',
             f'{indent}}}',
         ]
+    elif type_str == 'TypeExpression*':
+        return [
+            f'{indent}if (static_cast<bool>({field_name}) != static_cast<bool>(other_p.{field_name})) {{',
+            f'{indent}\treturn false;',
+            f'{indent}}}',
+            f'{indent}if ({field_name} && !{field_name}->Equals(*other_p.{field_name})) {{',
+            f'{indent}\treturn false;',
+            f'{indent}}}',
+        ]
     elif type_str == 'SelectStatement*':
         return [
             f'{indent}if (!{field_name} || !other_p.{field_name} || !{field_name}->Equals(*other_p.{field_name})) {{',
@@ -294,6 +303,11 @@ def generate_member_copy(member, indent='\t'):
     if is_order_modifier_ptr(type_str):
         base = member.get('base', 'ResultModifier')
         return [f'{indent}copy->{field} = {field} ? unique_ptr_cast<{base}, OrderModifier>({field}->Copy()) : nullptr;']
+
+    if type_str == 'TypeExpression*':
+        return [
+            f'{indent}copy->{field} = {field} ? unique_ptr_cast<ParsedExpression, TypeExpression>({field}->Copy()) : nullptr;'
+        ]
 
     if type_str == 'SelectStatement*':
         return [
@@ -403,6 +417,8 @@ def generate_member_hash(member, indent='\t'):
     field_name = get_member_field_name(member)
     type_str = member['type']
 
+    if type_str == 'TypeExpression*':
+        return [f'{indent}hash = CombineHash(hash, {field_name} ? {field_name}->Hash() : 0);']
     # Covered by EnumerateChildren in ParsedExpression::Hash
     if is_parsed_expression_ptr(type_str):
         return []

--- a/src/catalog/default/default_types.cpp
+++ b/src/catalog/default/default_types.cpp
@@ -91,12 +91,12 @@ LogicalType BindVarcharType(BindLogicalTypeInput &input) {
 LogicalType BindCollatedVarcharType(BindLogicalTypeInput &input) {
 	auto &collation = StringValue::Get(input.modifiers[0].GetValue());
 
-	if (!input.context) {
-		throw BinderException(input.query_location, "Cannot bind varchar with collation without a connection");
+	// The collation can only be checked against the catalog when there is a connection. Without one this is a
+	// type that was bound before - re-binding it, for instance to serialize it, must not lose the collation.
+	if (input.context) {
+		// Ensure this is a valid collation
+		ExpressionBinder::TestCollation(*input.context, collation);
 	}
-
-	// Ensure this is a valid collation
-	ExpressionBinder::TestCollation(*input.context, collation);
 
 	return LogicalType::VARCHAR_COLLATION(collation);
 }

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1990,6 +1990,10 @@ LogicalType UnboundType::TryDefaultBind(const LogicalType &unbound_type) {
 	return TryDefaultBindTypeExpression(*expr);
 }
 
+LogicalType UnboundType::TryDefaultBind(const ParsedExpression &type_expr) {
+	return TryDefaultBindTypeExpression(type_expr);
+}
+
 //===--------------------------------------------------------------------===//
 // Logical Type
 //===--------------------------------------------------------------------===//

--- a/src/common/util/util_parsed_expression.cpp
+++ b/src/common/util/util_parsed_expression.cpp
@@ -384,7 +384,10 @@ bool CastExpression::Equals(const ParsedExpression &other) const {
 	if (!ParsedExpression::Equals(child, other_p.child)) {
 		return false;
 	}
-	if (cast_type != other_p.cast_type) {
+	if (static_cast<bool>(cast_type) != static_cast<bool>(other_p.cast_type)) {
+		return false;
+	}
+	if (cast_type && !cast_type->Equals(*other_p.cast_type)) {
 		return false;
 	}
 	if (try_cast != other_p.try_cast) {
@@ -395,7 +398,7 @@ bool CastExpression::Equals(const ParsedExpression &other) const {
 
 hash_t CastExpression::Hash() const {
 	hash_t hash = ParsedExpression::Hash();
-	hash = CombineHash(hash, cast_type.Hash());
+	hash = CombineHash(hash, cast_type ? cast_type->Hash() : 0);
 	hash = CombineHash(hash, duckdb::Hash<bool>(try_cast));
 	return hash;
 }
@@ -403,7 +406,7 @@ hash_t CastExpression::Hash() const {
 unique_ptr<ParsedExpression> CastExpression::Copy() const {
 	auto copy = duckdb::unique_ptr<CastExpression>(new CastExpression());
 	copy->child = child ? child->Copy() : nullptr;
-	copy->cast_type = cast_type;
+	copy->cast_type = cast_type ? unique_ptr_cast<ParsedExpression, TypeExpression>(cast_type->Copy()) : nullptr;
 	copy->try_cast = try_cast;
 	copy->CopyBase(*this);
 	return std::move(copy);

--- a/src/include/duckdb/common/types.hpp
+++ b/src/include/duckdb/common/types.hpp
@@ -503,6 +503,7 @@ struct UnboundType {
 	// Try to bind the unbound type into a concrete type, using just the built in types
 	DUCKDB_API static LogicalType TryParseAndDefaultBind(const string &type_str);
 	DUCKDB_API static LogicalType TryDefaultBind(const LogicalType &unbound_type);
+	DUCKDB_API static LogicalType TryDefaultBind(const ParsedExpression &type_expr);
 	DUCKDB_API static const unique_ptr<ParsedExpression> &GetTypeExpression(const LogicalType &type);
 };
 

--- a/src/include/duckdb/parser/expression/cast_expression.hpp
+++ b/src/include/duckdb/parser/expression/cast_expression.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/parser/expression/type_expression.hpp"
 
 namespace duckdb {
 
@@ -19,15 +20,26 @@ public:
 	static constexpr const ExpressionClass TYPE = ExpressionClass::CAST;
 
 public:
-	DUCKDB_API CastExpression(LogicalType target, unique_ptr<ParsedExpression> child, bool try_cast = false);
+	DUCKDB_API CastExpression(unique_ptr<TypeExpression> target, unique_ptr<ParsedExpression> child,
+	                          bool try_cast = false);
+
+	//! Cast to an already-resolved type.
+	//! The type is written back out as a TypeExpression, so the target is always an unbound type expression.
+	//! See TypeExpression::FromLogicalType.
+	DUCKDB_API CastExpression(const LogicalType &target, unique_ptr<ParsedExpression> child, bool try_cast = false);
 
 public:
-	const LogicalType &TargetType() const {
+	const TypeExpression &TargetType() const {
+		return *cast_type;
+	}
+	const unique_ptr<TypeExpression> &GetTargetType() const {
 		return cast_type;
 	}
-	LogicalType &TargetTypeMutable() {
-		return cast_type;
+	TypeExpression &TargetTypeMutable() {
+		return *cast_type;
 	}
+	void SetTargetType(unique_ptr<TypeExpression> target);
+
 	const ParsedExpression &Child() const {
 		return *child;
 	}
@@ -58,8 +70,8 @@ public:
 private:
 	//! The child of the cast expression
 	unique_ptr<ParsedExpression> child;
-	//! The type to cast to
-	LogicalType cast_type;
+	//! The type to cast to, as an unbound type expression
+	unique_ptr<TypeExpression> cast_type;
 	//! Whether or not this is a try_cast expression
 	bool try_cast;
 

--- a/src/include/duckdb/parser/expression/type_expression.hpp
+++ b/src/include/duckdb/parser/expression/type_expression.hpp
@@ -25,6 +25,11 @@ public:
 	TypeExpression(const string &type_name, vector<unique_ptr<ParsedExpression>> children);
 
 public:
+	//! The type expression that binds back to `type`. The inverse of binding a TypeExpression: every
+	//! parameterised built-in is written out with its parameters, and a type that carries an alias (a
+	//! user-defined type) is named by that alias. Throws for types that have no SQL spelling.
+	DUCKDB_API static unique_ptr<TypeExpression> FromLogicalType(const LogicalType &type);
+
 	const QualifiedName &GetQualifiedName() const {
 		return qualified_name;
 	}

--- a/src/include/duckdb/planner/binder.hpp
+++ b/src/include/duckdb/planner/binder.hpp
@@ -360,6 +360,8 @@ public:
 	static void BindSchemaOrCatalog(ClientContext &context, QualifiedName &qualified_name);
 
 	void BindLogicalType(LogicalType &type);
+	//! Resolve a type expression into a concrete type
+	LogicalType BindLogicalType(const ParsedExpression &type_expr);
 
 	optional_ptr<Binding> GetMatchingBinding(const Identifier &table_name, const Identifier &column_name,
 	                                         ErrorData &error);
@@ -645,8 +647,6 @@ private:
 
 	vector<CatalogSearchEntry> GetSearchPath(Catalog &catalog, const Identifier &schema_name,
 	                                         bool default_schema_precedence = false);
-
-	LogicalType BindLogicalTypeInternal(const unique_ptr<ParsedExpression> &type_expr);
 
 	BoundStatement BindSelectNode(SelectNode &statement, BoundStatement from_table);
 

--- a/src/include/duckdb/storage/serialization/parsed_expression.json
+++ b/src/include/duckdb/storage/serialization/parsed_expression.json
@@ -115,14 +115,15 @@
       {
         "id": 201,
         "name": "cast_type",
-        "type": "LogicalType"
+        "type": "TypeExpression*"
       },
       {
         "id": 202,
         "name": "try_cast",
         "type": "bool"
       }
-    ]
+    ],
+    "custom_implementation": true
   },
   {
     "class": "CollateExpression",

--- a/src/optimizer/remote_pushdown_optimizer.cpp
+++ b/src/optimizer/remote_pushdown_optimizer.cpp
@@ -1404,16 +1404,10 @@ void RemotePushdownOptimizer::StripCatalogName(ParsedExpression &expr, const Ide
 		}
 		// Fall through to EnumerateChildren to strip catalog refs inside partitions/orders/children
 	} else if (expr.GetExpressionClass() == ExpressionClass::CAST) {
-		// CastExpression stores the cast target as a LogicalType, not an expression child — EnumerateChildren
-		// only visits the value being cast. For unbound (user-defined) types we must strip the catalog from the
-		// embedded TypeExpression and reconstruct the LogicalType::UNBOUND wrapper.
+		// The cast target is not an expression child, so EnumerateChildren only visits the value being cast -
+		// strip the catalog from the target type expression separately.
 		auto &cast_expr = expr.Cast<CastExpression>();
-		auto &target_type = cast_expr.TargetTypeMutable();
-		if (target_type.id() == LogicalTypeId::UNBOUND) {
-			auto type_expr = UnboundType::GetTypeExpression(target_type)->Copy();
-			StripCatalogName(*type_expr, catalog_name);
-			target_type = LogicalType::UNBOUND(std::move(type_expr));
-		}
+		StripCatalogName(cast_expr.TargetTypeMutable(), catalog_name);
 		// Fall through to EnumerateChildren to strip catalog refs inside the cast argument
 	} else if (expr.GetExpressionClass() == ExpressionClass::TYPE) {
 		// TypeExpression (used as a type argument) may carry catalog/schema qualifiers.

--- a/src/parser/expression/cast_expression.cpp
+++ b/src/parser/expression/cast_expression.cpp
@@ -35,9 +35,11 @@ void CastExpression::Serialize(Serializer &serializer) const {
 	ParsedExpression::Serialize(serializer);
 	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(200, "child", child);
 	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
-		// older versions store the cast target as a LogicalType
+		// Older versions store the cast target as a LogicalType. Resolve built-in types rather than writing an
+		// unbound type: below v1.5.0 an unbound type degrades to the legacy USER type, whose modifiers are bare
+		// values, so a named modifier such as a VARCHAR collation would be lost.
 		D_ASSERT(cast_type);
-		serializer.WriteProperty<LogicalType>(201, "cast_type", LogicalType::UNBOUND(cast_type->Copy()));
+		serializer.WriteProperty<LogicalType>(201, "cast_type", UnboundType::TryDefaultBind(*cast_type));
 	}
 	serializer.WritePropertyWithDefault<bool>(202, "try_cast", try_cast);
 	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {

--- a/src/parser/expression/cast_expression.cpp
+++ b/src/parser/expression/cast_expression.cpp
@@ -1,20 +1,65 @@
 #include "duckdb/parser/expression/cast_expression.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/storage/storage_info.hpp"
 
 namespace duckdb {
 
-CastExpression::CastExpression(LogicalType target, unique_ptr<ParsedExpression> child, bool try_cast_p)
+CastExpression::CastExpression(unique_ptr<TypeExpression> target, unique_ptr<ParsedExpression> child_p, bool try_cast_p)
     : ParsedExpression(ExpressionType::OPERATOR_CAST, ExpressionClass::CAST), cast_type(std::move(target)),
       try_cast(try_cast_p) {
-	D_ASSERT(child);
-	this->child = std::move(child);
+	D_ASSERT(child_p);
+	D_ASSERT(cast_type);
+	this->child = std::move(child_p);
+}
+
+CastExpression::CastExpression(const LogicalType &target, unique_ptr<ParsedExpression> child_p, bool try_cast_p)
+    : CastExpression(TypeExpression::FromLogicalType(target), std::move(child_p), try_cast_p) {
 }
 
 CastExpression::CastExpression() : ParsedExpression(ExpressionType::OPERATOR_CAST, ExpressionClass::CAST) {
 }
 
+void CastExpression::SetTargetType(unique_ptr<TypeExpression> target) {
+	D_ASSERT(target);
+	cast_type = std::move(target);
+}
+
 string CastExpression::ToString() const {
 	return ToString<CastExpression, ParsedExpression>(*this);
+}
+
+void CastExpression::Serialize(Serializer &serializer) const {
+	ParsedExpression::Serialize(serializer);
+	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(200, "child", child);
+	if (!serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+		// older versions store the cast target as a LogicalType
+		D_ASSERT(cast_type);
+		serializer.WriteProperty<LogicalType>(201, "cast_type", LogicalType::UNBOUND(cast_type->Copy()));
+	}
+	serializer.WritePropertyWithDefault<bool>(202, "try_cast", try_cast);
+	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
+		serializer.WritePropertyWithDefault<unique_ptr<TypeExpression>>(203, "type_expr", cast_type);
+	}
+}
+
+unique_ptr<ParsedExpression> CastExpression::Deserialize(Deserializer &deserializer) {
+	auto result = duckdb::unique_ptr<CastExpression>(new CastExpression());
+	deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(200, "child", result->child);
+	auto cast_type = deserializer.ReadPropertyWithExplicitDefault<LogicalType>(201, "cast_type", LogicalType::INVALID);
+	deserializer.ReadPropertyWithDefault<bool>(202, "try_cast", result->try_cast);
+	auto type_expression =
+	    deserializer.ReadPropertyWithExplicitDefault<unique_ptr<ParsedExpression>>(203, "type_expr", nullptr);
+
+	if (type_expression) {
+		result->cast_type = unique_ptr_cast<ParsedExpression, TypeExpression>(std::move(type_expression));
+	} else {
+		// written by a version that stored the target as a LogicalType
+		result->cast_type = TypeExpression::FromLogicalType(cast_type);
+	}
+	return std::move(result);
 }
 
 } // namespace duckdb

--- a/src/parser/expression/type_expression.cpp
+++ b/src/parser/expression/type_expression.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/parser/expression/type_expression.hpp"
+#include "duckdb/common/types/geometry_crs.hpp"
+#include "duckdb/common/extension_type_info.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -106,6 +108,206 @@ string TypeExpression::ToString() const {
 		result += ")";
 	}
 	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// LogicalType -> TypeExpression
+//===--------------------------------------------------------------------===//
+
+namespace {
+
+unique_ptr<ParsedExpression> TypeChild(const LogicalType &type, const Identifier &name) {
+	auto child = TypeExpression::FromLogicalType(type);
+	if (!name.empty()) {
+		child->SetAlias(name);
+	}
+	return std::move(child);
+}
+
+unique_ptr<ParsedExpression> ValueChild(Value value, const char *label = nullptr) {
+	auto child = make_uniq_base<ParsedExpression, ConstantExpression>(std::move(value));
+	if (label) {
+		child->SetAlias(Identifier(label));
+	}
+	return child;
+}
+
+//! The name a built-in type is spelled with. Must be a name DefaultTypeGenerator knows.
+const char *BuiltinTypeName(LogicalTypeId id) {
+	switch (id) {
+	case LogicalTypeId::BOOLEAN:
+		return "BOOLEAN";
+	case LogicalTypeId::TINYINT:
+		return "TINYINT";
+	case LogicalTypeId::SMALLINT:
+		return "SMALLINT";
+	case LogicalTypeId::INTEGER:
+		return "INTEGER";
+	case LogicalTypeId::BIGINT:
+		return "BIGINT";
+	case LogicalTypeId::HUGEINT:
+		return "HUGEINT";
+	case LogicalTypeId::UTINYINT:
+		return "UTINYINT";
+	case LogicalTypeId::USMALLINT:
+		return "USMALLINT";
+	case LogicalTypeId::UINTEGER:
+		return "UINTEGER";
+	case LogicalTypeId::UBIGINT:
+		return "UBIGINT";
+	case LogicalTypeId::UHUGEINT:
+		return "UHUGEINT";
+	case LogicalTypeId::FLOAT:
+		return "FLOAT";
+	case LogicalTypeId::DOUBLE:
+		return "DOUBLE";
+	case LogicalTypeId::BIGNUM:
+		return "BIGNUM";
+	case LogicalTypeId::DATE:
+		return "DATE";
+	case LogicalTypeId::TIME:
+		return "TIME";
+	case LogicalTypeId::TIME_NS:
+		return "TIME_NS";
+	case LogicalTypeId::TIME_TZ:
+		return "TIMETZ";
+	case LogicalTypeId::TIMESTAMP:
+		return "TIMESTAMP_US";
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return "TIMESTAMP_S";
+	case LogicalTypeId::TIMESTAMP_MS:
+		return "TIMESTAMP_MS";
+	case LogicalTypeId::TIMESTAMP_NS:
+		return "TIMESTAMP_NS";
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return "TIMESTAMPTZ";
+	case LogicalTypeId::TIMESTAMP_TZ_NS:
+		return "TIMESTAMPTZ_NS";
+	case LogicalTypeId::INTERVAL:
+		return "INTERVAL";
+	case LogicalTypeId::VARCHAR:
+		return "VARCHAR";
+	case LogicalTypeId::BLOB:
+		return "BLOB";
+	case LogicalTypeId::BIT:
+		return "BIT";
+	case LogicalTypeId::UUID:
+		return "UUID";
+	case LogicalTypeId::SQLNULL:
+		return "NULL";
+	case LogicalTypeId::TYPE:
+		return "TYPE";
+	case LogicalTypeId::VARIANT:
+		return "VARIANT";
+	case LogicalTypeId::GEOMETRY:
+		return "GEOMETRY";
+	case LogicalTypeId::DECIMAL:
+		return "DECIMAL";
+	case LogicalTypeId::ENUM:
+		return "ENUM";
+	case LogicalTypeId::LIST:
+		return "LIST";
+	case LogicalTypeId::ARRAY:
+		return "ARRAY";
+	case LogicalTypeId::STRUCT:
+		return "STRUCT";
+	case LogicalTypeId::TUPLE:
+		return "TUPLE";
+	case LogicalTypeId::MAP:
+		return "MAP";
+	case LogicalTypeId::UNION:
+		return "UNION";
+	default:
+		return nullptr;
+	}
+}
+
+} // namespace
+
+unique_ptr<TypeExpression> TypeExpression::FromLogicalType(const LogicalType &type) {
+	if (type.IsUnbound()) {
+		auto &expr = UnboundType::GetTypeExpression(type);
+		if (expr->GetExpressionClass() != ExpressionClass::TYPE) {
+			throw InternalException("Unbound type does not wrap a type expression");
+		}
+		return unique_ptr_cast<ParsedExpression, TypeExpression>(expr->Copy());
+	}
+
+	vector<unique_ptr<ParsedExpression>> children;
+
+	// A type that carries an alias is a user-defined type: name it, and let the binder resolve it again.
+	auto alias = type.GetAlias();
+	if (!alias.empty()) {
+		if (type.HasExtensionInfo()) {
+			for (auto &modifier : type.GetExtensionInfo()->modifiers) {
+				children.push_back(ValueChild(modifier.value));
+			}
+		}
+		return make_uniq<TypeExpression>(Identifier(alias), std::move(children));
+	}
+
+	auto name = BuiltinTypeName(type.id());
+	if (!name) {
+		// only the internal placeholder ids (ANY, UNKNOWN, INVALID, ...) have no name, and none of them is a
+		// type a user can name in the first place
+		throw InternalException("Type '%s' cannot be expressed as a type expression", type.ToString());
+	}
+
+	switch (type.id()) {
+	case LogicalTypeId::DECIMAL:
+		children.push_back(ValueChild(Value::UTINYINT(DecimalType::GetWidth(type))));
+		children.push_back(ValueChild(Value::UTINYINT(DecimalType::GetScale(type))));
+		break;
+	case LogicalTypeId::VARCHAR: {
+		auto collation = StringType::GetCollation(type);
+		if (!collation.empty()) {
+			children.push_back(ValueChild(Value(collation), "collation"));
+		}
+		break;
+	}
+	case LogicalTypeId::GEOMETRY:
+		if (GeoType::HasCRS(type)) {
+			children.push_back(ValueChild(Value(GeoType::GetCRS(type).GetDefinition())));
+		}
+		break;
+	case LogicalTypeId::ENUM:
+		for (idx_t i = 0; i < EnumType::GetSize(type); i++) {
+			children.push_back(ValueChild(Value(EnumType::GetString(type, i).GetString())));
+		}
+		break;
+	case LogicalTypeId::LIST:
+		children.push_back(TypeChild(ListType::GetChildType(type), Identifier()));
+		break;
+	case LogicalTypeId::ARRAY:
+		children.push_back(TypeChild(ArrayType::GetChildType(type), Identifier()));
+		if (!ArrayType::IsAnySize(type)) {
+			children.push_back(ValueChild(Value::UBIGINT(ArrayType::GetSize(type))));
+		}
+		break;
+	case LogicalTypeId::STRUCT:
+		for (auto &child : StructType::GetChildTypes(type)) {
+			children.push_back(TypeChild(child.second, child.first));
+		}
+		break;
+	case LogicalTypeId::TUPLE:
+		for (auto &child : StructType::GetChildTypes(type)) {
+			children.push_back(TypeChild(child.second, Identifier()));
+		}
+		break;
+	case LogicalTypeId::MAP:
+		children.push_back(TypeChild(MapType::KeyType(type), Identifier()));
+		children.push_back(TypeChild(MapType::ValueType(type), Identifier()));
+		break;
+	case LogicalTypeId::UNION:
+		for (idx_t i = 0; i < UnionType::GetMemberCount(type); i++) {
+			children.push_back(TypeChild(UnionType::GetMemberType(type, i), UnionType::GetMemberName(type, i)));
+		}
+		break;
+	default:
+		break;
+	}
+
+	return make_uniq<TypeExpression>(Identifier(name), std::move(children));
 }
 
 void TypeExpression::Verify() const {

--- a/src/planner/binder/expression/bind_cast_expression.cpp
+++ b/src/planner/binder/expression/bind_cast_expression.cpp
@@ -14,18 +14,18 @@ BindResult ExpressionBinder::BindExpression(CastExpression &expr, idx_t depth) {
 	}
 	// FIXME: We can also implement 'hello'::schema.custom_type; and pass by the schema down here.
 	// Right now just considering its DEFAULT_SCHEMA always
-	binder.BindLogicalType(expr.TargetTypeMutable());
+	auto target_type = binder.BindLogicalType(expr.TargetType());
 	// the children have been successfully resolved
 	auto child = std::move(result.expression);
 	if (expr.IsTryCast()) {
-		if (ExpressionBinder::GetExpressionReturnType(*child) == expr.TargetType()) {
+		if (ExpressionBinder::GetExpressionReturnType(*child) == target_type) {
 			// no cast required: type matches
 			return BindResult(std::move(child));
 		}
-		child = BoundCastExpression::AddCastToType(context, std::move(child), expr.TargetType(), true);
+		child = BoundCastExpression::AddCastToType(context, std::move(child), target_type, true);
 	} else {
 		// otherwise add a cast to the target type
-		child = BoundCastExpression::AddCastToType(context, std::move(child), expr.TargetType());
+		child = BoundCastExpression::AddCastToType(context, std::move(child), target_type);
 	}
 	return BindResult(std::move(child));
 }

--- a/src/planner/binder/statement/bind_create.cpp
+++ b/src/planner/binder/statement/bind_create.cpp
@@ -601,17 +601,17 @@ SchemaCatalogEntry &Binder::BindCreateFunctionInfo(CreateInfo &info) {
 	return BindCreateSchema(info);
 }
 
-LogicalType Binder::BindLogicalTypeInternal(const unique_ptr<ParsedExpression> &type_expr) {
+LogicalType Binder::BindLogicalType(const ParsedExpression &type_expr) {
 	ConstantBinder binder(*this, context, "Type binding");
-	auto copy = type_expr->Copy();
+	auto copy = type_expr.Copy();
 	auto expr = binder.Bind(copy);
 
 	if (!expr->IsFoldable()) {
-		throw BinderException(*type_expr, "Type expression is not constant");
+		throw BinderException(type_expr, "Type expression is not constant");
 	}
 
 	if (expr->GetReturnType() != LogicalTypeId::TYPE) {
-		throw BinderException(*type_expr, "Expected a type returning expression, but got expression of type '%s'",
+		throw BinderException(type_expr, "Expected a type returning expression, but got expression of type '%s'",
 		                      expr->GetReturnType().ToString());
 	}
 
@@ -639,7 +639,7 @@ void Binder::BindLogicalType(LogicalType &type) {
 	type = TypeVisitor::VisitReplace(type, [&](const LogicalType &ty) {
 		if (ty.id() == LogicalTypeId::UNBOUND) {
 			auto &type_expr = UnboundType::GetTypeExpression(ty);
-			return BindLogicalTypeInternal(type_expr);
+			return BindLogicalType(*type_expr);
 		}
 
 		return ty;

--- a/src/storage/serialization/serialize_parsed_expression.cpp
+++ b/src/storage/serialization/serialize_parsed_expression.cpp
@@ -123,21 +123,6 @@ unique_ptr<ParsedExpression> CaseExpression::Deserialize(Deserializer &deseriali
 	return std::move(result);
 }
 
-void CastExpression::Serialize(Serializer &serializer) const {
-	ParsedExpression::Serialize(serializer);
-	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(200, "child", child);
-	serializer.WriteProperty<LogicalType>(201, "cast_type", cast_type);
-	serializer.WritePropertyWithDefault<bool>(202, "try_cast", try_cast);
-}
-
-unique_ptr<ParsedExpression> CastExpression::Deserialize(Deserializer &deserializer) {
-	auto result = duckdb::unique_ptr<CastExpression>(new CastExpression());
-	deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(200, "child", result->child);
-	deserializer.ReadProperty<LogicalType>(201, "cast_type", result->cast_type);
-	deserializer.ReadPropertyWithDefault<bool>(202, "try_cast", result->try_cast);
-	return std::move(result);
-}
-
 void CollateExpression::Serialize(Serializer &serializer) const {
 	ParsedExpression::Serialize(serializer);
 	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(200, "child", child);

--- a/test/sql/types/cast_expression_storage_version.test
+++ b/test/sql/types/cast_expression_storage_version.test
@@ -1,0 +1,80 @@
+# name: test/sql/types/cast_expression_storage_version.test
+# description: A CastExpression stores its target as a TypeExpression from v2.0.0 on, and as a LogicalType below that. Both are readable.
+# group: [types]
+
+# Generated columns and macro bodies put a CastExpression into the catalog, so both storage versions
+# have to round-trip through the persisted format.
+
+statement ok
+ATTACH '{TEST_DIR}/cast_expr_old.db' AS oldb (STORAGE_VERSION 'v1.5.0');
+
+statement ok
+ATTACH '{TEST_DIR}/cast_expr_new.db' AS newb (STORAGE_VERSION 'v2.0.0');
+
+statement ok
+CREATE TYPE oldb.mood AS ENUM('sad', 'ok', 'happy');
+
+statement ok
+CREATE TYPE newb.mood AS ENUM('sad', 'ok', 'happy');
+
+foreach db oldb newb
+
+statement ok
+CREATE TABLE {db}.t (
+    v VARCHAR,
+    g DECIMAL(9,2)               GENERATED ALWAYS AS (1.5),
+    s STRUCT(k INTEGER, v VARCHAR) GENERATED ALWAYS AS ({'k':1,'v':'x'}),
+    e {db}.mood                 GENERATED ALWAYS AS ('ok')
+);
+
+statement ok
+CREATE MACRO {db}.mm(a) AS a::DECIMAL(9,2);
+
+statement ok
+INSERT INTO {db}.t (v) VALUES ('a');
+
+endloop
+
+statement ok
+CHECKPOINT oldb;
+
+statement ok
+CHECKPOINT newb;
+
+statement ok
+DETACH oldb;
+
+statement ok
+DETACH newb;
+
+# reopen both and check the cast targets survived
+statement ok
+ATTACH '{TEST_DIR}/cast_expr_old.db' AS oldb (READ_ONLY);
+
+statement ok
+ATTACH '{TEST_DIR}/cast_expr_new.db' AS newb (READ_ONLY);
+
+query I
+SELECT tags.storage_version FROM duckdb_databases() WHERE database_name = 'oldb';
+----
+v1.5.0+
+
+query IIII
+SELECT typeof(g), typeof(s), typeof(e), g FROM oldb.t
+----
+DECIMAL(9,2)	STRUCT(k INTEGER, v VARCHAR)	ENUM('sad', 'ok', 'happy')	1.50
+
+query IIII
+SELECT typeof(g), typeof(s), typeof(e), g FROM newb.t
+----
+DECIMAL(9,2)	STRUCT(k INTEGER, v VARCHAR)	ENUM('sad', 'ok', 'happy')	1.50
+
+query I
+SELECT typeof(oldb.mm(1))
+----
+DECIMAL(9,2)
+
+query I
+SELECT typeof(newb.mm(1))
+----
+DECIMAL(9,2)

--- a/test/sql/types/cast_expression_storage_version.test
+++ b/test/sql/types/cast_expression_storage_version.test
@@ -78,3 +78,36 @@ query I
 SELECT typeof(newb.mm(1))
 ----
 DECIMAL(9,2)
+
+# A cast target carrying a named type modifier - a VARCHAR collation - must survive the pre-v1.5.0
+# format, which stores an unbound type as a legacy USER type whose modifiers carry no names. The
+# generated column wraps its expression in a cast to the bound (collated) type.
+
+statement ok
+ATTACH '{TEST_DIR}/cast_expr_collate.db' AS colldb (STORAGE_VERSION 'v1.4.0');
+
+statement ok
+CREATE TABLE colldb.coll (g AS (x), x VARCHAR COLLATE NOCASE);
+
+statement ok
+INSERT INTO colldb.coll VALUES ('string'), ('STRING');
+
+statement ok
+CHECKPOINT colldb;
+
+statement ok
+DETACH colldb;
+
+statement ok
+ATTACH '{TEST_DIR}/cast_expr_collate.db' AS colldb (READ_ONLY);
+
+query I
+SELECT generation_expression FROM duckdb_columns() WHERE table_name = 'coll' AND column_name = 'g';
+----
+CAST(x AS VARCHAR COLLATE NOCASE)
+
+# the collation is not just rendered, it is still applied to the generated column
+query I
+SELECT count(*) FROM colldb.coll WHERE g = 'string';
+----
+2

--- a/test/sql/types/type_expression_roundtrip.test
+++ b/test/sql/types/type_expression_roundtrip.test
@@ -1,0 +1,84 @@
+# name: test/sql/types/type_expression_roundtrip.test
+# description: A bound type written back out as a TypeExpression (CastExpression's LogicalType constructor) binds to the same type
+# group: [types]
+
+statement ok
+CREATE TYPE mood AS ENUM('sad', 'ok', 'happy');
+
+statement ok
+CREATE TYPE pt AS STRUCT(x DOUBLE, y DOUBLE);
+
+# Generated columns wrap their expression in a cast to the declared type, so the declared type is
+# bound, written back out as a type expression, and bound again.
+
+statement ok
+CREATE TABLE gen (
+    v VARCHAR,
+    c_dec      DECIMAL(9,2)                        GENERATED ALWAYS AS (1.5),
+    c_arr      INTEGER[3]                          GENERATED ALWAYS AS ([1,2,3]),
+    c_list     INTEGER[]                           GENERATED ALWAYS AS ([1,2]),
+    c_nested   INTEGER[][]                         GENERATED ALWAYS AS ([[1],[2]]),
+    c_struct   STRUCT(k INTEGER, v VARCHAR)        GENERATED ALWAYS AS ({'k':1,'v':'x'}),
+    c_tuple    TUPLE(INTEGER, VARCHAR)             GENERATED ALWAYS AS ((1,'a')),
+    c_map      MAP(VARCHAR, INTEGER)               GENERATED ALWAYS AS (MAP{'a':1}),
+    c_union    UNION(n INTEGER, s VARCHAR)         GENERATED ALWAYS AS (union_value(n := 1)),
+    c_enum     mood                                GENERATED ALWAYS AS ('ok'),
+    c_udt      pt                                  GENERATED ALWAYS AS ({'x':1.0,'y':2.0}),
+    c_tsns     TIMESTAMP_NS                        GENERATED ALWAYS AS (TIMESTAMP '2020-01-01'),
+    c_tstz     TIMESTAMPTZ                         GENERATED ALWAYS AS (TIMESTAMP '2020-01-01'),
+    c_ts_s     TIMESTAMP_S                         GENERATED ALWAYS AS (TIMESTAMP '2020-01-01'),
+    c_timetz   TIMETZ                              GENERATED ALWAYS AS (TIME '12:00:00'),
+    c_uuid     UUID                                GENERATED ALWAYS AS ('00000000-0000-0000-0000-000000000001'),
+    c_blob     BLOB                                GENERATED ALWAYS AS ('abc'),
+    c_bit      BIT                                 GENERATED ALWAYS AS ('101'),
+    c_bignum   BIGNUM                              GENERATED ALWAYS AS (1),
+    c_hugeint  HUGEINT                             GENERATED ALWAYS AS (1),
+    c_uhugeint UHUGEINT                            GENERATED ALWAYS AS (1),
+    c_interval INTERVAL                            GENERATED ALWAYS AS (INTERVAL 1 DAY),
+    c_null     "NULL"                              GENERATED ALWAYS AS (NULL)
+);
+
+statement ok
+INSERT INTO gen (v) VALUES ('a');
+
+query IIIIII
+SELECT typeof(c_dec), typeof(c_arr), typeof(c_list), typeof(c_nested), typeof(c_struct), typeof(c_tuple) FROM gen
+----
+DECIMAL(9,2)	INTEGER[3]	INTEGER[]	INTEGER[][]	STRUCT(k INTEGER, v VARCHAR)	TUPLE(INTEGER, VARCHAR)
+
+query IIIIII
+SELECT typeof(c_map), typeof(c_union), typeof(c_tsns), typeof(c_tstz), typeof(c_ts_s), typeof(c_timetz) FROM gen
+----
+MAP(VARCHAR, INTEGER)	UNION(n INTEGER, s VARCHAR)	TIMESTAMP_NS	TIMESTAMP WITH TIME ZONE	TIMESTAMP_S	TIME WITH TIME ZONE
+
+query IIIIIII
+SELECT typeof(c_uuid), typeof(c_blob), typeof(c_bit), typeof(c_bignum), typeof(c_hugeint), typeof(c_uhugeint), typeof(c_interval) FROM gen
+----
+UUID	BLOB	BIT	BIGNUM	HUGEINT	UHUGEINT	INTERVAL
+
+query II
+SELECT c_enum, c_udt FROM gen
+----
+ok	{'x': 1.0, 'y': 2.0}
+
+# the values survive the round trip, not just the types
+query IIIII
+SELECT c_dec, c_arr, c_map, c_union, c_interval FROM gen
+----
+1.50	[1, 2, 3]	{a=1}	1	1 day
+
+# typed macro parameters take the same path: the bound parameter type becomes a cast target.
+# TEMP so the test does not depend on the database's storage version - typed parameters require v1.4.0+.
+statement ok
+CREATE TEMP MACRO take_dec(a DECIMAL(9,2)) AS a;
+
+statement ok
+CREATE TEMP MACRO take_struct(a STRUCT(k INTEGER, v VARCHAR)) AS a;
+
+statement ok
+CREATE TEMP MACRO take_arr(a INTEGER[3]) AS a;
+
+query III
+SELECT typeof(take_dec(1.5::DECIMAL(9,2))), typeof(take_struct({'k':1,'v':'x'})), typeof(take_arr([1,2,3]::INTEGER[3]))
+----
+DECIMAL(9,2)	STRUCT(k INTEGER, v VARCHAR)	INTEGER[3]


### PR DESCRIPTION
This PR removes the `LogicalType cast_type` member from the parsed `CastExpression`, replacing it with a `TypeExpression`.

This is mostly to future-proof serialization and a minor step towards removing bound `LogicalTypes` from the parser/parse tree entirely.

Backwards compatibility is preserved by serializing into a UNBOUND type, which itself gets default-bound when serialized.