### PR TITLE
Apply collations to struct and tuple fields

### DIFF
--- a/src/function/scalar/list/contains_or_position.cpp
+++ b/src/function/scalar/list/contains_or_position.cpp
@@ -1,12 +1,43 @@
 #include "duckdb/function/scalar/list_functions.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/storage/statistics/list_stats.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
 
 namespace duckdb {
+
+static unique_ptr<FunctionData> ListSearchBind(BindScalarFunctionInput &input) {
+	auto &arguments = input.GetArguments();
+	auto &function = input.GetBoundFunction();
+	auto &context = input.GetClientContext();
+	auto list_type = arguments[0]->GetReturnType();
+	if (list_type.id() != LogicalTypeId::LIST && list_type.id() != LogicalTypeId::ARRAY) {
+		return nullptr;
+	}
+	auto &child_type =
+	    list_type.id() == LogicalTypeId::LIST ? ListType::GetChildType(list_type) : ArrayType::GetChildType(list_type);
+	auto is_struct = [](const LogicalType &type) {
+		return StructType::IsStruct(type);
+	};
+	if (!TypeVisitor::Contains(child_type, is_struct) &&
+	    !TypeVisitor::Contains(arguments[1]->GetReturnType(), is_struct)) {
+		return nullptr;
+	}
+	auto comparison_type = LogicalType::MaxLogicalType(context, child_type, arguments[1]->GetReturnType());
+	// Merge the element types before pushing collations so each field uses the collation from either argument.
+	vector<LogicalType> types {LogicalType::LIST(comparison_type), comparison_type};
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		arguments[i] = BoundCastExpression::AddCastToType(context, std::move(arguments[i]), types[i]);
+		ExpressionBinder::PushCollation(context, arguments[i], types[i], CollationType::COMBINABLE_COLLATIONS);
+		function.GetArguments()[i] = arguments[i]->GetReturnType();
+	}
+	return nullptr;
+}
 
 template <class RETURN_TYPE, bool FIND_NULLS = false>
 static void ListSearchFunction(DataChunk &input, ExpressionState &state, Vector &result) {
@@ -77,6 +108,7 @@ ScalarFunction ListContainsFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::TEMPLATE("T")},
 	                          LogicalType::BOOLEAN, ListSearchFunction<bool>);
 	fun.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
+	fun.SetBindCallback(ListSearchBind);
 	fun.SetFilterPruneCallback(ListContainsFilterPrune);
 	return fun;
 }
@@ -86,6 +118,7 @@ ScalarFunction ListPositionFun::GetFunction() {
 	                          LogicalType::INTEGER, ListSearchFunction<int32_t, true>);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	fun.SetCollationHandling(FunctionCollationHandling::PUSH_COMBINABLE_COLLATIONS);
+	fun.SetBindCallback(ListSearchBind);
 	fun.SetStatisticsCallback(ListPositionPropagateStats);
 	return fun;
 }

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -2,7 +2,10 @@
 #include "duckdb/catalog/catalog_entry/collate_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_case_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_lambda_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/settings.hpp"
@@ -106,24 +109,76 @@ void CollationBinding::RegisterCollation(CollationCallback callback) {
 	collations.push_back(callback);
 }
 
-//! Binds the scalar function with the given name (looked up from the system catalog) around "source".
-static unique_ptr<Expression> ApplyCollationFunction(ClientContext &context, const string &function_name,
-                                                     unique_ptr<Expression> source) {
+static unique_ptr<Expression> BindCollationFunction(ClientContext &context, const string &function_name,
+                                                    vector<unique_ptr<Expression>> children) {
 	auto &catalog = Catalog::GetSystemCatalog(context);
 	auto &function_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
 	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), Identifier(function_name)));
-	auto source_alias = source->GetAlias();
-	vector<unique_ptr<Expression>> children;
-	children.push_back(std::move(source));
-
 	FunctionBinder function_binder(context);
 	ErrorData error;
 	auto function = function_binder.BindScalarFunction(function_entry, std::move(children), error);
 	if (!function) {
 		error.Throw();
 	}
