### PR TITLE
Publish alpha only on default branch, use consistent static/shared libs artifact names

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -812,7 +812,12 @@ jobs:
       run: |
         make cli-release-artifact ARTIFACT_SUFFIX=${{ matrix.config.artifact_suffix }} CLI_BINARY=build/release/duckdb
         make shared-libs-release-artifact ARTIFACT_SUFFIX=${{ matrix.config.artifact_suffix }} SHARED_LIBRARIES="build/release/src/libduckdb.so*"
-        ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-${{ matrix.config.artifact_suffix }}.tar.gz duckdb-shared-libs-${{ matrix.config.artifact_suffix }}.tar.gz
+        make gather-libs
+        make static-libs-release-artifact ARTIFACT_SUFFIX=${{ matrix.config.artifact_suffix }} STATIC_LIBRARIES="build/release/libs/*"
+        ./scripts/upload-assets-to-staging.sh github_release \
+          duckdb-cli-${{ matrix.config.artifact_suffix }}.tar.gz \
+          duckdb-shared-libs-${{ matrix.config.artifact_suffix }}.tar.gz \
+          duckdb-static-libs-${{ matrix.config.artifact_suffix }}.tar.gz
 
     - uses: actions/upload-artifact@v7
       with:
@@ -822,6 +827,11 @@ jobs:
     - uses: actions/upload-artifact@v7
       with:
         path: duckdb-shared-libs-${{ matrix.config.artifact_suffix }}.tar.gz
+        archive: false
+
+    - uses: actions/upload-artifact@v7
+      with:
+        path: duckdb-static-libs-${{ matrix.config.artifact_suffix }}.tar.gz
         archive: false
 
     - name: Release tests

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -590,13 +590,8 @@ jobs:
         fi
         if [[ "${{ matrix.config.publish_static }}" == "true" ]]; then
           make gather-libs
-          zip -r -j static-libs-${{ matrix.config.artifact_suffix }}.zip \
-            src/include/duckdb.h \
-            src/include/duckdb_v2.h \
-            src/include/duckdb_extension.h \
-            src/include/duckdb_extension_v2.h \
-            build/release/libs/
-          assets+=(static-libs-${{ matrix.config.artifact_suffix }}.zip)
+          make static-libs-release-artifact ARTIFACT_SUFFIX=${{ matrix.config.artifact_suffix }} STATIC_LIBRARIES="build/release/libs/*"
+          assets+=(duckdb-static-libs-${{ matrix.config.artifact_suffix }}.tar.gz)
         fi
         if [[ "${{ matrix.config.is_canonical_build }}" == "true" ]]; then
           make cli-release-artifact ARTIFACT_SUFFIX=${{ matrix.config.artifact_suffix }} CLI_BINARY=build/release/duckdb
@@ -620,8 +615,8 @@ jobs:
     - uses: actions/upload-artifact@v7
       if: ${{ matrix.config.publish_static }}
       with:
-        name: duckdb-static-libs-${{ matrix.config.artifact_suffix }}
-        path: static-libs-${{ matrix.config.artifact_suffix }}.zip
+        path: duckdb-static-libs-${{ matrix.config.artifact_suffix }}.tar.gz
+        archive: false
 
     - name: ARM64 release tests
       if: ${{ matrix.config.run_arm_tests && !fromJson(needs.prepare.outputs.skip_tests) }}

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1204,6 +1204,8 @@ jobs:
           DUCKDB_COMMIT: ${{ needs.prepare.outputs.duckdb_commit }}
           STAGED_VERSION: ${{ needs.prepare.outputs.staged_version }}
           RELEASE_STATUS_SUCCESS: ${{ steps.release-status.outputs.success || 'false' }}
+          CURRENT_REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           is_release_event=false
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
@@ -1220,8 +1222,13 @@ jobs:
             run_release_dispatch=true
           fi
 
+          is_default_branch=false
+          if [[ "$CURRENT_REF" == "refs/heads/$DEFAULT_BRANCH" ]]; then
+            is_default_branch=true
+          fi
+
           publish_latest_alpha=false
-          if [[ "$is_duckdb_repo" == "true" && "$RELEASE_STATUS_SUCCESS" == "true" && -n "$STAGED_VERSION" ]]; then
+          if [[ "$is_duckdb_repo" == "true" && "$is_default_branch" == "true" && "$RELEASE_STATUS_SUCCESS" == "true" && -n "$STAGED_VERSION" ]]; then
             publish_latest_alpha=true
           fi
 
@@ -1234,6 +1241,9 @@ jobs:
           echo "  is_duckdb_repo=$is_duckdb_repo"
           echo "  run_release_dispatch=$run_release_dispatch"
           echo "  staged_version=$STAGED_VERSION"
