### PR TITLE
Report and allow aborting on a WAL that cannot be fully replayed

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -7,6 +7,12 @@
         "custom_implementation": true
     },
     {
+        "name": "abort_on_wal_failure",
+        "description": "Whether to abort startup when the write-ahead log cannot be fully replayed, instead of discarding the part that could not be replayed",
+        "type": "BOOLEAN",
+        "scope": "global"
+    },
+    {
         "name": "access_mode",
         "description": "Access mode of the database (AUTOMATIC, READ_ONLY or READ_WRITE)",
         "type": "ENUM<AccessMode>",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -117,6 +117,19 @@ struct DeltaOnlyVariantEncodingEnabledSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct AbortOnWalFailureSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "abort_on_wal_failure";
+	static constexpr const char *Description = "Whether to abort startup when the write-ahead log cannot be fully "
+	                                           "replayed, instead of discarding the part that could not be replayed";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr bool IsDebug = false;
+	static constexpr bool IsDeprecated = false;
+	static void SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &parameter);
+	static void ResetGlobal(DatabaseInstance *db, DBConfig &config);
+	static Value GetSetting(const ClientContext &context);
+};
+
 struct AccessModeSetting {
 	using RETURN_TYPE = AccessMode;
 	static constexpr const char *Name = "access_mode";

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -71,6 +71,7 @@ DebugVerificationMode DBConfigOptions::global_verification_mode = DebugVerificat
 static const ConfigurationOption internal_options[] = {
 
     DUCKDB_GLOBAL(DeltaOnlyVariantEncodingEnabledSetting),
+    DUCKDB_GLOBAL(AbortOnWalFailureSetting),
     DUCKDB_GLOBAL(AccessModeSetting),
     DUCKDB_LOCAL(ActiveGrammarExtensionsSetting),
     DUCKDB_SETTING_CALLBACK(AllocatorBackgroundThreadsSetting),

--- a/src/main/settings/autogenerated_settings.cpp
+++ b/src/main/settings/autogenerated_settings.cpp
@@ -15,6 +15,22 @@
 namespace duckdb {
 
 //===----------------------------------------------------------------------===//
+// Abort On Wal Failure
+//===----------------------------------------------------------------------===//
+void AbortOnWalFailureSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.options.abort_on_wal_failure = input.GetValue<bool>();
+}
+
+void AbortOnWalFailureSetting::ResetGlobal(DatabaseInstance *db, DBConfig &config) {
+	config.options.abort_on_wal_failure = DBConfigOptions().abort_on_wal_failure;
+}
+
+Value AbortOnWalFailureSetting::GetSetting(const ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.options.abort_on_wal_failure);
+}
+
+//===----------------------------------------------------------------------===//
 // Access Mode
 //===----------------------------------------------------------------------===//
 void AccessModeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/enums/checkpoint_abort.hpp"
 #include "duckdb/execution/index/art/art.hpp"
 #include "duckdb/execution/index/index_type_set.hpp"
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_data.hpp"
@@ -641,6 +642,12 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 		if (config.options.abort_on_wal_failure || error.Type() != ExceptionType::SERIALIZATION) {
 			error.Throw("Failure while replaying WAL file \"" + wal_path + "\": ");
 		}
+		// the WAL is torn: everything after successful_offset is dropped
+		// report it - this is silent data loss from the user's point of view
+		DUCKDB_LOG_WARNING(database.GetDatabase(),
+		                   StringUtil::Format("WAL replay of \"%s\" stopped at offset %llu - the remainder of the "
+		                                      "file could not be replayed and is discarded: %s",
+		                                      wal_path, successful_offset, error.RawMessage()));
 	} catch (...) {
 		// exception thrown in WAL replay: rollback
 		con.Query("ROLLBACK");

--- a/test/sql/storage/wal_torn_write.cpp
+++ b/test/sql/storage/wal_torn_write.cpp
@@ -158,6 +158,79 @@ TEST_CASE("Test torn WAL writes followed by successful commits", "[storage][.]")
 	DeleteDatabase(storage_database);
 }
 
