### PR TITLE
Fix remap_struct leaving rows uninitialized for constant MAP/LIST input

### DIFF
--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -88,6 +88,33 @@ void RemapChildVectors(const Vector &result, const vector<reference<Vector>> &in
 	}
 }
 
+//! Copy the list_entry_t values from the input vector into the result, preserving top-level validity
+//! Returns false if the input is a constant NULL - in that case the result is set to a constant NULL
+bool CopyListEntries(Vector &input, Vector &result, idx_t result_size) {
+	bool is_constant = input.GetVectorType() == VectorType::CONSTANT_VECTOR;
+	if (is_constant && ConstantVector::IsNull(input)) {
+		ConstantVector::SetNull(result, count_t(result_size));
+		return false;
+	}
+	auto writer = FlatVector::Writer<list_entry_t>(result, result_size);
+	if (is_constant) {
+		// broadcast the single list entry over all result rows
+		auto list_entry = *ConstantVector::GetData<list_entry_t>(input);
+		for (idx_t i = 0; i < result_size; i++) {
+			writer.WriteValue(list_entry);
+		}
+		return true;
+	}
+	for (const auto entry : input.Values<list_entry_t>()) {
+		if (entry.IsValid()) {
+			writer.WriteValue(entry.GetValueUnsafe());
+		} else {
+			writer.WriteNull();
+		}
+	}
+	return true;
+}
+
 void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_t result_size,
               const vector<RemapColumnInfo> &remap_info) {
 	auto &input_key_vector = MapVector::GetKeys(input);
@@ -100,23 +127,8 @@ void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_t resul
 	ListVector::SetListSize(result, list_size);
 
 	// copy over the list_entry_t values from the input vector, preserving top-level validity
-	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-		if (ConstantVector::IsNull(input)) {
-			ConstantVector::SetNull(result, count_t(result_size));
-			return;
-		}
-		auto list_data = ConstantVector::GetData<list_entry_t>(input);
-		auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
-		memcpy(result_list_data, list_data, sizeof(list_entry_t));
-	} else {
-		auto writer = FlatVector::Writer<list_entry_t>(result, result_size);
-		for (const auto entry : input.Values<list_entry_t>()) {
-			if (entry.IsValid()) {
-				writer.WriteValue(entry.GetValueUnsafe());
-			} else {
-				writer.WriteNull();
-			}
-		}
+	if (!CopyListEntries(input, result, result_size)) {
+		return;
 	}
 	// set up the correct vector references
 	D_ASSERT(remap_info.size() == 2);
@@ -142,23 +154,8 @@ void RemapList(Vector &input, Vector &default_vector, Vector &result, idx_t resu
 	ListVector::SetListSize(result, list_size);
 
 	// copy over the list_entry_t values from the input vector, preserving top-level validity
-	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-		if (ConstantVector::IsNull(input)) {
-			ConstantVector::SetNull(result, count_t(result_size));
-			return;
-		}
-		auto list_data = ConstantVector::GetData<list_entry_t>(input);
-		auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
-		memcpy(result_list_data, list_data, sizeof(list_entry_t));
-	} else {
-		auto writer = FlatVector::Writer<list_entry_t>(result, result_size);
-		for (const auto entry : input.Values<list_entry_t>()) {
-			if (entry.IsValid()) {
-				writer.WriteValue(entry.GetValueUnsafe());
-			} else {
-				writer.WriteNull();
-			}
-		}
+	if (!CopyListEntries(input, result, result_size)) {
+		return;
 	}
 
 	//! Build up the input for remapping the child of the list

--- a/test/sql/types/struct/remap_struct_constant_nested.test
+++ b/test/sql/types/struct/remap_struct_constant_nested.test
@@ -1,0 +1,62 @@
+# name: test/sql/types/struct/remap_struct_constant_nested.test
+# description: remap_struct with a constant MAP/LIST source must broadcast the value to all rows
+# group: [struct]
+
+query I
+SELECT remap_struct(struct_pack(id := id, m := MAP {1: 'a', 2: 'b'}),
+                    NULL::STRUCT(id INTEGER, m2 MAP(INTEGER, VARCHAR)),
+                    {'id': 'id', 'm2': ROW('m', {'key': 'key', 'value': 'value'})},
+                    NULL)
+FROM range(3) t(id)
+----
+{'id': 0, 'm2': {1=a, 2=b}}
+{'id': 1, 'm2': {1=a, 2=b}}
+{'id': 2, 'm2': {1=a, 2=b}}
+
+query I
+SELECT remap_struct(struct_pack(id := id, l := [1, 2, 3]),
+                    NULL::STRUCT(id INTEGER, l2 INTEGER[]),
+                    {'id': 'id', 'l2': ROW('l', {'list': 'list'})},
+                    NULL)
+FROM range(3) t(id)
+----
+{'id': 0, 'l2': [1, 2, 3]}
+{'id': 1, 'l2': [1, 2, 3]}
+{'id': 2, 'l2': [1, 2, 3]}
+
+# nested constant list within a list
+query I
+SELECT remap_struct(struct_pack(id := id, l := [[1, 2], [3]]),
+                    NULL::STRUCT(id INTEGER, l2 INTEGER[][]),
+                    {'id': 'id', 'l2': ROW('l', {'list': ROW('list', {'list': 'list'})})},
+                    NULL)
+FROM range(3) t(id)
+----
+{'id': 0, 'l2': [[1, 2], [3]]}
+{'id': 1, 'l2': [[1, 2], [3]]}
+{'id': 2, 'l2': [[1, 2], [3]]}
+
+# constant NULL source
+query I
+SELECT remap_struct(struct_pack(id := id, m := NULL::MAP(INTEGER, VARCHAR)),
+                    NULL::STRUCT(id INTEGER, m2 MAP(INTEGER, VARCHAR)),
+                    {'id': 'id', 'm2': ROW('m', {'key': 'key', 'value': 'value'})},
+                    NULL)
+FROM range(3) t(id)
+----
+{'id': 0, 'm2': NULL}
+{'id': 1, 'm2': NULL}
+{'id': 2, 'm2': NULL}
+
+# more rows than a single vector
+query III
+SELECT count(*), count(DISTINCT r.m2), min(cardinality(r.m2))
+FROM (
+    SELECT remap_struct(struct_pack(id := id, m := MAP {1: 'a', 2: 'b'}),
+                        NULL::STRUCT(id INTEGER, m2 MAP(INTEGER, VARCHAR)),
+                        {'id': 'id', 'm2': ROW('m', {'key': 'key', 'value': 'value'})},
+                        NULL) AS r
+    FROM range(5000) t(id)
+)
+----
+5000	1	2


### PR DESCRIPTION
Fixes #25272.

`RemapMap()`/`RemapList()` copied one `list_entry_t` into `result[0]` for a `CONSTANT_VECTOR` source, leaving rows `1..N-1` stale and the result size unset. The garbage `{offset, length}` pairs then index the child vectors - assertion failure on debug builds, empty maps/lists otherwise.

Both branches are identical, so they refactored into one `CopyListEntries()` helper that broadcast the entry over every row via the writer, which also sets the size.

Added regression test.