+          echo "  current_ref=$CURRENT_REF"
+          echo "  default_branch=$DEFAULT_BRANCH"
+          echo "  is_default_branch=$is_default_branch"
           echo "  publish_latest_alpha=$publish_latest_alpha"
 
           {

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -451,10 +451,11 @@ jobs:
 
     - uses: emscripten-core/setup-emsdk@v16
       with:
-        version: latest
+        version: '6.0.9'
 
     - uses: ./.github/actions/ccache-action
       with:
+        key: wasm-eh-emscripten-6.0.9
         save: ${{ fromJson(needs.prepare.outputs.save_cache) }}
 
     - name: Build

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -164,20 +164,10 @@ jobs:
           make cli-release-artifact ARTIFACT_SUFFIX=osx-arm64 CLI_BINARY=build/release_arm64/duckdb
           make cli-release-artifact ARTIFACT_SUFFIX=osx-amd64 CLI_BINARY=build/release_amd64/duckdb
           make shared-libs-release-artifact ARTIFACT_SUFFIX=osx-universal SHARED_LIBRARIES="build/release/src/libduckdb*.dylib"
-          zip -r -j static-libs-osx-arm64.zip \
-            src/include/duckdb.h \
-            src/include/duckdb_v2.h \
-            src/include/duckdb_extension.h \
-            src/include/duckdb_extension_v2.h \
-            build/release_arm64/libs/
-          zip -r -j static-libs-osx-amd64.zip \
-            src/include/duckdb.h \
-            src/include/duckdb_v2.h \
-            src/include/duckdb_extension.h \
-            src/include/duckdb_extension_v2.h \
-            build/release_amd64/libs/
+          make static-libs-release-artifact ARTIFACT_SUFFIX=osx-arm64 STATIC_LIBRARIES="build/release_arm64/libs/*"
+          make static-libs-release-artifact ARTIFACT_SUFFIX=osx-amd64 STATIC_LIBRARIES="build/release_amd64/libs/*"
 
-          ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-osx-universal.tar.gz duckdb-cli-osx-arm64.tar.gz duckdb-cli-osx-amd64.tar.gz duckdb-shared-libs-osx-universal.tar.gz static-libs-osx-arm64.zip static-libs-osx-amd64.zip
+          ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-osx-universal.tar.gz duckdb-cli-osx-arm64.tar.gz duckdb-cli-osx-amd64.tar.gz duckdb-shared-libs-osx-universal.tar.gz duckdb-static-libs-osx-arm64.tar.gz duckdb-static-libs-osx-amd64.tar.gz
 
       - uses: actions/upload-artifact@v7
         with:
@@ -201,13 +191,13 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: duckdb-static-libs-osx-arm64
-          path: static-libs-osx-arm64.zip
+          path: duckdb-static-libs-osx-arm64.tar.gz
+          archive: false
 
       - uses: actions/upload-artifact@v7
         with:
-          name: duckdb-static-libs-osx-amd64
-          path: static-libs-osx-amd64.zip
+          path: duckdb-static-libs-osx-amd64.tar.gz
+          archive: false
 
       - name: Unit Test
         shell: bash

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -148,9 +148,27 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
-          mkdir -p build/release_arm64/libs build/release_amd64/libs
+          mkdir -p \
+            build/release_arm64/libs \
+            build/release_arm64/src \
+            build/release_amd64/libs \
+            build/release_amd64/src
           lipo -extract arm64 -output build/release_arm64/duckdb build/release/duckdb
           lipo -extract x86_64 -output build/release_amd64/duckdb build/release/duckdb
+
+          for library in build/release/src/libduckdb*.dylib; do
+            library_name="$(basename "$library")"
+            if [[ -L "$library" ]]; then
+              library_target="$(readlink "$library")"
+              ln -s "$library_target" "build/release_arm64/src/$library_name"
+              ln -s "$library_target" "build/release_amd64/src/$library_name"
+              continue
+            fi
+            lipo -extract arm64 -output "build/release_arm64/src/$library_name" "$library"
+            lipo "build/release_arm64/src/$library_name" -verify_arch arm64
+            lipo -extract x86_64 -output "build/release_amd64/src/$library_name" "$library"
+            lipo "build/release_amd64/src/$library_name" -verify_arch x86_64
+          done
 
           for library in build/release/libs/*.a; do
             library_name="$(basename "$library")"
@@ -164,10 +182,20 @@ jobs:
           make cli-release-artifact ARTIFACT_SUFFIX=osx-arm64 CLI_BINARY=build/release_arm64/duckdb
           make cli-release-artifact ARTIFACT_SUFFIX=osx-amd64 CLI_BINARY=build/release_amd64/duckdb
           make shared-libs-release-artifact ARTIFACT_SUFFIX=osx-universal SHARED_LIBRARIES="build/release/src/libduckdb*.dylib"
+          make shared-libs-release-artifact ARTIFACT_SUFFIX=osx-arm64 SHARED_LIBRARIES="build/release_arm64/src/libduckdb*.dylib"
+          make shared-libs-release-artifact ARTIFACT_SUFFIX=osx-amd64 SHARED_LIBRARIES="build/release_amd64/src/libduckdb*.dylib"
           make static-libs-release-artifact ARTIFACT_SUFFIX=osx-arm64 STATIC_LIBRARIES="build/release_arm64/libs/*"
           make static-libs-release-artifact ARTIFACT_SUFFIX=osx-amd64 STATIC_LIBRARIES="build/release_amd64/libs/*"
 
-          ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-osx-universal.tar.gz duckdb-cli-osx-arm64.tar.gz duckdb-cli-osx-amd64.tar.gz duckdb-shared-libs-osx-universal.tar.gz duckdb-static-libs-osx-arm64.tar.gz duckdb-static-libs-osx-amd64.tar.gz
+          ./scripts/upload-assets-to-staging.sh github_release \
+            duckdb-cli-osx-universal.tar.gz \
+            duckdb-cli-osx-arm64.tar.gz \
+            duckdb-cli-osx-amd64.tar.gz \
+            duckdb-shared-libs-osx-universal.tar.gz \
+            duckdb-shared-libs-osx-arm64.tar.gz \
+            duckdb-shared-libs-osx-amd64.tar.gz \
+            duckdb-static-libs-osx-arm64.tar.gz \
+            duckdb-static-libs-osx-amd64.tar.gz
 
       - uses: actions/upload-artifact@v7
         with:
@@ -187,6 +215,16 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           path: duckdb-shared-libs-osx-universal.tar.gz
+          archive: false
+
+      - uses: actions/upload-artifact@v7
+        with:
+          path: duckdb-shared-libs-osx-arm64.tar.gz
+          archive: false
+
+      - uses: actions/upload-artifact@v7
+        with:
+          path: duckdb-shared-libs-osx-amd64.tar.gz
           archive: false
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -134,20 +134,10 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
       run: |
-        tmp_zip_dir="$(mktemp -d)"
-        archive_path="$(pwd)/static-libs-windows-amd64.zip"
-        cp \
-          src/include/duckdb.h \
-          src/include/duckdb_v2.h \
-          src/include/duckdb_extension.h \
-          src/include/duckdb_extension_v2.h \
-          "${tmp_zip_dir}/"
-        find libs -type f -exec cp {} "${tmp_zip_dir}/" \;
-        (cd "${tmp_zip_dir}" && "/c/Program Files/7-Zip/7z.exe" a -tzip "${archive_path}" ./*)
-        rm -rf "${tmp_zip_dir}"
         make cli-release-artifact ARTIFACT_SUFFIX=windows-amd64 CLI_BINARY=duckdb.exe
         make shared-libs-release-artifact ARTIFACT_SUFFIX=windows-amd64 SHARED_LIBRARIES="src/duckdb.dll src/duckdb.lib"
-        ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-windows-amd64.tar.gz duckdb-shared-libs-windows-amd64.tar.gz static-libs-windows-amd64.zip
+        make static-libs-release-artifact ARTIFACT_SUFFIX=windows-amd64 STATIC_LIBRARIES="libs/*"
+        ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-windows-amd64.tar.gz duckdb-shared-libs-windows-amd64.tar.gz duckdb-static-libs-windows-amd64.tar.gz
 
     - uses: actions/upload-artifact@v7
       with:
@@ -161,8 +151,8 @@ jobs:
 
     - uses: actions/upload-artifact@v7
       with:
-        name: duckdb-static-libs-windows-amd64
-        path: static-libs-windows-amd64.zip
+        path: duckdb-static-libs-windows-amd64.tar.gz
+        archive: false
 
  win-release-32:
     name: Windows (32 Bit)
@@ -280,20 +270,10 @@ jobs:
          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
        run: |
-         tmp_zip_dir="$(mktemp -d)"
-         archive_path="$(pwd)/static-libs-windows-arm64.zip"
-         cp \
-           src/include/duckdb.h \
-           src/include/duckdb_v2.h \
-           src/include/duckdb_extension.h \
-           src/include/duckdb_extension_v2.h \
-           "${tmp_zip_dir}/"
-         find libs -type f -exec cp {} "${tmp_zip_dir}/" \;
-         (cd "${tmp_zip_dir}" && "/c/Program Files/7-Zip/7z.exe" a -tzip "${archive_path}" ./*)
-         rm -rf "${tmp_zip_dir}"
          make cli-release-artifact ARTIFACT_SUFFIX=windows-arm64 CLI_BINARY=duckdb.exe
          make shared-libs-release-artifact ARTIFACT_SUFFIX=windows-arm64 SHARED_LIBRARIES="src/duckdb.dll src/duckdb.lib"
-         ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-windows-arm64.tar.gz duckdb-shared-libs-windows-arm64.tar.gz static-libs-windows-arm64.zip
+         make static-libs-release-artifact ARTIFACT_SUFFIX=windows-arm64 STATIC_LIBRARIES="libs/*"
+         ./scripts/upload-assets-to-staging.sh github_release duckdb-cli-windows-arm64.tar.gz duckdb-shared-libs-windows-arm64.tar.gz duckdb-static-libs-windows-arm64.tar.gz
 
      - uses: actions/upload-artifact@v7
        with:
@@ -307,8 +287,8 @@ jobs:
 
      - uses: actions/upload-artifact@v7
        with:
-         name: duckdb-static-libs-windows-arm64
-         path: static-libs-windows-arm64.zip
+         path: duckdb-static-libs-windows-arm64.tar.gz
+         archive: false
 
  mingw:
      name: MinGW (64 Bit)
@@ -402,20 +382,10 @@ jobs:
            AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
            AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
          run: |
-           tmp_zip_dir="$(mktemp -d)"
-           archive_path="$(pwd)/static-libs-windows-mingw.zip"
-           cp \
-             src/include/duckdb.h \
-             src/include/duckdb_v2.h \
-             src/include/duckdb_extension.h \
-             src/include/duckdb_extension_v2.h \
-             "${tmp_zip_dir}/"
-           find build/release/libs -type f -exec cp {} "${tmp_zip_dir}/" \;
-           (cd "${tmp_zip_dir}" && "/c/Program Files/7-Zip/7z.exe" a -tzip "${archive_path}" ./*)
-           rm -rf "${tmp_zip_dir}"
-           ./scripts/upload-assets-to-staging.sh github_release static-libs-windows-mingw.zip
+           make static-libs-release-artifact ARTIFACT_SUFFIX=windows-mingw STATIC_LIBRARIES="build/release/libs/*"
+           ./scripts/upload-assets-to-staging.sh github_release duckdb-static-libs-windows-mingw.tar.gz
 
        - uses: actions/upload-artifact@v7
          with:
-           name: duckdb-static-libs-windows-mingw
-           path: static-libs-windows-mingw.zip
+           path: duckdb-static-libs-windows-mingw.tar.gz
+           archive: false

--- a/Makefile
+++ b/Makefile
@@ -678,6 +678,11 @@ cli-release-artifact:
 shared-libs-release-artifact:
 	bash scripts/package_release_artifact.sh shared-libs "$(ARTIFACT_SUFFIX)" $(SHARED_LIBRARIES)
 
+.PHONY: static-libs-release-artifact
+
+static-libs-release-artifact:
+	bash scripts/package_release_artifact.sh static-libs "$(ARTIFACT_SUFFIX)" $(STATIC_LIBRARIES)
+
 .PHONY: symbol-checks symbol-leakage-check banned-symbol-check
 
 symbol-checks: symbol-leakage-check banned-symbol-check

--- a/scripts/ccache_workflow_summary.py
+++ b/scripts/ccache_workflow_summary.py
@@ -4,25 +4,86 @@ Summarize ccache usage for a GitHub Actions workflow run.
 
 Examples:
   python3 scripts/ccache_workflow_summary.py 22331644275
+  python3 scripts/ccache_workflow_summary.py 22331644275 --all-jobs
   python3 scripts/ccache_workflow_summary.py 22331644275 --repo duckdb/duckdb --format csv --output summary.csv
-  python3 scripts/ccache_workflow_summary.py 22331644275 --keep-retries --verbose
+  python3 scripts/ccache_workflow_summary.py 22331644275 --attempt 2 --threshold 90 --verbose
 """
 
 import argparse
+import csv
+import io
 import json
 import re
 import subprocess
 import sys
-from typing import Dict, List, Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional, Sequence
 
 
-HITS_RE = re.compile(r"Hits:\s*\d+\s*/\s*\d+\s*\(\s*([0-9]+(?:\.[0-9]+)?)\s*%\)")
+MAX_LOG_WORKERS = 8
+CCACHE_STEP_RE = re.compile(r"ccache", re.IGNORECASE)
+CCACHE_VERSION_RE = re.compile(r"\bccache version\s+(\S+)", re.IGNORECASE)
+CACHEABLE_CALLS_RE = re.compile(r"Cacheable calls:\s*(\d+)\s*/\s*(\d+)", re.IGNORECASE)
+HITS_RE = re.compile(r"\bHits:\s*(\d+)\s*/\s*(\d+)", re.IGNORECASE)
+MISSES_RE = re.compile(r"\bMisses:\s*(\d+)\s*/\s*(\d+)", re.IGNORECASE)
+CCACHE_RESTORE_HIT_RE = re.compile(
+    r"(?:Cache hit for restore-key|Cache restored from key):\s*[\"']?ccache-", re.IGNORECASE
+)
+RESTORE_GROUP_RE = re.compile(r"(?:##\[group\]|::group::)Restore cache", re.IGNORECASE)
+NO_CACHE_RE = re.compile(r"No cache found\.", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class CCacheStats:
+    hits: int
+    misses: int
+    cacheable_calls: int
+    ccache_version: Optional[str]
+
+    @property
+    def hit_rate_percent(self) -> float:
+        if self.cacheable_calls == 0:
+            return 0.0
+        return 100.0 * self.hits / self.cacheable_calls
+
+
+@dataclass(frozen=True)
+class JobResult:
+    job_id: int
+    job_name: str
+    conclusion: str
+    ccache_configured: bool
+    cache_restore_status: str
+    stats_available: bool
+    hits: Optional[int]
+    misses: Optional[int]
+    cacheable_calls: Optional[int]
+    hit_rate_percent: Optional[float]
+    ccache_version: Optional[str]
+    log_status: str
+    log_error: Optional[str]
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def percentage(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0 or parsed > 100:
+        raise argparse.ArgumentTypeError("must be between 0 and 100")
+    return parsed
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Analyze ccache summary for a GitHub Actions run via gh CLI.")
-    parser.add_argument("run_id", type=int, help="GitHub Actions run ID (for example: 22331644275).")
+    parser = argparse.ArgumentParser(description="Analyze ccache usage for a GitHub Actions run via gh CLI.")
+    parser.add_argument("run_id", type=positive_int, help="GitHub Actions run ID (for example: 22331644275).")
     parser.add_argument("--repo", default="duckdb/duckdb", help="Repository in owner/name format.")
+    parser.add_argument("--attempt", type=positive_int, help="Workflow attempt number; defaults to the latest attempt.")
     parser.add_argument(
         "--format",
         choices=["markdown", "table", "csv", "json"],
@@ -31,15 +92,21 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--output", default="", help="Optional output file path; otherwise prints to stdout.")
     parser.add_argument(
-        "--keep-retries",
+        "--threshold",
+        type=percentage,
+        default=80.0,
+        help="Hit rate below which a job is highlighted (default: 80).",
+    )
+    parser.add_argument(
+        "--all-jobs",
         action="store_true",
-        help="Include all job attempts. By default retries are collapsed to the latest attempt per job name.",
+        help="Include the complete per-job table in human-readable output.",
     )
     parser.add_argument("--verbose", action="store_true", help="Print progress messages to stderr.")
     return parser.parse_args()
 
 
-def run_gh(args: List[str]) -> str:
+def run_gh(args: Sequence[str]) -> str:
     proc = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     if proc.returncode != 0:
         cmd = " ".join(args)
@@ -47,196 +114,364 @@ def run_gh(args: List[str]) -> str:
     return proc.stdout
 
 
-def get_jobs(repo: str, run_id: int) -> List[Dict]:
-    output = run_gh(["gh", "run", "view", str(run_id), "--repo", repo, "--json", "jobs"])
-    payload = json.loads(output)
-    return payload.get("jobs", [])
+def get_jobs(repo: str, run_id: int, attempt: Optional[int]) -> tuple[List[Dict[str, Any]], int]:
+    command = ["gh", "run", "view", str(run_id), "--repo", repo]
+    if attempt is not None:
+        command.extend(["--attempt", str(attempt)])
+    command.extend(["--json", "attempt,jobs"])
+    payload = json.loads(run_gh(command))
+    if not isinstance(payload, dict):
+        raise RuntimeError("The GitHub CLI returned an invalid workflow run payload.")
+    jobs = payload.get("jobs", [])
+    if not isinstance(jobs, list):
+        raise RuntimeError("The GitHub CLI returned an invalid jobs payload.")
+    actual_attempt = int(payload.get("attempt") or attempt or 1)
+    return jobs, actual_attempt
 
 
-def dedupe_jobs_keep_latest(jobs: List[Dict]) -> List[Dict]:
-    by_name: Dict[str, Dict] = {}
-    for job in jobs:
-        name = job.get("name", "")
-        started_at = job.get("startedAt") or ""
-        completed_at = job.get("completedAt") or ""
-        dbid = int(job.get("databaseId") or 0)
-        candidate_key = (started_at, completed_at, dbid)
-        previous = by_name.get(name)
-        if previous is None:
-            by_name[name] = job
+def job_has_ccache_step(job: Dict[str, Any]) -> bool:
+    for step in job.get("steps", []):
+        if step.get("conclusion") == "skipped":
             continue
-        prev_key = (
-            previous.get("startedAt") or "",
-            previous.get("completedAt") or "",
-            int(previous.get("databaseId") or 0),
+        if CCACHE_STEP_RE.search(str(step.get("name") or "")):
+            return True
+    return False
+
+
+def parse_ccache_stats(log_text: str) -> Optional[CCacheStats]:
+    lines = log_text.splitlines()
+    versions = [match.group(1) for line in lines if (match := CCACHE_VERSION_RE.search(line))]
+    version = versions[-1] if versions else None
+    candidates: List[CCacheStats] = []
+
+    for index, line in enumerate(lines):
+        cacheable_match = CACHEABLE_CALLS_RE.search(line)
+        if cacheable_match is None:
+            continue
+
+        cacheable_calls = int(cacheable_match.group(1))
+        hits: Optional[int] = None
+        misses: Optional[int] = None
+        for stats_line in lines[index + 1 : index + 16]:
+            if CACHEABLE_CALLS_RE.search(stats_line):
+                break
+            if hits is None:
+                hits_match = HITS_RE.search(stats_line)
+                if hits_match is not None:
+                    hits = int(hits_match.group(1))
+            if misses is None:
+                misses_match = MISSES_RE.search(stats_line)
+                if misses_match is not None:
+                    misses = int(misses_match.group(1))
+            if hits is not None and misses is not None:
+                break
+
+        if hits is None or hits > cacheable_calls:
+            continue
+        if misses is None:
+            misses = cacheable_calls - hits
+        if hits + misses != cacheable_calls:
+            continue
+        candidates.append(CCacheStats(hits, misses, cacheable_calls, version))
+
+    return candidates[-1] if candidates else None
+
+
+def parse_cache_restore_status(log_text: str, ccache_configured: bool) -> str:
+    if not ccache_configured:
+        return "not_configured"
+    if CCACHE_RESTORE_HIT_RE.search(log_text):
+        return "hit"
+
+    lines = log_text.splitlines()
+    for index, line in enumerate(lines):
+        if not NO_CACHE_RE.search(line):
+            continue
+        window = "\n".join(lines[max(0, index - 30) : index + 1])
+        if RESTORE_GROUP_RE.search(window) and ("ccache-action" in window.lower() or "ccache-" in window.lower()):
+            return "miss"
+    return "unknown"
+
+
+def fetch_job_result(repo: str, run_id: int, job: Dict[str, Any]) -> JobResult:
+    job_id = int(job.get("databaseId") or 0)
+    job_name = str(job.get("name") or "")
+    conclusion = str(job.get("conclusion") or "")
+    configured_from_steps = job_has_ccache_step(job)
+
+    try:
+        log_text = run_gh(["gh", "run", "view", str(run_id), "--repo", repo, "--job", str(job_id), "--log"])
+    except (OSError, RuntimeError) as error:
+        return JobResult(
+            job_id=job_id,
+            job_name=job_name,
+            conclusion=conclusion,
+            ccache_configured=configured_from_steps,
+            cache_restore_status="unknown" if configured_from_steps else "not_configured",
+            stats_available=False,
+            hits=None,
+            misses=None,
+            cacheable_calls=None,
+            hit_rate_percent=None,
+            ccache_version=None,
+            log_status="error",
+            log_error=str(error),
         )
-        if candidate_key > prev_key:
-            by_name[name] = job
-    ordered_names = []
-    seen = set()
-    for job in jobs:
-        name = job.get("name", "")
-        if name not in seen:
-            ordered_names.append(name)
-            seen.add(name)
-    return [by_name[name] for name in ordered_names if name in by_name]
+
+    stats = parse_ccache_stats(log_text)
+    ccache_configured = configured_from_steps or stats is not None
+    restore_status = parse_cache_restore_status(log_text, ccache_configured)
+    return JobResult(
+        job_id=job_id,
+        job_name=job_name,
+        conclusion=conclusion,
+        ccache_configured=ccache_configured,
+        cache_restore_status=restore_status,
+        stats_available=stats is not None,
+        hits=stats.hits if stats else None,
+        misses=stats.misses if stats else None,
+        cacheable_calls=stats.cacheable_calls if stats else None,
+        hit_rate_percent=stats.hit_rate_percent if stats else None,
+        ccache_version=stats.ccache_version if stats else None,
+        log_status="ok",
+        log_error=None,
+    )
 
 
-def parse_hit_rate_percent(log_text: str) -> Optional[int]:
-    in_stats = False
-    for line in log_text.splitlines():
-        if "ccache -s" in line:
-            in_stats = True
-            continue
-        if in_stats and "ccache --version" in line:
-            in_stats = False
-            continue
-        if not in_stats:
-            continue
-        match = HITS_RE.search(line)
-        if match:
-            value = float(match.group(1))
-            return int(value + 0.5)
-    return None
+def fetch_job_results(repo: str, run_id: int, jobs: List[Dict[str, Any]], verbose: bool = False) -> List[JobResult]:
+    if not jobs:
+        return []
+
+    results: List[Optional[JobResult]] = [None] * len(jobs)
+    with ThreadPoolExecutor(max_workers=min(MAX_LOG_WORKERS, len(jobs))) as executor:
+        futures = {executor.submit(fetch_job_result, repo, run_id, job): index for index, job in enumerate(jobs)}
+        for future in as_completed(futures):
+            index = futures[future]
+            result = future.result()
+            results[index] = result
+            if verbose:
+                print(f"Processed job {result.job_id}: {result.job_name}", file=sys.stderr, flush=True)
+
+    return [result for result in results if result is not None]
 
 
-def parse_found_ccache_file(log_text: str) -> str:
-    if "##[group]Restore cache" not in log_text:
-        return "N/A"
-    if "Cache hit for restore-key" in log_text or "Cache restored successfully" in log_text:
-        return "Yes"
-    if "No cache found." in log_text:
-        return "No"
-    return "No"
+def summarize_results(results: List[JobResult]) -> Dict[str, Any]:
+    configured = [result for result in results if result.ccache_configured]
+    with_stats = [result for result in configured if result.stats_available]
+    total_hits = sum(result.hits or 0 for result in with_stats)
+    total_misses = sum(result.misses or 0 for result in with_stats)
+    total_cacheable_calls = sum(result.cacheable_calls or 0 for result in with_stats)
+    weighted_rate = 100.0 * total_hits / total_cacheable_calls if total_cacheable_calls else None
+    mean_rate = sum(result.hit_rate_percent or 0.0 for result in with_stats) / len(with_stats) if with_stats else None
+
+    return {
+        "total_jobs": len(results),
+        "ccache_configured_jobs": len(configured),
+        "stats_available_jobs": len(with_stats),
+        "cache_restore_hits": sum(result.cache_restore_status == "hit" for result in configured),
+        "cache_restore_misses": sum(result.cache_restore_status == "miss" for result in configured),
+        "cache_restore_unknown": sum(result.cache_restore_status == "unknown" for result in configured),
+        "log_error_jobs": sum(result.log_status == "error" for result in results),
+        "total_hits": total_hits,
+        "total_misses": total_misses,
+        "total_cacheable_calls": total_cacheable_calls,
+        "weighted_hit_rate_percent": weighted_rate,
+        "mean_job_hit_rate_percent": mean_rate,
+    }
 
 
-def format_table(rows: List[Dict[str, str]], columns: List[str]) -> str:
-    widths = {col: len(col) for col in columns}
-    for row in rows:
-        for col in columns:
-            widths[col] = max(widths[col], len(str(row.get(col, ""))))
-    header = "  ".join(col.ljust(widths[col]) for col in columns)
-    sep = "  ".join("-" * widths[col] for col in columns)
-    body = ["  ".join(str(row.get(col, "")).ljust(widths[col]) for col in columns) for row in rows]
-    return "\n".join([header, sep] + body)
+def format_percent(value: Optional[float]) -> str:
+    return "N/A" if value is None else f"{value:.2f}%"
+
+
+def result_row(result: JobResult) -> Dict[str, str]:
+    return {
+        "job_name": result.job_name,
+        "conclusion": result.conclusion,
+        "ccache": "Yes" if result.ccache_configured else "No",
+        "restore": result.cache_restore_status,
+        "hits": "N/A" if result.hits is None else str(result.hits),
+        "cacheable_calls": "N/A" if result.cacheable_calls is None else str(result.cacheable_calls),
+        "hit_rate": format_percent(result.hit_rate_percent),
+        "log": result.log_status,
+    }
+
+
+def escape_markdown(cell: str) -> str:
+    return cell.replace("\\", "\\\\").replace("|", "\\|").replace("\n", "<br>")
 
 
 def format_markdown_table(rows: List[Dict[str, str]], columns: List[str]) -> str:
     header = "| " + " | ".join(columns) + " |"
     separator = "| " + " | ".join(["---"] * len(columns)) + " |"
-    body = ["| " + " | ".join(str(row.get(col, "")) for col in columns) + " |" for row in rows]
+    body = ["| " + " | ".join(escape_markdown(str(row.get(column, ""))) for column in columns) + " |" for row in rows]
     return "\n".join([header, separator] + body)
 
 
-def to_csv(rows: List[Dict[str, str]], columns: List[str]) -> str:
-    def escape(cell: str) -> str:
-        if any(ch in cell for ch in [",", "\"", "\n"]):
-            return "\"" + cell.replace("\"", "\"\"") + "\""
-        return cell
-
-    lines = [",".join(columns)]
+def format_table(rows: List[Dict[str, str]], columns: List[str]) -> str:
+    widths = {column: len(column) for column in columns}
     for row in rows:
-        lines.append(",".join(escape(str(row.get(col, ""))) for col in columns))
-    return "\n".join(lines)
+        for column in columns:
+            widths[column] = max(widths[column], len(str(row.get(column, ""))))
+    header = "  ".join(column.ljust(widths[column]) for column in columns)
+    separator = "  ".join("-" * widths[column] for column in columns)
+    body = ["  ".join(str(row.get(column, "")).ljust(widths[column]) for column in columns) for row in rows]
+    return "\n".join([header, separator] + body)
+
+
+def human_summary(summary: Dict[str, Any]) -> List[str]:
+    return [
+        (
+            f"Jobs: {summary['total_jobs']} total; {summary['ccache_configured_jobs']} configured for ccache; "
+            f"{summary['stats_available_jobs']} with statistics."
+        ),
+        (
+            f"Restore: {summary['cache_restore_hits']} hits; {summary['cache_restore_misses']} misses; "
+            f"{summary['cache_restore_unknown']} unknown."
+        ),
+        (
+            f"Hit rate: {format_percent(summary['weighted_hit_rate_percent'])} weighted "
+            f"({summary['total_hits']} / {summary['total_cacheable_calls']}); "
+            f"{format_percent(summary['mean_job_hit_rate_percent'])} mean across jobs."
+        ),
+        f"Log errors: {summary['log_error_jobs']}.",
+    ]
+
+
+def format_human_output(
+    results: List[JobResult], summary: Dict[str, Any], output_format: str, threshold: float, all_jobs: bool
+) -> str:
+    markdown = output_format == "markdown"
+    parts: List[str] = []
+    summary_lines = human_summary(summary)
+    if markdown:
+        parts.append("# Ccache workflow summary\n\n" + "\n".join(f"- {line}" for line in summary_lines))
+    else:
+        parts.append("CCache workflow summary\n" + "\n".join(summary_lines))
+
+    low_hit_results = sorted(
+        (result for result in results if result.hit_rate_percent is not None and result.hit_rate_percent < threshold),
+        key=lambda result: (result.hit_rate_percent, result.job_name),
+    )
+    incomplete_results = [
+        result
+        for result in results
+        if result.ccache_configured and (not result.stats_available or result.log_status == "error")
+    ]
+    columns = ["job_name", "conclusion", "restore", "hits", "cacheable_calls", "hit_rate"]
+    formatter = format_markdown_table if markdown else format_table
+
+    low_title = f"Jobs below {threshold:g}%"
+    low_body = formatter([result_row(result) for result in low_hit_results], columns) if low_hit_results else "None."
+    parts.append((f"## {low_title}" if markdown else low_title) + "\n\n" + low_body)
+
+    incomplete_columns = ["job_name", "conclusion", "restore", "log"]
+    incomplete_body = (
+        formatter([result_row(result) for result in incomplete_results], incomplete_columns)
+        if incomplete_results
+        else "None."
+    )
+    parts.append(("## Missing statistics" if markdown else "Missing statistics") + "\n\n" + incomplete_body)
+
+    if all_jobs:
+        all_columns = ["job_name", "conclusion", "ccache", "restore", "hits", "cacheable_calls", "hit_rate", "log"]
+        all_body = formatter([result_row(result) for result in results], all_columns)
+        parts.append(("## All jobs" if markdown else "All jobs") + "\n\n" + all_body)
+    return "\n\n".join(parts)
+
+
+def job_to_machine_row(result: JobResult) -> Dict[str, Any]:
+    return asdict(result)
+
+
+def to_csv(results: List[JobResult]) -> str:
+    columns = [
+        "job_id",
+        "job_name",
+        "conclusion",
+        "ccache_configured",
+        "cache_restore_status",
+        "stats_available",
+        "hits",
+        "misses",
+        "cacheable_calls",
+        "hit_rate_percent",
+        "ccache_version",
+        "log_status",
+        "log_error",
+    ]
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=columns, lineterminator="\n")
+    writer.writeheader()
+    for result in results:
+        row = job_to_machine_row(result)
+        row["ccache_configured"] = str(result.ccache_configured).lower()
+        row["stats_available"] = str(result.stats_available).lower()
+        writer.writerow(row)
+    return output.getvalue().rstrip("\n")
+
+
+def format_output(
+    repo: str,
+    run_id: int,
+    attempt: Optional[int],
+    results: List[JobResult],
+    output_format: str,
+    threshold: float,
+    all_jobs: bool,
+) -> str:
+    summary = summarize_results(results)
+    if output_format == "json":
+        payload = {
+            "repository": repo,
+            "run_id": run_id,
+            "attempt": attempt,
+            "threshold_percent": threshold,
+            "summary": summary,
+            "jobs": [job_to_machine_row(result) for result in results],
+        }
+        return json.dumps(payload, indent=2)
+    if output_format == "csv":
+        return to_csv(results)
+    return format_human_output(results, summary, output_format, threshold, all_jobs)
 
 
 def emit(text: str, output_path: str) -> None:
     if output_path:
-        with open(output_path, "w", encoding="utf-8") as f:
-            f.write(text)
+        with open(output_path, "w", encoding="utf-8") as output_file:
+            output_file.write(text)
             if not text.endswith("\n"):
-                f.write("\n")
+                output_file.write("\n")
         return
     print(text)
-
-
-def summarize_rows(rows: List[Dict[str, str]]) -> str:
-    total_jobs = len(rows)
-    found_ccache_jobs = sum(1 for row in rows if row.get("found_ccache_file") == "Yes")
-    numeric_rates: List[int] = []
-    for row in rows:
-        rate = row.get("ccache_hit_rate", "")
-        if rate.endswith("%"):
-            try:
-                numeric_rates.append(int(rate[:-1]))
-            except ValueError:
-                pass
-    if numeric_rates:
-        avg_rate = int(sum(numeric_rates) / len(numeric_rates) + 0.5)
-        avg_text = f"{avg_rate}%"
-    else:
-        avg_text = "N/A"
-    return (
-        f"- Total jobs is {total_jobs} where {found_ccache_jobs} use a ccache file.\n"
-        f"- The average ccache hit rate is {avg_text}."
-    )
 
 
 def main() -> int:
     args = parse_args()
     try:
         print(
-            f"Fetching workflow run log files for run {args.run_id} from {args.repo}...",
+            f"Fetching workflow run logs for run {args.run_id} from {args.repo}...",
             file=sys.stderr,
             flush=True,
         )
-        jobs = get_jobs(args.repo, args.run_id)
-        selected_jobs = jobs if args.keep_retries else dedupe_jobs_keep_latest(jobs)
-
+        all_jobs, actual_attempt = get_jobs(args.repo, args.run_id, args.attempt)
+        jobs = [job for job in all_jobs if job.get("conclusion") != "skipped"]
         if args.verbose:
-            print(
-                f"Found {len(jobs)} jobs ({len(selected_jobs)} after retry filtering).",
-                file=sys.stderr,
-            )
-
-        rows: List[Dict[str, str]] = []
-        for job in selected_jobs:
-            job_id = int(job.get("databaseId") or 0)
-            name = str(job.get("name") or "")
-            conclusion = str(job.get("conclusion") or "")
-            if args.verbose:
-                print(f"Fetching log for job {job_id}: {name}", file=sys.stderr, flush=True)
-
-            try:
-                log_text = run_gh(
-                    ["gh", "run", "view", str(args.run_id), "--repo", args.repo, "--job", str(job_id), "--log"]
-                )
-            except RuntimeError:
-                hit_rate = "N/A"
-                found_ccache = "N/A"
-            else:
-                parsed_rate = parse_hit_rate_percent(log_text)
-                hit_rate = f"{parsed_rate}%" if parsed_rate is not None else "N/A"
-                found_ccache = parse_found_ccache_file(log_text)
-
-            rows.append(
-                {
-                    "job_id": str(job_id),
-                    "job_name": name,
-                    "conclusion": conclusion,
-                    "ccache_hit_rate": hit_rate,
-                    "found_ccache_file": found_ccache,
-                }
-            )
-            print(f"Processed job {job_id}: {name}", file=sys.stderr, flush=True)
-
-        rows = [row for row in rows if row.get("conclusion") != "skipped"]
-        columns = ["job_id", "job_name", "conclusion", "ccache_hit_rate", "found_ccache_file"]
-        if args.format == "json":
-            text = json.dumps(rows, indent=2)
-        elif args.format == "csv":
-            text = to_csv(rows, columns)
-        elif args.format == "markdown":
-            markdown_columns = ["job_name", "ccache_hit_rate", "found_ccache_file"]
-            text = format_markdown_table(rows, markdown_columns) + "\n\n" + summarize_rows(rows)
-        else:
-            table_columns = ["job_name", "conclusion", "ccache_hit_rate", "found_ccache_file"]
-            text = format_table(rows, table_columns) + "\n\n" + summarize_rows(rows)
-
+            print(f"Fetching {len(jobs)} non-skipped job logs with up to {MAX_LOG_WORKERS} workers.", file=sys.stderr)
+        results = fetch_job_results(args.repo, args.run_id, jobs, args.verbose)
+        text = format_output(
+            args.repo,
+            args.run_id,
+            actual_attempt,
+            results,
+            args.format,
+            args.threshold,
+            args.all_jobs,
+        )
         emit(text, args.output)
-        return 0
-    except RuntimeError as err:
-        print(str(err), file=sys.stderr)
+        return 2 if any(result.log_status == "error" for result in results) else 0
+    except (json.JSONDecodeError, OSError, RuntimeError, ValueError) as error:
+        print(str(error), file=sys.stderr)
         return 1
 
 

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -84,6 +84,7 @@ class TestCase:
 class FailedAttempt:
     lines: list[str]
     reproduce_batch: list[str]
+    failed_test_names: list[str]
 
 
 @dataclass(frozen=True)
@@ -141,6 +142,7 @@ class BatchRunState:
         self.retry_count = 0
         self.stop_launching = False
         self.failed_attempts = {}
+        self.failed_test_names = set()
 
     def record_retry(self):
         self.retry_count += 1
@@ -148,10 +150,16 @@ class BatchRunState:
     def record_failure(self):
         self.failed_count += 1
 
-    def add_failed_attempt(self, batch_idx: int, lines: list[str], reproduce_batch: list[str]):
+    def add_failed_attempt(
+        self, batch_idx: int, lines: list[str], reproduce_batch: list[str], failed_test_names: list[str]
+    ):
         self.failed_attempts.setdefault(batch_idx, []).append(
-            FailedAttempt(lines=lines, reproduce_batch=reproduce_batch)
+            FailedAttempt(lines=lines, reproduce_batch=reproduce_batch, failed_test_names=failed_test_names)
         )
+
+    def record_failed_test_names(self, attempts: list[FailedAttempt]):
+        for attempt in attempts:
+            self.failed_test_names.update(attempt.failed_test_names)
 
     def pop_failed_attempts(self, batch_idx: int):
         return self.failed_attempts.pop(batch_idx, [])
@@ -656,27 +664,31 @@ def extract_failed_reason_line(stdout_lines: list[str]):
     return None
 
 
+def find_catch_failure_test_name(stdout_lines: list[str], failure_idx: int):
+    separator_indices = []
+    for idx in range(failure_idx - 1, -1, -1):
+        stripped = stdout_lines[idx].strip()
+        if stripped and set(stripped) == {"-"}:
+            separator_indices.append(idx)
+            if len(separator_indices) == 2:
+                break
+    if not separator_indices:
+        return None, separator_indices
+
+    name_idx = separator_indices[0] - 1
+    if name_idx < 0:
+        return None, separator_indices
+    test_name = stdout_lines[name_idx].strip()
+    return test_name or None, separator_indices
+
+
 def iter_stdout_failure_blocks(stdout_lines: list[str]):
     for failure_idx, line in enumerate(stdout_lines):
         if not FAILED_HEADER_PATTERN.match(line):
             continue
 
-        separator_indices = []
-        for idx in range(failure_idx - 1, -1, -1):
-            stripped = stdout_lines[idx].strip()
-            if stripped and set(stripped) == {"-"}:
-                separator_indices.append(idx)
-                if len(separator_indices) == 2:
-                    break
+        test_name, separator_indices = find_catch_failure_test_name(stdout_lines, failure_idx)
         start_idx = separator_indices[-1] if separator_indices else failure_idx
-
-        test_name = None
-        if len(separator_indices) >= 2:
-            name_idx = separator_indices[-1] + 1
-            if name_idx < len(stdout_lines):
-                candidate_name = stdout_lines[name_idx].strip()
-                if candidate_name:
-                    test_name = candidate_name
 
         end_idx = len(stdout_lines)
         for idx in range(failure_idx + 1, len(stdout_lines)):
@@ -704,6 +716,37 @@ def iter_stdout_failure_blocks(stdout_lines: list[str]):
         if any(EXPLICIT_MESSAGE_PATTERN.match(entry) for entry in block):
             continue
         yield test_name, block
+
+
+def extract_failed_test_names(failure: FailureInfo, stdout: str, stderr: str, batch: list[str]):
+    stdout_lines = strip_skipped_test_summary_lines(strip_ansi(stdout).splitlines())
+    stderr_lines = strip_skipped_test_summary_lines(strip_ansi(stderr).splitlines())
+    failed_names = []
+
+    def add_name(test_name: str | None):
+        if test_name and test_name not in failed_names:
+            failed_names.append(test_name)
+
+    for line in stderr_lines:
+        stripped = line.strip()
+        match = FAILING_TEST_PATTERN.match(stripped)
+        if match:
+            add_name(match.group(1))
+            continue
+        match = WRONG_RESULT_PATTERN.match(stripped)
+        if match and match.group(1):
+            add_name(match.group(1))
+
+    for failure_idx, line in enumerate(stdout_lines):
+        if FAILED_HEADER_PATTERN.match(line):
+            test_name, _ = find_catch_failure_test_name(stdout_lines, failure_idx)
+            add_name(test_name)
+
+    add_name(failure.test_name)
+    if not failed_names:
+        for test_name in failure.reproduce_batch or batch:
+            add_name(test_name)
+    return failed_names
 
 
 def extract_stdout_failure_block(stdout_lines: list[str]):
@@ -1178,6 +1221,33 @@ def format_unittest_bin_for_display(unittest_bin: str):
     return unittest_bin
 
 
+def format_test_runner_for_display(unittest_bin: str):
+    runner_name = "run.py" if os.name == "nt" else "run"
+    return format_unittest_bin_for_display(os.fspath(Path(unittest_bin).with_name(runner_name)))
+
+
+def quote_catch_test_name(test_name: str):
+    escaped_name = test_name.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped_name}"'
+
+
+def format_failed_tests_reproducer(
+    unittest_bin: str, test_flags: str, failed_test_configs: list[str], failed_test_names: list[str]
+):
+    runner = format_test_runner_for_display(unittest_bin)
+    command = [runner]
+    if os.name == "nt":
+        command.insert(0, sys.executable)
+    if test_flags:
+        command.extend(["--test-flags", test_flags])
+    for test_config in failed_test_configs:
+        command.extend(["--test-config", test_config])
+    command.append(",".join(quote_catch_test_name(test_name) for test_name in failed_test_names))
+    if os.name == "nt":
+        return subprocess.list2cmdline(command)
+    return shlex.join(command)
+
+
 def normalize_output(output):
     if isinstance(output, bytes):
         return output.decode("utf8", errors="backslashreplace")
@@ -1566,7 +1636,8 @@ def handle_failed_batch(ctx: RunContext, batch_info, result):
     )
     lines = render_failure_lines_with_diagnostics(failure, result["stdout"], result["stderr"])
     reproduce_batch = failure.reproduce_batch
-    ctx.state.add_failed_attempt(batch_info["batch_idx"], lines, reproduce_batch)
+    failed_test_names = extract_failed_test_names(failure, result["stdout"], result["stderr"], batch_info["batch"])
+    ctx.state.add_failed_attempt(batch_info["batch_idx"], lines, reproduce_batch, failed_test_names)
     retry_target = format_failed_test_retry_target(failure.test_name, batch_info)
     if result.get("allow_retry", True) and ctx.state.can_retry(batch_info, ctx.config):
         ctx.state.record_retry()
@@ -1590,11 +1661,13 @@ def handle_failed_batch(ctx: RunContext, batch_info, result):
             f"not retrying failed test {retry_target} after reaching {ctx.config.max_retries} retries"
         )
 
+    attempt_summaries = ctx.state.pop_failed_attempts(batch_info["batch_idx"])
+    ctx.state.record_failed_test_names(attempt_summaries)
     ctx.progress.print_message(
         format_batch_failure(
             batch_info["batch"],
             ctx.config,
-            ctx.state.pop_failed_attempts(batch_info["batch_idx"]),
+            attempt_summaries,
             recovered=False,
             retry_count=batch_info["attempt"],
         )
@@ -1706,6 +1779,7 @@ class ConfigRunResult:
     failed_tests: int
     skipped_tests: int
     elapsed_seconds: float
+    failed_test_names: tuple[str, ...] = ()
 
 
 def build_test_flags(base_flags: str, test_config: str | None):
@@ -1825,6 +1899,7 @@ def run_single_config(
         )
 
         stabilization_failed = False
+        stabilization_failed_test_names = []
         for rerun_idx in range(max(fast_extra_runs, slow_extra_runs)):
             rerun_round = rerun_idx + 1
             if rerun_idx < fast_extra_runs and fast_tests:
@@ -1833,12 +1908,14 @@ def run_single_config(
                 fast_result = run_tests(config, fast_batches, len(fast_tests))
                 if fast_result.returncode != 0:
                     stabilization_failed = True
+                    stabilization_failed_test_names.extend(fast_result.failed_test_names)
             if rerun_idx < slow_extra_runs and slow_tests:
                 print(f"stabilization rerun {rerun_round}/{slow_extra_runs} for slow tests")
                 slow_batches = list(chunked(slow_tests, computed_batch_size))
                 slow_result = run_tests(config, slow_batches, len(slow_tests))
                 if slow_result.returncode != 0:
                     stabilization_failed = True
+                    stabilization_failed_test_names.extend(slow_result.failed_test_names)
             if stabilization_failed:
                 break
 
@@ -1850,6 +1927,7 @@ def run_single_config(
                 failed_tests=max(1, initial_run_result.failed_tests),
                 skipped_tests=initial_run_result.skipped_tests,
                 elapsed_seconds=initial_run_result.elapsed_seconds,
+                failed_test_names=tuple(dict.fromkeys(stabilization_failed_test_names)),
             )
 
         return initial_run_result
@@ -1898,6 +1976,9 @@ def main_impl(argv: list[str] | None = None):
         unittest_bin = unittest_bin.replace("/", "\\")
     batch_size = args.batch_size
     failed_configs = []
+    failed_test_configs = []
+    failed_test_names = []
+    failed_test_name_set = set()
     if len(config_invocations) > 1:
         print(f"running {len(config_invocations)} configs")
     coverage_profile_tmp = None
@@ -1956,6 +2037,13 @@ def main_impl(argv: list[str] | None = None):
                 return 130
             if returncode != 0:
                 failed_configs.append(invocation.label)
+                if run_result.failed_test_names:
+                    if invocation.test_config is not None:
+                        failed_test_configs.append(invocation.test_config)
+                    for test_name in run_result.failed_test_names:
+                        if test_name not in failed_test_name_set:
+                            failed_test_name_set.add(test_name)
+                            failed_test_names.append(test_name)
 
         report_returncode = 0
         if args.coverage_report is not None:
@@ -1967,9 +2055,12 @@ def main_impl(argv: list[str] | None = None):
             coverage_profile_tmp.cleanup()
 
     if failed_configs:
-        if len(config_invocations) == 1:
-            return 1
-        print(f"error: {len(failed_configs)} config runs failed: {', '.join(failed_configs)}")
+        if len(config_invocations) > 1:
+            print(f"error: {len(failed_configs)} config runs failed: {', '.join(failed_configs)}")
+        if failed_test_names:
+            print()
+            print("reproduce all failed tests:")
+            print(format_failed_tests_reproducer(unittest_bin, args.test_flags, failed_test_configs, failed_test_names))
         return 1
     if args.coverage_report is not None and report_returncode != 0:
         return report_returncode
@@ -2081,12 +2172,19 @@ def run_tests(config: TestRunnerConfig, batches, total_tests: int):
             print(f"{reason}: {skipped_reason_counts[reason]}")
     failed_tests = state.failed_count
     passed_tests = max(0, total_tests - failed_tests - total_skipped_tests)
+    failed_test_names = []
+    for batch in batches:
+        for test_name in batch:
+            if test_name in state.failed_test_names and test_name not in failed_test_names:
+                failed_test_names.append(test_name)
+    failed_test_names.extend(sorted(state.failed_test_names.difference(failed_test_names)))
     return ConfigRunResult(
         returncode=exit_code,
         passed_tests=passed_tests,
         failed_tests=failed_tests,
         skipped_tests=total_skipped_tests,
         elapsed_seconds=elapsed,
+        failed_test_names=tuple(failed_test_names),
     )
 
 

--- a/scripts/ci/test_package_release_artifact.py
+++ b/scripts/ci/test_package_release_artifact.py
@@ -72,6 +72,42 @@ class PackageReleaseArtifactTest(unittest.TestCase):
                 self.assertTrue(members["libduckdb.so"].issym())
                 self.assertEqual(members["libduckdb.so"].linkname, "libduckdb.so.1")
 
+    def test_static_libraries_release_artifact(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            libraries = root / "libs"
+            libraries.mkdir()
+            library = libraries / "libduckdb_static.a"
+            library.write_bytes(b"library")
+            extension = libraries / "libcore_functions_extension.a"
+            extension.write_bytes(b"extension")
+
+            self.run_make(
+                "static-libs-release-artifact",
+                root,
+                ARTIFACT_SUFFIX="linux-amd64",
+                STATIC_LIBRARIES=str(libraries / "*"),
+            )
+
+            archive_path = root / "duckdb-static-libs-linux-amd64.tar.gz"
+            with tarfile.open(archive_path, mode="r:gz") as archive:
+                members = {member.name: member for member in archive.getmembers()}
+                self.assertEqual(
+                    set(members),
+                    {
+                        "libduckdb_static.a",
+                        "libcore_functions_extension.a",
+                        "duckdb.h",
+                        "duckdb_v2.h",
+                        "duckdb_extension.h",
+                        "duckdb_extension_v2.h",
+                    },
+                )
+                self.assertEqual(archive.extractfile(members["libduckdb_static.a"]).read(), b"library")
+                self.assertEqual(
+                    archive.extractfile(members["libcore_functions_extension.a"]).read(), b"extension"
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/test_package_release_artifact.py
+++ b/scripts/ci/test_package_release_artifact.py
@@ -104,9 +104,7 @@ class PackageReleaseArtifactTest(unittest.TestCase):
                     },
                 )
                 self.assertEqual(archive.extractfile(members["libduckdb_static.a"]).read(), b"library")
-                self.assertEqual(
-                    archive.extractfile(members["libcore_functions_extension.a"]).read(), b"extension"
-                )
+                self.assertEqual(archive.extractfile(members["libcore_functions_extension.a"]).read(), b"extension")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import shlex
 import sys
 import tempfile
 import textwrap
@@ -125,6 +126,26 @@ class RunTestsScriptTest(unittest.TestCase):
         finally:
             unittest_path.unlink(missing_ok=True)
             os.rmdir(wrapper_dir)
+
+    def test_failed_tests_reproducer_uses_runner_and_preserves_context(self):
+        command = run_tests.format_failed_tests_reproducer(
+            "/repo/build/reldebug/test/unittest",
+            "--force-storage --label 'two words'",
+            ["test/configs/a config.json"],
+            ["test/sql/a.test", "Compiled, test's name"],
+        )
+
+        self.assertEqual(
+            shlex.split(command),
+            [
+                os.path.relpath("/repo/build/reldebug/test/run", REPO_ROOT),
+                "--test-flags",
+                "--force-storage --label 'two words'",
+                "--test-config",
+                "test/configs/a config.json",
+                '"test/sql/a.test","Compiled, test\'s name"',
+            ],
+        )
 
     def test_summarizes_wrong_result_failure(self):
         stderr = """
@@ -255,6 +276,39 @@ mode skip unsupported: 1
                 self.assertIn("Skipped tests for the following reasons:", proc.stdout)
                 for expected_reason in case["expected_reasons"]:
                     self.assertIn(expected_reason, proc.stdout)
+
+    def test_successful_batches_print_progress_bar(self):
+        test_list_path = create_temp_file("test/sql/a.test\ntest/sql/b.test\n")
+        result = {
+            "failed": False,
+            "stdout": "All tests passed (1 assertion in 1 test case)\n",
+            "stderr": "",
+            "message": None,
+            "peak_rss_bytes": 0,
+        }
+
+        try:
+            with mock.patch("scripts.ci.run_tests.run_batch", side_effect=[result, result]):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--batch-size",
+                        "1",
+                        "--test-list",
+                        str(test_list_path),
+                        "--test-command",
+                        "echo fake-run {test_list}",
+                        "unused-binary",
+                    ]
+                )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertEqual(proc.stdout.count(".................................................."), 2)
+        self.assertIn("[ 50%]", proc.stdout)
+        self.assertIn("[100%]", proc.stdout)
 
     def test_aggregates_skipped_tests_from_multiple_batches(self):
         test_list_path = create_temp_file("test/sql/a.test\ntest/sql/b.test\n")
@@ -794,7 +848,12 @@ require windows: 2
                 returncode=0, passed_tests=1, failed_tests=0, skipped_tests=0, elapsed_seconds=0.0
             ),
             run_tests.ConfigRunResult(
-                returncode=1, passed_tests=0, failed_tests=1, skipped_tests=0, elapsed_seconds=0.0
+                returncode=1,
+                passed_tests=0,
+                failed_tests=1,
+                skipped_tests=0,
+                elapsed_seconds=0.0,
+                failed_test_names=("test/sql/fast.test",),
             ),
         ]
 
@@ -819,6 +878,8 @@ require windows: 2
 
         self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
         self.assertIn("error: stabilization rerun failure detected", proc.stdout)
+        self.assertIn("reproduce all failed tests:", proc.stdout)
+        self.assertIn("run '\"test/sql/fast.test\"'", proc.stdout)
 
     def test_retries_failed_fake_job(self):
         test_list_path = create_temp_file("test/sql/a.test\n")
@@ -870,6 +931,7 @@ require windows: 2
         self.assertIn("recovered: passed on retry 1/1", proc.stdout)
         self.assertEqual(proc.stdout.count("fake failure"), 1)
         self.assertIn("ran tests: ", proc.stdout)
+        self.assertNotIn("reproduce all failed tests:", proc.stdout)
 
     def test_retries_timed_out_sleep_job(self):
         test_list_path = create_temp_file("test/sql/a.test\n")
@@ -975,6 +1037,106 @@ require windows: 2
         self.assertIn("details: Mismatch on row 1, column count_star()(index 1)", proc.stdout)
         self.assertNotIn("### failed test batch", proc.stdout)
         self.assertNotIn("attempts:", proc.stdout)
+
+    def test_final_reproducer_includes_every_failure_in_test_list_order(self):
+        test_names = ["test/sql/a.test", "Compiled test name", "test/sql/b.test"]
+        test_list_path = create_temp_file("\n".join(test_names) + "\n")
+        stdout = """
+-------------------------------------------------------------------------------
+Compiled test name
+-------------------------------------------------------------------------------
+/repo/test.cpp:10
+...............................................................................
+
+/repo/test.cpp:12: FAILED:
+  REQUIRE( false )
+with expansion:
+  false
+"""
+        stderr = """
+1. test/sql/b.test:7
+================================================================================
+Error: Catalog Error: b failed
+================================================================================
+2. test/sql/a.test:9
+================================================================================
+Error: Catalog Error: a failed
+================================================================================
+"""
+
+        try:
+            with mock.patch(
+                "scripts.ci.run_tests.run_batch",
+                return_value={
+                    "failed": True,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                    "message": None,
+                    "peak_rss_bytes": 0,
+                },
+            ):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--batch-size",
+                        "3",
+                        "--test-list",
+                        str(test_list_path),
+                        "--test-command",
+                        "echo fake-run {test_list}",
+                        "unused-binary",
+                    ]
+                )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("reproduce all failed tests:", proc.stdout)
+        command = proc.stdout.rstrip().splitlines()[-1]
+        self.assertEqual(
+            shlex.split(command),
+            ["run", '"test/sql/a.test","Compiled test name","test/sql/b.test"'],
+        )
+
+    def test_final_reproducer_unions_failures_across_exhausted_retries(self):
+        test_list_path = create_temp_file("test/sql/a.test\ntest/sql/b.test\n")
+
+        def failure(test_name):
+            return {
+                "failed": True,
+                "stdout": "",
+                "stderr": f"1. {test_name}:4\nError: failed\n",
+                "message": None,
+                "peak_rss_bytes": 0,
+            }
+
+        try:
+            with mock.patch(
+                "scripts.ci.run_tests.run_batch",
+                side_effect=[failure("test/sql/b.test"), failure("test/sql/a.test")],
+            ):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--batch-size",
+                        "2",
+                        "--retry",
+                        "1",
+                        "--test-list",
+                        str(test_list_path),
+                        "--test-command",
+                        "echo fake-run {test_list}",
+                        "unused-binary",
+                    ]
+                )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        command = proc.stdout.rstrip().splitlines()[-1]
+        self.assertEqual(shlex.split(command), ["run", '"test/sql/a.test","test/sql/b.test"'])
 
     def test_failed_batch_includes_mismatch_context(self):
         test_list_path = create_temp_file("test/sql/a.test\n")
@@ -1888,6 +2050,56 @@ For more information, see https://duckdb.org/docs/current/dev/internal_errors
         self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
         self.assertIn("error: no tests selected for config 'test/configs/empty.json'", proc.stdout)
         self.assertIn("error: 1 config runs failed: test/configs/empty.json", proc.stdout)
+
+    def test_final_reproducer_preserves_flags_and_failed_configs(self):
+        test_list_path = create_temp_file("test/sql/a.test\ntest/sql/b.test\n")
+        run_results = [
+            run_tests.ConfigRunResult(
+                returncode=0, passed_tests=2, failed_tests=0, skipped_tests=0, elapsed_seconds=0.0
+            ),
+            run_tests.ConfigRunResult(
+                returncode=1,
+                passed_tests=1,
+                failed_tests=1,
+                skipped_tests=0,
+                elapsed_seconds=0.0,
+                failed_test_names=("test/sql/b.test",),
+            ),
+        ]
+
+        try:
+            with mock.patch("scripts.ci.run_tests.run_tests", side_effect=run_results):
+                proc = start_runner(
+                    [
+                        "--workers",
+                        "1",
+                        "--test-list",
+                        str(test_list_path),
+                        "--test-flags",
+                        "--force-storage --force-reload",
+                        "--test-config",
+                        "test/configs/pass.json",
+                        "--test-config",
+                        "test/configs/fail.json",
+                        "build/reldebug/test/unittest",
+                    ]
+                )
+        finally:
+            test_list_path.unlink(missing_ok=True)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        command = proc.stdout.rstrip().splitlines()[-1]
+        self.assertEqual(
+            shlex.split(command),
+            [
+                "build/reldebug/test/run",
+                "--test-flags",
+                "--force-storage --force-reload",
+                "--test-config",
+                "test/configs/fail.json",
+                '"test/sql/b.test"',
+            ],
+        )
 
     def test_ci_groups_close_when_all_configs_pass(self):
         listed_tests_path = create_temp_file(

--- a/scripts/package_release_artifact.sh
+++ b/scripts/package_release_artifact.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-	echo "Usage: $0 <cli|shared-libs> <artifact-suffix> <input> [...]" >&2
+	echo "Usage: $0 <cli|shared-libs|static-libs> <artifact-suffix> <input> [...]" >&2
 	exit 1
 }
 
@@ -29,6 +29,9 @@ cli)
 	;;
 shared-libs)
 	artifact_name="duckdb-shared-libs-${artifact_suffix}.tar.gz"
+	;;
+static-libs)
+	artifact_name="duckdb-static-libs-${artifact_suffix}.tar.gz"
 	;;
 *)
 	usage


### PR DESCRIPTION
- Show test run command with all fail test names.
```
config: workers=13, retry=0, max_retries=4, batch_size=1, batch_timeout_seconds=300, fail_require_skip=False
.................................................. [ 50%]
================================================================
error: FAIL test/sql/parallelism/interquery/concurrent_set_async_threads_read_ahead.test


    53  # the database must remain usable afterwards
  > 54  query I
    55  SELECT 42
    56  ----
    57  43

details: Mismatch on row 1, column 42(index 1)

Expected result:
43

Actual result:
42

reproduce:
build/release/test/unittest test/sql/parallelism/interquery/concurrent_set_async_threads_read_ahead.test

.................................................. [100%]
❌ ran tests: 1 passed, 1 failed, 0 skipped in 2s

reproduce all failed tests:
build/release/test/run '"test/sql/parallelism/interquery/concurrent_set_async_threads_read_ahead.test"'
```
- Use consistent naming for static/shared libs.
```
static-libs-${platform}-${arch}.zip  ->  duckdb-static-libs-${platform}-${arch}.tar.gz
shared-libs-${platform}-${arch}.zip  ->  duckdb-shared-libs-${platform}-${arch}.tar.gz
```
so they match existing `duckdb-cli-${platform}-${arch}.tar.gz`.
- Publish alpha only on default branch (= `v2.0-cyanoptera` now).
  - Later, if we switch the default branch back to `main`, CI starts to publish alpha for `2.1` releases on `main`.
- Pin emscripten in main CI workflow.
- Parse CI logs better in the ccache summary script.
  - I used this tool to analyse ccache usage in whole CI workflow runs.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/10624.
Fixes https://github.com/duckdblabs/duckdb-internal/issues/10660.