### PR TITLE
Identifier in error messages currently always quoted, revert back to quoted only if necessary

### DIFF
--- a/src/planner/binder/statement/bind_insert.cpp
+++ b/src/planner/binder/statement/bind_insert.cpp
@@ -43,7 +43,7 @@ void Binder::CheckInsertColumnCountMismatch(idx_t expected_columns, idx_t result
 		string msg = StringUtil::Format(!columns_provided ? "table %s has %lld columns but %lld values were supplied"
 		                                                  : "Column name/value mismatch for insert on %s: "
 		                                                    "expected %lld columns but %lld values were supplied",
-		                                tname, expected_columns, result_columns);
+		                                tname.GetIdentifierName(), expected_columns, result_columns);
 		throw BinderException(msg);
 	}
 }

--- a/test/sql/copy/csv/test_ignore_errors.test
+++ b/test/sql/copy/csv/test_ignore_errors.test
@@ -32,7 +32,7 @@ INSERT INTO integers SELECT * FROM read_csv('{DATA_DIR}/csv/test/error_too_littl
 statement error
 INSERT INTO integers SELECT * FROM read_csv('{DATA_DIR}/csv/test/error_too_little.csv', columns={'i': 'INTEGER'}, null_padding=0)
 ----
-table "integers" has 2 columns but 1 values were supplied
+table integers has 2 columns but 1 values were supplied
 
 # not enough columns provided
 query II


### PR DESCRIPTION
Minor, but bumped in the context of bumping extensions, and saw error messages changing formatting, see https://github.com/duckdb/duckdb-mysql/pull/300/changes/b2b23010465fb788879db6aa0963425d37f7495e.

I think this can be fixed duckdb/duckdb side by avoiding unnecessary quotes around Identifiers (introduced by Identifier in error messages rework).

Very much not critical, and might be also intentional as is now the code.