+TEST_CASE("Test abort_on_wal_failure setting", "[storage][.]") {
+	// a torn WAL is tolerated by default: the unreplayable remainder is discarded and startup
+	// continues. abort_on_wal_failure turns that into a startup failure instead, so that a
+	// deployment can choose to be told rather than silently lose the tail of the WAL.
+	auto storage_database = TestCreatePath("abort_on_wal_failure");
+	auto storage_wal = storage_database + ".wal";
+	auto source_database = TestCreatePath("abort_on_wal_failure_source");
+	auto source_wal = source_database + ".wal";
+
+	LocalFileSystem lfs;
+	idx_t wal_size_one_table;
+	DeleteDatabase(storage_database);
+	DeleteDatabase(source_database);
+	{
+		auto config = GetTestConfig();
+		config->options.checkpoint_wal_size = idx_t(-1);
+		config->options.checkpoint_on_shutdown = false;
+		DuckDB db(source_database, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE A (a INTEGER);"));
+		wal_size_one_table = GetWALFileSize(lfs, source_wal);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE B (a INTEGER);"));
+	}
+
+	// tear the WAL in the middle of the second commit
+	auto restore_torn_wal = [&]() {
+		DeleteDatabase(storage_database);
+		CopyFile(lfs, source_database, storage_database);
+		CopyFile(lfs, source_wal, storage_wal);
+		TruncateWAL(lfs, storage_wal, wal_size_one_table + 17);
+	};
+
+	restore_torn_wal();
+	{
+		// default: the torn tail is discarded, so A is there and B is not
+		auto config = GetTestConfig();
+		config->options.checkpoint_wal_size = idx_t(-1);
+		config->options.checkpoint_on_shutdown = false;
+		config->SetOptionByName("abort_on_wal_failure", Value::BOOLEAN(false));
+		DuckDB db(storage_database, config.get());
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("FROM A"));
+		REQUIRE_FAIL(con.Query("FROM B"));
+	}
+
+	restore_torn_wal();
+	{
+		// with the setting enabled the same file refuses to open
+		auto config = GetTestConfig();
+		config->options.checkpoint_wal_size = idx_t(-1);
+		config->options.checkpoint_on_shutdown = false;
+		config->SetOptionByName("abort_on_wal_failure", Value::BOOLEAN(true));
+		duckdb::unique_ptr<DuckDB> db;
+		REQUIRE_THROWS(db = make_uniq<DuckDB>(storage_database, config.get()));
+	}
+
+	// the setting is readable through the regular settings interface
+	{
+		DuckDB db(nullptr);
+		Connection con(db);
+		auto result = con.Query("SELECT current_setting('abort_on_wal_failure')");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->GetValue(0, 0) == Value::BOOLEAN(false));
+		REQUIRE_NO_FAIL(con.Query("SET abort_on_wal_failure=true"));
+		result = con.Query("SELECT current_setting('abort_on_wal_failure')");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->GetValue(0, 0) == Value::BOOLEAN(true));
+	}
+
+	DeleteDatabase(storage_database);
+	DeleteDatabase(source_database);
+}
+
 static void FlipWALByte(FileSystem &fs, const string &path, idx_t byte_pos) {
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ);
 	auto wal_size = handle->GetFileSize();


### PR DESCRIPTION
### The problem

A WAL whose tail cannot be replayed is handled two different ways depending on the exception that stopped the replay (`src/storage/wal_replay.cpp`):

```cpp
if (config.options.abort_on_wal_failure || error.Type() != ExceptionType::SERIALIZATION) {
    error.Throw("Failure while replaying WAL file \"" + wal_path + "\": ");
}
```

* `SERIALIZATION` — a torn WAL — is swallowed. The replay stops at the last entry that succeeded, everything after it is discarded, and startup continues.
* Anything else is rethrown and startup fails.

The tolerant half is **silent**. `WriteAheadLogReplayer::ReplayLog` writes nothing to the logger, so a database that came back with part of its committed data missing is indistinguishable from one that came back whole. From the outside the only symptom is that rows are gone.

### Why it cannot be noticed afterwards

The evidence does not survive. `WriteAheadLog::Initialize` truncates the file to `successful_offset` **lazily, at the first WAL write**. So the discarded tail is on disk only between the open and the first write of the new session; by the time anyone looks, the file already matches what was replayed.

There is no later moment at which this can be observed, which is why it has to be reported when it happens.

### `abort_on_wal_failure` is not reachable

The option already exists to turn the tolerant half into a failure, but it is not registered as a setting — the only places that assign it are DuckDB's own test helpers. No embedder or CLI user can reach it, which also means the default (tolerant) path is the one that ships while the tests exercise the other one.

### The change

* Log a warning when a replay stops early, naming the file, the offset that was replayed successfully, and the error that stopped it.
* Register `abort_on_wal_failure` as a regular global setting. It keeps its `DBConfigOptions` field, so the existing tests that set it directly are unaffected.

The new test tears a WAL in the middle of a commit and opens the same file twice: once with the setting off, where the tail is discarded and startup continues, and once with it on, where the open throws.

### How this was found

In a DuckDB-backed product, a `.wal` had grown to 25 MB while the database file had not changed for days. Restarts came back with data rewound and **not a single log line** explaining it. Reconstructing what happened meant reading `wal_replay.cpp` — there was nothing else to go on. Adding this warning is what would have made it a one-minute diagnosis.

### A related gap, not addressed here

`checkpoint_on_shutdown` has the same shape: it is not in `settings.json`, so it cannot be set with `SET`; only `PRAGMA disable_checkpoint_on_shutdown` exists, and that is one-way. The description of `checkpoint_on_detach` even refers to "the global `checkpoint_on_shutdown` setting", which users cannot actually set. Left out to keep this PR to one subject — happy to follow up if that is wanted.

### Testing

macOS arm64, `make debug` (ASAN):

* `Test abort_on_wal_failure setting` — 10 assertions, passes.
* `Test torn WAL writes` and `Test torn WAL writes followed by successful commits` — 242 assertions, pass. The tolerant path's behaviour is unchanged; only a log line is added.
* `[storage]` — 32/33 test cases pass. The one failure is `test/sql/storage/test_show_tables_persistent.test`, an ASAN stack overflow in `ListMatcher::MatchParseResultInternal`. **It reproduces identically on unmodified `main`** at 3f7a54d0fb — a plain `show tables;` is enough — so it is pre-existing and unrelated to this change. Filed separately as #25433.
