### PR TITLE
Fix out-of-bounds write on empty CSV line with duplicate empty nullstr

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -999,19 +999,21 @@ bool StringValueResult::EmptyLine(StringValueResult &result, const idx_t buffer_
 		result.last_position.buffer_pos++;
 	}
 	if (result.number_of_columns == 1) {
-		for (idx_t i = 0; i < result.null_str_count; i++) {
-			if (result.null_str_size[i] == 0) {
-				bool empty = false;
-				if (!result.state_machine.options.force_not_null.empty()) {
-					empty = result.state_machine.options.force_not_null[0];
-				}
-				if (empty) {
-					static_cast<string_t *>(result.vector_ptr[0])[result.number_of_rows] = string_t();
-				} else {
-					result.validity_mask[0]->SetInvalid(static_cast<idx_t>(result.number_of_rows));
-				}
-				result.number_of_rows++;
+		bool empty_is_null = false;
+		for (idx_t i = 0; i < result.null_str_count && !empty_is_null; i++) {
+			empty_is_null = result.null_str_size[i] == 0;
+		}
+		if (empty_is_null) {
+			bool empty = false;
+			if (!result.state_machine.options.force_not_null.empty()) {
+				empty = result.state_machine.options.force_not_null[0];
 			}
+			if (empty) {
+				static_cast<string_t *>(result.vector_ptr[0])[result.number_of_rows] = string_t();
+			} else {
+				result.validity_mask[0]->SetInvalid(static_cast<idx_t>(result.number_of_rows));
+			}
+			result.number_of_rows++;
 		}
 		if (static_cast<idx_t>(result.number_of_rows) >= result.result_size) {
 			// We have a full chunk

--- a/test/sql/copy/csv/25268.test
+++ b/test/sql/copy/csv/25268.test
@@ -1,0 +1,28 @@
+# name: test/sql/copy/csv/25268.test
+# description: Test empty lines with duplicate empty null strings
+# group: [csv]
+
+statement ok
+COPY (SELECT CASE WHEN i = 2 THEN NULL ELSE '0123456789' END AS a FROM range(1, 4) t(i)) TO '{TEST_DIR}/empty_line.csv' (HEADER false);
+
+# an empty line yields a single row, even if multiple null strings match it
+query I
+FROM read_csv('{TEST_DIR}/empty_line.csv', columns={'a': 'VARCHAR'}, header=false, nullstr=['', '', '']);
+----
+0123456789
+NULL
+0123456789
+
+# the empty line falls on a vector boundary, so the duplicates used to write out of bounds
+statement ok
+COPY (SELECT CASE WHEN i = 2030 THEN NULL ELSE '0123456789' END AS a FROM range(1, 2050) t(i)) TO '{TEST_DIR}/empty_line_boundary.csv' (HEADER false);
+
+query I
+SELECT count(*) FROM read_csv('{TEST_DIR}/empty_line_boundary.csv', columns={'a': 'VARCHAR'}, header=false, parallel=false, nullstr=['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']);
+----
+2049
+
+query I
+SELECT count(*) FROM read_csv('{TEST_DIR}/empty_line_boundary.csv', columns={'a': 'VARCHAR'}, header=false, nullstr=['', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '']);
+----
+2049


### PR DESCRIPTION
Fixes #25268.

`StringValueResult::EmptyLine()` added a row for every empty `nullstr` entry instead of one row per empty line, and only checked for a full chunk afterwards. Duplicate empty strings in `nullstr` then duplicated rows and wrote past the end of `parse_chunk`.

The loop now just tests if any null string is empty, so an empty line writes at most one row.