### PR TITLE
Update projection column by correct index in expression pushdown optimizers

### DIFF
--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -868,13 +868,6 @@ public:
 
 	static void MultiFileScan(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 		if (!data_p.local_state) {
-			auto &gstate = data_p.global_state->Cast<MultiFileGlobalState>();
-			auto &bind_data = data_p.bind_data->CastNoConst<MultiFileBindData>();
-			if (gstate.global_state && bind_data.interface &&
-			    bind_data.interface->FinalizeScan(context, *gstate.global_state, output)) {
-				data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
-				return;
-			}
 			data_p.async_result = SourceResultType::FINISHED;
 			return;
 		}
@@ -891,7 +884,11 @@ public:
 				case ScanReadAheadAcquire::PARKED:
 					return;
 				case ScanReadAheadAcquire::EXHAUSTED:
-					if (bind_data.interface->FinalizeScan(context, *gstate.global_state, output)) {
+					// If a thread is exhausted without getting a job, data.job
+					// is nullptr. If FinalizeScan returns true, duckdb calls
+					// scan function again, and after it returns, calls
+					// MultiFileGetPartitionData which in turn uses data.job.
+					if (data.job && bind_data.interface->FinalizeScan(context, *gstate.global_state, output)) {
 						data_p.async_result = SourceResultType::HAVE_MORE_OUTPUT;
 						return;
 					}

--- a/src/include/duckdb/optimizer/type_pushdown.hpp
+++ b/src/include/duckdb/optimizer/type_pushdown.hpp
@@ -88,9 +88,13 @@ void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections
 
 struct GetBinding {
 	GetAnalysis &analysis;
+	// Column index within LogicalGet
 	ProjectionIndex column_index;
 	// If column binding was part of a projection, this is non-nullptr
 	LogicalProjection *projection;
+	// If column binding was part of projection, column index within
+	// LogicalProjection wrapping a LogicalGet
+	ProjectionIndex projection_column_index;
 };
 
 /*

--- a/src/optimizer/scalar_fn_pushdown.cpp
+++ b/src/optimizer/scalar_fn_pushdown.cpp
@@ -71,12 +71,12 @@ unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundColumnRefExpression &e
 		return std::move(*ptr);
 	}
 
-	const auto &[analysis, column_index, projection] = *binding;
+	const auto &[analysis, column_index, projection, projection_column_index] = *binding;
 	if (CanPushdownColumn(analysis, column_index)) {
 		const LogicalType return_type = analysis.get.returned_types[analysis.StorageIndex(column_index)];
 		expr.SetReturnType(return_type);
 		if (projection != nullptr && !projection->types.empty()) {
-			projection->types[column_index] = return_type;
+			projection->types[projection_column_index] = return_type;
 		}
 	}
 
@@ -99,7 +99,7 @@ unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundFunctionExpression &ex
 		return nullptr;
 	}
 
-	const auto &[analysis, column_index, projection] = *binding;
+	const auto &[analysis, column_index, projection, projection_column_index] = *binding;
 	if (!CanPushdownColumn(analysis, column_index)) {
 		return std::move(*ptr);
 	}
@@ -107,7 +107,7 @@ unique_ptr<Expression> ScalarFnReplace::VisitReplace(BoundFunctionExpression &ex
 	const LogicalType return_type = analysis.get.returned_types[analysis.StorageIndex(column_index)];
 	bound_col_base->SetReturnType(return_type);
 	if (projection != nullptr && !projection->types.empty()) {
-		projection->types[column_index] = return_type;
+		projection->types[projection_column_index] = return_type;
 	}
 	return std::move(bound_col_base);
 }

--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -92,7 +92,7 @@ optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Pr
 		return nullopt;
 	}
 	if (const auto it = analyses.find(binding.table_index); it != analyses.end()) {
-		return {{it->second, binding.column_index, nullptr}};
+		return {{it->second, binding.column_index, nullptr, binding.column_index}};
 	}
 
 	const auto projection_it = projections.find(binding.table_index);
@@ -110,7 +110,7 @@ optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Pr
 		return nullopt;
 	}
 	if (const auto it = analyses.find(get_binding.table_index); it != analyses.end()) {
-		return {{it->second, get_binding.column_index, &projection}};
+		return {{it->second, get_binding.column_index, &projection, binding.column_index}};
 	}
 	return nullopt;
 }
@@ -236,7 +236,7 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundColumnRefExpression &expr,
 		return std::move(*ptr);
 	}
 
-	const auto &[analysis, column_index, projection] = *binding;
+	const auto &[analysis, column_index, projection, projection_column_index] = *binding;
 	if (CanPushdownColumn(analysis, column_index)) {
 		const LogicalType return_type = analysis.get.returned_types[analysis.StorageIndex(column_index)];
 		expr.SetReturnType(return_type);
@@ -244,7 +244,7 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundColumnRefExpression &expr,
 		// LogicalProjection::ResolveTypes, so we need to check whether types in
 		// projection have been resolved, and updated them only if needed.
 		if (projection != nullptr && !projection->types.empty()) {
-			projection->types[column_index] = return_type;
+			projection->types[projection_column_index] = return_type;
 		}
 	}
 
@@ -265,7 +265,7 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundFunctionExpression &expr, 
 		return nullptr;
 	}
 
-	const auto &[analysis, column_index, projection] = *binding;
+	const auto &[analysis, column_index, projection, projection_column_index] = *binding;
 	if (!CanPushdownColumn(analysis, column_index)) {
 		return std::move(*ptr);
 	}
@@ -274,7 +274,7 @@ unique_ptr<Expression> CastReplace::VisitReplace(BoundFunctionExpression &expr, 
 	bound_col_base->SetReturnType(return_type);
 	// Same as in CastReplace::VisitReplace(BoundColumnRefExpression)
 	if (projection != nullptr && !projection->types.empty()) {
-		projection->types[column_index] = return_type;
+		projection->types[projection_column_index] = return_type;
 	}
 	return std::move(bound_col_base);
 }

--- a/test/optimizer/pushdown/type_pushdown_projection_index.test
+++ b/test/optimizer/pushdown/type_pushdown_projection_index.test
@@ -1,0 +1,30 @@
+# name: test/optimizer/pushdown/type_pushdown_projection_index.test
+# description: Expression pushdown indexes projection types correctly
+# group: [pushdown]
+
+require parquet
+
+statement ok
+COPY (
+    SELECT i % 2 = 0 AS f1, i AS f2, repeat('x', (i % 5)::INT) AS s
+    FROM range(100) t(i)
+) TO '{TEST_DIR}/type_pushdown_projection_index.parquet' (FORMAT parquet);
+
+query I
+SELECT sum(strlen(s))
+FROM (
+    SELECT s FROM '{TEST_DIR}/type_pushdown_projection_index.parquet'
+    WHERE f1 AND f2 >= 2
+);
+----
+100
+
+statement ok
+CREATE VIEW view AS
+SELECT s FROM '{TEST_DIR}/type_pushdown_projection_index.parquet'
+WHERE f1 AND f2 >= 2;
+
+query I
+SELECT sum(strlen(s)) FROM view;
+----
+100


### PR DESCRIPTION
This change fixes a bug in cast/scalar fn pushdown optimizers: whenever column was part of a Projection wrapping a Get, column's index within the projection may not have been the same as column's index within a Get.

This change also fixes a bug in FinalizeScan where a thread without a `scan.job` (exhausted without scanning anything) got to run FinalizeScan which failed in MultiFileGetPartitionData after.