### PR TITLE
Fix CSV reader leaking trailing \n of \r\r\n terminators into next value

### DIFF
--- a/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
+++ b/src/execution/operator/csv_scanner/scanner/string_value_scanner.cpp
@@ -215,6 +215,10 @@ bool StringValueResult::UnsetComment(StringValueResult &result, idx_t buffer_pos
 	result.comment = false;
 	if (result.state_machine.dialect_options.state_machine_options.new_line.GetValue() != NewLineIdentifier::CARRY_ON) {
 		result.last_position.buffer_pos = buffer_pos + 1;
+	} else if (buffer_pos + 2 < result.buffer_size && result.buffer_ptr[buffer_pos + 1] == '\r' &&
+	           result.buffer_ptr[buffer_pos + 2] == '\n') {
+		// The row terminator is \r\r\n (3 bytes), not \r\n (2 bytes), so skip it fully
+		result.last_position.buffer_pos = buffer_pos + 3;
 	} else {
 		result.last_position.buffer_pos = buffer_pos + 2;
 	}
@@ -962,6 +966,10 @@ bool StringValueResult::AddRow(StringValueResult &result, const idx_t buffer_pos
 			if (result.states.states[1] == CSVState::RECORD_SEPARATOR) {
 				// Even though this is marked as a carry on, this is a hippie mixie
 				result.last_position.buffer_pos = buffer_pos + 1;
+			} else if (buffer_pos + 2 < result.buffer_size && result.buffer_ptr[buffer_pos + 1] == '\r' &&
+			           result.buffer_ptr[buffer_pos + 2] == '\n') {
+				// The row terminator is \r\r\n (3 bytes), not \r\n (2 bytes), so skip it fully
+				result.last_position.buffer_pos = buffer_pos + 3;
 			} else {
 				result.last_position.buffer_pos = buffer_pos + 2;
 			}
@@ -1452,6 +1460,9 @@ void StringValueScanner::ProcessOverBufferValue() {
 		if (!iterator.IsBoundarySet()) {
 			if (buffer_handle_ptr[iterator.pos.buffer_pos] == '\n') {
 				iterator.pos.buffer_pos++;
+				// With a \r\r\n terminator split as \r\r | \n, the leading \n is the first byte of
+				// this buffer: start the next value after it, otherwise it leaks into the value
+				result.last_position = {iterator.pos.buffer_idx, iterator.pos.buffer_pos, result.buffer_size};
 			}
 		} else {
 			idx_t pre_carry_pos = iterator.pos.buffer_pos;
@@ -1473,6 +1484,9 @@ void StringValueScanner::ProcessOverBufferValue() {
 						        buffer_handle_ptr[iterator.pos.buffer_pos] == '\n')) {
 							state_machine->Transition(states, buffer_handle_ptr[iterator.pos.buffer_pos++]);
 						}
+						// The \r\r\n terminator is fully consumed here: start the next value after it, otherwise
+						// the trailing \n leaks into it
+						result.last_position = {iterator.pos.buffer_idx, iterator.pos.buffer_pos, result.buffer_size};
 						return;
 					}
 				} else {
@@ -1488,6 +1502,9 @@ void StringValueScanner::ProcessOverBufferValue() {
 			if (over_buffer_string.empty() && iterator.pos.buffer_pos > pre_carry_pos &&
 			    result.last_position.buffer_pos > previous_buffer_handle->actual_size &&
 			    buffer_handle_ptr[pre_carry_pos] == '\r') {
+				// The remaining \r\n of a \r\r\n terminator was consumed here: start the next value after
+				// it, otherwise the \n leaks into it
+				result.last_position = {iterator.pos.buffer_idx, iterator.pos.buffer_pos, result.buffer_size};
 				return;
 			}
 		}
@@ -1503,7 +1520,9 @@ void StringValueScanner::ProcessOverBufferValue() {
 		}
 		if (states.NewRow() || states.NewValue()) {
 			break;
-		} else if (!result.comment && !states.IsComment()) {
+		} else if (!result.comment && !states.IsComment() &&
+		           !(over_buffer_string.empty() && (buffer_handle_ptr[iterator.pos.buffer_pos] == '\r' ||
+		                                            buffer_handle_ptr[iterator.pos.buffer_pos] == '\n'))) {
 			over_buffer_string += buffer_handle_ptr[iterator.pos.buffer_pos];
 		}
 		if (states.IsQuoted()) {
@@ -1636,7 +1655,14 @@ void StringValueScanner::ProcessOverBufferValue() {
 	}
 	if (states.IsCarriageReturn() &&
 	    state_machine->dialect_options.state_machine_options.new_line == NewLineIdentifier::CARRY_ON) {
-		result.last_position = {iterator.pos.buffer_idx, ++iterator.pos.buffer_pos + 1, result.buffer_size};
+		iterator.pos.buffer_pos++;
+		// With a \r\r\n terminator the machine stops at the first \r; skip the second one too,
+		// otherwise the trailing \n leaks into the next value
+		if (iterator.pos.buffer_pos < cur_buffer_handle->actual_size &&
+		    buffer_handle_ptr[iterator.pos.buffer_pos] == '\r') {
+			iterator.pos.buffer_pos++;
+		}
+		result.last_position = {iterator.pos.buffer_idx, iterator.pos.buffer_pos + 1, result.buffer_size};
 	} else {
 		result.last_position = {iterator.pos.buffer_idx, ++iterator.pos.buffer_pos, result.buffer_size};
 	}

--- a/test/sql/copy/csv/test_rrrn_leading_newline.test
+++ b/test/sql/copy/csv/test_rrrn_leading_newline.test
@@ -1,0 +1,119 @@
+# name: test/sql/copy/csv/test_rrrn_leading_newline.test
+# description: Test CSV reader does not leak the trailing \n of a \r\r\n terminator into the next value (issue #25164, second symptom)
+# group: [csv]
+
+require notwindows
+
+# With auto_detect=false the CSV reader runs in CARRY_ON newline mode, which
+# historically assumed a 2-byte "\r\n" terminator. Files using "\r\r\n" (3
+# bytes) leaked the trailing "\n" into the first field of the following row
+# (e.g. id arriving as "\n05" instead of "05"). The leak is invisible when the
+# first column is cast to an integer type, so these tests use VARCHAR columns
+# and assert on the raw value prefix.
+#
+# Three layouts are exercised (sequential and parallel):
+#   1. all rows inside a single buffer (no boundary involved)
+#   2. buffer boundary splits a terminator as "\r" | "\r\n"
+#   3. buffer boundary splits a terminator as "\r\r" | "\n"
+#
+# Layout 2 (matches test_rrrn_parallel.test):
+#   - header line: 23 'p' chars + "\r\r\n" terminator  -> 26 bytes
+#   - 60 data rows of fixed width 25 bytes ("NN,x<19 x's>\r\r\n")
+#   - row 39's terminator starts at byte 1023, so the 1024-byte buffer
+#     boundary splits it as "\r" | "\r\n"
+# Layout 3:
+#   - header line: 38 'p' chars + "\r\r\n" terminator  -> 41 bytes
+#   - 60 data rows of fixed width 24 bytes ("NN,x<18 x's>\r\r\n")
+#   - row 40's terminator starts at byte 1022, so the 1024-byte buffer
+#     boundary splits it as "\r\r" | "\n"
+
+statement ok
+COPY (
+    SELECT (repeat('p', 23) || chr(13) || chr(13) || chr(10) ||
+        string_agg(lpad(CAST(t.id AS VARCHAR), 2, '0') || ',' ||
+                   repeat('x', 19) || chr(13) || chr(13) || chr(10), '')
+    )::BLOB
+    FROM generate_series(0, 59) t(id)
+) TO '{TEST_DIR}/rrrn_leading_layout2.csv' (FORMAT BLOB);
+
+statement ok
+COPY (
+    SELECT (repeat('p', 38) || chr(13) || chr(13) || chr(10) ||
+        string_agg(lpad(CAST(t.id AS VARCHAR), 2, '0') || ',' ||
+                   repeat('x', 18) || chr(13) || chr(13) || chr(10), '')
+    )::BLOB
+    FROM generate_series(0, 59) t(id)
+) TO '{TEST_DIR}/rrrn_leading_layout3.csv' (FORMAT BLOB);
+
+# Layout 1: single buffer, sequential and parallel. No id or val may start
+# with a "\n", all 60 rows present, values intact (sum of ids 0..59 = 1770)
+query IIII
+SELECT
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout2.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=4096, parallel=false)) AS total,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout2.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=4096, parallel=false)
+     WHERE starts_with(id, chr(10)) OR starts_with(val, chr(10))) AS leaked,
+    (SELECT SUM(CAST(id AS BIGINT)) FROM read_csv('{TEST_DIR}/rrrn_leading_layout2.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=4096, parallel=false)) AS id_sum,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout2.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=4096, parallel=true)
+     WHERE starts_with(id, chr(10)) OR starts_with(val, chr(10))) AS leaked_parallel
+----
+60	0	1770	0
+
+# Layout 2: boundary splits the terminator as "\r" | "\r\n"
+query IIII
+SELECT
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout2.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=1024, parallel=false)) AS total,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout2.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=1024, parallel=false)
+     WHERE starts_with(id, chr(10)) OR starts_with(val, chr(10))) AS leaked,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout2.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=1024, parallel=true)) AS total_parallel,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout2.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=1024, parallel=true)
+     WHERE starts_with(id, chr(10)) OR starts_with(val, chr(10))) AS leaked_parallel
+----
+60	0	60	0
+
+# Layout 3: boundary splits the terminator as "\r\r" | "\n"
+query IIII
+SELECT
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout3.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=1024, parallel=false)) AS total,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout3.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=1024, parallel=false)
+     WHERE starts_with(id, chr(10)) OR starts_with(val, chr(10))) AS leaked,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout3.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=1024, parallel=true)) AS total_parallel,
+    (SELECT COUNT(*) FROM read_csv('{TEST_DIR}/rrrn_leading_layout3.csv',
+        auto_detect=false, header=true, delim=',',
+        columns={'id':'VARCHAR','val':'VARCHAR'},
+        strict_mode=false, buffer_size=1024, parallel=true)
+     WHERE starts_with(id, chr(10)) OR starts_with(val, chr(10))) AS leaked_parallel
+----
+60	0	60	0


