### PR TITLE
[ART] Fix oversized Node256Leaf validity mask allocation

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -47,6 +47,28 @@ struct ARTIndexScanState : public IndexScanState {
 // ART
 //===--------------------------------------------------------------------===//
 
+static idx_t GetNode256LeafSegmentSize(const IndexStorageInfo &info, StorageVersion storage_version) {
+	// Preserve the oversized mask and padding of the persisted legacy layout.
+	struct LegacyNode256Leaf {
+		uint16_t count;
+		validity_t mask[Node256Leaf::CAPACITY / sizeof(validity_t)];
+	};
+	constexpr idx_t compact_size = sizeof(Node256Leaf);
+	constexpr idx_t legacy_size = sizeof(LegacyNode256Leaf);
+	const auto allocator_idx = NodePtr::GetAllocatorIdx(NType::NODE_256_LEAF);
+	if (info.allocator_infos.size() > allocator_idx) {
+		// Preserve the persisted segment size so existing buffers retain their original layout.
+		const auto saved_segment_size = info.allocator_infos[allocator_idx].segment_size;
+		if (saved_segment_size != compact_size && saved_segment_size != legacy_size) {
+			throw SerializationException("Invalid Node256Leaf segment size %llu (expected %llu or %llu)",
+			                             saved_segment_size, compact_size, legacy_size);
+		}
+		return saved_segment_size;
+	}
+	// New indexes must retain the original layout when targeting older storage versions.
+	return storage_version >= StorageVersion::V2_0_0 ? compact_size : legacy_size;
+}
+
 ART::ART(const Identifier &name, const IndexConstraintType index_constraint_type, const vector<column_t> &column_ids,
          TableIOManager &table_io_manager, const vector<unique_ptr<Expression>> &unbound_expressions,
          AttachedDatabase &db,
@@ -83,6 +105,7 @@ ART::ART(const Identifier &name, const IndexConstraintType index_constraint_type
 		owns_data = true;
 		auto prefix_size = NumericCast<idx_t>(prefix_count) + NumericCast<idx_t>(Prefix::METADATA_SIZE);
 		auto &block_manager = table_io_manager.GetIndexBlockManager();
+		const auto leaf256_size = GetNode256LeafSegmentSize(info, db.GetStorageManager().GetStorageVersion());
 
 		array<unsafe_unique_ptr<FixedSizeAllocator>, ALLOCATOR_COUNT> allocator_array = {
 		    make_unsafe_uniq<FixedSizeAllocator>(prefix_size, block_manager),
@@ -93,7 +116,7 @@ ART::ART(const Identifier &name, const IndexConstraintType index_constraint_type
 		    make_unsafe_uniq<FixedSizeAllocator>(sizeof(Node256), block_manager),
 		    make_unsafe_uniq<FixedSizeAllocator>(sizeof(Node7Leaf), block_manager),
 		    make_unsafe_uniq<FixedSizeAllocator>(sizeof(Node15Leaf), block_manager),
-		    make_unsafe_uniq<FixedSizeAllocator>(sizeof(Node256Leaf), block_manager),
+		    make_unsafe_uniq<FixedSizeAllocator>(leaf256_size, block_manager),
 		};
 		allocators =
 		    make_shared_ptr<array<unsafe_unique_ptr<FixedSizeAllocator>, ALLOCATOR_COUNT>>(std::move(allocator_array));
@@ -1317,6 +1340,13 @@ bool ART::MergeIndexes(IndexLock &state, BoundIndex &source_index) {
 	if (other_art.owns_data) {
 		if (prefix_count != other_art.prefix_count) {
 			throw InternalException("Failed to merge ARTs - prefix count does not match");
+		}
+		const auto target_size = NodePtr::GetAllocator(*this, NType::NODE_256_LEAF).GetSegmentSize();
+		const auto source_size = NodePtr::GetAllocator(other_art, NType::NODE_256_LEAF).GetSegmentSize();
+		if (target_size != source_size) {
+			throw InternalException(
+			    "Failed to merge ARTs - Node256Leaf segment sizes do not match (target %llu, source %llu)", target_size,
+			    source_size);
 		}
 		if (tree.HasMetadata()) {
 			// Fully deserialize other_index, and traverse it to increment its buffer IDs.

--- a/src/include/duckdb/execution/index/art/node256_leaf.hpp
+++ b/src/include/duckdb/execution/index/art/node256_leaf.hpp
@@ -31,7 +31,7 @@ public:
 
 private:
 	uint16_t count;
-	validity_t mask[CAPACITY / sizeof(validity_t)];
+	validity_t mask[CAPACITY / ValidityMask::BITS_PER_VALUE];
 
 public:
 	//! Get a new Node256Leaf handle and initialize the leaf.

--- a/test/sql/index/art/storage/test_art_node256_leaf_layout.test
+++ b/test/sql/index/art/storage/test_art_node256_leaf_layout.test
@@ -1,0 +1,220 @@
+# name: test/sql/index/art/storage/test_art_node256_leaf_layout.test
+# description: Node256Leaf bitmap boundaries, reinsertion and persisted allocator layouts
+# group: [storage]
+
+statement ok
+SET index_scan_max_count = 1000;
+
+statement ok
+SET index_scan_percentage = 1.0;
+
+foreach version v1.0.0 v1.5.0 v2.0.0
+
+# Small blocks exercise multiple compact allocator buffers with a modest row count.
+statement ok
+ATTACH '{TEST_DIR}/node256_{version}.db' AS leaf_db (STORAGE_VERSION '{version}', BLOCK_SIZE 16384)
+
+statement ok
+CREATE TABLE leaf_db.t AS SELECT i // 256 AS k, i AS id FROM range(262144) r(i)
+
+statement ok
+CREATE INDEX leaf_idx ON leaf_db.t(k)
+
+statement ok
+CHECKPOINT leaf_db
+
+statement ok
+DETACH leaf_db
+
+statement ok
+ATTACH '{TEST_DIR}/node256_{version}.db' AS leaf_db
+
+# A selective lookup should use the persisted ART after reopening.
+query II
+EXPLAIN ANALYZE SELECT count(*), min(id), max(id) FROM leaf_db.t WHERE k=1023;
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+# Includes every bit boundary, and leaves in multiple allocator buffers.
+query III
+SELECT count(*), min(id), max(id) FROM leaf_db.t WHERE k=1023
+----
+256	261888	262143
+
+query I
+SELECT count(*) FROM leaf_db.t WHERE k=0 AND id IN (0,63,64,127,128,191,192,255)
+----
+8
+
+# Delete most rows for one key, then insert rows for that key again.
+statement ok
+DELETE FROM leaf_db.t WHERE k=0 AND id>=12
+
+query I
+SELECT count(*) FROM leaf_db.t WHERE k=0
+----
+12
+
+statement ok
+INSERT INTO leaf_db.t SELECT 0,i FROM range(12,256) r(i)
+
+statement ok
+INSERT INTO leaf_db.t SELECT 0,i FROM range(262144,262400) r(i)
+
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM leaf_db.t WHERE k=0
+
+statement ok
+ROLLBACK
+
+query I
+SELECT count(*) FROM leaf_db.t WHERE k=0
+----
+512
+
+statement ok
+UPDATE leaf_db.t SET k=0 WHERE k=1
+
+statement ok
+CHECKPOINT leaf_db
+
+statement ok
+DETACH leaf_db
+
+statement ok
+ATTACH '{TEST_DIR}/node256_{version}.db' AS leaf_db
+
+query I
+SELECT count(*) FROM leaf_db.t WHERE k=0
+----
+768
+
+query I
+SELECT count(*) FROM leaf_db.t WHERE k=1
+----
+0
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM leaf_db.t WHERE k=0;
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query I
+SELECT count(*) FROM leaf_db.t
+----
+262400
+
+statement ok
+DETACH leaf_db
+
+endloop
+
+# Upgrade the same database file in place, retaining the old index layout.
+statement ok
+ATTACH '{TEST_DIR}/node256_upgrade.db' AS upgrade_db (STORAGE_VERSION 'v1.5.0', BLOCK_SIZE 16384)
+
+statement ok
+CREATE TABLE upgrade_db.old_t AS SELECT i // 256 AS k, i AS id FROM range(262144) r(i)
+
+statement ok
+CREATE INDEX old_idx ON upgrade_db.old_t(k)
+
+statement ok
+CHECKPOINT upgrade_db
+
+statement ok
+DETACH upgrade_db
+
+statement ok
+ATTACH '{TEST_DIR}/node256_upgrade.db' AS upgrade_db (STORAGE_VERSION 'v2.0.0')
+
+query I
+SELECT count(*) FROM upgrade_db.old_t WHERE k=1023
+----
+256
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM upgrade_db.old_t WHERE k=1023
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+statement ok
+INSERT INTO upgrade_db.old_t SELECT 0, i FROM range(262144,262400) r(i)
+
+statement ok
+DELETE FROM upgrade_db.old_t WHERE k=1
+
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM upgrade_db.old_t WHERE k=0
+
+statement ok
+ROLLBACK
+
+statement ok
+CREATE TABLE upgrade_db.new_t AS SELECT i // 256 AS k, i AS id FROM range(1024) r(i)
+
+statement ok
+CREATE INDEX new_idx ON upgrade_db.new_t(k)
+
+query I
+SELECT count(*) FROM upgrade_db.old_t WHERE k=0
+----
+512
+
+query I
+SELECT count(*) FROM upgrade_db.new_t WHERE k=3
+----
+256
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM upgrade_db.new_t WHERE k=3
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+statement ok
+CHECKPOINT upgrade_db
+
+statement ok
+DETACH upgrade_db
+
+statement ok
+ATTACH '{TEST_DIR}/node256_upgrade.db' AS upgrade_db
+
+query I
+SELECT count(*) FROM upgrade_db.old_t WHERE k=1023
+----
+256
+
+query I
+SELECT count(*) FROM upgrade_db.old_t WHERE k=0
+----
+512
+
+query I
+SELECT count(*) FROM upgrade_db.old_t WHERE k=1
+----
+0
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM upgrade_db.old_t WHERE k=0
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+query I
+SELECT count(*) FROM upgrade_db.new_t WHERE k=3
+----
+256
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM upgrade_db.new_t WHERE k=3
+----
+analyzed_plan	<REGEX>:.*Type: Index Scan.*
+
+statement ok
+DETACH upgrade_db


### PR DESCRIPTION
Summary

This fixes an oversized validity mask allocation in Node256Leaf.

The fix itself is small: 
validity_t mask[CAPACITY / sizeof(validity_t)] -> validity_t mask[CAPACITY / ValidityMask::BITS_PER_VALUE];

The main complication is storage compatibility. Existing databases may already contain ART indexes written with the old, larger Node256Leaf allocation size. The patch therefore preserves the persisted allocator stride when loading existing indexes, while new indexes use the corrected compact layout.

Tests cover both the new layout and compatibility with the previous persisted layout.