### PR TITLE
perf(variant): Optimize shredded vector value retrieval

### DIFF
--- a/src/common/vector/shredded_vector.cpp
+++ b/src/common/vector/shredded_vector.cpp
@@ -40,23 +40,10 @@ void ShreddedVectorBuffer::SetVectorType(VectorType new_vector_type) {
 }
 
 Value ShreddedVectorBuffer::GetValue(const LogicalType &type, idx_t index) const {
-	// FIXME: this is extremely inefficient
-	auto &shredded = StructVector::GetEntries(*shredded_data)[1];
-	auto &unshredded = StructVector::GetEntries(*shredded_data)[0];
-
-	auto shredded_val = shredded.GetValue(index);
-	auto unshredded_val = unshredded.GetValue(index);
-
-	child_list_t<LogicalType> shredded_subtypes;
-	shredded_subtypes.emplace_back(make_pair("unshredded", unshredded.GetType()));
-	shredded_subtypes.emplace_back(make_pair("shredded", shredded.GetType()));
-	Vector new_shredded(LogicalType::STRUCT(std::move(shredded_subtypes)));
-	StructVector::GetEntries(new_shredded)[0].Reference(unshredded_val, count_t(1));
-	StructVector::GetEntries(new_shredded)[1].Reference(shredded_val, count_t(1));
-
-	Vector result_vec(LogicalType::VARIANT(), 1);
-	VariantUtils::UnshredVariantData(new_shredded, result_vec, 1);
-	return result_vec.GetValue(0);
+	Vector input(*shredded_data, index, index + 1);
+	Vector result(LogicalType::VARIANT(), 1);
+	VariantUtils::UnshredVariantData(input, result, 1);
+	return result.GetValue(0);
 }
 
 buffer_ptr<VectorBuffer> ShreddedVectorBuffer::SliceInternal(const LogicalType &type, idx_t offset, idx_t end) {

--- a/test/sql/storage/types/variant/variant_shredding_small.test
+++ b/test/sql/storage/types/variant/variant_shredding_small.test
@@ -51,3 +51,28 @@ query I
 SELECT col FROM tbl WHERE col.i=3
 ----
 {'i': 3, 'j': 300}
+
+# Returning a shredded vector materializes each result row through GetValue.
+# Keep a partially shredded nested object, an incompatible value, and NULL in one vector.
+statement ok
+CREATE TABLE get_value_rows (id INTEGER, col VARIANT);
+
+statement ok
+INSERT INTO get_value_rows VALUES
+    (0, {'kind': 'profile', 'id': 1, 'details': {'active': true, 'fallback': 'first'}}::VARIANT),
+    (1, {'kind': 'profile', 'id': 2, 'details': {'active': false, 'extra': [1, 2]}}::VARIANT),
+    (2, NULL),
+    (3, ['not', 'an', 'object']::VARIANT),
+    (4, {'kind': 'profile', 'id': 5, 'details': {'active': true}}::VARIANT);
+
+statement ok
+CHECKPOINT;
+
+query I
+SELECT col FROM get_value_rows ORDER BY id;
+----
+{'details': {'active': true, 'fallback': first}, 'id': 1, 'kind': profile}
+{'details': {'active': false, 'extra': [1, 2]}, 'id': 2, 'kind': profile}
+NULL
+[not, an, object]
+{'details': {'active': true}, 'id': 5, 'kind': profile}


### PR DESCRIPTION
## Summary

  - Avoid intermediate Value and STRUCT materialization in ShreddedVectorBuffer::GetValue
  - Directly slice the requested row from the shredded backing vector before unshredding it
  - Add regression coverage for partially shredded nested VARIANT values, fallback values, and NULLs
  - Add a focused microbenchmark for shredded VARIANT GetValue calls

  ## Performance

  ShreddedVectorGetValue benchmark, 10 timed runs:

| Benchmark | Timed Runs | Before (Median) | After (Median) | Improvement |
|---|---:|---:|---:|---:|
| `ShreddedVectorGetValue` | 10 | 5.087 s | 3.289 s | 35.34% faster (1.55x) |

  This reduces elapsed time by 35.34% (1.55x faster) for repeated row-wise reads from a partially shredded nested VARIANT vector.

  ## Testing

  - make reldebug
  - make benchmark
  - build/reldebug/test/unittest test/sql/storage/types/variant/variant_shredding_small.test
  - build/reldebug/test/unittest test/sql/storage/types/variant/variant_shredded_slice.test
  - clang-format --dry-run --Werror benchmark/micro/shredded_vector.cpp src/common/vector/shredded_vector.cpp

  ## Risk and Rollback

  The change reuses the existing UnshredVariantData implementation and preserves the GetValue API behavior. Roll back by reverting this commit.