+	return function;
+}
+
+//! Binds the scalar function with the given name (looked up from the system catalog) around "source".
+static unique_ptr<Expression> ApplyCollationFunction(ClientContext &context, const string &function_name,
+                                                     unique_ptr<Expression> source) {
+	auto source_alias = source->GetAlias();
+	vector<unique_ptr<Expression>> children;
+	children.push_back(std::move(source));
+	auto function = BindCollationFunction(context, function_name, std::move(children));
 	function->SetAlias(source_alias);
 	return function;
+}
+
+//! Pushes collations into STRUCT/TUPLE fields using invoke with a lambda that rebuilds the value and preserves NULLs.
+//! Evaluates the source once. Returns false if no fields require collation.
+static bool PushStructCollation(ClientContext &context, unique_ptr<Expression> &source, const LogicalType &sql_type,
+                                CollationType type, const CollationBinding &binding) {
+	const Identifier lambda_parameter("x");
+	auto lambda_parameter_expr = make_uniq<BoundReferenceExpression>(lambda_parameter, sql_type, idx_t(0));
+	const bool is_tuple = sql_type.id() == LogicalTypeId::TUPLE;
+	vector<unique_ptr<Expression>> fields;
+
+	bool requires_collation = false;
+	auto &child_types = StructType::GetChildTypes(sql_type);
+	for (idx_t i = 0; i < child_types.size(); i++) {
+		vector<unique_ptr<Expression>> arguments;
+		arguments.push_back(lambda_parameter_expr->Copy());
+		arguments.push_back(make_uniq<BoundConstantExpression>(Value::BIGINT(NumericCast<int64_t>(i + 1))));
+		auto field =
+		    BindCollationFunction(context, is_tuple ? "struct_extract" : "struct_extract_at", std::move(arguments));
+		// Wrap the extracted field in its collation functions, recursing into nested fields.
+		requires_collation |= binding.PushCollation(context, field, child_types[i].second, type);
+		field->SetAlias(Identifier(child_types[i].first));
+		fields.push_back(std::move(field));
+	}
+
+	if (!requires_collation) {
+		return false;
+	}
+
+	// Rebuild with the transformed field types, as the fields type can change
+	auto result = BindCollationFunction(context, is_tuple ? "row" : "struct_pack", std::move(fields));
+	// A NULL struct must remain distinct from a struct containing only NULL fields.
+	auto is_null = make_uniq<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
+	is_null->GetChildrenMutable().push_back(lambda_parameter_expr->Copy());
+	auto null_result = make_uniq<BoundConstantExpression>(Value(result->GetReturnType()));
+	auto body = make_uniq<BoundCaseExpression>(std::move(is_null), std::move(null_result), std::move(result));
+	auto lambda = make_uniq<BoundLambdaExpression>(ExpressionType::LAMBDA, LogicalType::LAMBDA, std::move(body), 1);
+	lambda->SetParameterNames({lambda_parameter});
+
+	// Invoke evaluates the source once, even when several fields need collations.
+	auto source_alias = source->GetAlias();
+	vector<unique_ptr<Expression>> arguments;
+	arguments.push_back(std::move(lambda));
+	arguments.push_back(std::move(source));
+	source = BindCollationFunction(context, "invoke", std::move(arguments));
+	source->SetAlias(source_alias);
+	return true;
 }
 
 //! Pushes a collation into a LIST/ARRAY type by wrapping the source in a list_transform that applies the collation to
