### PR TITLE
Add double star and helix join order solvers

### DIFF
--- a/src/common/settings.json
+++ b/src/common/settings.json
@@ -588,6 +588,13 @@
         "custom_implementation": true
     },
     {
+        "name": "double_star_join_order",
+        "description": "Reorder double star (bowtie) join graphs with a shape-specific solver instead of dynamic programming",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "false"
+    },
+    {
         "name": "duckdb_api",
         "description": "DuckDB API surface",
         "type": "VARCHAR",
@@ -888,6 +895,20 @@
         "type": "BOOLEAN",
         "default_scope": "local",
         "default_value": "true"
+    },
+    {
+        "name": "helix_join_order",
+        "description": "Reorder helix (chain of diamonds) join graphs with a shape-specific solver instead of dynamic programming",
+        "type": "BOOLEAN",
+        "default_scope": "local",
+        "default_value": "false"
+    },
+    {
+        "name": "helix_join_order_max_relations",
+        "description": "The maximum number of relations the helix join order solver will search, which costs 3^n time",
+        "type": "UBIGINT",
+        "default_scope": "local",
+        "default_value": "13"
     },
     {
         "name": "home_directory",

--- a/src/include/duckdb/main/settings.hpp
+++ b/src/include/duckdb/main/settings.hpp
@@ -918,6 +918,17 @@ struct DisabledOptimizersSetting {
 	static Value GetSetting(const ClientContext &context);
 };
 
+struct DoubleStarJoinOrderSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "double_star_join_order";
+	static constexpr const char *Description =
+	    "Reorder double star (bowtie) join graphs with a shape-specific solver instead of dynamic programming";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
 struct DuckDBAPISetting {
 	using RETURN_TYPE = string;
 	static constexpr const char *Name = "duckdb_api";
@@ -1312,6 +1323,28 @@ struct HeapBasedParserSetting {
 	static constexpr const char *Description = "Use the heap-based PEG parser";
 	static constexpr const char *InputType = "BOOLEAN";
 	static constexpr const char *DefaultValue = "true";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
+struct HelixJoinOrderSetting {
+	using RETURN_TYPE = bool;
+	static constexpr const char *Name = "helix_join_order";
+	static constexpr const char *Description =
+	    "Reorder helix (chain of diamonds) join graphs with a shape-specific solver instead of dynamic programming";
+	static constexpr const char *InputType = "BOOLEAN";
+	static constexpr const char *DefaultValue = "false";
+	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
+	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
+};
+
+struct HelixJoinOrderMaxRelationsSetting {
+	using RETURN_TYPE = idx_t;
+	static constexpr const char *Name = "helix_join_order_max_relations";
+	static constexpr const char *Description =
+	    "The maximum number of relations the helix join order solver will search, which costs 3^n time";
+	static constexpr const char *InputType = "UBIGINT";
+	static constexpr const char *DefaultValue = "13";
 	static constexpr SettingScopeTarget Scope = SettingScopeTarget::LOCAL_DEFAULT;
 	static constexpr idx_t SettingIndex = NEXT_SETTING_INDEX();
 };

--- a/src/include/duckdb/optimizer/join_order/plan_enumerator.hpp
+++ b/src/include/duckdb/optimizer/join_order/plan_enumerator.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/optimizer/join_order/query_graph.hpp"
 #include "duckdb/optimizer/join_order/join_node.hpp"
 #include "duckdb/optimizer/join_order/cost_model.hpp"
+#include "duckdb/optimizer/join_order/shape_solver.hpp"
 #include "duckdb/parser/expression_map.hpp"
 #include "duckdb/common/reference_map.hpp"
 #include "duckdb/planner/logical_operator.hpp"
@@ -65,6 +66,12 @@ private:
 	bool SolveJoinOrderExactly();
 	//! Solve the join order approximately using a greedy algorithm
 	bool SolveJoinOrderApproximately();
+	//! Solve the join order with a shape-specific solver, when one is enabled and the graph matches
+	bool SolveJoinOrderWithShape();
+	//! Price the join graph from the cardinality estimator, so every solver sees the same numbers
+	unique_ptr<ShapeGraph> BuildShapeGraph();
+	//! Write the order a shape solver chose into the DP table
+	bool MaterializeShapeTree(const ShapeTree &tree, optional_ptr<JoinRelationSet> &result);
 	bool PlanUsesCrossProduct(const DPJoinNode &node) const;
 	bool HasCompletePlan() const;
 	bool ActivateRequiredCrossProducts();

--- a/src/include/duckdb/optimizer/join_order/shape_solver.hpp
+++ b/src/include/duckdb/optimizer/join_order/shape_solver.hpp
@@ -1,0 +1,158 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/join_order/shape_solver.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/pair.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+//! Ceiling on relations in a shape graph, set by the width of the neighbour bitmask.
+constexpr idx_t MAX_SHAPE_RELATIONS = 64;
+
+//! Hard ceiling on relations in a helix search, which costs 3^n time and 2^n memory.
+constexpr idx_t MAX_HELIX_RELATIONS = 22;
+
+//! Upper bound on spokes joined to one hub of a double star.
+constexpr idx_t MAX_SPOKES_PER_HUB = 64;
+
+//! A subset of relations, one bit per relation index.
+using ShapeSubset = uint64_t;
+
+//! An equijoin edge and the selectivity of the predicate connecting its two relations.
+struct ShapeEdge {
+	idx_t left;
+	idx_t right;
+	double selectivity;
+};
+
+//! A join order, as a binary tree over relation indices.
+struct ShapeTree {
+	explicit ShapeTree(idx_t relation);
+	ShapeTree(unique_ptr<ShapeTree> left_p, unique_ptr<ShapeTree> right_p);
+
+	//! The relations this tree covers, left to right.
+	vector<idx_t> Leaves() const;
+
+	bool is_leaf;
+	idx_t relation;
+	unique_ptr<ShapeTree> left;
+	unique_ptr<ShapeTree> right;
+};
+
+//! A chosen join order and its estimated cost, in rows flowing through joins.
+struct ShapePlan {
+	unique_ptr<ShapeTree> tree;
+	double cost;
+};
+
+//! A join graph priced for shape solving: a cardinality per relation, a selectivity per pair.
+class ShapeGraph {
+public:
+	ShapeGraph(vector<double> weights_p, vector<ShapeEdge> edges_p);
+
+public:
+	idx_t RelationCount() const {
+		return weights.size();
+	}
+	const vector<ShapeEdge> &Edges() const {
+		return edges;
+	}
+	double Weight(idx_t relation) const {
+		return weights[relation];
+	}
+	//! False when a weight or selectivity is absent, negative or infinite, or a pair is repeated.
+	bool IsUsable() const {
+		return usable;
+	}
+	//! Selectivity of the edge joining two relations, or 1 when none does.
+	double Selectivity(idx_t left, idx_t right) const;
+	//! Product of the cardinalities in the subset and of every selectivity inside it.
+	double SubsetSize(ShapeSubset subset) const;
+	//! Whether every relation in the subset reaches the others without leaving it.
+	bool IsConnected(ShapeSubset subset) const;
+	//! Whether any edge joins a relation in left to one in right.
+	bool Crosses(ShapeSubset left, ShapeSubset right) const;
+
+private:
+	vector<double> weights;
+	vector<ShapeEdge> edges;
+	//! selectivity[i][j] for i < j, 1 where no edge joins the two.
+	vector<vector<double>> selectivity;
+	vector<ShapeSubset> neighbors;
+	bool usable;
+};
+
+//! A relation joined to exactly one hub, with the selectivity of the edge reaching it.
+struct Spoke {
+	idx_t id;
+	double weight;
+	double selectivity;
+
+	//! The factor by which absorbing this spoke multiplies the running size. Below 1 shrinks.
+	double Fanout() const {
+		return weight * selectivity;
+	}
+};
+
+//! Cost, resulting size, and the order a chain of spokes was joined in.
+struct ChainResult {
+	double cost = 0;
+	double size = 0;
+	vector<idx_t> order;
+};
+
+//! Cost and size of one side of a double star for every split point.
+struct SideTable {
+	vector<double> cost;
+	vector<double> size;
+};
+
+//! Sort spokes cheapest fanout first, stably, so ties cannot reorder between runs.
+void SortByFanout(vector<Spoke> &spokes);
+//! Join spokes onto a hub cheapest fanout first, which is optimal for a single star.
+ChainResult ChainCostAndSize(double hub_weight, const vector<Spoke> &spokes);
+//! Entry p covers joining the p cheapest spokes onto the hub, plus extra when supplied.
+SideTable BuildSideTable(double hub_weight, const vector<Spoke> &sorted_spokes, bool has_extra, const Spoke &extra);
+//! Multiplier pricing the merge plus every deferred spoke. The leading 1 is the merge itself.
+double LeftoverMultiplier(const vector<Spoke> &deferred_a, const vector<Spoke> &deferred_b);
+
+//! Two hubs with their single-edge spokes, bridged by a central relation.
+struct DoubleStarShape {
+	idx_t central;
+	idx_t hub_a;
+	idx_t hub_b;
+	vector<idx_t> spokes_a;
+	vector<idx_t> spokes_b;
+};
+
+//! A chain of diamonds: spine relations joined by pairs of parallel relations.
+struct HelixShape {
+	vector<idx_t> spine;
+	//! links[i] runs between spine[i] and spine[i + 1].
+	vector<pair<idx_t, idx_t>> links;
+};
+
+//! Neighbour lists for each relation, each sorted ascending.
+vector<vector<idx_t>> BuildShapeAdjacency(idx_t relation_count, const vector<ShapeEdge> &edges);
+//! Whether every relation is reachable from relation zero.
+bool IsShapeConnected(const vector<vector<idx_t>> &adjacency);
+
+//! Every valid double star decomposition of the graph, ordered by central relation.
+vector<DoubleStarShape> DetectDoubleStars(idx_t relation_count, const vector<ShapeEdge> &edges);
+//! The cheapest order for one decomposition, or nullptr when no candidate had a finite cost.
+unique_ptr<ShapePlan> SolveDoubleStar(const ShapeGraph &graph, const DoubleStarShape &shape);
+
+//! The graph read as a chain of diamonds, or nullptr when it is not one.
+unique_ptr<HelixShape> DetectHelix(idx_t relation_count, const vector<ShapeEdge> &edges);
+//! The cheapest order over all connected subgraphs, or nullptr when none had a finite cost.
+unique_ptr<ShapePlan> SolveHelix(const ShapeGraph &graph, idx_t max_relations);
+
+} // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -139,6 +139,7 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(DisabledFilesystemsSetting),
     DUCKDB_GLOBAL(DisabledLogTypes),
     DUCKDB_GLOBAL(DisabledOptimizersSetting),
+    DUCKDB_SETTING(DoubleStarJoinOrderSetting),
     DUCKDB_SETTING_CALLBACK(DuckDBAPISetting),
     DUCKDB_SETTING(DynamicOrFilterThresholdSetting),
     DUCKDB_SETTING(EnableCachingOperatorsSetting),
@@ -175,6 +176,8 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_GLOBAL(ForceVariantShredding),
     DUCKDB_SETTING(GeometryMinimumShreddingSize),
     DUCKDB_SETTING(HeapBasedParserSetting),
+    DUCKDB_SETTING(HelixJoinOrderSetting),
+    DUCKDB_SETTING(HelixJoinOrderMaxRelationsSetting),
     DUCKDB_SETTING_CALLBACK(HomeDirectorySetting),
     DUCKDB_GLOBAL(HTTPProxySetting),
     DUCKDB_SETTING(HTTPProxyPasswordSetting),
@@ -251,12 +254,12 @@ static const ConfigurationOption internal_options[] = {
     DUCKDB_SETTING(ZstdMinStringLengthSetting),
     FINAL_SETTING};
 
-static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 131),
+static const ConfigurationAlias setting_aliases[] = {DUCKDB_SETTING_ALIAS("memory_limit", 134),
                                                      DUCKDB_SETTING_ALIAS("null_order", 61),
-                                                     DUCKDB_SETTING_ALIAS("profile_output", 154),
-                                                     DUCKDB_SETTING_ALIAS("user", 174),
+                                                     DUCKDB_SETTING_ALIAS("profile_output", 157),
+                                                     DUCKDB_SETTING_ALIAS("user", 177),
                                                      DUCKDB_SETTING_ALIAS("wal_autocheckpoint", 31),
-                                                     DUCKDB_SETTING_ALIAS("worker_threads", 172),
+                                                     DUCKDB_SETTING_ALIAS("worker_threads", 175),
                                                      FINAL_ALIAS};
 
 vector<ConfigurationOption> DBConfig::GetOptions() {

--- a/src/optimizer/join_order/CMakeLists.txt
+++ b/src/optimizer/join_order/CMakeLists.txt
@@ -10,6 +10,9 @@ add_library_unity(
   join_order_optimizer.cpp
   cardinality_estimator.cpp
   cost_model.cpp
+  shape_solver.cpp
+  double_star_solver.cpp
+  helix_solver.cpp
   plan_enumerator.cpp
   relation_manager.cpp
   query_graph_manager.cpp)

--- a/src/optimizer/join_order/double_star_solver.cpp
+++ b/src/optimizer/join_order/double_star_solver.cpp
@@ -1,0 +1,281 @@
+#include "duckdb/optimizer/join_order/shape_solver.hpp"
+
+#include "duckdb/common/algorithm.hpp"
+
+#include <cmath>
+
+namespace duckdb {
+
+// Stable, so ties keep input order and two runs cannot disagree on the chosen plan.
+void SortByFanout(vector<Spoke> &spokes) {
+	std::stable_sort(spokes.begin(), spokes.end(),
+	                 [](const Spoke &a, const Spoke &b) { return a.Fanout() < b.Fanout(); });
+}
+
+ChainResult ChainCostAndSize(double hub_weight, const vector<Spoke> &spokes) {
+	auto sorted = spokes;
+	SortByFanout(sorted);
+
+	ChainResult result;
+	result.size = hub_weight;
+	for (auto &spoke : sorted) {
+		// Two multiplications rather than one: (size * weight) * selectivity rounds differently.
+		result.cost += result.size * spoke.weight * spoke.selectivity;
+		result.size *= spoke.weight;
+		result.size *= spoke.selectivity;
+		result.order.push_back(spoke.id);
+	}
+	return result;
+}
+
+static vector<Spoke> Prefix(const vector<Spoke> &spokes, idx_t count) {
+	vector<Spoke> result;
+	for (idx_t i = 0; i < count; i++) {
+		result.push_back(spokes[i]);
+	}
+	return result;
+}
+
+static vector<Spoke> Suffix(const vector<Spoke> &spokes, idx_t from) {
+	vector<Spoke> result;
+	for (idx_t i = from; i < spokes.size(); i++) {
+		result.push_back(spokes[i]);
+	}
+	return result;
+}
+
+SideTable BuildSideTable(double hub_weight, const vector<Spoke> &sorted_spokes, bool has_extra, const Spoke &extra) {
+	SideTable table;
+	for (idx_t p = 0; p <= sorted_spokes.size(); p++) {
+		auto before_merge = Prefix(sorted_spokes, p);
+		if (has_extra) {
+			// Appended rather than pinned last, so it is re-sorted into its fanout position.
+			before_merge.push_back(extra);
+		}
+		auto chain = ChainCostAndSize(hub_weight, before_merge);
+		table.cost.push_back(chain.cost);
+		table.size.push_back(chain.size);
+	}
+	return table;
+}
+
+//! Deferred spokes of both hubs pool together, since the merge made them one cluster.
+static vector<Spoke> MergedLeftovers(const vector<Spoke> &deferred_a, const vector<Spoke> &deferred_b) {
+	vector<Spoke> leftovers = deferred_a;
+	leftovers.insert(leftovers.end(), deferred_b.begin(), deferred_b.end());
+	SortByFanout(leftovers);
+	return leftovers;
+}
+
+double LeftoverMultiplier(const vector<Spoke> &deferred_a, const vector<Spoke> &deferred_b) {
+	auto leftovers = MergedLeftovers(deferred_a, deferred_b);
+	double multiplier = 1;
+	double running = 1;
+	for (auto &spoke : leftovers) {
+		// Associates differently from ChainCostAndSize above, which is intentional.
+		running *= spoke.weight * spoke.selectivity;
+		multiplier += running;
+	}
+	return multiplier;
+}
+
+namespace {
+
+//! The best pair of split points found for one assignment of the central relation.
+struct SideSolution {
+	double cost = 0;
+	//! Left-hub spokes absorbed before the merge.
+	idx_t p = 0;
+	//! Right-hub spokes absorbed before the merge.
+	idx_t q = 0;
+};
+
+unique_ptr<ShapeTree> Leaf(idx_t relation) {
+	return make_uniq<ShapeTree>(relation);
+}
+
+unique_ptr<ShapeTree> Join(unique_ptr<ShapeTree> left, unique_ptr<ShapeTree> right) {
+	return make_uniq<ShapeTree>(std::move(left), std::move(right));
+}
+
+//! One assignment of the central relation to a hub. Left absorbs it before the merge.
+struct Orientation {
+	idx_t left_hub;
+	double left_hub_weight;
+	idx_t right_hub;
+	double right_hub_weight;
+	idx_t central;
+	double central_weight;
+	//! Selectivity of the central-to-left-hub edge.
+	double sel_left;
+	//! Selectivity of the central-to-right-hub edge, which is the merge itself.
+	double sel_right;
+	vector<Spoke> left_spokes;
+	vector<Spoke> right_spokes;
+
+	//! The central relation seen as a spoke of the left hub.
+	Spoke SharedEntry() const {
+		return Spoke {central, central_weight, sel_left};
+	}
+
+	//! Search every split point pair. False when no candidate had a finite cost.
+	bool Solve(SideSolution &result) const {
+		const auto left_table = BuildSideTable(left_hub_weight, left_spokes, true, SharedEntry());
+		const auto right_table = BuildSideTable(right_hub_weight, right_spokes, false, Spoke {0, 0, 0});
+
+		bool found = false;
+		for (idx_t p = 0; p <= left_spokes.size(); p++) {
+			for (idx_t q = 0; q <= right_spokes.size(); q++) {
+				const auto critical_size = left_table.size[p] * right_table.size[q] * sel_right;
+				const auto multiplier = LeftoverMultiplier(Suffix(left_spokes, p), Suffix(right_spokes, q));
+				const auto total = left_table.cost[p] + right_table.cost[q] + critical_size * multiplier;
+				if (!std::isfinite(total)) {
+					continue;
+				}
+				// Strictly less, so the lowest p then lowest q wins ties.
+				if (!found || total < result.cost) {
+					found = true;
+					result.cost = total;
+					result.p = p;
+					result.q = q;
+				}
+			}
+		}
+		return found;
+	}
+
+	//! Expand split points into the join tree they describe.
+	unique_ptr<ShapePlan> Materialize(const SideSolution &solution) const {
+		// Rebuilt through ChainCostAndSize so the central relation lands where the costing assumed.
+		auto before_merge = Prefix(left_spokes, solution.p);
+		before_merge.push_back(SharedEntry());
+		const auto left_chain = ChainCostAndSize(left_hub_weight, before_merge);
+		const auto right_chain = ChainCostAndSize(right_hub_weight, Prefix(right_spokes, solution.q));
+
+		auto left = Leaf(left_hub);
+		for (auto relation : left_chain.order) {
+			left = Join(std::move(left), Leaf(relation));
+		}
+		auto right = Leaf(right_hub);
+		for (auto relation : right_chain.order) {
+			right = Join(std::move(right), Leaf(relation));
+		}
+
+		auto top = Join(std::move(left), std::move(right));
+		for (auto &spoke : MergedLeftovers(Suffix(left_spokes, solution.p), Suffix(right_spokes, solution.q))) {
+			top = Join(std::move(top), Leaf(spoke.id));
+		}
+
+		auto plan = make_uniq<ShapePlan>();
+		plan->tree = std::move(top);
+		plan->cost = solution.cost;
+		return plan;
+	}
+};
+
+vector<Spoke> CollectSpokes(const ShapeGraph &graph, idx_t hub, const vector<idx_t> &spokes) {
+	vector<Spoke> result;
+	for (auto spoke : spokes) {
+		result.push_back(Spoke {spoke, graph.Weight(spoke), graph.Selectivity(hub, spoke)});
+	}
+	SortByFanout(result);
+	return result;
+}
+
+} // namespace
+
+vector<DoubleStarShape> DetectDoubleStars(idx_t relation_count, const vector<ShapeEdge> &edges) {
+	vector<DoubleStarShape> shapes;
+	// Below four relations there is only one possible shape, so there is nothing to decide.
+	if (relation_count < 4) {
+		return shapes;
+	}
+	// A connected graph with n - 1 edges is a tree. Cycles are refused: correlated predicates
+	// would be multiplied as though independent, which is a wrong answer rather than a poor one.
+	if (edges.size() + 1 != relation_count) {
+		return shapes;
+	}
+
+	const auto adjacency = BuildShapeAdjacency(relation_count, edges);
+	if (adjacency.empty() || !IsShapeConnected(adjacency)) {
+		return shapes;
+	}
+
+	for (idx_t central = 0; central < relation_count; central++) {
+		if (adjacency[central].size() != 2) {
+			continue;
+		}
+		const auto hub_a = MinValue(adjacency[central][0], adjacency[central][1]);
+		const auto hub_b = MaxValue(adjacency[central][0], adjacency[central][1]);
+
+		DoubleStarShape shape;
+		shape.central = central;
+		shape.hub_a = hub_a;
+		shape.hub_b = hub_b;
+		bool valid = true;
+		for (idx_t relation = 0; relation < relation_count && valid; relation++) {
+			if (relation == central || relation == hub_a || relation == hub_b) {
+				continue;
+			}
+			// Anything hanging off a spoke, or bridging the hubs a second time, disqualifies this reading.
+			if (adjacency[relation].size() != 1) {
+				valid = false;
+				break;
+			}
+			const auto neighbor = adjacency[relation][0];
+			if (neighbor == hub_a) {
+				shape.spokes_a.push_back(relation);
+			} else if (neighbor == hub_b) {
+				shape.spokes_b.push_back(relation);
+			} else {
+				valid = false;
+			}
+		}
+		if (valid) {
+			shapes.push_back(std::move(shape));
+		}
+	}
+	return shapes;
+}
+
+unique_ptr<ShapePlan> SolveDoubleStar(const ShapeGraph &graph, const DoubleStarShape &shape) {
+	if (!graph.IsUsable()) {
+		return nullptr;
+	}
+	// The search is O(n * m * (n + m)) over spoke counts taken from a user query.
+	if (shape.spokes_a.size() > MAX_SPOKES_PER_HUB || shape.spokes_b.size() > MAX_SPOKES_PER_HUB) {
+		return nullptr;
+	}
+
+	const auto spokes_a = CollectSpokes(graph, shape.hub_a, shape.spokes_a);
+	const auto spokes_b = CollectSpokes(graph, shape.hub_b, shape.spokes_b);
+	const auto sel_a = graph.Selectivity(shape.hub_a, shape.central);
+	const auto sel_b = graph.Selectivity(shape.hub_b, shape.central);
+
+	// The central relation can attach to either hub, and the choice changes the cost.
+	Orientation central_on_a {shape.hub_a,   graph.Weight(shape.hub_a),
+	                          shape.hub_b,   graph.Weight(shape.hub_b),
+	                          shape.central, graph.Weight(shape.central),
+	                          sel_a,         sel_b,
+	                          spokes_a,      spokes_b};
+	Orientation central_on_b {shape.hub_b,   graph.Weight(shape.hub_b),
+	                          shape.hub_a,   graph.Weight(shape.hub_a),
+	                          shape.central, graph.Weight(shape.central),
+	                          sel_b,         sel_a,
+	                          spokes_b,      spokes_a};
+
+	SideSolution solution_a;
+	SideSolution solution_b;
+	const auto solved_a = central_on_a.Solve(solution_a);
+	const auto solved_b = central_on_b.Solve(solution_b);
+
+	if (solved_a && (!solved_b || solution_a.cost <= solution_b.cost)) {
+		return central_on_a.Materialize(solution_a);
+	}
+	if (solved_b) {
+		return central_on_b.Materialize(solution_b);
+	}
+	return nullptr;
+}
+
+} // namespace duckdb

--- a/src/optimizer/join_order/helix_solver.cpp
+++ b/src/optimizer/join_order/helix_solver.cpp
@@ -1,0 +1,261 @@
+#include "duckdb/optimizer/join_order/shape_solver.hpp"
+
+#include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/bit_utils.hpp"
+
+#include <cmath>
+#include <limits>
+
+namespace duckdb {
+
+namespace {
+
+constexpr double INFINITE_COST = std::numeric_limits<double>::infinity();
+
+ShapeSubset Bit(idx_t relation) {
+	return ShapeSubset(1) << relation;
+}
+
+//! Walk the quotient graph as a path, returning the spine in chain order.
+bool SpinePath(const vector<vector<idx_t>> &quotient, const vector<bool> &is_link, idx_t expected,
+               vector<idx_t> &result) {
+	vector<idx_t> members;
+	for (idx_t relation = 0; relation < quotient.size(); relation++) {
+		if (!is_link[relation]) {
+			members.push_back(relation);
+		}
+	}
+	if (members.size() != expected) {
+		return false;
+	}
+	// A branch fails the degree check, a cycle of diamonds fails the ends check below.
+	for (auto relation : members) {
+		if (quotient[relation].size() > 2) {
+			return false;
+		}
+	}
+
+	vector<idx_t> ends;
+	for (auto relation : members) {
+		if (quotient[relation].size() == 1) {
+			ends.push_back(relation);
+		}
+	}
+	if (ends.size() != 2) {
+		return false;
+	}
+	std::sort(ends.begin(), ends.end());
+
+	// Start from the lower end so the reported order is deterministic.
+	auto current = ends[0];
+	bool has_previous = false;
+	idx_t previous = 0;
+	while (true) {
+		result.push_back(current);
+		bool advanced = false;
+		for (auto neighbor : quotient[current]) {
+			if (has_previous && neighbor == previous) {
+				continue;
+			}
+			previous = current;
+			has_previous = true;
+			current = neighbor;
+			advanced = true;
+			break;
+		}
+		if (!advanced) {
+			break;
+		}
+	}
+	// Fewer than expected means the quotient graph is several chains rather than one.
+	return result.size() == expected;
+}
+
+unique_ptr<ShapeTree> Materialize(ShapeSubset subset, const vector<ShapeSubset> &split) {
+	if (subset != 0 && (subset & (subset - 1)) == 0) {
+		return make_uniq<ShapeTree>(CountZeros<ShapeSubset>::Trailing(subset));
+	}
+	const auto left = split[subset];
+	return make_uniq<ShapeTree>(Materialize(left, split), Materialize(subset ^ left, split));
+}
+
+} // namespace
+
+unique_ptr<HelixShape> DetectHelix(idx_t relation_count, const vector<ShapeEdge> &edges) {
+	// A helix of m diamonds has 3m + 1 relations and 4m edges.
+	if (relation_count < 4 || (relation_count - 1) % 3 != 0) {
+		return nullptr;
+	}
+	const auto diamonds = (relation_count - 1) / 3;
+	if (edges.size() != 4 * diamonds) {
+		return nullptr;
+	}
+
+	const auto adjacency = BuildShapeAdjacency(relation_count, edges);
+	if (adjacency.empty() || !IsShapeConnected(adjacency)) {
+		return nullptr;
+	}
+
+	// A link has degree two, and its partner is the other relation with the same two neighbours.
+	vector<pair<pair<idx_t, idx_t>, vector<idx_t>>> groups;
+	for (idx_t relation = 0; relation < relation_count; relation++) {
+		if (adjacency[relation].size() != 2) {
+			continue;
+		}
+		const auto key = make_pair(adjacency[relation][0], adjacency[relation][1]);
+		bool merged = false;
+		for (auto &group : groups) {
+			if (group.first == key) {
+				group.second.push_back(relation);
+				merged = true;
+				break;
+			}
+		}
+		if (!merged) {
+			groups.emplace_back(key, vector<idx_t> {relation});
+		}
+	}
+
+	vector<pair<idx_t, idx_t>> links;
+	for (auto &group : groups) {
+		if (group.second.size() == 2) {
+			links.emplace_back(group.second[0], group.second[1]);
+		}
+	}
+
+	// One diamond is a four-cycle, so both opposite pairs group this way and either could be the
+	// spine. Keep the reading that leaves the lowest relation on the spine.
+	if (diamonds == 1 && links.size() == 2) {
+		vector<pair<idx_t, idx_t>> filtered;
+		for (auto &link : links) {
+			if (link.first != 0 && link.second != 0) {
+				filtered.push_back(link);
+			}
+		}
+		links = std::move(filtered);
+	}
+	if (links.size() != diamonds) {
+		return nullptr;
+	}
+
+	// Everything not a link is spine. Without this count a link could pair with another link.
+	vector<bool> is_link(relation_count, false);
+	idx_t link_count = 0;
+	for (auto &link : links) {
+		is_link[link.first] = true;
+		is_link[link.second] = true;
+	}
+	for (idx_t relation = 0; relation < relation_count; relation++) {
+		link_count += is_link[relation] ? 1 : 0;
+	}
+	if (link_count != 2 * diamonds) {
+		return nullptr;
+	}
+
+	// The quotient graph: one edge per diamond, joining the spine relations its links run between.
+	vector<vector<idx_t>> quotient(relation_count);
+	vector<pair<idx_t, idx_t>> collapsed;
+	for (auto &link : links) {
+		const auto &ends = adjacency[link.first];
+		if (ends.size() != 2 || is_link[ends[0]] || is_link[ends[1]]) {
+			return nullptr;
+		}
+		quotient[ends[0]].push_back(ends[1]);
+		quotient[ends[1]].push_back(ends[0]);
+		collapsed.emplace_back(ends[0], ends[1]);
+	}
+
+	auto result = make_uniq<HelixShape>();
+	if (!SpinePath(quotient, is_link, diamonds + 1, result->spine)) {
+		return nullptr;
+	}
+
+	// Order the diamonds along the chain, so links[i] runs between spine[i] and spine[i + 1].
+	for (idx_t step = 0; step + 1 < result->spine.size(); step++) {
+		const auto from = result->spine[step];
+		const auto to = result->spine[step + 1];
+		bool found = false;
+		for (idx_t index = 0; index < collapsed.size(); index++) {
+			const auto &ends = collapsed[index];
+			if ((ends.first == from && ends.second == to) || (ends.first == to && ends.second == from)) {
+				auto link = links[index];
+				result->links.emplace_back(MinValue(link.first, link.second), MaxValue(link.first, link.second));
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			return nullptr;
+		}
+	}
+	return result;
+}
+
+unique_ptr<ShapePlan> SolveHelix(const ShapeGraph &graph, idx_t max_relations) {
+	if (!graph.IsUsable()) {
+		return nullptr;
+	}
+	const auto count = graph.RelationCount();
+	const auto limit = MinValue(max_relations, MAX_HELIX_RELATIONS);
+	if (count < 2 || count > limit) {
+		return nullptr;
+	}
+
+	const ShapeSubset all = Bit(count) - 1;
+	vector<double> cost(all + 1, INFINITE_COST);
+	vector<bool> connected(all + 1, false);
+	vector<ShapeSubset> split(all + 1, 0);
+
+	// Ascending order suffices: every proper subset of a subset is numerically smaller than it.
+	for (ShapeSubset subset = 1; subset <= all; subset++) {
+		if (!graph.IsConnected(subset)) {
+			continue;
+		}
+		connected[subset] = true;
+		if ((subset & (subset - 1)) == 0) {
+			cost[subset] = 0;
+			continue;
+		}
+
+		// Pin the lowest relation left so each unordered split is visited once, not twice.
+		const ShapeSubset anchor = subset & (~subset + 1);
+		const ShapeSubset rest = subset ^ anchor;
+		ShapeSubset extra = 0;
+		auto best = INFINITE_COST;
+		bool found = false;
+		while (true) {
+			const ShapeSubset left = anchor | extra;
+			const ShapeSubset right = subset ^ left;
+			if (right != 0 && connected[left] && connected[right]) {
+				// The subset is connected and these halves partition it, so an edge must cross.
+				D_ASSERT(graph.Crosses(left, right));
+				const auto candidate = cost[left] + cost[right];
+				// Strictly less, so the lowest left half wins ties and the plan is deterministic.
+				if (!found || candidate < best) {
+					found = true;
+					best = candidate;
+					split[subset] = left;
+				}
+			}
+			if (extra == rest) {
+				break;
+			}
+			// The next subset of rest, ascending.
+			extra = ((extra | ~rest) + 1) & rest;
+		}
+		if (found) {
+			cost[subset] = best + graph.SubsetSize(subset);
+		}
+	}
+
+	const auto total = cost[all];
+	if (!std::isfinite(total) || !connected[all]) {
+		return nullptr;
+	}
+	auto plan = make_uniq<ShapePlan>();
+	plan->tree = Materialize(all, split);
+	plan->cost = total;
+	return plan;
+}
+
+} // namespace duckdb

--- a/src/optimizer/join_order/plan_enumerator.cpp
+++ b/src/optimizer/join_order/plan_enumerator.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/optimizer/join_order/plan_enumerator.hpp"
 
+#include "duckdb/logging/logger.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/optimizer/join_order/join_node.hpp"
 #include "duckdb/optimizer/join_order/query_graph_manager.hpp"
@@ -506,6 +507,116 @@ bool PlanEnumerator::SolveJoinOrderApproximately() {
 	return true;
 }
 
+unique_ptr<ShapeGraph> PlanEnumerator::BuildShapeGraph() {
+	auto &estimator = cost_model.GetCardinalityEstimator();
+	auto &set_manager = query_graph_manager.set_manager;
+	const auto count = query_graph_manager.relation_manager.NumRelations();
+
+	vector<reference<JoinRelationSet>> singles;
+	vector<double> weights;
+	for (idx_t relation = 0; relation < count; relation++) {
+		auto &set = set_manager.GetJoinRelation(RelationIndex(relation));
+		singles.push_back(set);
+		weights.push_back(estimator.EstimateCardinalityWithSet<double>(set));
+	}
+
+	// Selectivity is derived from the estimator too, so a shape solver prices the same graph the
+	// dynamic programming does and a comparison between them isolates the search.
+	vector<ShapeEdge> edges;
+	for (idx_t left = 0; left < count; left++) {
+		for (idx_t right = left + 1; right < count; right++) {
+			bool has_predicate = false;
+			for (auto &connection : GetConnections(singles[left].get(), singles[right].get())) {
+				// A connection without predicates carries no selectivity to reason about.
+				if (!connection.get().predicates.empty() && !connection.get().generated_cross_product) {
+					has_predicate = true;
+					break;
+				}
+			}
+			if (!has_predicate) {
+				continue;
+			}
+			const auto product = weights[left] * weights[right];
+			if (product <= 0) {
+				return nullptr;
+			}
+			auto &pair_set = set_manager.Union(singles[left].get(), singles[right].get());
+			const auto pair_cardinality = estimator.EstimateCardinalityWithSet<double>(pair_set);
+			edges.push_back(ShapeEdge {left, right, pair_cardinality / product});
+		}
+	}
+
+	auto graph = make_uniq<ShapeGraph>(std::move(weights), std::move(edges));
+	if (!graph->IsUsable()) {
+		return nullptr;
+	}
+	return graph;
+}
+
+bool PlanEnumerator::MaterializeShapeTree(const ShapeTree &tree, optional_ptr<JoinRelationSet> &result) {
+	if (tree.is_leaf) {
+		result = query_graph_manager.set_manager.GetJoinRelation(RelationIndex(tree.relation));
+		return true;
+	}
+	optional_ptr<JoinRelationSet> left;
+	optional_ptr<JoinRelationSet> right;
+	if (!MaterializeShapeTree(*tree.left, left) || !MaterializeShapeTree(*tree.right, right)) {
+		return false;
+	}
+	auto &connections = GetConnections(*left, *right);
+	if (connections.empty()) {
+		return false;
+	}
+	// Reuses the normal emit path, so the node is priced by the cost model like any other.
+	if (!EmitPair(*left, *right, connections)) {
+		return false;
+	}
+	result = query_graph_manager.set_manager.Union(*left, *right);
+	return true;
+}
+
+bool PlanEnumerator::SolveJoinOrderWithShape() {
+	auto &context = query_graph_manager.context;
+	const auto use_double_star = Settings::Get<DoubleStarJoinOrderSetting>(context);
+	const auto use_helix = Settings::Get<HelixJoinOrderSetting>(context);
+	if (!use_double_star && !use_helix) {
+		return false;
+	}
+
+	auto graph = BuildShapeGraph();
+	if (!graph) {
+		return false;
+	}
+
+	string solver;
+	unique_ptr<ShapePlan> chosen;
+	if (use_double_star) {
+		// One graph can decompose several ways, so each is priced and the cheapest kept.
+		for (auto &shape : DetectDoubleStars(graph->RelationCount(), graph->Edges())) {
+			auto candidate = SolveDoubleStar(*graph, shape);
+			if (candidate && (!chosen || candidate->cost < chosen->cost)) {
+				chosen = std::move(candidate);
+				solver = "double star";
+			}
+		}
+	}
+	if (use_helix && !chosen && DetectHelix(graph->RelationCount(), graph->Edges())) {
+		chosen = SolveHelix(*graph, Settings::Get<HelixJoinOrderMaxRelationsSetting>(context));
+		solver = "helix";
+	}
+	if (!chosen) {
+		return false;
+	}
+
+	optional_ptr<JoinRelationSet> root;
+	if (!MaterializeShapeTree(*chosen->tree, root) || !HasCompletePlan()) {
+		return false;
+	}
+	DUCKDB_LOG_DEBUG(context, "join order: %s solver ordered %llu relations, estimated cost %f", solver,
+	                 static_cast<uint64_t>(graph->RelationCount()), chosen->cost);
+	return true;
+}
+
 bool PlanEnumerator::HasCompletePlan() const {
 	unordered_set<RelationIndex> bindings;
 	for (idx_t relation_idx = 0; relation_idx < query_graph_manager.relation_manager.NumRelations(); relation_idx++) {
@@ -570,20 +681,23 @@ bool PlanEnumerator::SolveJoinOrder() {
 	auto swap_to_approximate_threshold =
 	    Settings::Get<ApproximateJoinOrderThresholdSetting>(query_graph_manager.context);
 
-	// first try to solve the join order exactly
-	bool solved;
-	if (query_graph_manager.relation_manager.NumRelations() >= swap_to_approximate_threshold) {
-		solved = SolveJoinOrderApproximately();
-	} else {
-		auto completed_exactly = SolveJoinOrderExactly();
-		if (completed_exactly && !HasCompletePlan() && ActivateRequiredCrossProducts()) {
-			completed_exactly = SolveJoinOrderExactly();
-		}
-		if (!completed_exactly || !HasCompletePlan()) {
-			// Exact enumeration either reached its pair budget or could not connect the graph.
+	// a shape-specific solver replaces the search when one is enabled and recognizes the graph
+	bool solved = SolveJoinOrderWithShape();
+	if (!solved) {
+		// first try to solve the join order exactly
+		if (query_graph_manager.relation_manager.NumRelations() >= swap_to_approximate_threshold) {
 			solved = SolveJoinOrderApproximately();
 		} else {
-			solved = true;
+			auto completed_exactly = SolveJoinOrderExactly();
+			if (completed_exactly && !HasCompletePlan() && ActivateRequiredCrossProducts()) {
+				completed_exactly = SolveJoinOrderExactly();
+			}
+			if (!completed_exactly || !HasCompletePlan()) {
+				// Exact enumeration either reached its pair budget or could not connect the graph.
+				solved = SolveJoinOrderApproximately();
+			} else {
+				solved = true;
+			}
 		}
 	}
 

--- a/src/optimizer/join_order/shape_solver.cpp
+++ b/src/optimizer/join_order/shape_solver.cpp
@@ -1,0 +1,164 @@
+#include "duckdb/optimizer/join_order/shape_solver.hpp"
+
+#include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/bit_utils.hpp"
+
+#include <cmath>
+
+namespace duckdb {
+
+static bool UsableValue(double value) {
+	return std::isfinite(value) && value >= 0;
+}
+
+ShapeTree::ShapeTree(idx_t relation_p) : is_leaf(true), relation(relation_p) {
+}
+
+ShapeTree::ShapeTree(unique_ptr<ShapeTree> left_p, unique_ptr<ShapeTree> right_p)
+    : is_leaf(false), relation(DConstants::INVALID_INDEX), left(std::move(left_p)), right(std::move(right_p)) {
+}
+
+static void CollectLeaves(const ShapeTree &tree, vector<idx_t> &result) {
+	if (tree.is_leaf) {
+		result.push_back(tree.relation);
+		return;
+	}
+	CollectLeaves(*tree.left, result);
+	CollectLeaves(*tree.right, result);
+}
+
+vector<idx_t> ShapeTree::Leaves() const {
+	vector<idx_t> result;
+	CollectLeaves(*this, result);
+	return result;
+}
+
+ShapeGraph::ShapeGraph(vector<double> weights_p, vector<ShapeEdge> edges_p)
+    : weights(std::move(weights_p)), edges(std::move(edges_p)), usable(true) {
+	// Bounded by the neighbour bitmask, not by what a given solver can afford to search.
+	const auto count = weights.size();
+	if (count < 2 || count > MAX_SHAPE_RELATIONS) {
+		usable = false;
+		return;
+	}
+	for (auto weight : weights) {
+		if (!UsableValue(weight)) {
+			usable = false;
+			return;
+		}
+	}
+
+	selectivity.resize(count, vector<double>(count, 1));
+	neighbors.resize(count, 0);
+	for (auto &edge : edges) {
+		if (edge.left == edge.right || edge.left >= count || edge.right >= count || !UsableValue(edge.selectivity)) {
+			usable = false;
+			return;
+		}
+		const auto low = MinValue(edge.left, edge.right);
+		const auto high = MaxValue(edge.left, edge.right);
+		// Several predicates over one pair are a single edge whose selectivities are already combined.
+		if (neighbors[low] & (ShapeSubset(1) << high)) {
+			usable = false;
+			return;
+		}
+		selectivity[low][high] = edge.selectivity;
+		neighbors[low] |= ShapeSubset(1) << high;
+		neighbors[high] |= ShapeSubset(1) << low;
+	}
+}
+
+double ShapeGraph::Selectivity(idx_t left, idx_t right) const {
+	return selectivity[MinValue(left, right)][MaxValue(left, right)];
+}
+
+double ShapeGraph::SubsetSize(ShapeSubset subset) const {
+	double total = 1;
+	for (idx_t relation = 0; relation < weights.size(); relation++) {
+		if (subset & (ShapeSubset(1) << relation)) {
+			total *= weights[relation];
+		}
+	}
+	for (idx_t left = 0; left < selectivity.size(); left++) {
+		if (!(subset & (ShapeSubset(1) << left))) {
+			continue;
+		}
+		for (idx_t right = left + 1; right < selectivity.size(); right++) {
+			if (subset & (ShapeSubset(1) << right)) {
+				total *= selectivity[left][right];
+			}
+		}
+	}
+	return total;
+}
+
+bool ShapeGraph::IsConnected(ShapeSubset subset) const {
+	if (subset == 0) {
+		return false;
+	}
+	ShapeSubset reached = subset & (~subset + 1);
+	auto frontier = reached;
+	while (frontier != 0) {
+		ShapeSubset adjacent = 0;
+		auto remaining = frontier;
+		while (remaining != 0) {
+			const auto relation = CountZeros<ShapeSubset>::Trailing(remaining);
+			adjacent |= neighbors[relation] & subset;
+			remaining &= remaining - 1;
+		}
+		frontier = adjacent & ~reached;
+		reached |= frontier;
+	}
+	return reached == subset;
+}
+
+bool ShapeGraph::Crosses(ShapeSubset left, ShapeSubset right) const {
+	auto remaining = left;
+	while (remaining != 0) {
+		const auto relation = CountZeros<ShapeSubset>::Trailing(remaining);
+		if (neighbors[relation] & right) {
+			return true;
+		}
+		remaining &= remaining - 1;
+	}
+	return false;
+}
+
+vector<vector<idx_t>> BuildShapeAdjacency(idx_t relation_count, const vector<ShapeEdge> &edges) {
+	vector<vector<idx_t>> adjacency(relation_count);
+	for (auto &edge : edges) {
+		if (edge.left >= relation_count || edge.right >= relation_count) {
+			return vector<vector<idx_t>>();
+		}
+		adjacency[edge.left].push_back(edge.right);
+		adjacency[edge.right].push_back(edge.left);
+	}
+	for (auto &neighbors : adjacency) {
+		std::sort(neighbors.begin(), neighbors.end());
+	}
+	return adjacency;
+}
+
+bool IsShapeConnected(const vector<vector<idx_t>> &adjacency) {
+	if (adjacency.empty()) {
+		return false;
+	}
+	vector<bool> seen(adjacency.size(), false);
+	vector<idx_t> stack {0};
+	seen[0] = true;
+	idx_t reached = 1;
+	while (!stack.empty()) {
+		const auto relation = stack.back();
+		stack.pop_back();
+		for (auto neighbor : adjacency[relation]) {
+			if (!seen[neighbor]) {
+				seen[neighbor] = true;
+				reached++;
+				stack.push_back(neighbor);
+			}
+		}
+	}
+	return reached == adjacency.size();
+}
+
+} // namespace duckdb

--- a/test/optimizer/CMakeLists.txt
+++ b/test/optimizer/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library_unity(
   common_subplan_nonserializable.cpp
   filter_pushdown_alias.cpp
   join_order_conflict_detector.cpp
+  join_order_shape_solver.cpp
   logical_plan_verification.cpp
   relation_statistics.cpp
   remove_unused_columns.cpp

--- a/test/optimizer/join_order_shape_solver.cpp
+++ b/test/optimizer/join_order_shape_solver.cpp
@@ -1,0 +1,623 @@
+#include "catch.hpp"
+
+#include "duckdb/optimizer/join_order/shape_solver.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace duckdb;
+
+namespace {
+
+// Ported from the DataFusion prototype's unit tests. Relation ids there were sparse (hubs 10 and
+// 11, central 12); here a ShapeGraph is dense, so the reference cases are renumbered as
+// hub_a 0, hub_b 1, central 2, spokes upward from 3, and the expected orders renumbered with them.
+constexpr idx_t HUB_A = 0;
+constexpr idx_t HUB_B = 1;
+constexpr idx_t CENTRAL = 2;
+
+//! Relative tolerance, sized to absorb reassociation noise but not a different search result.
+constexpr double TOLERANCE = 1e-9;
+
+bool Close(double actual, double expected) {
+	if (actual == expected) {
+		return true;
+	}
+	return std::fabs(actual - expected) <= TOLERANCE * std::fabs(expected);
+}
+
+vector<ShapeEdge> Edges(const vector<pair<idx_t, idx_t>> &pairs) {
+	vector<ShapeEdge> edges;
+	for (auto &entry : pairs) {
+		edges.push_back(ShapeEdge {entry.first, entry.second, 0.5});
+	}
+	return edges;
+}
+
+//! Structure as text, so a bushy order can be asserted exactly rather than by leaf order alone.
+string TreeString(const ShapeTree &tree) {
+	if (tree.is_leaf) {
+		return to_string(tree.relation);
+	}
+	return "(" + TreeString(*tree.left) + " " + TreeString(*tree.right) + ")";
+}
+
+Spoke MakeSpoke(idx_t id, double weight, double selectivity) {
+	return Spoke {id, weight, selectivity};
+}
+
+//! Fanouts of 1.0, 5.0 and 0.2, spanning neutral, growing and shrinking.
+vector<Spoke> ReferenceSpokes() {
+	return {MakeSpoke(3, 50.0, 0.02), MakeSpoke(4, 10.0, 0.5), MakeSpoke(5, 200.0, 0.001)};
+}
+
+vector<Spoke> SortedReferenceSpokes() {
+	auto spokes = ReferenceSpokes();
+	SortByFanout(spokes);
+	return spokes;
+}
+
+//! A double star built directly from weights and selectivities, bypassing detection.
+struct StarInputs {
+	double hub_a_weight;
+	double hub_b_weight;
+	double central_weight;
+	double sel_a;
+	double sel_b;
+	vector<Spoke> spokes_a;
+	vector<Spoke> spokes_b;
+};
+
+unique_ptr<ShapeGraph> BuildStarGraph(const StarInputs &inputs, DoubleStarShape &shape) {
+	vector<double> weights(3 + inputs.spokes_a.size() + inputs.spokes_b.size(), 0);
+	weights[HUB_A] = inputs.hub_a_weight;
+	weights[HUB_B] = inputs.hub_b_weight;
+	weights[CENTRAL] = inputs.central_weight;
+
+	vector<ShapeEdge> edges;
+	edges.push_back(ShapeEdge {HUB_A, CENTRAL, inputs.sel_a});
+	edges.push_back(ShapeEdge {HUB_B, CENTRAL, inputs.sel_b});
+	for (auto &spoke : inputs.spokes_a) {
+		weights[spoke.id] = spoke.weight;
+		edges.push_back(ShapeEdge {HUB_A, spoke.id, spoke.selectivity});
+		shape.spokes_a.push_back(spoke.id);
+	}
+	for (auto &spoke : inputs.spokes_b) {
+		weights[spoke.id] = spoke.weight;
+		edges.push_back(ShapeEdge {HUB_B, spoke.id, spoke.selectivity});
+		shape.spokes_b.push_back(spoke.id);
+	}
+	shape.central = CENTRAL;
+	shape.hub_a = HUB_A;
+	shape.hub_b = HUB_B;
+	return make_uniq<ShapeGraph>(std::move(weights), std::move(edges));
+}
+
+unique_ptr<ShapeGraph> SingleDiamond() {
+	return make_uniq<ShapeGraph>(vector<double> {50.0, 200.0, 1000.0, 5000.0},
+	                             vector<ShapeEdge> {{2, 0, 0.01}, {2, 1, 0.005}, {0, 3, 0.002}, {1, 3, 0.001}});
+}
+
+//! Two diamonds sharing P1: A0 0, A1 1, B0 2, B1 3, P0 4, P1 5, P2 6.
+unique_ptr<ShapeGraph> TwoDiamondHelix() {
+	return make_uniq<ShapeGraph>(vector<double> {50.0, 80.0, 200.0, 300.0, 1000.0, 5000.0, 2000.0},
+	                             vector<ShapeEdge> {{4, 0, 0.01},
+	                                                {4, 2, 0.005},
+	                                                {0, 5, 0.002},
+	                                                {2, 5, 0.001},
+	                                                {5, 1, 0.02},
+	                                                {5, 3, 0.004},
+	                                                {1, 6, 0.0015},
+	                                                {3, 6, 0.003}});
+}
+
+//! A four relation path a - b - c - d, numbered in that order.
+unique_ptr<ShapeGraph> PathGraph() {
+	return make_uniq<ShapeGraph>(vector<double> {100.0, 1000.0, 20000.0, 300.0},
+	                             vector<ShapeEdge> {{0, 1, 0.01}, {1, 2, 0.001}, {2, 3, 0.005}});
+}
+
+//! Price a tree back independently, to catch a split the search recorded wrongly.
+double CostOfTree(const ShapeGraph &graph, const ShapeTree &tree, ShapeSubset &subset) {
+	if (tree.is_leaf) {
+		subset = ShapeSubset(1) << tree.relation;
+		return 0;
+	}
+	ShapeSubset left_subset = 0;
+	ShapeSubset right_subset = 0;
+	const auto left_cost = CostOfTree(graph, *tree.left, left_subset);
+	const auto right_cost = CostOfTree(graph, *tree.right, right_subset);
+	subset = left_subset | right_subset;
+	return left_cost + right_cost + graph.SubsetSize(subset);
+}
+
+} // namespace
+
+//===--------------------------------------------------------------------===//
+// Double star shape detection
+//===--------------------------------------------------------------------===//
+
+TEST_CASE("Double star detects the canonical bowtie", "[optimizer][join_order]") {
+	//   1  2        4  5
+	//    \ |        | /
+	//      0 -- 3 -- 6         0 and 6 are hubs, 3 is central
+	auto shapes = DetectDoubleStars(7, Edges({{0, 1}, {0, 2}, {0, 3}, {3, 6}, {6, 4}, {6, 5}}));
+
+	REQUIRE(shapes.size() == 1);
+	REQUIRE(shapes[0].central == 3);
+	REQUIRE(shapes[0].hub_a == 0);
+	REQUIRE(shapes[0].hub_b == 6);
+	REQUIRE(shapes[0].spokes_a == vector<idx_t> {1, 2});
+	REQUIRE(shapes[0].spokes_b == vector<idx_t> {4, 5});
+}
+
+TEST_CASE("Double star reads a four path two ways", "[optimizer][join_order]") {
+	// 0 - 1 - 2 - 3 has two degree-two relations, so both readings are valid.
+	auto shapes = DetectDoubleStars(4, Edges({{0, 1}, {1, 2}, {2, 3}}));
+
+	REQUIRE(shapes.size() == 2);
+	REQUIRE(shapes[0].central == 1);
+	REQUIRE(shapes[1].central == 2);
+}
+
+TEST_CASE("Double star reads a five path one way", "[optimizer][join_order]") {
+	// Only the middle relation leaves every other one hanging off a hub.
+	auto shapes = DetectDoubleStars(5, Edges({{0, 1}, {1, 2}, {2, 3}, {3, 4}}));
+
+	REQUIRE(shapes.size() == 1);
+	REQUIRE(shapes[0].central == 2);
+}
+
+TEST_CASE("Double star rejects a cycle", "[optimizer][join_order]") {
+	REQUIRE(DetectDoubleStars(4, Edges({{0, 1}, {1, 2}, {2, 3}, {3, 0}})).empty());
+}
+
+TEST_CASE("Double star rejects a disconnected graph", "[optimizer][join_order]") {
+	// Four relations and three edges, but one relation is isolated.
+	REQUIRE(DetectDoubleStars(5, Edges({{0, 1}, {1, 2}, {2, 0}, {3, 4}})).empty());
+}
+
+TEST_CASE("Double star rejects a single star", "[optimizer][join_order]") {
+	// One hub with three spokes has no bridging relation.
+	REQUIRE(DetectDoubleStars(4, Edges({{0, 1}, {0, 2}, {0, 3}})).empty());
+}
+
+TEST_CASE("Double star rejects a triple star", "[optimizer][join_order]") {
+	//   1     3     5        three hubs chained by two centrals
+	//   |     |     |
+	//   0 - 2 - 4 - 6        hub 4 sits between two bridges
+	REQUIRE(DetectDoubleStars(8, Edges({{0, 1}, {0, 2}, {2, 4}, {4, 3}, {4, 6}, {6, 5}, {6, 7}})).empty());
+}
+
+TEST_CASE("Double star rejects a spoke with its own child", "[optimizer][join_order]") {
+	// The canonical bowtie, but spoke 1 carries a child of its own:
+	//
+	//   7 - 1  2            5  6
+	//        \ |            | /
+	//          0 ---- 3 ---- 4
+	//
+	// Relation 1 now has degree two, so neither candidate works: central 1 is stranded by
+	// relation 3, and central 3 by relation 1. This needs the full bowtie, since a smaller graph
+	// tends to admit some other valid assignment of roles.
+	REQUIRE(DetectDoubleStars(8, Edges({{0, 1}, {0, 2}, {0, 3}, {3, 4}, {4, 5}, {4, 6}, {1, 7}})).empty());
+}
+
+TEST_CASE("Double star rejects graphs too small to reorder", "[optimizer][join_order]") {
+	REQUIRE(DetectDoubleStars(3, Edges({{0, 1}, {1, 2}})).empty());
+	REQUIRE(DetectDoubleStars(2, Edges({{0, 1}})).empty());
+}
+
+//===--------------------------------------------------------------------===//
+// Double star cost model
+//===--------------------------------------------------------------------===//
+
+TEST_CASE("Chain joins cheapest fanout first", "[optimizer][join_order]") {
+	// By hand: 1000 -> (x0.2) 200 -> (x1.0) 200 -> (x5.0) 1000, paying 200 + 200 + 1000.
+	auto chain = ChainCostAndSize(1000.0, ReferenceSpokes());
+
+	REQUIRE(chain.cost == 1400.0);
+	REQUIRE(chain.size == 1000.0);
+	REQUIRE(chain.order == vector<idx_t> {5, 3, 4});
+}
+
+TEST_CASE("Chain of nothing is free", "[optimizer][join_order]") {
+	auto chain = ChainCostAndSize(1000.0, vector<Spoke> {});
+
+	REQUIRE(chain.cost == 0.0);
+	REQUIRE(chain.size == 1000.0);
+	REQUIRE(chain.order.empty());
+}
+
+TEST_CASE("Chain order beats the worst order", "[optimizer][join_order]") {
+	auto sorted = SortedReferenceSpokes();
+	std::reverse(sorted.begin(), sorted.end());
+	double reversed = 0;
+	double size = 1000.0;
+	for (auto &spoke : sorted) {
+		reversed += size * spoke.weight * spoke.selectivity;
+		size *= spoke.weight;
+		size *= spoke.selectivity;
+	}
+
+	REQUIRE(ChainCostAndSize(1000.0, ReferenceSpokes()).cost == 1400.0);
+	REQUIRE(reversed == 11000.0);
+}
+
+TEST_CASE("Side table prices every split point", "[optimizer][join_order]") {
+	auto table = BuildSideTable(1000.0, SortedReferenceSpokes(), false, MakeSpoke(0, 0, 0));
+
+	REQUIRE(table.cost == vector<double> {0.0, 200.0, 400.0, 1400.0});
+	REQUIRE(table.size == vector<double> {1000.0, 200.0, 200.0, 1000.0});
+}
+
+TEST_CASE("Side table places the central relation by fanout", "[optimizer][join_order]") {
+	// Fanout 3.0 sorts after the 0.2 and 1.0 spokes but before the 5.0 one.
+	auto table = BuildSideTable(1000.0, SortedReferenceSpokes(), true, MakeSpoke(CENTRAL, 300.0, 0.01));
+
+	REQUIRE(table.cost == vector<double> {3000.0, 800.0, 1000.0, 4000.0});
+	REQUIRE(table.size == vector<double> {3000.0, 600.0, 600.0, 3000.0});
+}
+
+TEST_CASE("Leftover multiplier pools both piles", "[optimizer][join_order]") {
+	vector<Spoke> deferred_a {MakeSpoke(3, 50.0, 0.02)};                         // fanout 1.0
+	vector<Spoke> deferred_b {MakeSpoke(6, 10.0, 0.5), MakeSpoke(7, 4.0, 0.25)}; // 5.0 and 1.0
+
+	// Merged order is 1.0, 1.0, 5.0, so the multiplier is 1 + 1 + 1 + 5.
+	REQUIRE(LeftoverMultiplier(deferred_a, deferred_b) == 8.0);
+}
+
+TEST_CASE("Leftover multiplier of nothing is the merge alone", "[optimizer][join_order]") {
+	REQUIRE(LeftoverMultiplier(vector<Spoke> {}, vector<Spoke> {}) == 1.0);
+}
+
+TEST_CASE("Double star solves the symmetric reference case", "[optimizer][join_order]") {
+	// Every spoke is worth absorbing before the merge, so both split points sit at their maximum.
+	StarInputs inputs {
+	    1000.0, 2000.0, 300.0, 0.01, 0.005, ReferenceSpokes(), {MakeSpoke(6, 20.0, 0.1), MakeSpoke(7, 5.0, 0.4)}};
+	DoubleStarShape shape;
+	auto graph = BuildStarGraph(inputs, shape);
+	auto plan = SolveDoubleStar(*graph, shape);
+
+	REQUIRE(plan);
+	REQUIRE(plan->cost == 136000.0);
+	// hub_a then its three spokes and the central relation in fanout order 0.2, 1.0, 3.0, 5.0,
+	// then hub_b with its two spokes, and nothing deferred.
+	REQUIRE(plan->tree->Leaves() == vector<idx_t> {HUB_A, 5, 3, CENTRAL, 4, HUB_B, 6, 7});
+}
+
+TEST_CASE("Double star picks the cheaper orientation", "[optimizer][join_order]") {
+	// Attaching the central relation to the other hub is worth 35% here.
+	StarInputs inputs {500000.0, 10.0, 100.0, 0.5, 0.001, {MakeSpoke(3, 1000.0, 0.9)}, {MakeSpoke(4, 2.0, 0.1)}};
+	DoubleStarShape shape;
+	auto graph = BuildStarGraph(inputs, shape);
+	auto plan = SolveDoubleStar(*graph, shape);
+
+	REQUIRE(plan);
+	REQUIRE(Close(plan->cost, 45050001.2));
+	// hub_b leads, taking the central relation and its own spoke; the fanout-900 spoke is deferred.
+	REQUIRE(plan->tree->Leaves() == vector<idx_t> {HUB_B, CENTRAL, 4, HUB_A, 3});
+}
+
+TEST_CASE("Double star defers growing spokes past the merge", "[optimizer][join_order]") {
+	StarInputs inputs {1000.0, 1000.0, 100.0, 0.01, 0.01, {MakeSpoke(3, 10.0, 0.001), MakeSpoke(4, 1000.0, 5.0)}, {}};
+	DoubleStarShape shape;
+	auto graph = BuildStarGraph(inputs, shape);
+	auto plan = SolveDoubleStar(*graph, shape);
+
+	REQUIRE(plan);
+	// The shrinking spoke is absorbed before the merge, the fanout-5000 one after.
+	auto leaves = plan->tree->Leaves();
+	REQUIRE(leaves.back() == 4);
+	REQUIRE(std::find(leaves.begin(), leaves.end(), idx_t(3)) < std::find(leaves.begin(), leaves.end(), HUB_B));
+}
+
+TEST_CASE("Double star plan visits every relation exactly once", "[optimizer][join_order]") {
+	StarInputs inputs {
+	    1000.0, 2000.0, 300.0, 0.01, 0.005, ReferenceSpokes(), {MakeSpoke(6, 20.0, 0.1), MakeSpoke(7, 5.0, 0.4)}};
+	DoubleStarShape shape;
+	auto graph = BuildStarGraph(inputs, shape);
+	auto plan = SolveDoubleStar(*graph, shape);
+
+	REQUIRE(plan);
+	auto leaves = plan->tree->Leaves();
+	std::sort(leaves.begin(), leaves.end());
+	REQUIRE(leaves == vector<idx_t> {0, 1, 2, 3, 4, 5, 6, 7});
+}
+
+TEST_CASE("Double star with no spokes is just the merge", "[optimizer][join_order]") {
+	StarInputs inputs {100.0, 200.0, 50.0, 0.1, 0.2, {}, {}};
+	DoubleStarShape shape;
+	auto graph = BuildStarGraph(inputs, shape);
+	auto plan = SolveDoubleStar(*graph, shape);
+
+	REQUIRE(plan);
+	REQUIRE(plan->tree->Leaves() == vector<idx_t> {HUB_A, CENTRAL, HUB_B});
+}
+
+TEST_CASE("Double star rejects unusable statistics", "[optimizer][join_order]") {
+	// A zero distinct count surfaces as an infinite selectivity, absent statistics as NaN.
+	DoubleStarShape shape;
+	shape.central = CENTRAL;
+	shape.hub_a = HUB_A;
+	shape.hub_b = HUB_B;
+	ShapeGraph infinite(
+	    vector<double> {1000.0, 2000.0, 300.0},
+	    vector<ShapeEdge> {{HUB_A, CENTRAL, std::numeric_limits<double>::infinity()}, {HUB_B, CENTRAL, 0.005}});
+	REQUIRE(!SolveDoubleStar(infinite, shape));
+
+	ShapeGraph negative(vector<double> {1000.0, -1.0, 300.0},
+	                    vector<ShapeEdge> {{HUB_A, CENTRAL, 0.01}, {HUB_B, CENTRAL, 0.005}});
+	REQUIRE(!SolveDoubleStar(negative, shape));
+}
+
+TEST_CASE("Double star with empty relations costs nothing", "[optimizer][join_order]") {
+	StarInputs inputs {0.0, 0.0, 0.0, 0.5, 0.5, {}, {}};
+	DoubleStarShape shape;
+	auto graph = BuildStarGraph(inputs, shape);
+	auto plan = SolveDoubleStar(*graph, shape);
+
+	REQUIRE(plan);
+	REQUIRE(plan->cost == 0.0);
+}
+
+TEST_CASE("Double star resolves tied costs deterministically", "[optimizer][join_order]") {
+	// Every spoke has the same fanout, so only the tie break decides the order.
+	StarInputs inputs {1000.0,
+	                   1000.0,
+	                   100.0,
+	                   0.01,
+	                   0.01,
+	                   {MakeSpoke(3, 10.0, 0.1), MakeSpoke(4, 10.0, 0.1)},
+	                   {MakeSpoke(5, 10.0, 0.1), MakeSpoke(6, 10.0, 0.1)}};
+	DoubleStarShape first_shape;
+	auto first_graph = BuildStarGraph(inputs, first_shape);
+	auto first = SolveDoubleStar(*first_graph, first_shape);
+	DoubleStarShape second_shape;
+	auto second_graph = BuildStarGraph(inputs, second_shape);
+	auto second = SolveDoubleStar(*second_graph, second_shape);
+
+	REQUIRE(first);
+	REQUIRE(second);
+	REQUIRE(TreeString(*first->tree) == TreeString(*second->tree));
+	REQUIRE(first->cost == second->cost);
+}
+
+TEST_CASE("Double star cheapest fanout first beats every other order", "[optimizer][join_order]") {
+	auto spokes = ReferenceSpokes();
+	const auto best = ChainCostAndSize(1000.0, spokes).cost;
+
+	auto permuted = spokes;
+	std::sort(permuted.begin(), permuted.end(), [](const Spoke &a, const Spoke &b) { return a.id < b.id; });
+	do {
+		double cost = 0;
+		double size = 1000.0;
+		for (auto &spoke : permuted) {
+			cost += size * spoke.weight * spoke.selectivity;
+			size *= spoke.weight;
+			size *= spoke.selectivity;
+		}
+		REQUIRE(best <= cost);
+	} while (std::next_permutation(permuted.begin(), permuted.end(),
+	                               [](const Spoke &a, const Spoke &b) { return a.id < b.id; }));
+}
+
+//===--------------------------------------------------------------------===//
+// Helix shape detection
+//===--------------------------------------------------------------------===//
+
+TEST_CASE("Helix detects a two diamond helix", "[optimizer][join_order]") {
+	// Spine 0 - 3 - 6, links {1,2} and {4,5}.
+	auto shape = DetectHelix(7, Edges({{0, 1}, {0, 2}, {1, 3}, {2, 3}, {3, 4}, {3, 5}, {4, 6}, {5, 6}}));
+
+	REQUIRE(shape);
+	REQUIRE(shape->spine == vector<idx_t> {0, 3, 6});
+	REQUIRE(shape->links.size() == 2);
+	REQUIRE(shape->links[0] == make_pair(idx_t(1), idx_t(2)));
+	REQUIRE(shape->links[1] == make_pair(idx_t(4), idx_t(5)));
+}
+
+TEST_CASE("Helix detects a three diamond helix", "[optimizer][join_order]") {
+	auto shape = DetectHelix(
+	    10, Edges({{0, 1}, {0, 2}, {1, 3}, {2, 3}, {3, 4}, {3, 5}, {4, 6}, {5, 6}, {6, 7}, {6, 8}, {7, 9}, {8, 9}}));
+
+	REQUIRE(shape);
+	REQUIRE(shape->spine == vector<idx_t> {0, 3, 6, 9});
+	REQUIRE(shape->links.size() == 3);
+}
+
+TEST_CASE("Helix accepts a single diamond", "[optimizer][join_order]") {
+	// A four cycle: both opposite pairs group as links, and the reading keeping relation 0 on the
+	// spine is the one taken.
+	auto shape = DetectHelix(4, Edges({{0, 1}, {0, 2}, {1, 3}, {2, 3}}));
+
+	REQUIRE(shape);
+	REQUIRE(shape->spine == vector<idx_t> {0, 3});
+	REQUIRE(shape->links.size() == 1);
+	REQUIRE(shape->links[0] == make_pair(idx_t(1), idx_t(2)));
+}
+
+TEST_CASE("Helix reports the spine in chain order not index order", "[optimizer][join_order]") {
+	// Spine relations 6, 0, 3 in chain order, which is not their index order.
+	auto shape = DetectHelix(7, Edges({{6, 1}, {6, 2}, {1, 0}, {2, 0}, {0, 4}, {0, 5}, {4, 3}, {5, 3}}));
+
+	REQUIRE(shape);
+	REQUIRE(shape->spine == vector<idx_t> {3, 0, 6});
+}
+
+TEST_CASE("Helix rejects a relation count that is not three m plus one", "[optimizer][join_order]") {
+	REQUIRE(!DetectHelix(6, Edges({{0, 1}, {0, 2}, {1, 3}, {2, 3}, {3, 4}, {4, 5}})));
+}
+
+TEST_CASE("Helix rejects the right relation count with the wrong edge count", "[optimizer][join_order]") {
+	// Seven relations wants eight edges, not six.
+	REQUIRE(!DetectHelix(7, Edges({{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}})));
+}
+
+TEST_CASE("Helix rejects a bowtie", "[optimizer][join_order]") {
+	REQUIRE(!DetectHelix(7, Edges({{0, 1}, {0, 2}, {0, 3}, {3, 6}, {6, 4}, {6, 5}})));
+}
+
+TEST_CASE("Helix rejects a disconnected graph", "[optimizer][join_order]") {
+	// Two independent diamonds: the right counts, but no single chain.
+	REQUIRE(!DetectHelix(7, Edges({{0, 1}, {0, 2}, {1, 3}, {2, 3}, {4, 5}, {4, 6}, {5, 6}, {5, 6}})));
+}
+
+TEST_CASE("Helix rejects a ring of diamonds", "[optimizer][join_order]") {
+	// Three diamonds joined head to tail: the spine is a cycle, not a path.
+	REQUIRE(!DetectHelix(
+	    10, Edges({{0, 1}, {0, 2}, {1, 3}, {2, 3}, {3, 4}, {3, 5}, {4, 6}, {5, 6}, {6, 7}, {6, 8}, {7, 0}, {8, 0}})));
+}
+
+TEST_CASE("Helix rejects a diamond whose links touch each other", "[optimizer][join_order]") {
+	REQUIRE(!DetectHelix(4, Edges({{0, 1}, {1, 2}, {2, 3}, {1, 2}})));
+}
+
+TEST_CASE("Helix rejects graphs too small to be a helix", "[optimizer][join_order]") {
+	REQUIRE(!DetectHelix(3, Edges({{0, 1}, {1, 2}})));
+	REQUIRE(!DetectHelix(2, Edges({{0, 1}})));
+}
+
+//===--------------------------------------------------------------------===//
+// Helix cost model
+//===--------------------------------------------------------------------===//
+
+TEST_CASE("Helix matches the reference on a single diamond", "[optimizer][join_order]") {
+	auto graph = SingleDiamond();
+	auto plan = SolveHelix(*graph, MAX_HELIX_RELATIONS);
+
+	REQUIRE(plan);
+	REQUIRE(Close(plan->cost, 605.0));
+	// (((A0 P1) B0) P0): the two smallest first, then the diamond closes before P0 is absorbed.
+	REQUIRE(TreeString(*plan->tree) == "(((0 3) 1) 2)");
+}
+
+TEST_CASE("Helix matches the reference on a two diamond helix", "[optimizer][join_order]") {
+	auto graph = TwoDiamondHelix();
+	auto plan = SolveHelix(*graph, MAX_HELIX_RELATIONS);
+
+	REQUIRE(plan);
+	// The reference prints 552.85439999999994; the digits past this are reassociation noise.
+	REQUIRE(Close(plan->cost, 552.8544));
+	REQUIRE(TreeString(*plan->tree) == "(((0 (((1 6) 3) 5)) 2) 4)");
+}
+
+TEST_CASE("Helix matches the reference on a path", "[optimizer][join_order]") {
+	auto graph = PathGraph();
+	auto plan = SolveHelix(*graph, MAX_HELIX_RELATIONS);
+
+	REQUIRE(plan);
+	REQUIRE(Close(plan->cost, 51000.0));
+	REQUIRE(TreeString(*plan->tree) == "(((0 1) 2) 3)");
+}
+
+TEST_CASE("Helix gives two relations a single order", "[optimizer][join_order]") {
+	ShapeGraph graph(vector<double> {100.0, 1000.0}, vector<ShapeEdge> {{0, 1, 0.01}});
+	auto plan = SolveHelix(graph, MAX_HELIX_RELATIONS);
+
+	REQUIRE(plan);
+	REQUIRE(Close(plan->cost, 1000.0));
+	REQUIRE(TreeString(*plan->tree) == "(0 1)");
+}
+
+TEST_CASE("Helix chosen tree costs what the search said", "[optimizer][join_order]") {
+	// The recorded splits are the one piece with nothing to compare against, so price them back.
+	for (auto &graph : {SingleDiamond(), TwoDiamondHelix(), PathGraph()}) {
+		auto plan = SolveHelix(*graph, MAX_HELIX_RELATIONS);
+		REQUIRE(plan);
+		ShapeSubset covered = 0;
+		REQUIRE(Close(CostOfTree(*graph, *plan->tree, covered), plan->cost));
+	}
+}
+
+TEST_CASE("Helix covers every relation exactly once", "[optimizer][join_order]") {
+	for (auto &graph : {SingleDiamond(), TwoDiamondHelix(), PathGraph()}) {
+		auto plan = SolveHelix(*graph, MAX_HELIX_RELATIONS);
+		REQUIRE(plan);
+		auto leaves = plan->tree->Leaves();
+		std::sort(leaves.begin(), leaves.end());
+		REQUIRE(leaves.size() == graph->RelationCount());
+		for (idx_t relation = 0; relation < graph->RelationCount(); relation++) {
+			REQUIRE(leaves[relation] == relation);
+		}
+	}
+}
+
+TEST_CASE("Helix gives every join a predicate", "[optimizer][join_order]") {
+	// Both halves of every split are connected and an edge crosses between them, so the emitted
+	// tree contains no cross product.
+	for (auto &graph : {SingleDiamond(), TwoDiamondHelix(), PathGraph()}) {
+		auto plan = SolveHelix(*graph, MAX_HELIX_RELATIONS);
+		REQUIRE(plan);
+		ShapeSubset covered = 0;
+		CostOfTree(*graph, *plan->tree, covered);
+		REQUIRE(graph->IsConnected(covered));
+	}
+}
+
+TEST_CASE("Helix finds a bushy order", "[optimizer][join_order]") {
+	// A left deep search cannot produce this tree; the two diamond helix joins two composites.
+	auto graph = TwoDiamondHelix();
+	auto plan = SolveHelix(*graph, MAX_HELIX_RELATIONS);
+
+	REQUIRE(plan);
+	REQUIRE(!plan->tree->left->is_leaf);
+	REQUIRE(!plan->tree->left->left->is_leaf);
+	REQUIRE(!plan->tree->left->left->right->is_leaf);
+}
+
+TEST_CASE("Helix is deterministic", "[optimizer][join_order]") {
+	auto first_graph = TwoDiamondHelix();
+	auto second_graph = TwoDiamondHelix();
+	auto first = SolveHelix(*first_graph, MAX_HELIX_RELATIONS);
+	auto second = SolveHelix(*second_graph, MAX_HELIX_RELATIONS);
+
+	REQUIRE(first);
+	REQUIRE(second);
+	REQUIRE(TreeString(*first->tree) == TreeString(*second->tree));
+	REQUIRE(first->cost == second->cost);
+}
+
+TEST_CASE("Helix declines a disconnected graph", "[optimizer][join_order]") {
+	ShapeGraph graph(vector<double> {100.0, 200.0, 300.0}, vector<ShapeEdge> {{0, 1, 0.01}});
+	REQUIRE(!SolveHelix(graph, MAX_HELIX_RELATIONS));
+}
+
+TEST_CASE("Helix declines more relations than the cap", "[optimizer][join_order]") {
+	auto graph = TwoDiamondHelix();
+	REQUIRE(!SolveHelix(*graph, 6));
+	REQUIRE(SolveHelix(*graph, 7));
+}
+
+TEST_CASE("Helix declines fewer than two relations", "[optimizer][join_order]") {
+	ShapeGraph graph(vector<double> {100.0}, vector<ShapeEdge> {});
+	REQUIRE(!SolveHelix(graph, MAX_HELIX_RELATIONS));
+}
+
+TEST_CASE("Helix declines unusable numbers", "[optimizer][join_order]") {
+	ShapeGraph nan_weight(vector<double> {100.0, std::nan("")}, vector<ShapeEdge> {{0, 1, 0.01}});
+	REQUIRE(!SolveHelix(nan_weight, MAX_HELIX_RELATIONS));
+
+	ShapeGraph infinite(vector<double> {100.0, 200.0},
+	                    vector<ShapeEdge> {{0, 1, std::numeric_limits<double>::infinity()}});
+	REQUIRE(!SolveHelix(infinite, MAX_HELIX_RELATIONS));
+}
+
+TEST_CASE("Helix declines a malformed edge", "[optimizer][join_order]") {
+	// An edge naming one relation twice, and a relation pair appearing twice.
+	ShapeGraph self_edge(vector<double> {100.0, 200.0}, vector<ShapeEdge> {{0, 0, 0.01}});
+	REQUIRE(!SolveHelix(self_edge, MAX_HELIX_RELATIONS));
+
+	ShapeGraph repeated(vector<double> {100.0, 200.0}, vector<ShapeEdge> {{0, 1, 0.01}, {1, 0, 0.02}});
+	REQUIRE(!SolveHelix(repeated, MAX_HELIX_RELATIONS));
+
+	ShapeGraph out_of_range(vector<double> {100.0, 200.0}, vector<ShapeEdge> {{0, 5, 0.01}});
+	REQUIRE(!SolveHelix(out_of_range, MAX_HELIX_RELATIONS));
+}
+
+TEST_CASE("Helix declines when every order overflows", "[optimizer][join_order]") {
+	// Cardinalities large enough that any product is infinite.
+	const auto huge = std::numeric_limits<double>::max();
+	ShapeGraph graph(vector<double> {huge, huge, huge}, vector<ShapeEdge> {{0, 1, 1.0}, {1, 2, 1.0}});
+	auto plan = SolveHelix(graph, MAX_HELIX_RELATIONS);
+	REQUIRE(!plan);
+}

--- a/test/sql/optimizer/join_order/double_star.test
+++ b/test/sql/optimizer/join_order/double_star.test
@@ -1,0 +1,128 @@
+# name: test/sql/optimizer/join_order/double_star.test
+# description: Test the double star (bowtie) join order solver
+# group: [join_order]
+
+# A bowtie: two fact tables bridged by a link table, each carrying its own dimension.
+#
+#   dim_a          dim_b
+#     |              |
+#   fact_a -- link -- fact_b
+#
+# Column counts differ per table on purpose: with uniform widths a mistaken offset can land on a
+# valid column of the wrong table and still produce well-formed output.
+
+statement ok
+CREATE TABLE dim_a(id INTEGER, label VARCHAR);
+
+statement ok
+CREATE TABLE fact_a(id INTEGER, dim_id INTEGER, a_val INTEGER);
+
+statement ok
+CREATE TABLE link(a_id INTEGER, b_id INTEGER);
+
+statement ok
+CREATE TABLE fact_b(id INTEGER, dim_id INTEGER, b_val INTEGER, extra INTEGER);
+
+statement ok
+CREATE TABLE dim_b(id INTEGER, label VARCHAR);
+
+statement ok
+INSERT INTO dim_a SELECT i, 'a'||i FROM range(50) t(i);
+
+statement ok
+INSERT INTO fact_a SELECT i, i%50, i FROM range(20000) t(i);
+
+statement ok
+INSERT INTO link SELECT i, i FROM range(300) t(i);
+
+statement ok
+INSERT INTO fact_b SELECT i, i%40, i, i FROM range(50000) t(i);
+
+statement ok
+INSERT INTO dim_b SELECT i, 'b'||i FROM range(40) t(i);
+
+# ---------- the rule is off by default ----------
+
+query IIII rowsort bowtie_rows
+SELECT fact_a.id, dim_a.label, fact_b.b_val, dim_b.label
+FROM fact_a, dim_a, link, fact_b, dim_b
+WHERE fact_a.dim_id = dim_a.id AND fact_a.id = link.a_id
+  AND link.b_id = fact_b.id AND fact_b.dim_id = dim_b.id
+ORDER BY fact_a.id LIMIT 5
+----
+
+query II nosort chain_plan
+EXPLAIN SELECT count(*) FROM fact_a, link, fact_b
+WHERE fact_a.id = link.a_id AND link.b_id = fact_b.id
+----
+
+query II nosort outer_plan
+EXPLAIN SELECT count(*) FROM fact_a LEFT JOIN dim_a ON fact_a.dim_id = dim_a.id
+----
+
+statement ok
+SET double_star_join_order=true
+
+# ---------- reordering must not change the answer ----------
+
+query IIII rowsort bowtie_rows
+SELECT fact_a.id, dim_a.label, fact_b.b_val, dim_b.label
+FROM fact_a, dim_a, link, fact_b, dim_b
+WHERE fact_a.dim_id = dim_a.id AND fact_a.id = link.a_id
+  AND link.b_id = fact_b.id AND fact_b.dim_id = dim_b.id
+ORDER BY fact_a.id LIMIT 5
+----
+
+# ---------- the solver joins along edges only ----------
+
+query II
+EXPLAIN SELECT count(*) FROM fact_a, dim_a, link, fact_b, dim_b
+WHERE fact_a.dim_id = dim_a.id AND fact_a.id = link.a_id
+  AND link.b_id = fact_b.id AND fact_b.dim_id = dim_b.id
+----
+physical_plan	<!REGEX>:.*CROSS_PRODUCT.*
+
+# ---------- graphs the solver declines, which must plan exactly as they did with it off ----------
+
+# A chain is not a bowtie.
+query II nosort chain_plan
+EXPLAIN SELECT count(*) FROM fact_a, link, fact_b
+WHERE fact_a.id = link.a_id AND link.b_id = fact_b.id
+----
+
+# An outer join is not freely reorderable.
+query II nosort outer_plan
+EXPLAIN SELECT count(*) FROM fact_a LEFT JOIN dim_a ON fact_a.dim_id = dim_a.id
+----
+
+# ---------- the same query twice gives the same plan ----------
+
+query II nosort bowtie_plan
+EXPLAIN SELECT count(*) FROM fact_a, dim_a, link, fact_b, dim_b
+WHERE fact_a.dim_id = dim_a.id AND fact_a.id = link.a_id
+  AND link.b_id = fact_b.id AND fact_b.dim_id = dim_b.id
+----
+
+query II nosort bowtie_plan
+EXPLAIN SELECT count(*) FROM fact_a, dim_a, link, fact_b, dim_b
+WHERE fact_a.dim_id = dim_a.id AND fact_a.id = link.a_id
+  AND link.b_id = fact_b.id AND fact_b.dim_id = dim_b.id
+----
+
+# ---------- turning it back off restores the default search ----------
+
+statement ok
+SET double_star_join_order=false
+
+query IIII rowsort bowtie_rows
+SELECT fact_a.id, dim_a.label, fact_b.b_val, dim_b.label
+FROM fact_a, dim_a, link, fact_b, dim_b
+WHERE fact_a.dim_id = dim_a.id AND fact_a.id = link.a_id
+  AND link.b_id = fact_b.id AND fact_b.dim_id = dim_b.id
+ORDER BY fact_a.id LIMIT 5
+----
+
+query II nosort chain_plan
+EXPLAIN SELECT count(*) FROM fact_a, link, fact_b
+WHERE fact_a.id = link.a_id AND link.b_id = fact_b.id
+----

--- a/test/sql/optimizer/join_order/helix.test
+++ b/test/sql/optimizer/join_order/helix.test
@@ -1,0 +1,216 @@
+# name: test/sql/optimizer/join_order/helix.test
+# description: Test the helix (chain of diamonds) join order solver
+# group: [join_order]
+
+# A single diamond: p0 and p1 linked by both a0 and b0.
+#
+#        a0
+#       /  \
+#     p0    p1
+#       \  /
+#        b0
+#
+# The two paths between p0 and p1 make this a cycle, which is what separates it from every
+# tree-shaped join graph. Column counts differ per table on purpose.
+
+statement ok
+CREATE TABLE p0(ka INTEGER, kb INTEGER, tag VARCHAR);
+
+statement ok
+CREATE TABLE a0(from_p0 INTEGER, to_p1 INTEGER);
+
+statement ok
+CREATE TABLE b0(from_p0 INTEGER, to_p1 INTEGER, note VARCHAR);
+
+statement ok
+CREATE TABLE p1(ka INTEGER, kb INTEGER, ka2 INTEGER, kb2 INTEGER, val INTEGER);
+
+statement ok
+CREATE TABLE a1(from_p1 INTEGER, to_p2 INTEGER);
+
+statement ok
+CREATE TABLE b1(from_p1 INTEGER, to_p2 INTEGER, note VARCHAR);
+
+statement ok
+CREATE TABLE p2(ka INTEGER, kb INTEGER, val INTEGER, extra INTEGER);
+
+statement ok
+INSERT INTO p0 SELECT i, i, 't'||i FROM range(100) t(i);
+
+statement ok
+INSERT INTO a0 SELECT i, i FROM range(5000) t(i);
+
+statement ok
+INSERT INTO b0 SELECT i, i, 'n'||i FROM range(3000) t(i);
+
+statement ok
+INSERT INTO p1 SELECT i, i, i, i, i FROM range(80000) t(i);
+
+statement ok
+INSERT INTO a1 SELECT i, i FROM range(4000) t(i);
+
+statement ok
+INSERT INTO b1 SELECT i, i, 'm'||i FROM range(2000) t(i);
+
+statement ok
+INSERT INTO p2 SELECT i, i, i, i FROM range(60000) t(i);
+
+# A bowtie, to check the helix solver declines a tree.
+statement ok
+CREATE TABLE hub_a(id INTEGER, ck INTEGER, sk INTEGER);
+
+statement ok
+CREATE TABLE hub_b(id INTEGER, ck INTEGER, sk INTEGER);
+
+statement ok
+CREATE TABLE bridge(ka INTEGER, kb INTEGER);
+
+statement ok
+CREATE TABLE spoke_a(id INTEGER);
+
+statement ok
+CREATE TABLE spoke_b(id INTEGER);
+
+statement ok
+INSERT INTO hub_a SELECT i, i%40, i%30 FROM range(9000) t(i);
+
+statement ok
+INSERT INTO hub_b SELECT i, i%40, i%20 FROM range(7000) t(i);
+
+statement ok
+INSERT INTO bridge SELECT i%40, i%40 FROM range(200) t(i);
+
+statement ok
+INSERT INTO spoke_a SELECT i FROM range(30) t(i);
+
+statement ok
+INSERT INTO spoke_b SELECT i FROM range(20) t(i);
+
+# ---------- the rule is off by default ----------
+
+query III rowsort diamond_rows
+SELECT p0.tag, b0.note, p1.val
+FROM p0, a0, b0, p1
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+ORDER BY p0.ka LIMIT 5
+----
+
+query IIII rowsort helix_rows
+SELECT p0.tag, b0.note, b1.note, p2.val
+FROM p0, a0, b0, p1, a1, b1, p2
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+  AND p1.ka2 = a1.from_p1 AND p1.kb2 = b1.from_p1 AND a1.to_p2 = p2.ka AND b1.to_p2 = p2.kb
+ORDER BY p0.ka LIMIT 5
+----
+
+query II nosort chain_plan
+EXPLAIN SELECT count(*) FROM p0, a0 WHERE p0.ka = a0.from_p0
+----
+
+query II nosort bowtie_plan
+EXPLAIN SELECT count(*) FROM hub_a, hub_b, bridge, spoke_a, spoke_b
+WHERE hub_a.ck = bridge.ka AND hub_b.ck = bridge.kb
+  AND hub_a.sk = spoke_a.id AND hub_b.sk = spoke_b.id
+----
+
+query II nosort outer_plan
+EXPLAIN SELECT count(*) FROM p0 LEFT JOIN a0 ON p0.ka = a0.from_p0
+----
+
+statement ok
+SET helix_join_order=true
+
+# ---------- reordering must not change the answer ----------
+# Both predicates between p0 and p1 still apply exactly once, however the search splits them.
+
+query III rowsort diamond_rows
+SELECT p0.tag, b0.note, p1.val
+FROM p0, a0, b0, p1
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+ORDER BY p0.ka LIMIT 5
+----
+
+query IIII rowsort helix_rows
+SELECT p0.tag, b0.note, b1.note, p2.val
+FROM p0, a0, b0, p1, a1, b1, p2
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+  AND p1.ka2 = a1.from_p1 AND p1.kb2 = b1.from_p1 AND a1.to_p2 = p2.ka AND b1.to_p2 = p2.kb
+ORDER BY p0.ka LIMIT 5
+----
+
+# ---------- the solver joins along edges only ----------
+
+query II
+EXPLAIN SELECT count(*) FROM p0, a0, b0, p1
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+----
+physical_plan	<!REGEX>:.*CROSS_PRODUCT.*
+
+query II
+EXPLAIN SELECT count(*) FROM p0, a0, b0, p1, a1, b1, p2
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+  AND p1.ka2 = a1.from_p1 AND p1.kb2 = b1.from_p1 AND a1.to_p2 = p2.ka AND b1.to_p2 = p2.kb
+----
+physical_plan	<!REGEX>:.*CROSS_PRODUCT.*
+
+# ---------- graphs the solver declines, which must plan exactly as they did with it off ----------
+
+# A chain is not a helix.
+query II nosort chain_plan
+EXPLAIN SELECT count(*) FROM p0, a0 WHERE p0.ka = a0.from_p0
+----
+
+# A bowtie is a tree, not a chain of diamonds.
+query II nosort bowtie_plan
+EXPLAIN SELECT count(*) FROM hub_a, hub_b, bridge, spoke_a, spoke_b
+WHERE hub_a.ck = bridge.ka AND hub_b.ck = bridge.kb
+  AND hub_a.sk = spoke_a.id AND hub_b.sk = spoke_b.id
+----
+
+# An outer join is not freely reorderable.
+query II nosort outer_plan
+EXPLAIN SELECT count(*) FROM p0 LEFT JOIN a0 ON p0.ka = a0.from_p0
+----
+
+# ---------- the same query twice gives the same plan ----------
+
+query II nosort diamond_plan
+EXPLAIN SELECT count(*) FROM p0, a0, b0, p1
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+----
+
+query II nosort diamond_plan
+EXPLAIN SELECT count(*) FROM p0, a0, b0, p1
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+----
+
+# ---------- below the relation cap the solver declines ----------
+
+statement ok
+SET helix_join_order_max_relations=3
+
+query II nosort diamond_off_plan
+EXPLAIN SELECT count(*) FROM p0, a0, b0, p1
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+----
+
+statement ok
+RESET helix_join_order_max_relations
+
+# ---------- turning it back off restores the default search ----------
+
+statement ok
+SET helix_join_order=false
+
+query II nosort diamond_off_plan
+EXPLAIN SELECT count(*) FROM p0, a0, b0, p1
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+----
+
+query IIII rowsort helix_rows
+SELECT p0.tag, b0.note, b1.note, p2.val
+FROM p0, a0, b0, p1, a1, b1, p2
+WHERE p0.ka = a0.from_p0 AND p0.kb = b0.from_p0 AND a0.to_p1 = p1.ka AND b0.to_p1 = p1.kb
+  AND p1.ka2 = a1.from_p1 AND p1.kb2 = b1.from_p1 AND a1.to_p2 = p2.ka AND b1.to_p2 = p2.kb
+ORDER BY p0.ka LIMIT 5
+----


### PR DESCRIPTION
Ports two shape-specific join reordering algorithms from a DataFusion prototype so they can be benchmarked head to head against the DPhyp plan enumerator. Both are off by default.

A double star (bowtie) is two hubs with their single-edge spokes bridged by a central relation, solved analytically by ordering spokes cheapest fanout first and searching the split point on each side. A helix is a chain of diamonds, which contains cycles and is solved by dynamic programming over connected subgraphs.

Only the search algorithms are ported. Cardinalities come from the CardinalityEstimator and edge selectivity is derived from it as card({a,b}) / (card(a) * card(b)), so a shape solver prices the same graph the dynamic programming does. The chosen order is materialized through the existing EmitPair, so the plan is costed by the same CostModel and rebuilt by QueryGraphManager::Reconstruct whichever algorithm chose it.

Settings:
  double_star_join_order          select the bowtie solver
  helix_join_order                select the helix solver
  helix_join_order_max_relations  bound the 3^n helix search


Claude-Session: https://claude.ai/code/session_01Fu4sminrLZNEWmc2J2CXPQ