### PR TITLE
Defer foreign key constraint validation until the end of the statement

### DIFF
--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -321,6 +321,9 @@ private:
 	ErrorData EndQueryInternal(ClientContextLock &lock, bool success, bool invalidate_transaction,
 	                           optional_ptr<ErrorData> previous_error);
 
+	//! Verify the foreign keys of all rows appended by the current statement
+	void VerifyDeferredForeignKeys();
+
 	//! Wait until a task is available to execute
 	void WaitForTask(ClientContextLock &lock, BaseQueryResult &result);
 	PendingExecutionResult ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result, bool dry_run = false);

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -259,6 +259,9 @@ public:
 	//! Verify constraints with a chunk from the Append containing all columns of the table
 	void VerifyAppendConstraints(ConstraintState &constraint_state, ClientContext &context, DataChunk &chunk,
 	                             optional_ptr<LocalTableStorage> local_storage, optional_ptr<ConflictManager> manager);
+	//! Verify the foreign keys of rows appended to the transaction-local storage in [start, end)
+	void VerifyAppendedForeignKeys(ClientContext &context, idx_t start, idx_t end,
+	                               const vector<unique_ptr<BoundConstraint>> &bound_constraints);
 
 	shared_ptr<DataTableInfo> &GetDataTableInfo();
 

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -16,6 +16,7 @@
 #include "duckdb/transaction/transaction_data.hpp"
 
 namespace duckdb {
+class ClientContext;
 class ColumnSegment;
 class DataTable;
 class LocalTableStorage;
@@ -135,6 +136,8 @@ struct LocalAppendState {
 	TableAppendState append_state;
 	LocalTableStorage *storage;
 	unique_ptr<ConstraintState> constraint_state;
+	//! The client context this append belongs to
+	optional_ptr<ClientContext> context;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/transaction/local_storage.hpp
+++ b/src/include/duckdb/transaction/local_storage.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/storage/table/table_index_list.hpp"
 #include "duckdb/storage/optimistic_data_writer.hpp"
+#include "duckdb/common/constants.hpp"
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/common/reference_map.hpp"
 
@@ -71,6 +72,10 @@ public:
 	IndexAppendMode index_append_mode = IndexAppendMode::DEFAULT;
 	//! The number of deleted rows
 	idx_t deleted_rows;
+	//! Statement number of the currently tracked append range
+	transaction_t append_query_number = MAXIMUM_QUERY_ID;
+	//! Start (local row position) of the append range tracked in append_query_number
+	idx_t append_query_start = 0;
 
 	//! The optimistic row group collections associated with this table.
 	vector<unique_ptr<OptimisticWriteCollection>> optimistic_collections;
@@ -101,6 +106,10 @@ public:
 	ErrorData AppendToIndexes(DuckTransaction &transaction, RowGroupCollection &source, TableIndexList &index_list,
 	                          const vector<LogicalType> &table_types, row_t &start_row);
 	void AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete_chunk);
+	//! Track the start of the append range for the given statement number
+	void TrackAppendForQuery(transaction_t query_number);
+	//! Whether the given statement number appended rows, and if so sets the appended local row range
+	bool GetAppendRange(transaction_t query_number, idx_t &start, idx_t &end);
 
 	//! Create an optimistic row group collection for this table.
 	//! Returns the index into the optimistic_collections vector for newly created collection.
@@ -145,6 +154,13 @@ public:
 		reference_map_t<DataTable, unique_ptr<TableAppendState>> append_states;
 	};
 
+	//! A table that had rows appended to it in a statement, with the appended local row range
+	struct AppendedRows {
+		DuckTableEntry &table_entry;
+		idx_t start;
+		idx_t end;
+	};
+
 public:
 	explicit LocalStorage(ClientContext &context, DuckTransaction &transaction);
 
@@ -160,6 +176,9 @@ public:
 	void InitializeParallelScan(DataTable &table, ParallelCollectionScanState &state);
 	bool NextParallelScan(ClientContext &context, DataTable &table, ParallelCollectionScanState &state,
 	                      CollectionScanState &scan_state);
+
+	//! The local row ranges appended to under the given statement number
+	vector<AppendedRows> GetAppendedRows(transaction_t query_number);
 
 	//! Begin appending to the local storage
 	void InitializeAppend(LocalAppendState &state, DataTable &table, DuckTableEntry &table_entry);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -59,6 +59,7 @@
 #include "duckdb/common/enums/current_transaction_state.hpp"
 #include "duckdb/planner/statement_preprocessor.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/transaction/transaction_context.hpp"