### PR DESCRIPTION
Fixes the second symptom reported in #25164 (supplements #25232)

## Problem

Issue #25164 also reports a second symptom on files with `\r\r\n` line
endings: the reader consumes `\r\r` as the row terminator and leaves the
`\n` attached to the front of the first field of the next row (e.g.
symbol arriving as `"\nSPXW"` instead of `"SPXW"`). Unlike the
duplicate-rows bug fixed in #25232, this happens on **sequential reads
too**, and is invisible when the first column is cast to an integer type
(the cast silently trims the `\n`).

## Root cause

With `auto_detect=false` (or mixed-newline files) the scanner runs in
`CARRY_ON` newline mode, where five sites advance the value start
position by a hard-coded 2 bytes — written for 2-byte `"\r\n"`
terminators. With a 3-byte `"\r\r\n"` terminator the leftover `"\n"`
lands on the start of the next value, both when the terminator is fully
inside one buffer and when a buffer boundary splits it as `"\r" |
"\r\n"` or `"\r\r" | "\n"`.

## Fix

Make those sites aware of the 3-byte terminator:
- `AddRow` / `UnsetComment`: when the bytes after the terminator are
  `"\r\r\n"`, skip 3 instead of 2
- `ProcessOverBufferValue`: after consuming the remaining `"\r\n"` of a
  split terminator, refresh `last_position` to point past it (both
  early-return paths, including the double-count guard added in #25232)
- `ProcessOverBufferValue`: start the next value after a
  boundary-leading newline and never append leading newline bytes to a
  pending value

## Testing

New regression test `test/sql/copy/csv/test_rrrn_leading_newline.test`
(uses VARCHAR ids so the leak is assertable): three layouts — all rows
in a single buffer, boundary splitting as `"\r" | "\r\n"`, and as
`"\r\r" | "\n"` — asserting in both parallel and sequential modes that
no id/val starts with `"\n"`, row counts are exact and values intact.

Verified: the test **fails without the fix** and passes with it.
Full `test/sql/copy/*` suite: 549 test cases, 186,683 assertions, all
passing. Formatting checked with clang-format.
