### PR TITLE
Fix missing includes for non-unity build

### DIFF
--- a/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -42,6 +42,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
+#include "duckdb/parser/parsed_data/create_window_function_info.hpp"
 
 namespace duckdb {
 

--- a/src/storage/checkpoint_manager.cpp
+++ b/src/storage/checkpoint_manager.cpp
@@ -38,6 +38,7 @@
 #include "duckdb/transaction/transaction_manager.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/parser/parsed_data/create_view_info.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
Description: Compiling the main branch with DISABLE_UNITY=1 fails on duck_schema_entry.cpp and checkpoint_manager.cpp due to missing includes for CreateWindowFunctionInfo and CreateViewInfo. This patch explicitly includes their respective headers so the dynamic_cast can resolve the complete types.