### PR TITLE
Add support for directly pushing OpenFileInfo into the MultiFileReader list from SQL

### DIFF
--- a/extension/parquet/parquet_multi_file_info.cpp
+++ b/extension/parquet/parquet_multi_file_info.cpp
@@ -450,17 +450,11 @@ const vector<ParquetMetadataCacheEntry> &ParquetReadBindData::TryLoadCaches(cons
 			return caches;
 		}
 		// check if the file has any deletes
+		// if it has, skip emitting partition stats
+		// FIXME: we could emit partition stats but set count to `COUNT_APPROXIMATE` instead of `COUNT_EXACT`
 		bool has_deletes = false;
 		if (file.extended_info) {
-			auto entry = file.extended_info->options.find("has_deletes");
-			if (entry != file.extended_info->options.end()) {
-				if (BooleanValue::Get(entry->second)) {
-					// the file has deletes - skip emitting partition stats
-					// FIXME: we could emit partition stats but set count to `COUNT_APPROXIMATE` instead of
-					// `COUNT_EXACT`
-					has_deletes = true;
-				}
-			}
+			file.extended_info->TryGetOption("has_deletes", has_deletes);
 		}
 
 		// check if the cache is valid based ONLY on the OpenFileInfo (do not do any file system requests here)
@@ -756,14 +750,13 @@ unique_ptr<NodeStatistics> ParquetMultiFileInfo::GetCardinality(ClientContext &c
 			estimated_file_row_count = 0;
 			break;
 		}