@@ -766,7 +767,12 @@ void ClientContext::VerifyDeferredForeignKeys() {
 	auto query_number = transaction.GetActiveQuery();
 	auto &meta_transaction = MetaTransaction::Get(*this);
 	for (auto &database : meta_transaction.OpenedTransactions()) {
-		auto &local_storage = LocalStorage::Get(*this, database.get());
+		// only DuckDB databases have transaction-local storage
+		auto db_transaction = meta_transaction.TryGetTransaction(database.get());
+		if (!db_transaction || !db_transaction->IsDuckTransaction()) {
+			continue;
+		}
+		auto &local_storage = db_transaction->Cast<DuckTransaction>().GetLocalStorage();
 		auto appended_rows = local_storage.GetAppendedRows(query_number);
 		for (auto &entry : appended_rows) {
 			bool has_foreign_key = false;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/main/client_context.hpp"
 
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_search_path.hpp"
@@ -51,12 +52,14 @@
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/tableref/column_data_ref.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/constraints/bound_foreign_key_constraint.hpp"
 #include "duckdb/planner/logical_plan_verifier.hpp"
 #include "duckdb/planner/operator/logical_execute.hpp"
 #include "duckdb/planner/planner.hpp"
 #include "duckdb/common/enums/current_transaction_state.hpp"
 #include "duckdb/planner/statement_preprocessor.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/transaction/transaction_context.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
@@ -95,6 +98,8 @@ public:
 	unique_ptr<Executor> executor;
 	//! The progress bar
 	unique_ptr<ProgressBar> progress_bar;
+	//! Whether the foreign keys of the rows appended by this statement have been verified already
+	bool foreign_keys_verified = false;
 
 public:
 	void SetOpenResult(BaseQueryResult &result) {
@@ -716,6 +721,11 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 			throw InterruptException();
 		}
 		auto query_result = active_query->executor->ExecuteTask(dry_run);
+		if (!dry_run && query_result == PendingExecutionResult::EXECUTION_FINISHED &&
+		    !active_query->foreign_keys_verified && transaction.HasActiveTransaction()) {
+			active_query->foreign_keys_verified = true;
+			VerifyDeferredForeignKeys();
+		}
 		if (active_query->progress_bar) {
 			auto is_finished = PendingQueryResult::IsResultReady(query_result);
 			active_query->progress_bar->Update(is_finished);
@@ -750,6 +760,30 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 	} // LCOV_EXCL_STOP
 	EndQueryInternal(lock, false, invalidate_transaction, result.GetErrorObject());
 	return PendingExecutionResult::EXECUTION_ERROR;
+}
+
+void ClientContext::VerifyDeferredForeignKeys() {
+	auto query_number = transaction.GetActiveQuery();
+	auto &meta_transaction = MetaTransaction::Get(*this);
+	for (auto &database : meta_transaction.OpenedTransactions()) {
+		auto &local_storage = LocalStorage::Get(*this, database.get());
+		auto appended_rows = local_storage.GetAppendedRows(query_number);
+		for (auto &entry : appended_rows) {
+			bool has_foreign_key = false;
+			for (auto &constraint : entry.table_entry.GetConstraints()) {
+				if (constraint->type == ConstraintType::FOREIGN_KEY) {
+					has_foreign_key = true;
+					break;
+				}
+			}
+			if (!has_foreign_key) {
+				continue;
+			}
+			auto binder = Binder::CreateBinder(*this);
+			auto bound_constraints = binder->BindConstraints(entry.table_entry);
+			entry.table_entry.GetStorage().VerifyAppendedForeignKeys(*this, entry.start, entry.end, bound_constraints);
+		}
+	}
 }
 
 void ClientContext::InitialCleanup(ClientContextLock &lock) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -799,11 +799,14 @@ void DataTable::VerifyAppendedForeignKeys(ClientContext &context, idx_t start, i
 	if (append_constraints.empty()) {
 		return;
 	}
-
 	auto &transaction = DuckTransaction::Get(context, db);
+	auto &local_storage = LocalStorage::Get(context, db);
+	auto local_table_storage = local_storage.GetStorage(*this);
+	if (!local_table_storage) {
+		return;
+	}
+	auto &collection = local_table_storage->GetCollection();
 	auto types = GetTypes();
-	ColumnFetchState fetch_state;
-	Vector row_ids(LogicalType::ROW_TYPE);
 	for (auto &bound_foreign_key_ref : append_constraints) {
 		auto &bound_foreign_key = bound_foreign_key_ref.get();
 		auto &fk_keys = bound_foreign_key.info.fk_keys;
@@ -813,26 +816,29 @@ void DataTable::VerifyAppendedForeignKeys(ClientContext &context, idx_t start, i
 			column_ids.emplace_back(fk_key.index);
 			fk_types.push_back(types[fk_key.index]);
 		}
+		// Read the key columns with a vectorized range scan instead of a per-row fetch; the scan starts at the
+		// enclosing vector boundary, so a few rows appended by earlier statements may be verified again
+		TableScanState scan_state;
+		scan_state.Initialize(column_ids);
+		auto local_start = NumericCast<idx_t>(MAX_ROW_ID) + start;
+		auto local_end = NumericCast<idx_t>(MAX_ROW_ID) + end;
+		collection.InitializeScanWithOffset(QueryContext(context), scan_state.table_state, column_ids, local_start,
+		                                    local_end);
 		DataChunk fk_chunk;
 		fk_chunk.Initialize(context, fk_types);
-		for (idx_t offset = start; offset < end; offset += STANDARD_VECTOR_SIZE) {
+		while (true) {
 			context.InterruptCheck();
-			auto count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, end - offset);
-			row_ids.SetVectorType(VectorType::FLAT_VECTOR);
-			auto row_id_data = FlatVector::GetDataMutable<row_t>(row_ids);
-			for (idx_t i = 0; i < count; i++) {
-				row_id_data[i] = MAX_ROW_ID + NumericCast<row_t>(offset + i);
-			}
 			fk_chunk.Reset();
-			Fetch(transaction, fk_chunk, column_ids, row_ids, count, fetch_state);
-
+			if (!scan_state.table_state.Scan(transaction, fk_chunk)) {
+				break;
+			}
 			// Build a shell chunk holding the key columns at their physical positions
 			DataChunk shell_chunk;
 			shell_chunk.InitializeEmpty(types);
 			for (idx_t i = 0; i < fk_keys.size(); i++) {
 				shell_chunk.data[fk_keys[i].index].Reference(fk_chunk.data[i]);
 			}
-			shell_chunk.SetChildCardinality(count);
+			shell_chunk.SetChildCardinality(fk_chunk.size());
 			VerifyAppendForeignKeyConstraint(nullptr, bound_foreign_key, context, shell_chunk);
 		}
 	}

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -911,7 +911,7 @@ void DataTable::VerifyAppendConstraints(ConstraintState &constraint_state, Clien
 			// so that all rows written by the statement are visible to the check
 			if (!context.transaction.HasActiveTransaction() ||
 			    context.transaction.GetActiveQuery() == MAXIMUM_QUERY_ID) {
-				// appends outside of a statement (e.g. the internal appender) have no statement end to defer to
+				// appends outside of a statement (e.g. the internal appender) are not verified later
 				auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
 				if (bound_foreign_key.info.IsAppendConstraint()) {
 					VerifyAppendForeignKeyConstraint(storage, bound_foreign_key, context, chunk);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -781,6 +781,63 @@ void DataTable::VerifyAppendForeignKeyConstraint(optional_ptr<LocalTableStorage>
 	VerifyForeignKeyConstraint(storage, bound_foreign_key, context, chunk, VerifyExistenceType::APPEND_FK);
 }
 
+void DataTable::VerifyAppendedForeignKeys(ClientContext &context, idx_t start, idx_t end,
+                                          const vector<unique_ptr<BoundConstraint>> &bound_constraints) {
+	if (start >= end) {
+		return;
+	}
+	vector<reference<BoundForeignKeyConstraint>> append_constraints;
+	for (auto &constraint : bound_constraints) {
+		if (constraint->type != ConstraintType::FOREIGN_KEY) {
+			continue;
+		}
+		auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
+		if (bound_foreign_key.info.IsAppendConstraint()) {
+			append_constraints.push_back(bound_foreign_key);
+		}
+	}
+	if (append_constraints.empty()) {
+		return;
+	}
+
+	auto &transaction = DuckTransaction::Get(context, db);
+	auto types = GetTypes();
+	ColumnFetchState fetch_state;
+	Vector row_ids(LogicalType::ROW_TYPE);
+	for (auto &bound_foreign_key_ref : append_constraints) {
+		auto &bound_foreign_key = bound_foreign_key_ref.get();
+		auto &fk_keys = bound_foreign_key.info.fk_keys;
+		vector<StorageIndex> column_ids;
+		vector<LogicalType> fk_types;
+		for (auto &fk_key : fk_keys) {
+			column_ids.emplace_back(fk_key.index);
+			fk_types.push_back(types[fk_key.index]);
+		}
+		DataChunk fk_chunk;
+		fk_chunk.Initialize(context, fk_types);
+		for (idx_t offset = start; offset < end; offset += STANDARD_VECTOR_SIZE) {
+			context.InterruptCheck();
+			auto count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, end - offset);
+			row_ids.SetVectorType(VectorType::FLAT_VECTOR);
+			auto row_id_data = FlatVector::GetDataMutable<row_t>(row_ids);
+			for (idx_t i = 0; i < count; i++) {
+				row_id_data[i] = MAX_ROW_ID + NumericCast<row_t>(offset + i);
+			}
+			fk_chunk.Reset();
+			Fetch(transaction, fk_chunk, column_ids, row_ids, count, fetch_state);
+
+			// Build a shell chunk holding the key columns at their physical positions
+			DataChunk shell_chunk;
+			shell_chunk.InitializeEmpty(types);
+			for (idx_t i = 0; i < fk_keys.size(); i++) {
+				shell_chunk.data[fk_keys[i].index].Reference(fk_chunk.data[i]);
+			}
+			shell_chunk.SetChildCardinality(count);
+			VerifyAppendForeignKeyConstraint(nullptr, bound_foreign_key, context, shell_chunk);
+		}
+	}
+}
+
 void DataTable::VerifyDeleteForeignKeyConstraint(optional_ptr<LocalTableStorage> storage,
                                                  const BoundForeignKeyConstraint &bound_foreign_key,
                                                  ClientContext &context, DataChunk &chunk) {
@@ -844,9 +901,15 @@ void DataTable::VerifyAppendConstraints(ConstraintState &constraint_state, Clien
 			break;
 		}
 		case ConstraintType::FOREIGN_KEY: {
-			auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
-			if (bound_foreign_key.info.IsAppendConstraint()) {
-				VerifyAppendForeignKeyConstraint(storage, bound_foreign_key, context, chunk);
+			// Foreign keys are verified after the statement has finished (ClientContext::VerifyDeferredForeignKeys)
+			// so that all rows written by the statement are visible to the check
+			if (!context.transaction.HasActiveTransaction() ||
+			    context.transaction.GetActiveQuery() == MAXIMUM_QUERY_ID) {
+				// appends outside of a statement (e.g. the internal appender) have no statement end to defer to
+				auto &bound_foreign_key = constraint->Cast<BoundForeignKeyConstraint>();
+				if (bound_foreign_key.info.IsAppendConstraint()) {
+					VerifyAppendForeignKeyConstraint(storage, bound_foreign_key, context, chunk);
+				}
 			}
 			break;
 		}

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -397,6 +397,23 @@ RowGroupCollection &LocalTableStorage::GetCollection() {
 	return *row_groups->collection;
 }
 
+void LocalTableStorage::TrackAppendForQuery(transaction_t query_number) {
+	if (append_query_number == query_number) {
+		return;
+	}
+	append_query_number = query_number;
+	append_query_start = GetCollection().GetNextRowId();
+}
+
+bool LocalTableStorage::GetAppendRange(transaction_t query_number, idx_t &start, idx_t &end) {
+	if (append_query_number != query_number) {
+		return false;
+	}
+	start = append_query_start;
+	end = GetCollection().GetNextRowId();
+	return end > start;
+}
+
 OptimisticWriteCollection &LocalTableStorage::GetPrimaryCollection() {
 	return *row_groups;
 }
@@ -413,12 +430,14 @@ bool LocalStorage::NextParallelScan(ClientContext &context, DataTable &table, Pa
 void LocalStorage::InitializeAppend(LocalAppendState &state, DataTable &table, DuckTableEntry &table_entry) {
 	state.storage = &table_manager.GetOrCreateStorage(context, table);
 	state.storage->table_entry = &table_entry;
+	state.context = context;
 	state.storage->GetCollection().InitializeAppend(TransactionData(transaction), state.append_state);
 }
 
 void LocalStorage::InitializeStorage(LocalAppendState &state, DataTable &table, DuckTableEntry &table_entry) {
 	state.storage = &table_manager.GetOrCreateStorage(context, table);
 	state.storage->table_entry = &table_entry;
+	state.context = context;
 }
 
 void LocalTableStorage::AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete_chunk) {
@@ -456,6 +475,8 @@ void LocalTableStorage::AppendToDeleteIndexes(Vector &row_ids, DataChunk &delete
 void LocalStorage::Append(LocalAppendState &state, DuckTableEntry &table_entry, DataChunk &table_chunk) {
 	auto storage = state.storage;
 	storage->table_entry = &table_entry;
+	D_ASSERT(state.context);
+	storage->TrackAppendForQuery(state.context->transaction.GetActiveQuery());
 	auto offset = NumericCast<idx_t>(MAX_ROW_ID) + storage->GetCollection().GetNextRowId();
 	idx_t base_id = offset + state.append_state.total_append_count;
 
@@ -480,9 +501,26 @@ void LocalStorage::FinalizeAppend(LocalAppendState &state) {
 	state.storage->GetCollection().FinalizeAppend(state.append_state.transaction, state.append_state);
 }
 
+vector<LocalStorage::AppendedRows> LocalStorage::GetAppendedRows(transaction_t query_number) {
+	vector<AppendedRows> result;
+	for (auto &storage : table_manager.GetEntries()) {
+		idx_t start;
+		idx_t end;
+		if (!storage->GetAppendRange(query_number, start, end)) {
+			continue;
+		}
+		// The range and the entry are set together on the append path and refer to the same table version
+		D_ASSERT(storage->table_entry);
+		D_ASSERT(&storage->table_entry->GetStorage() == &storage->table_ref.get());
+		result.push_back({*storage->table_entry, start, end});
+	}
+	return result;
+}
+
 void LocalStorage::LocalMerge(DataTable &table, DuckTableEntry &table_entry, OptimisticWriteCollection &collection) {
 	auto &storage = table_manager.GetOrCreateStorage(context, table);
 	storage.table_entry = &table_entry;
+	storage.TrackAppendForQuery(context.transaction.GetActiveQuery());
 	if (!storage.append_indexes.Empty()) {
 		// append data to indexes if required
 		row_t base_id = MAX_ROW_ID + NumericCast<row_t>(storage.GetCollection().GetNextRowId());

--- a/test/api/test_appender_api.cpp
+++ b/test/api/test_appender_api.cpp
@@ -1,7 +1,11 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
-#include "duckdb/main/appender.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/main/appender.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 
 using namespace duckdb;
 
@@ -285,4 +289,31 @@ TEST_CASE("Test appender during stack unwinding", "[api]") {
 		{ throw std::runtime_error("Hello"); }
 	} catch (...) {
 	}
+}
+
+TEST_CASE("Test internal appender foreign key checks", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE parent(i INTEGER PRIMARY KEY)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE child(j INTEGER REFERENCES parent(i))"));
+	// Begin a transaction: this leaves us with an active transaction but no active statement
+	REQUIRE_NO_FAIL(con.Query("BEGIN"));
+	auto &context = *con.context;
+	auto &table_entry =
+	    Catalog::GetEntry<TableCatalogEntry>(context, QualifiedName(INVALID_CATALOG, DEFAULT_SCHEMA, "child"));
+
+	// Rows referencing a non-existent parent are rejected: the internal appender has no statement end to defer to
+	{
+		InternalAppender appender(context, table_entry);
+		appender.AppendRow(1);
+		REQUIRE_THROWS(appender.Close());
+	}
+	// Rows referencing an existing parent are accepted
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO parent VALUES (1)"));
+	{
+		InternalAppender appender(context, table_entry);
+		appender.AppendRow(1);
+		appender.Close();
+	}
+	REQUIRE_NO_FAIL(con.Query("ROLLBACK"));
 }

--- a/test/api/test_appender_api.cpp
+++ b/test/api/test_appender_api.cpp
@@ -302,7 +302,7 @@ TEST_CASE("Test internal appender foreign key checks", "[api]") {
 	auto &table_entry =
 	    Catalog::GetEntry<TableCatalogEntry>(context, QualifiedName(INVALID_CATALOG, DEFAULT_SCHEMA, "child"));
 
-	// Rows referencing a non-existent parent are rejected: the internal appender has no statement end to defer to
+	// Appends outside a statement are still checked eagerly, so the row is rejected when the appender is flushed
 	{
 		InternalAppender appender(context, table_entry);
 		appender.AppendRow(1);

--- a/test/api/test_storage_extension_alias.cpp
+++ b/test/api/test_storage_extension_alias.cpp
@@ -3,6 +3,8 @@
 #include "duckdb/main/config.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/transaction/duck_transaction_manager.hpp"
+#include "duckdb/transaction/transaction.hpp"
+#include "duckdb/transaction/transaction_manager.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
 
 using namespace duckdb;
@@ -63,4 +65,61 @@ TEST_CASE("Test storage extension lookup alias", "[api]") {
 		     "Query: " +
 		     query + "\n" + "Error: " + result->GetError());
 	}
+}
+
+//! A transaction manager that is not backed by DuckDB storage. Extensions such as sqlite_scanner or
+//! ducklake attach catalogs whose transactions are not DuckTransactions.
+struct DummyNonDuckTransactionManager : TransactionManager {
+	explicit DummyNonDuckTransactionManager(AttachedDatabase &db) : TransactionManager(db) {
+	}
+
+	Transaction &StartTransaction(ClientContext &context) override {
+		transaction = make_uniq<Transaction>(*this, context);
+		return *transaction;
+	}
+	ErrorData CommitTransaction(ClientContext &context, Transaction &transaction) override {
+		return ErrorData();
+	}
+	void RollbackTransaction(Transaction &transaction) override {
+	}
+	void Checkpoint(ClientContext &context, bool force = false) override {
+	}
+
+	unique_ptr<Transaction> transaction;
+};
+
+struct DummyNonDuckStorageExtension : StorageExtension {
+	DummyNonDuckStorageExtension() {
+		attach = [](optional_ptr<StorageExtensionInfo>, ClientContext &, AttachedDatabase &db, const string &,
+		            AttachInfo &, AttachOptions &) -> unique_ptr<Catalog> {
+			return make_uniq_base<Catalog, DuckCatalog>(db);
+		};
+		create_transaction_manager = [](optional_ptr<StorageExtensionInfo>, AttachedDatabase &db,
+		                                Catalog &) -> unique_ptr<TransactionManager> {
+			return make_uniq<DummyNonDuckTransactionManager>(db);
+		};
+	}
+};
+
+TEST_CASE("Statements executed while a non-DuckDB catalog is attached", "[api]") {
+	DBConfig config;
+	StorageExtension::Register(config, "dummy_non_duckdb", make_shared_ptr<DummyNonDuckStorageExtension>());
+	DuckDB db(nullptr, &config);
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("ATTACH ':memory:' AS dummy_db (TYPE DUMMY_NON_DUCKDB)"));
+	REQUIRE_NO_FAIL(con.Query("BEGIN"));
+
+	// mimic extensions such as sqlite_scanner, which have a non-DuckDB transaction open for their catalog
+	auto &attached = Catalog::GetCatalog(*con.context, "dummy_db").GetAttached();
+	Transaction::Get(*con.context, attached);
+
+	// statements in the main database must keep working while the non-DuckDB catalog is attached
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE parent(i INTEGER PRIMARY KEY)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE child(j INTEGER, FOREIGN KEY (j) REFERENCES parent(i))"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO parent VALUES (1), (2)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO child VALUES (1), (2)"));
+
+	REQUIRE_NO_FAIL(con.Query("ROLLBACK"));
+	REQUIRE_NO_FAIL(con.Query("DETACH dummy_db"));
 }

--- a/test/sql/constraints/foreignkey/fk_statement_level_validation.test
+++ b/test/sql/constraints/foreignkey/fk_statement_level_validation.test
@@ -1,0 +1,46 @@
+# name: test/sql/constraints/foreignkey/fk_statement_level_validation.test
+# description: Foreign key constraints are validated at the end of the statement: rows may reference other rows inserted by the same statement (#7168)
+# group: [foreignkey]
+
+# issue #7168: inserting a complete tree in a single statement is valid
+statement ok
+CREATE TABLE t(id INT PRIMARY KEY, parent INT REFERENCES t(id));
+
+statement ok
+INSERT INTO t VALUES (1, NULL), (2, 1), (3, 2);
+
+# rows may reference rows that appear later in the statement
+statement ok
+INSERT INTO t VALUES (8, 7), (7, 6), (6, NULL);
+
+query II
+SELECT id, parent FROM t ORDER BY id;
+----
+1	NULL
+2	1
+3	2
+6	NULL
+7	6
+8	7
+
+# rows may reference rows of a previous chunk of the same statement (multi-chunk insert)
+statement ok
+CREATE TABLE t2(id INT PRIMARY KEY, parent INT REFERENCES t2(id));
+
+statement ok
+INSERT INTO t2 SELECT i, CASE WHEN i = 1 THEN NULL ELSE i - 1 END FROM range(1, 5000) t(i);
+
+query I
+SELECT count(*) FROM t2;
+----
+4999
+
+# inserts with RETURNING are validated at statement level as well
+statement ok
+CREATE TABLE t3(id INT PRIMARY KEY, parent INT REFERENCES t3(id));
+
+query II
+INSERT INTO t3 VALUES (1, NULL), (2, 1) RETURNING *;
+----
+1	NULL
+2	1

--- a/test/sql/constraints/foreignkey/fk_statement_level_validation.test_slow
+++ b/test/sql/constraints/foreignkey/fk_statement_level_validation.test_slow
@@ -1,0 +1,28 @@
+# name: test/sql/constraints/foreignkey/fk_statement_level_validation.test_slow
+# description: Statement-level FK validation on the row-group merge path (batch insert of a self-referencing table)
+# group: [foreignkey]
+
+# larger than a row group: the batch insert merges into the transaction-local storage
+# before the (deferred) foreign key verification runs
+statement ok
+CREATE TABLE t(id INT PRIMARY KEY, parent INT REFERENCES t(id));
+
+statement ok
+INSERT INTO t SELECT i, CASE WHEN i = 1 THEN NULL ELSE i - 1 END FROM range(1, 250000) t(i);
+
+query I
+SELECT count(*) FROM t;
+----
+249999
+
+# FK violations are still detected on the merge path
+statement error
+INSERT INTO t SELECT i + 250000, 123456789 FROM range(1, 2) t(i);
+----
+Constraint Error: Violates foreign key constraint because key "id: 123456789" does not exist in the referenced table
+
+# the failed statement inserted no rows
+query I
+SELECT count(*) FROM t;
+----
+249999

--- a/test/sql/constraints/foreignkey/foreign_key_matching_columns.test
+++ b/test/sql/constraints/foreignkey/foreign_key_matching_columns.test
@@ -69,7 +69,7 @@ CREATE TABLE routes (
 );
 ----
 
-# self-referential primary key
+# self-referential foreign key: a row may reference itself, as it is part of the same statement (#7168)
 statement ok
 CREATE TABLE routes (
 	route_id TEXT PRIMARY KEY,
@@ -80,12 +80,11 @@ CREATE TABLE routes (
 statement ok
 INSERT INTO routes VALUES (1, NULL);
 
-statement error
+statement ok
 INSERT INTO routes VALUES (2, 2);
-----
 
 statement ok
-INSERT INTO routes VALUES (2, 1);
+INSERT INTO routes VALUES (3, 1);
 
 # multi-column primary key constraint
 statement ok

--- a/test/sql/constraints/foreignkey/foreign_key_matching_columns.test
+++ b/test/sql/constraints/foreignkey/foreign_key_matching_columns.test
@@ -69,7 +69,7 @@ CREATE TABLE routes (
 );
 ----
 
-# self-referential foreign key: a row may reference itself, as it is part of the same statement (#7168)
+# self-referential foreign key: a row may reference itself, as it is part of the same statement
 statement ok
 CREATE TABLE routes (
 	route_id TEXT PRIMARY KEY,

--- a/test/sql/constraints/foreignkey/test_fk_self_referencing.test
+++ b/test/sql/constraints/foreignkey/test_fk_self_referencing.test
@@ -22,7 +22,7 @@ statement ok
 INSERT INTO employee VALUES (1, NULL, 'Smith'), (2, NULL, 'Jhon'), (3, NULL, 'Romeo');
 
 statement error
-INSERT INTO employee VALUES (4, 4, 'Mark');
+INSERT INTO employee VALUES (4, 99, 'Mark');
 ----
 <REGEX>:Constraint Error.*Violates foreign key constraint.*
 
@@ -101,7 +101,25 @@ UPDATE employee SET id = 5, managerid = 2 WHERE id = 4;
 query IIT
 SELECT * FROM employee WHERE managerid = 2;
 ----
-5	2	Juliet	
+5	2	Juliet
+
+# a row may reference itself: the referenced row is part of the same statement, so it is visible when the
+# foreign key is validated at the end of the statement (#7168)
+statement ok
+CREATE TABLE employee_self(id INTEGER PRIMARY KEY, managerid INTEGER REFERENCES employee_self(id));
+
+statement ok
+INSERT INTO employee_self VALUES (1, NULL), (2, 2), (3, 1);
+
+query II
+SELECT * FROM employee_self ORDER BY id;
+----
+1	NULL
+2	2
+3	1
+
+statement ok
+DROP TABLE employee_self;
 
 statement error
 ALTER TABLE employee RENAME COLUMN managerid TO managerid_new;

--- a/test/sql/constraints/foreignkey/test_fk_self_referencing.test
+++ b/test/sql/constraints/foreignkey/test_fk_self_referencing.test
@@ -104,7 +104,7 @@ SELECT * FROM employee WHERE managerid = 2;
 5	2	Juliet
 
 # a row may reference itself: the referenced row is part of the same statement, so it is visible when the
-# foreign key is validated at the end of the statement (#7168)
+# foreign key is validated at the end of the statement
 statement ok
 CREATE TABLE employee_self(id INTEGER PRIMARY KEY, managerid INTEGER REFERENCES employee_self(id));
 

--- a/test/sql/copy_database/copy_database_fk.test
+++ b/test/sql/copy_database/copy_database_fk.test
@@ -2,8 +2,11 @@
 # description: Test COPY DATABASE with foreign key constraint
 # group: [copy_database]
 
-# FIXME - this is not working right now - we need to correctly take dependencies into account for COPY FROM DATABASE
-mode skip instable
+statement ok
+ATTACH ':memory:' AS src
+
+statement ok
+USE src
 
 statement ok
 CREATE TABLE pk_integers(i INTEGER PRIMARY KEY)
@@ -22,7 +25,7 @@ statement ok
 ATTACH ':memory:' AS db1
 
 statement ok
-COPY FROM DATABASE memory TO db1
+COPY FROM DATABASE src TO db1
 
 statement ok
 USE db1
@@ -50,11 +53,7 @@ UPDATE pk_integers SET i=5 WHERE i=2
 ----
 
 statement error
-UPDATE fk_integers SET i=4 WHERE j=2
-----
-
-statement error
-UPDATE fk_integers SET i=4 WHERE j=2
+UPDATE fk_integers SET j=4 WHERE j=2
 ----
 
 statement error


### PR DESCRIPTION
Fixes #7168, #10574, #24215, #16785.

Foreign keys are currently checked while a statement is still executing (per chunk in the insert sinks), before the rows of that chunk have been appended. A statement that inserts multiple rows into a self-referencing table therefore fails, even though all referenced rows exist by the end of the statement. The same early checking makes statements that write multiple tables depend on pipeline execution order: COPY FROM DATABASE is a single statement with one INSERT per table, and whether it succeeds depends on the table order and on parallel pipeline execution.

Issue relations: #7168 and #10574 are the same problem on a single table (#10574 is batch loading into a self-referencing table). #24215 reports the same failure as the original #16785 report; the thread of #16785 additionally contains a self-referencing FK variant, which is covered by the same change.

This PR defers the check to the end of the statement:

- The FK case is removed from the eager per-chunk VerifyAppendConstraints (NOT NULL / CHECK / UNIQUE remain eager).
- Transaction-local storage records the row range each statement appended (statement = query number, range = local row positions), in the two functions through which appends enter local storage (LocalStorage::Append and LocalStorage::LocalMerge).
- Once a statement has finished executing (all pipelines completed, before any commit), the client context verifies the foreign keys for the rows that statement appended. Only the foreign key columns are read, in batches of STANDARD_VECTOR_SIZE rows, so memory stays bounded; no pipeline ordering is needed for foreign keys.
- The key columns are read back from transaction-local storage with a range scan over the appended rows (vectorized, only the FK key columns); index construction already read these columns at the end of the insert, so this is usually cache-warm.
- Nothing is buffered or copied - the rows already live in transaction-local storage, and only the appended row range is tracked.
- Verification runs before the commit decision, and a foreign key violation is reported as a statement error through the existing error path.
- Appends made while no statement is running (the internal appender can be used that way) keep their eager checks, since there is no statement end to defer to. When the internal appender is used during a statement, its appends are deferred like any other.
- Catalogs whose transaction objects are not DuckDB transactions (storage extensions) are skipped during verification, so attaching such a catalog does not interfere with statement execution.

Not covered by this PR:

- DELETE/TRUNCATE-side statement-level visibility (#13819).

Performance (release build, Apple M3):

- benchmark/micro/index/insert/insert_pk_fk.benchmark (in-memory, three foreign keys): median 310.4 ms -> 314 ms (+0.7%). An earlier version read the key columns back row by row and showed +17.9% (310.4 ms -> 365.8 ms) on the same benchmark.
- Largest overhead we measured: inserting 6M rows of TPC-H SF1 lineitem into a 16-column table with one foreign key, on a file-backed database where completed row groups are written to disk and compressed while the insert runs: +8-14%.
- insert_pk_fk.benchmark is not part of .github/regression/micro.csv, so CI does not run this workload today.

Tests:

- new: test/sql/constraints/foreignkey/fk_statement_level_validation.test (+ _slow), and test/api/test_appender_api.cpp "Test internal appender foreign key checks"
- new: test/api/test_storage_extension_alias.cpp "Statements executed while a non-DuckDB catalog is attached"
- un-skipped: test/sql/copy_database/copy_database_fk.test (previously "mode skip instable" with an FK ordering FIXME) now passes
- updated expectations: test_fk_self_referencing.test and foreign_key_matching_columns.test. A row may now reference itself, which is consistent with statement-level visibility (SQLite allows this as well); both tests encoded the previous, earlier checking behavior.