@@ -167,6 +222,9 @@ static bool PushNestedCollation(ClientContext &context, unique_ptr<Expression> &
 
 bool CollationBinding::PushCollation(ClientContext &context, unique_ptr<Expression> &source,
                                      const LogicalType &sql_type, CollationType type) const {
+	if (StructType::IsStruct(sql_type)) {
+		return PushStructCollation(context, source, sql_type, type, *this);
+	}
 	if (sql_type.id() == LogicalTypeId::LIST) {
 		return PushNestedCollation(context, source, ListType::GetChildType(sql_type), type, *this);
 	}

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -222,14 +222,17 @@ static bool PushNestedCollation(ClientContext &context, unique_ptr<Expression> &
 
 bool CollationBinding::PushCollation(ClientContext &context, unique_ptr<Expression> &source,
                                      const LogicalType &sql_type, CollationType type) const {
-	if (StructType::IsStruct(sql_type)) {
-		return PushStructCollation(context, source, sql_type, type, *this);
-	}
-	if (sql_type.id() == LogicalTypeId::LIST) {
-		return PushNestedCollation(context, source, ListType::GetChildType(sql_type), type, *this);
-	}
-	if (sql_type.id() == LogicalTypeId::ARRAY) {
-		return PushNestedCollation(context, source, ArrayType::GetChildType(sql_type), type, *this);
+	// Leave collation of aliased structs, lists and arrays to the registered callbacks.
+	if (!sql_type.HasAlias()) {
+		if (StructType::IsStruct(sql_type)) {
+			return PushStructCollation(context, source, sql_type, type, *this);
+		}
+		if (sql_type.id() == LogicalTypeId::LIST) {
+			return PushNestedCollation(context, source, ListType::GetChildType(sql_type), type, *this);
+		}
+		if (sql_type.id() == LogicalTypeId::ARRAY) {
+			return PushNestedCollation(context, source, ArrayType::GetChildType(sql_type), type, *this);
+		}
 	}
 	for (auto &collation : collations) {
 		auto functions = collation.get_collation_functions(context, sql_type, type);

--- a/test/sql/collate/collate_nested.test
+++ b/test/sql/collate/collate_nested.test
@@ -1,0 +1,189 @@
+# name: test/sql/collate/collate_nested.test
+# description: Test that collations are applied to elements inside nested types
+# group: [collate]
+
+# preserve NULL structs separately from structs with NULL fields
+query I
+SELECT NULL::STRUCT(x VARCHAR) = {'x': 'a' COLLATE NOCASE}
+----
+NULL
+
+query I
+SELECT NULL::STRUCT(x VARCHAR) IS DISTINCT FROM {'x': NULL::VARCHAR COLLATE NOCASE}
+----
+true
+
+query I
+SELECT {'x': NULL::VARCHAR COLLATE NOCASE} = {'x': NULL::VARCHAR}
+----
+true
+
+query I
+SELECT [{'x': 'a' COLLATE NOCASE}, NULL::STRUCT(x VARCHAR)] = [{'x': 'A'}, NULL::STRUCT(x VARCHAR)]
+----
+true
+
+# the source is evaluated once even when both fields require collation
+statement ok
+CREATE SEQUENCE collate_sequence
+
+query I
+SELECT {'x': nextval('collate_sequence')::VARCHAR COLLATE NOCASE,
+        'y': nextval('collate_sequence')::VARCHAR COLLATE NOCASE} = {'x': '1', 'y': '2'}
+----
+true
+
+query I
+SELECT currval('collate_sequence')
+----
+2
+
+statement ok
+DROP SEQUENCE collate_sequence
+
+# scalar and tuple ordering use the same collation
+query I
+SELECT 'a' COLLATE NOCASE < 'B'
+----
+true
+
+query I
+SELECT ('a' COLLATE NOCASE, 0) < ('B', 0)
+----
+true
+
+query I
+SELECT {'x': 'b' COLLATE NOCASE} = {'x': 'B'}
+----
+true
+
+query I
+SELECT {'x': 'b' COLLATE NOCASE} != {'x': 'B'}
+----
+false
+
+query I
+SELECT {'x': 'a' COLLATE NOCASE} < {'x': 'B'}
+----
+true
+
+query I
+SELECT {'x': 'B' COLLATE NOCASE} >= {'x': 'a'}
+----
+true
+
+# TIMETZ ordering accounts for the timezone offset
+query I
+SELECT {'x': '10:00:00+00'::TIMETZ} < {'x': '09:00:00-05'::TIMETZ}
+----
+true
+
+# fields compare in order, so 'y' decides once the 'x' fields are equal under NOCASE
+query I
+SELECT {'x': 'a' COLLATE NOCASE, 'y': 2} < {'x': 'A', 'y': 1}
+----
+false
+
+# the first field decides when its values differ under NOCASE
+query I
+SELECT {'x': 'B' COLLATE NOCASE, 'y': 2} < {'x': 'a', 'y': 1}
+----
+false
+
+# combined collations
+query I
+SELECT {'x': 'héllo' COLLATE NOACCENT.NOCASE} = {'x': 'HELLO'}
+----
+true
+
+# comparisons without a collation remain case-sensitive
+query I
+SELECT {'x': 'b'} = {'x': 'B'}
+----
+false
+
+query I
+SELECT ('b', 0) < ('B', 0)
+----
+false
+
+# nesting in either direction
+query I
+SELECT [{'x': 'a' COLLATE NOCASE}] < [{'x': 'B'}]
+----
+true
+
+query I
+SELECT {'x': ['a' COLLATE NOCASE]} < {'x': ['B']}
+----
+true
+
+query I
+SELECT {'x': {'y': 'b' COLLATE NOCASE}} = {'x': {'y': 'B'}}
+----
+true
+
+statement ok
+CREATE TABLE t(id INTEGER, s VARCHAR COLLATE NOCASE)
+
+statement ok
+INSERT INTO t VALUES (1, 'B'), (2, 'a'), (3, 'b')
+
+query I
+SELECT id FROM t ORDER BY {'x': s}, id
+----
+2
+1
+3
+
+# 'B' and 'b' are one value under NOCASE
+query I
+SELECT count(*) FROM (SELECT DISTINCT {'x': s} FROM t)
+----
+2
+
+query I
+SELECT count(*) FROM (SELECT {'x': s} AS g, count(*) FROM t GROUP BY g)
+----
+2
+
+query I
+SELECT count(*) FROM t AS l JOIN t AS r ON {'x': l.s} = {'x': r.s}
+----
+5
+
+statement ok
+CREATE TABLE tz(t TIMETZ)
+
+statement ok
+INSERT INTO tz VALUES ('10:00:00+00'), ('09:00:00-05')
+
+query I
+SELECT string_agg(t::VARCHAR, ',' ORDER BY t) FROM tz
+----
+10:00:00+00,09:00:00-05
+
+query I
+SELECT string_agg(t::VARCHAR, ',' ORDER BY {'x': t}) FROM tz
+----
+10:00:00+00,09:00:00-05
+
+# IN with a list uses list membership
+query I
+SELECT {'x': 'a' COLLATE NOCASE} IN [{'x': 'A'}, {'x': 'z'}]
+----
+true
+
+# the collation comes from the setting rather than from the type
+statement ok
+PRAGMA default_collation=NOCASE
+
+query I
+SELECT {'x': 'b'} = {'x': 'B'}
+----
+true
+
+query I
+SELECT ('b', 0) = ('B', 0)
+----
+true

--- a/test/sql/collate/test_collate_list_contains.test
+++ b/test/sql/collate/test_collate_list_contains.test
@@ -106,3 +106,79 @@ query I
 SELECT list_contains([1, 2, 3], 2)
 ----
 true
+
+# the collation is pushed into struct elements too
+query I
+SELECT list_contains([{'x': 'hello'}, {'x': 'world'}], {'x': 'HELLO' COLLATE NOCASE})
+----
+true
+
+query I
+SELECT list_position([{'x': 'hello'}, {'x': 'world'}], {'x': 'WORLD' COLLATE NOCASE})
+----
+2
+
+query I
+SELECT contains([{'x': 'hello'}], {'x': 'HELLO' COLLATE NOCASE})
+----
+true
+
+# combined collations on a struct field
+query I
+SELECT list_contains([{'x': 'héllo'}], {'x': 'HELLO' COLLATE NOACCENT.NOCASE})
+----
+true
+
+# list fields inside struct elements
+query I
+SELECT list_contains([{'x': ['hello']}], {'x': ['HELLO' COLLATE NOCASE]})
+----
+true
+
+# struct elements without a collation remain case-sensitive
+query I
+SELECT list_contains([{'x': 'hello'}], {'x': 'HELLO'})
+----
+false
+
+# the collation can come from either argument
+query II
+SELECT id, list_contains([{'x': 'Apple'}, {'x': 'Banana'}], {'x': needle})
+FROM t ORDER BY id
+----
+1	true
+2	false
+3	false
+
+query II
+SELECT id, list_position([{'x': 'Apple'}, {'x': 'Banana'}], {'x': needle})
+FROM t ORDER BY id
+----
+1	2
+2	NULL
+3	NULL
+
+query II
+SELECT id, list_contains([{'x': needle}], {'x': 'BANANA'})
+FROM t ORDER BY id
+----
+1	true
+2	false
+3	false
+
+# a field's collation does not apply to other fields
+query I
+SELECT list_contains([{'x': 'a', 'y': 'b'}], {'x': 'A' COLLATE NOCASE, 'y': 'B'})
+----
+false
+
+# different fields can use different collations
+query I
+SELECT list_contains([{'x': 'a', 'y': 'é'}], {'x': 'A' COLLATE NOCASE, 'y': 'e' COLLATE NOACCENT})
+----
+true
+
+query I
+SELECT list_contains([{'x': 'A' COLLATE NOCASE, 'y': 'e' COLLATE NOACCENT}], {'x': 'a', 'y': 'é'})
+----
+true


### PR DESCRIPTION
Tuple and struct comparisons ignored field collations. For example, `('a' COLLATE NOCASE, 0) < ('B', 0)` returned `false` instead of `true`.

### Changes
- This PR applies collations recursively to struct and tuple fields using a lambda. This also fixes ordering of nested `TIMETZ` values. 
- Aliased structs, lists and arrays are left to registered collation callbacks, because the extraction and transformation functions used here do not accept aliased types by default. Without a callback, field collations are not applied automatically.

Fixes https://github.com/duckdb/duckdb/issues/24047
Fixes https://github.com/duckdblabs/duckdb-internal/issues/9701