-		auto entry = file.extended_info->options.find("file_size");
-		if (entry == file.extended_info->options.end()) {
+		idx_t current_file_size;
+		if (!file.extended_info->TryGetOption("file_size", current_file_size)) {
 			// no file size available
 			estimated_file_row_count = 0;
 			break;
 		}
 		// we have the file size - estimate row count based on estimated bytes per row
-		auto current_file_size = entry->second.GetValue<uint64_t>();
 		files_with_sizes++;
 		idx_t rows_in_this_file = MaxValue<idx_t>(current_file_size / estimated_bytes_per_row, 1ULL);
 		estimated_file_row_count += rows_in_this_file;

--- a/extension/parquet/parquet_reader.cpp
+++ b/extension/parquet/parquet_reader.cpp
@@ -1456,15 +1456,14 @@ ParquetReader::ParquetReader(ClientContext &context_p, OpenFileInfo file_p, Parq
 	// read the extended file open info (if any)
 	optional_idx footer_size;
 	if (file.extended_info) {
-		auto &open_options = file.extended_info->options;
-		auto encryption_entry = file.extended_info->options.find("encryption_key");
-		if (encryption_entry != open_options.end()) {
-			parquet_options.encryption_config =
-			    make_shared_ptr<ParquetEncryptionConfig>(StringValue::Get(encryption_entry->second));
+		auto &extended_info = *file.extended_info;
+		string encryption_key;
+		if (extended_info.TryGetOption("encryption_key", encryption_key)) {
+			parquet_options.encryption_config = make_shared_ptr<ParquetEncryptionConfig>(std::move(encryption_key));
 		}
-		auto footer_entry = file.extended_info->options.find("footer_size");
-		if (footer_entry != open_options.end()) {
-			footer_size = UBigIntValue::Get(footer_entry->second);
+		idx_t footer_size_option;
+		if (extended_info.TryGetOption("footer_size", footer_size_option)) {
+			footer_size = footer_size_option;
 		}
 	}
 

--- a/scripts/run-clangd-tidy.py
+++ b/scripts/run-clangd-tidy.py
@@ -39,6 +39,11 @@ RETRY_PATTERNS = (
     'jsonrpc',
 )
 
+# clangd-tidy reports every diagnostic with its code in trailing brackets. clang-tidy checks are named
+# "group-check-name", while clangd reports the diagnostics of the compiler itself under clang's internal
+# names, which never contain a dash - e.g. "[undeclared_var_use]".
+DIAGNOSTIC_CODE_REGEX = re.compile(r'^\S+:\d+:\d+: \w+: .*\[([A-Za-z0-9_.-]+)\]\s*$')
+
 
 def color_text(text, color):
     if not FORCE_COLOR_OUTPUT:
@@ -153,12 +158,24 @@ def reset_pch_dir(pch_dir):
     os.makedirs(pch_dir, exist_ok=True)
 
 
+def has_compiler_diagnostics(text):
+    for line in (text or '').splitlines():
+        match = DIAGNOSTIC_CODE_REGEX.match(line)
+        if match and '-' not in match.group(1):
+            return True
+    return False
+
+
 def is_retryable_failure(result):
     if result.returncode == 0:
         return False
     text = (result.stdout or '') + '\n' + (result.stderr or '')
     lower = text.lower()
-    return any(pattern in lower for pattern in RETRY_PATTERNS)
+    if any(pattern in lower for pattern in RETRY_PATTERNS):
+        return True
+    # a file that does not compile here does compile in every build job - the translation unit was parsed
+    # against a broken preamble, which happens when the runner runs out of room for the preamble caches
+    return has_compiler_diagnostics(text)
 
 
 def print_output_tail(label, text):
@@ -215,11 +232,9 @@ def run_chunk_with_retries(base_command, chunk, repo_root, env, log_dir, pch_roo
                     f'retry limit reached after attempt {attempt_id}; '
                     f'not retrying. stdout: {stdout_path}; stderr: {stderr_path}'
                 )
-                reset_pch_dir(pch_dir)
-            else:
-                print_output_tail('stdout', result.stdout)
-                print_output_tail('stderr', result.stderr)
-                reset_pch_dir(pch_dir)
+            print_output_tail('stdout', result.stdout)
+            print_output_tail('stderr', result.stderr)
+            reset_pch_dir(pch_dir)
             return {
                 'attempt_id': attempt_id,
                 'stdout_path': stdout_path,

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library_unity(
   memory_mapped_file.cpp
   error_data.cpp
   opener_file_system.cpp
+  open_file_info.cpp
   optional_idx.cpp
   printer.cpp
   radix_partitioning.cpp

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -573,11 +573,11 @@ bool FileSystem::IsDirectory(const OpenFileInfo &info) {
 	if (!info.extended_info) {
 		return false;
 	}
-	auto entry = info.extended_info->options.find("type");
-	if (entry == info.extended_info->options.end()) {
+	string type;
+	if (!info.extended_info->TryGetOption("type", type)) {
 		return false;
 	}
-	return StringValue::Get(entry->second) == "directory";
+	return type == "directory";
 }
 
 bool FileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,

--- a/src/common/multi_file/multi_file_list.cpp
+++ b/src/common/multi_file/multi_file_list.cpp
@@ -356,7 +356,20 @@ bool LazyMultiFileList::ExpandNextPathInternal() const {
 //===--------------------------------------------------------------------===//
 // GlobMultiFileList
 //===--------------------------------------------------------------------===//
+static vector<OpenFileInfo> PathsToFiles(vector<string> paths) {
+	vector<OpenFileInfo> result;
+	result.reserve(paths.size());
+	for (auto &path : paths) {
+		result.emplace_back(std::move(path));
+	}
+	return result;
+}
+
 GlobMultiFileList::GlobMultiFileList(ClientContext &context_p, vector<string> globs_p, FileGlobInput glob_input_p)
+    : GlobMultiFileList(context_p, PathsToFiles(std::move(globs_p)), std::move(glob_input_p)) {
+}
+
+GlobMultiFileList::GlobMultiFileList(ClientContext &context_p, vector<OpenFileInfo> globs_p, FileGlobInput glob_input_p)
     : LazyMultiFileList(&context_p), context(context_p), globs(std::move(globs_p)), glob_input(std::move(glob_input_p)),
       current_glob(0) {
 }
@@ -377,13 +390,23 @@ bool GlobMultiFileList::ExpandNextPath() const {
 	if (current_glob >= globs.size()) {
 		return false;
 	}
+	auto &current_entry = globs[current_glob];
+	if (current_entry.extended_info) {
+		// the file was specified together with the options to open it with - use it as-is
+		expanded_files.push_back(current_entry);
+		current_glob++;
+		return true;
+	}
 	if (current_glob >= file_lists.size()) {
+		file_lists.resize(current_glob + 1);
+	}
+	if (!file_lists[current_glob]) {
 		// glob is not yet started for this file - start it and initiate the scan over this file
 		auto &fs = FileSystem::GetFileSystem(context);
-		auto glob_result = fs.GlobFileList(globs[current_glob], glob_input);
+		auto glob_result = fs.GlobFileList(current_entry.path, glob_input);
 		scan_state = MultiFileListScanData();
 		glob_result->InitializeScan(scan_state);
-		file_lists.push_back(std::move(glob_result));
+		file_lists[current_glob] = std::move(glob_result);
 	}
 	// get the next batch of files we can fetch through the glob
 	auto &glob_list = *file_lists[current_glob];

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -118,6 +118,69 @@ vector<string> MultiFileReader::ParsePaths(const Value &input) {
 	}
 }
 
+OpenFileInfo MultiFileReader::ParseFileEntry(const Value &input) {
+	if (input.IsNull()) {
+		throw ParserException("%s reader cannot take NULL input as parameter", function_name);
+	}
+	if (input.type().id() == LogicalTypeId::VARCHAR) {
+		return OpenFileInfo(StringValue::Get(input));
+	}
+	if (input.type().id() == LogicalTypeId::VARIANT) {
+		// a VARIANT lets every file carry its own set of open options - unpack it to its logical value
+		// a variant never unpacks to another variant, so this recurses at most once
+		return ParseFileEntry(VariantValue::GetValue(input));
+	}
+	if (input.type().id() != LogicalTypeId::STRUCT) {
+		throw ParserException("%s reader can only take a list of strings, structs or variants as a parameter",
+		                      function_name);
+	}
+	// a file specified as a struct holds the path in the "filename" field - every other field is an open option
+	auto &child_types = StructType::GetChildTypes(input.type());
+	auto &children = StructValue::GetChildren(input);
+	OpenFileInfo result;
+	auto extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	bool found_path = false;
+	for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
+		auto &name = child_types[child_idx].first;
+		auto &child = children[child_idx];
+		if (name == MultiFileReader::FILE_PATH_FIELD) {
+			if (child.IsNull() || child.type().id() != LogicalTypeId::VARCHAR) {
+				throw ParserException("%s reader requires the \"%s\" field of a file struct to be a non-NULL VARCHAR",
+				                      function_name, MultiFileReader::FILE_PATH_FIELD);
+			}
+			result.path = StringValue::Get(child);
+			found_path = true;
+			continue;
+		}
+		if (child.IsNull()) {
+			// a NULL option is an option that was not specified - a list of structs is typed by unifying the
+			// structs of its entries, which fills the options an entry did not specify with NULL
+			continue;
+		}
+		extended_info->SetUserOption(name.GetIdentifierName(), child);
+	}
+	if (!found_path) {
+		throw ParserException("%s reader requires a file struct to have a \"%s\" field holding the path of the file",
+		                      function_name, MultiFileReader::FILE_PATH_FIELD);
+	}
+	result.extended_info = std::move(extended_info);
+	return result;
+}
+
+vector<OpenFileInfo> MultiFileReader::ParseFileList(const Value &input) {
+	if (input.IsNull()) {
+		throw ParserException("%s cannot take NULL list as parameter", function_name);
+	}
+	if (input.type().id() != LogicalTypeId::LIST) {
+		return {ParseFileEntry(input)};
+	}
+	vector<OpenFileInfo> files;
+	for (auto &val : ListValue::GetChildren(input)) {
+		files.push_back(ParseFileEntry(val));
+	}
+	return files;
+}
+
 shared_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context, const vector<string> &paths,
                                                           const FileGlobInput &glob_input) {
 	auto res = make_uniq<GlobMultiFileList>(context, paths, glob_input);
@@ -127,10 +190,34 @@ shared_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context
 	return std::move(res);
 }
 
+shared_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context, vector<OpenFileInfo> files,
+                                                          const FileGlobInput &glob_input) {
+	bool has_open_options = false;
+	for (auto &file : files) {
+		if (file.extended_info) {
+			has_open_options = true;
+			break;
+		}
+	}
+	if (!has_open_options) {
+		// no per-file open options - dispatch to the path based method so any overrides of it are used
+		vector<string> paths;
+		paths.reserve(files.size());
+		for (auto &file : files) {
+			paths.push_back(std::move(file.path));
+		}
+		return CreateFileList(context, paths, glob_input);
+	}
+	auto res = make_uniq<GlobMultiFileList>(context, std::move(files), glob_input);
+	if (res->GetExpandResult() == FileExpandResult::NO_FILES && !glob_input.AllowsEmpty()) {
+		throw IOException("%s needs at least one file to read", function_name);
+	}
+	return std::move(res);
+}
+
 shared_ptr<MultiFileList> MultiFileReader::CreateFileList(ClientContext &context, const Value &input,
                                                           const FileGlobInput &glob_input) {
-	auto paths = ParsePaths(input);
-	return CreateFileList(context, paths, glob_input);
+	return CreateFileList(context, ParseFileList(input), glob_input);
 }
 
 bool MultiFileReader::ParseOption(const Identifier &key, const Value &val, MultiFileOptions &options,
@@ -543,7 +630,14 @@ TableFunctionSet MultiFileReader::CreateFunctionSet(TableFunction table_function
 	TableFunctionSet function_set {table_function.name};
 	function_set.AddFunction(table_function);
 	D_ASSERT(!table_function.GetArguments().empty() && table_function.GetArguments()[0] == LogicalType::VARCHAR);
-	table_function.GetArguments()[0] = LogicalType::LIST(LogicalType::VARCHAR);
+	// the list variant takes ANY as its child type: a file is either a path (VARCHAR) or a STRUCT/VARIANT
+	// holding the path together with the options to open the file with
+	auto list_function = table_function;
+	list_function.GetArguments()[0] = LogicalType::LIST(LogicalType::ANY);
+	function_set.AddFunction(std::move(list_function));
+	// a single file can also be passed as a VARIANT - without this overload it would implicitly cast to VARCHAR
+	// and the stringified variant would be read as a path
+	table_function.GetArguments()[0] = LogicalType::VARIANT();
 	function_set.AddFunction(std::move(table_function));
 	return function_set;
 }

--- a/src/common/multi_file/multi_file_reader.cpp
+++ b/src/common/multi_file/multi_file_reader.cpp
@@ -94,30 +94,6 @@ void MultiFileReader::AddParameters(TableFunction &table_function) {
 	table_function.named_parameters["allow_empty"] = LogicalType::BOOLEAN;
 }
 
-vector<string> MultiFileReader::ParsePaths(const Value &input) {
-	if (input.IsNull()) {
-		throw ParserException("%s cannot take NULL list as parameter", function_name);
-	}
-
-	if (input.type().id() == LogicalTypeId::VARCHAR) {
-		return {StringValue::Get(input)};
-	} else if (input.type().id() == LogicalTypeId::LIST) {
-		vector<string> paths;
-		for (auto &val : ListValue::GetChildren(input)) {
-			if (val.IsNull()) {
-				throw ParserException("%s reader cannot take NULL input as parameter", function_name);
-			}
-			if (val.type().id() != LogicalTypeId::VARCHAR) {
-				throw ParserException("%s reader can only take a list of strings as a parameter", function_name);
-			}
-			paths.push_back(StringValue::Get(val));
-		}
-		return paths;
-	} else {
-		throw InternalException("Unsupported type for MultiFileReader::ParsePaths called with: '%s'");
-	}
-}
-
 OpenFileInfo MultiFileReader::ParseFileEntry(const Value &input) {
 	if (input.IsNull()) {
 		throw ParserException("%s reader cannot take NULL input as parameter", function_name);

--- a/src/common/open_file_info.cpp
+++ b/src/common/open_file_info.cpp
@@ -1,0 +1,109 @@
+#include "duckdb/common/open_file_info.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+namespace {
+
+struct OpenFileOption {
+	const char *name;
+	LogicalTypeId type;
+};
+
+//! The open options the core knows about, together with the type they are read back as. Options that are not
+//! listed here are stored as-is - extensions are free to define options of their own.
+const OpenFileOption OPEN_FILE_OPTIONS[] = {{"file_size", LogicalTypeId::UBIGINT},
+                                            {"last_modified", LogicalTypeId::TIMESTAMP},
+                                            {"etag", LogicalTypeId::VARCHAR},
+                                            {"type", LogicalTypeId::VARCHAR},
+                                            {"force_full_download", LogicalTypeId::BOOLEAN},
+                                            {"validate_external_file_cache", LogicalTypeId::BOOLEAN},
+                                            {"footer_size", LogicalTypeId::UBIGINT}};
+
+optional_ptr<const OpenFileOption> FindOpenFileOption(const string &name) {
+	for (auto &option : OPEN_FILE_OPTIONS) {
+		if (StringUtil::CIEquals(name, option.name)) {
+			return &option;
+		}
+	}
+	return nullptr;
+}
+
+} // namespace
+
+void ExtendedOpenFileInfo::SetUserOption(const string &name, const Value &value) {
+	auto known_option = FindOpenFileOption(name);
+	if (!known_option) {
+		// not an option the core knows about - store it as-is for extensions to interpret
+		options[name] = value;
+		return;
+	}
+	LogicalType target_type(known_option->type);
+	string error_message;
+	auto casted_value = value.DefaultTryCastAs(target_type, &error_message);
+	if (!casted_value) {
+		throw InvalidInputException("Invalid value for file option \"%s\" - expected a value of type %s, but \"%s\" "
+		                            "was provided",
+		                            known_option->name, target_type.ToString(), value.ToString());
+	}
+	// store the option under its canonical name, so a lookup of the option always finds it
+	options[known_option->name] = std::move(*casted_value);
+}
+
+template <>
+bool ExtendedOpenFileInfo::TryGetOption(const string &name, bool &result) const {
+	auto entry = options.find(name);
+	if (entry == options.end()) {
+		return false;
+	}
+	auto &value = entry->second;
+	string error_message;
+	auto bool_value = value.DefaultTryCastAs(LogicalType::BOOLEAN, &error_message);
+	if (!bool_value || bool_value->IsNull()) {
+		throw InvalidInputException(
+		    "Invalid value for file option \"%s\" - expected a BOOLEAN, but \"%s\" was provided", name,
+		    value.ToString());
+	}
+	result = BooleanValue::Get(*bool_value);
+	return true;
+}
+
+template <>
+bool ExtendedOpenFileInfo::TryGetOption(const string &name, string &result) const {
+	auto entry = options.find(name);
+	if (entry == options.end()) {
+		return false;
+	}
+	auto &value = entry->second;
+	// a string option can be stored as a VARCHAR or as a BLOB - both are read back with StringValue::Get,
+	// and casting a BLOB to VARCHAR here would escape the bytes it holds
+	if (value.IsNull() || value.type().InternalType() != PhysicalType::VARCHAR) {
+		throw InvalidInputException(
+		    "Invalid value for file option \"%s\" - expected a VARCHAR, but \"%s\" was provided", name,
+		    value.ToString());
+	}
+	result = StringValue::Get(value);
+	return true;
+}
+
+template <>
+bool ExtendedOpenFileInfo::TryGetOption(const string &name, idx_t &result) const {
+	auto entry = options.find(name);
+	if (entry == options.end()) {
+		return false;
+	}
+	auto &value = entry->second;
+	string error_message;
+	auto ubigint_value = value.DefaultTryCastAs(LogicalType::UBIGINT, &error_message);
+	if (!ubigint_value || ubigint_value->IsNull()) {
+		throw InvalidInputException(
+		    "Invalid value for file option \"%s\" - expected a UBIGINT, but \"%s\" was provided", name,
+		    value.ToString());
+	}
+	result = UBigIntValue::Get(*ubigint_value);
+	return true;
+}
+
+} // namespace duckdb

--- a/src/include/duckdb/common/multi_file/multi_file_list.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_list.hpp
@@ -196,6 +196,9 @@ protected:
 class GlobMultiFileList : public LazyMultiFileList {
 public:
 	GlobMultiFileList(ClientContext &context, vector<string> globs, FileGlobInput input);
+	//! Entries that carry explicit open options (i.e. an ExtendedOpenFileInfo) are emitted as-is instead of
+	//! being glob-expanded - they refer to a file the caller already knows the exact identity of
+	GlobMultiFileList(ClientContext &context, vector<OpenFileInfo> globs, FileGlobInput input);
 
 	vector<OpenFileInfo> GetDisplayFileList(optional_idx max_files = optional_idx()) const override;
 
@@ -206,7 +209,7 @@ protected:
 	//! The ClientContext for globbing
 	ClientContext &context;
 	//! The list of globs to expand
-	const vector<string> globs;
+	const vector<OpenFileInfo> globs;
 	//! Glob input
 	const FileGlobInput glob_input;
 	//! The current glob to expand

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -119,8 +119,6 @@ public:
 	//! Creates a table function set from a single reader function (including e.g. list parameters, etc)
 	DUCKDB_API static TableFunctionSet CreateFunctionSet(TableFunction table_function);
 
-	//! Parse a Value containing 1 or more paths into a vector of paths. Note: no expansion is performed here
-	DUCKDB_API virtual vector<string> ParsePaths(const Value &input);
 	//! Parse a Value containing 1 or more files into a vector of files. A file is specified either as a path
 	//! (VARCHAR) or as a STRUCT/VARIANT holding the path together with the options to open the file with
 	DUCKDB_API virtual vector<OpenFileInfo> ParseFileList(const Value &input);

--- a/src/include/duckdb/common/multi_file/multi_file_reader.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_reader.hpp
@@ -100,6 +100,8 @@ public:
 	static constexpr int32_t ROW_ID_FIELD_ID = 2147483540;
 	// Reserved field id used for the "_last_updated_sequence_number" field according to the iceberg spec
 	static constexpr int32_t LAST_UPDATED_SEQUENCE_NUMBER_ID = 2147483539;
+	//! The field of a file STRUCT that holds the path of the file - all other fields are open options
+	static constexpr const char *FILE_PATH_FIELD = "filename";
 
 public:
 	virtual ~MultiFileReader();
@@ -119,11 +121,21 @@ public:
 
 	//! Parse a Value containing 1 or more paths into a vector of paths. Note: no expansion is performed here
 	DUCKDB_API virtual vector<string> ParsePaths(const Value &input);
+	//! Parse a Value containing 1 or more files into a vector of files. A file is specified either as a path
+	//! (VARCHAR) or as a STRUCT/VARIANT holding the path together with the options to open the file with
+	DUCKDB_API virtual vector<OpenFileInfo> ParseFileList(const Value &input);
+	//! Parse a single entry of a file list - see ParseFileList
+	DUCKDB_API OpenFileInfo ParseFileEntry(const Value &input);
 	//! Create a MultiFileList from a vector of paths. Any globs will be expanded using the default filesystem
 	DUCKDB_API virtual shared_ptr<MultiFileList>
 	CreateFileList(ClientContext &context, const vector<string> &paths,
 	               const FileGlobInput &glob_input = FileGlobOptions::DISALLOW_EMPTY);
-	//! Shorthand for ParsePaths + CreateFileList
+	//! Create a MultiFileList from a vector of files. Files that carry explicit open options are used as-is,
+	//! any other paths are expanded using the default filesystem
+	DUCKDB_API virtual shared_ptr<MultiFileList>
+	CreateFileList(ClientContext &context, vector<OpenFileInfo> files,
+	               const FileGlobInput &glob_input = FileGlobOptions::DISALLOW_EMPTY);
+	//! Shorthand for ParseFileList + CreateFileList
 	DUCKDB_API shared_ptr<MultiFileList>
 	CreateFileList(ClientContext &context, const Value &input,
 	               const FileGlobInput &glob_input = FileGlobOptions::DISALLOW_EMPTY);

--- a/src/include/duckdb/common/open_file_info.hpp
+++ b/src/include/duckdb/common/open_file_info.hpp
@@ -16,7 +16,27 @@ namespace duckdb {
 
 struct ExtendedOpenFileInfo {
 	unordered_map<string, Value> options;
+
+public:
+	//! Set an option to a value that originates from the user, casting it to the type the option is read back
+	//! as and storing it under its canonical name. Throws when the value cannot be converted to that type.
+	//! Options the core does not know about are stored as-is, for extensions to interpret
+	DUCKDB_API void SetUserOption(const string &name, const Value &value);
+	//! Read an option as a T - returns false when the option is not set, throws when it is set to a value
+	//! that cannot be read as a T. Only the types specialized below are supported
+	template <class T>
+	bool TryGetOption(const string &name, T &result) const;
 };
+
+//! A boolean option - anything that casts to BOOLEAN is accepted
+template <>
+DUCKDB_API bool ExtendedOpenFileInfo::TryGetOption(const string &name, bool &result) const;
+//! A string option - VARCHAR and BLOB are both stored as a string and both are accepted
+template <>
+DUCKDB_API bool ExtendedOpenFileInfo::TryGetOption(const string &name, string &result) const;
+//! An unsigned integer option - anything that casts to UBIGINT is accepted
+template <>
+DUCKDB_API bool ExtendedOpenFileInfo::TryGetOption(const string &name, idx_t &result) const;
 
 struct OpenFileInfo {
 	OpenFileInfo() = default;

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -185,8 +185,8 @@ bool CachingFileHandle::StripForceFullDownloadIfPresent() {
 	}
 
 	auto &extended_info = *extended_info_p;
-	const bool contains_force_full_download = extended_info.options.count("force_full_download");
-	if (!contains_force_full_download) {
+	bool force_full_download;
+	if (!extended_info.TryGetOption("force_full_download", force_full_download)) {
 		return false;
 	}
 
@@ -198,7 +198,7 @@ bool CachingFileHandle::StripForceFullDownloadIfPresent() {
 		new_extended_info->options["file_size"] = Value::UBIGINT(GetFileSize());
 	}
 	path.extended_info = new_extended_info;
-	return true;
+	return force_full_download;
 }
 
 shared_ptr<CachingFileHandle::CachedFile> CachingFileHandle::EnsureCachedFileCurrent() {

--- a/src/storage/external_file_cache/external_file_cache_util.cpp
+++ b/src/storage/external_file_cache/external_file_cache_util.cpp
@@ -19,16 +19,10 @@ CacheValidationMode ExternalFileCacheUtil::GetCacheValidationMode(const OpenFile
                                                                   optional_ptr<ClientContext> client_context,
                                                                   DatabaseInstance &db) {
 	// First check if explicitly set in OpenFileInfo options (per-file override).
-	if (info.extended_info != nullptr) {
-		const auto &open_options = info.extended_info->options;
-		const auto validate_entry = open_options.find("validate_external_file_cache");
-		if (validate_entry != open_options.end()) {
-			if (validate_entry->second.IsNull()) {
-				throw InvalidInputException("Cannot use NULL as argument for validate_external_file_cache");
-			}
-			const bool validate_cache = BooleanValue::Get(validate_entry->second);
-			return validate_cache ? CacheValidationMode::VALIDATE_ALL : CacheValidationMode::NO_VALIDATION;
-		}
+	bool validate_cache;
+	if (info.extended_info != nullptr &&
+	    info.extended_info->TryGetOption("validate_external_file_cache", validate_cache)) {
+		return validate_cache ? CacheValidationMode::VALIDATE_ALL : CacheValidationMode::NO_VALIDATION;
 	}
 
 	// If client context is available, check client-local settings first, then fall back to database config.

--- a/test/fuzzer/duckfuzz/read_ndjson_non_varchar_input.test
+++ b/test/fuzzer/duckfuzz/read_ndjson_non_varchar_input.test
@@ -7,9 +7,9 @@ require json
 statement error
 FROM read_ndjson([42])
 ----
-No function matches
+can only take a list of strings, structs or variants
 
 statement error
 FROM read_csv_auto([42])
 ----
-No function matches
+can only take a list of strings, structs or variants

--- a/test/sql/copy/csv/glob/read_csv_glob.test
+++ b/test/sql/copy/csv/glob/read_csv_glob.test
@@ -247,7 +247,7 @@ SELECT COUNT(*) FROM glob('{DATA_DIR}/csv/glob/*/*.csv');
 statement error
 SELECT * FROM read_csv_auto([]::INT[]) ORDER BY 1
 ----
-No function matches
+at least one file
 
 statement error
 SELECT * FROM read_csv_auto([]::VARCHAR[]) ORDER BY 1

--- a/test/sql/multi_file/multi_file_open_options.test
+++ b/test/sql/multi_file/multi_file_open_options.test
@@ -1,0 +1,266 @@
+# name: test/sql/multi_file/multi_file_open_options.test
+# description: Test specifying the options to open a file with as part of the file list
+# group: [multi_file]
+
+require parquet
+
+statement ok
+COPY (SELECT 42 a, 'hello' b) TO '{TEST_DIR}/open_options_1.parquet'
+
+statement ok
+COPY (SELECT 43 a, 'world' b) TO '{TEST_DIR}/open_options_2.parquet'
+
+# a file can be specified as a struct that holds the path
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet'}])
+----
+42	hello
+
+query II
+SELECT * FROM read_parquet([
+	{'filename': '{TEST_DIR}/open_options_1.parquet'},
+	{'filename': '{TEST_DIR}/open_options_2.parquet'}]) ORDER BY a
+----
+42	hello
+43	world
+
+# the other fields of the struct are the options to open the file with
+query II
+SELECT * FROM read_parquet([{
+	'filename': '{TEST_DIR}/open_options_1.parquet',
+	'validate_external_file_cache': false,
+	'etag': 'my_etag'}])
+----
+42	hello
+
+# an option that is explicitly set to NULL is an option that was not specified
+query II
+SELECT * FROM read_parquet([{
+	'filename': '{TEST_DIR}/open_options_1.parquet',
+	'validate_external_file_cache': NULL::BOOLEAN}])
+----
+42	hello
+
+# this works for any multi-file reader
+statement ok
+COPY (SELECT 42 a, 'hello' b) TO '{TEST_DIR}/open_options.csv'
+
+query II
+SELECT * FROM read_csv([{'filename': '{TEST_DIR}/open_options.csv'}])
+----
+42	hello
+
+query I
+SELECT * FROM glob([{'filename': '{TEST_DIR}/open_options.csv'}])
+----
+{TEST_DIR}/open_options.csv
+
+# files specified as a struct are taken literally - they are not glob expanded
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_*.parquet'}])
+----
+<REGEX>:IO Error.*open_options_\*\.parquet.*
+
+# the filename column option is unaffected by the file being given as a struct
+query III
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'etag': 'my_etag'}], filename=true)
+----
+42	hello	{TEST_DIR}/open_options_1.parquet
+
+# the path is mandatory and must be a non-NULL VARCHAR
+statement error
+SELECT * FROM read_parquet([{'etag': 'my_etag'}])
+----
+<REGEX>:Parser Error.*requires a file struct to have a "filename" field.*
+
+statement error
+SELECT * FROM read_parquet([{'filename': NULL}])
+----
+<REGEX>:Parser Error.*requires the "filename" field of a file struct to be a non-NULL VARCHAR.*
+
+statement error
+SELECT * FROM read_parquet([{'filename': 42}])
+----
+<REGEX>:Parser Error.*requires the "filename" field of a file struct to be a non-NULL VARCHAR.*
+
+# other types in the file list are still rejected
+statement error
+SELECT * FROM read_parquet([42])
+----
+<REGEX>:Parser Error.*only take a list of strings.*
+
+statement error
+SELECT * FROM read_parquet([NULL])
+----
+<REGEX>:Parser Error.*NULL.*
+
+# a list of structs is typed by unifying the structs of its entries, which fills in the options an entry did
+# not specify with NULL - a NULL option is an option that was not specified
+query II
+SELECT * FROM read_parquet([
+	{'filename': '{TEST_DIR}/open_options_1.parquet'},
+	{'filename': '{TEST_DIR}/open_options_2.parquet', 'etag': 'my_etag'}]) ORDER BY a
+----
+42	hello
+43	world
+
+# a VARIANT lets every file carry exactly the options it specifies, with the types it specifies
+query II
+SELECT * FROM read_parquet([
+	{'filename': '{TEST_DIR}/open_options_1.parquet'}::VARIANT,
+	{'filename': '{TEST_DIR}/open_options_2.parquet', 'etag': 'my_etag'}::VARIANT]) ORDER BY a
+----
+42	hello
+43	world
+
+# a single file can be passed as a VARIANT as well
+query II
+SELECT * FROM read_parquet({'filename': '{TEST_DIR}/open_options_1.parquet', 'etag': 'my_etag'}::VARIANT)
+----
+42	hello
+
+statement error
+SELECT * FROM read_parquet({'etag': 'my_etag'}::VARIANT)
+----
+<REGEX>:Parser Error.*requires a file struct to have a "filename" field.*
+
+# an option that is set to a value it cannot be read back as is an error, not a crash
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'file_size': 'notanumber'}])
+----
+<REGEX>:Invalid Input Error.*file option "file_size".*UBIGINT.*
+
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'file_size': -1}])
+----
+<REGEX>:Invalid Input Error.*file option "file_size".*UBIGINT.*
+
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'validate_external_file_cache': 'notabool'}])
+----
+<REGEX>:Invalid Input Error.*file option "validate_external_file_cache".*BOOLEAN.*
+
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'force_full_download': 'notabool'}])
+----
+<REGEX>:Invalid Input Error.*file option "force_full_download".*BOOLEAN.*
+
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'last_modified': 'notatimestamp'}])
+----
+<REGEX>:Invalid Input Error.*file option "last_modified".*TIMESTAMP.*
+
+# a VARCHAR option accepts anything that has a text representation - it is the type it is read back as that
+# matters, not the type it was written as
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'etag': 42}])
+----
+42	hello
+
+# the same holds for options passed through a VARIANT
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'file_size': 'notanumber'}::VARIANT])
+----
+<REGEX>:Invalid Input Error.*file option "file_size".*UBIGINT.*
+
+# a value that can be read back as the expected type is accepted and converted
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'file_size': 631}])
+----
+42	hello
+
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'validate_external_file_cache': 'true'}])
+----
+42	hello
+
+# known options are matched case-insensitively, so they are always found by the code reading them back
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'File_Size': 631::UBIGINT}])
+----
+42	hello
+
+# force_full_download is honoured as a boolean rather than by its mere presence
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'force_full_download': false}])
+----
+42	hello
+
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'force_full_download': true}])
+----
+42	hello
+
+# options the core does not know about are passed through untouched for extensions to interpret
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'some_extension_option': 42}])
+----
+42	hello
+
+# a file_size that does not match the file is a promise the caller makes to avoid a stat - it is not verified,
+# but it must not corrupt the read of a file system that does not use it
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'file_size': 99999999::UBIGINT}])
+----
+42	hello
+
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'file_size': 1::UBIGINT}])
+----
+42	hello
+
+# the external file cache is told not to validate, and the file is still read correctly
+statement ok
+SET enable_external_file_cache=true
+
+query II
+SELECT * FROM read_parquet([{
+	'filename': '{TEST_DIR}/open_options_1.parquet',
+	'validate_external_file_cache': false,
+	'file_size': 631::UBIGINT,
+	'etag': 'my_etag',
+	'last_modified': '2024-01-01 00:00:00'::TIMESTAMP}])
+----
+42	hello
+
+query II
+SELECT * FROM read_parquet([{
+	'filename': '{TEST_DIR}/open_options_1.parquet',
+	'validate_external_file_cache': true}])
+----
+42	hello
+
+# the parquet reader reads its own open options through the same safe accessors
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'footer_size': 'notanumber'}])
+----
+<REGEX>:Invalid Input Error.*file option "footer_size".*UBIGINT.*
+
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'encryption_key': 42}])
+----
+<REGEX>:Invalid Input Error.*file option "encryption_key".*VARCHAR.*
+
+# has_deletes is only read when partition statistics are gathered, so it is inert for a plain scan - what
+# matters is that carrying an unusable value does not crash the scan that ignores it
+query II
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'has_deletes': 'notabool'}])
+----
+42	hello
+
+# a footer_size that does not match the file is rejected by the parquet reader rather than crashing it
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'footer_size': 999999::UBIGINT}])
+----
+<REGEX>:Invalid Input Error.*Invalid footer length.*
+
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'footer_size': 1::UBIGINT}])
+----
+<REGEX>:Invalid Input Error.*footer length stored in file is not equal to footer length provided.*
+
+# an encryption key on an unencrypted file is an error, not a crash
+statement error
+SELECT * FROM read_parquet([{'filename': '{TEST_DIR}/open_options_1.parquet', 'encryption_key': '0123456789112345'}])
+----
+<REGEX>:Invalid Input Error.*is not encrypted.*


### PR DESCRIPTION
Currently the MultiFileReader only supports getting a list of file names. Internally, however, we support the more complex `OpenFileInfo` struct which can hold a bunch of extra information (e.g. file size, whether or not to check the cache, etc). This PR exposes this at the SQL level, allowing more complex reads to be constructed through SQL as well. 

CC @Tishj 