### PR TITLE
Test C++ 23 standard in one CI job

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -985,6 +985,8 @@ jobs:
       # Job-level on purpose: the Test step's `make unittest_release` depends on `release`, so a
       # step-scoped flag would silently reconfigure and rebuild WITH rtti and test the wrong binary.
       DISABLE_RTTI: 1
+      # Compile with C++23 to test compatibility with the newer standard.
+      CXX_STANDARD: 23
       EXTENSION_CONFIGS: .github/config/in_tree_extensions.cmake
       DUCKDB_TEST_DESCRIPTION: 'Compiled with DISABLE_RTTI=1 (-fno-rtti).'
 

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -827,7 +827,7 @@ public:
 		}
 
 		STATE_TYPE &Get() {
-			return *reinterpret_cast<STATE_TYPE *>(&storage);
+			return *reinterpret_cast<STATE_TYPE *>(storage);
 		}
 
 		void Initialize() {
@@ -845,7 +845,7 @@ public:
 		}
 
 	private:
-		typename std::aligned_storage<sizeof(STATE_TYPE), alignof(STATE_TYPE)>::type storage;
+		alignas(STATE_TYPE) data_t storage[sizeof(STATE_TYPE)];
 		AggregateInputData &aggr_input_data;
 		bool initialized = false;
 	};

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -565,6 +565,10 @@ auto Connection::GetFileSystem() const -> FileSystem {
 	return detail::Factory::Make<FileSystem>(fs);
 }
 
+auto Connection::CreateType(const QualifiedName &name) -> LogicalType {
+	return CreateType(name, {});
+}
+
 auto Connection::CreateType(const QualifiedName &name, const std::vector<TypeParam> &params) -> LogicalType {
 	TypeParamArrays split(params);
 	duckdb_v2_logical_type_handle type = nullptr;
@@ -802,6 +806,10 @@ auto Context::GetFileSystem() const -> FileSystem {
 	duckdb_v2_file_system_handle fs = nullptr;
 	CheckedAPICall(duckdb_v2_file_system_get_from_context, handle(), &fs);
 	return detail::Factory::Make<FileSystem>(fs);
+}
+
+auto Context::CreateType(const QualifiedName &name) const -> LogicalType {
+	return CreateType(name, {});
 }
 
 auto Context::CreateType(const QualifiedName &name, const std::vector<TypeParam> &params) const -> LogicalType {

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -432,7 +432,9 @@ public:
 
 	/// `CreateType` for a name that may be catalog- or schema-qualified. An unqualified name is resolved along the
 	/// search path and then in the system catalog; a qualified one is resolved exactly as written.
-	auto CreateType(const QualifiedName &name, const std::vector<TypeParam> &params = {}) const -> LogicalType;
+	auto CreateType(const QualifiedName &name, const std::vector<TypeParam> &params) const -> LogicalType;
+	/// Parameterless overload of the above.
+	auto CreateType(const QualifiedName &name) const -> LogicalType;
 
 	/// The file system this context reads and writes through. Borrowed, and valid only while the context is.
 	auto GetFileSystem() const -> FileSystem;
@@ -680,7 +682,9 @@ public:
 
 	/// `CreateType` for a name that may be catalog- or schema-qualified. An unqualified name is resolved along the
 	/// search path and then in the system catalog; a qualified one is resolved exactly as written.
-	auto CreateType(const QualifiedName &name, const std::vector<TypeParam> &params = {}) -> LogicalType;
+	auto CreateType(const QualifiedName &name, const std::vector<TypeParam> &params) -> LogicalType;
+	/// Parameterless overload of the above.
+	auto CreateType(const QualifiedName &name) -> LogicalType;
 
 	/// The file system this connection reads and writes through. Borrowed, and valid only while the connection is.
 	auto GetFileSystem() const -> FileSystem;


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/10625.

Adding the compile flag to `no-rtti` CI job so we can test C++ 23 compatibility in each PR. An alternative was adding a dedicated CI job in NightlyTests, but that would delay the feedback to the next day (detected in nightly CI run, and an issue forwarded to engineering).

See also: https://github.com/duckdb/duckdb/pull/22895.