### PR TITLE
ci: dump full raw unittest output in ThreadSanitizer runs

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1065,6 +1065,8 @@ jobs:
       DUCKDB_COMMIT: ${{ needs.prepare.outputs.duckdb_commit }}
       TSAN_OPTIONS: suppressions=.sanitizer-thread-suppressions.txt:external_symbolizer_path=/usr/bin/llvm-symbolizer
       DUCKDB_TEST_DESCRIPTION: 'Tests run with thread sanitizer.'
+      # dump the complete raw unittest stderr so full ThreadSanitizer race reports reach the CI logs
+      DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES: '0'
 
     steps:
     - name: "Checkout"

--- a/Makefile
+++ b/Makefile
@@ -636,12 +636,14 @@ allunit: release
 endif
 
 unittest_threadsan: export TSAN_OPTIONS ?= "suppressions=./.sanitizer-thread-suppressions.txt"
+unittest_threadsan: export DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES ?= "0"
 unittest_threadsan: unittest_reldebug
 	build/reldebug/test/run $(UNITTEST_HUGE_FLAGS) --test-config test/configs/threadsan.json "[intraquery],[interquery],[detailed_profiler],test/sql/tpch/tpch_sf01.test_slow" $(T)
 	build/reldebug/test/run $(UNITTEST_HUGE_FLAGS) --test-config test/configs/threadsan.json --test-flags="--force-storage --force-reload" "[interquery]" $(T)
 
 .PHONY: unittest_threadsan_extra
 unittest_threadsan_extra: export TSAN_OPTIONS ?= "suppressions=./.sanitizer-thread-suppressions.txt"
+unittest_threadsan_extra: export DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES ?= "0"
 unittest_threadsan_extra: unittest_reldebug
 	build/reldebug/test/run $(UNITTEST_HUGE_FLAGS) --test-config test/configs/threadsan.json --test-flags="--force-storage" "[interquery]" $(T)
 

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -1166,6 +1166,18 @@ def render_failure_lines(failure: FailureInfo):
 
 
 RAW_OUTPUT_TAIL_LINE_COUNT = 100
+# Set DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES to 0 to dump the full raw unittest output instead of just the tail
+RAW_OUTPUT_TAIL_LINE_COUNT_ENV = "DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES"
+
+
+def raw_output_tail_line_count() -> int:
+    value = os.environ.get(RAW_OUTPUT_TAIL_LINE_COUNT_ENV, "")
+    if not value:
+        return RAW_OUTPUT_TAIL_LINE_COUNT
+    try:
+        return max(0, int(value))
+    except ValueError:
+        return RAW_OUTPUT_TAIL_LINE_COUNT
 
 
 def is_low_information_failure(failure: FailureInfo):
@@ -1180,6 +1192,7 @@ def is_low_information_failure(failure: FailureInfo):
 
 def render_raw_output_tail(stdout: str, stderr: str):
     lines = []
+    tail_line_count = raw_output_tail_line_count()
     for stream_name, output in (("stdout", stdout), ("stderr", stderr)):
         stream_lines = [line.rstrip() for line in strip_ansi(normalize_output(output)).splitlines()]
         while stream_lines and not stream_lines[-1].strip():
@@ -1187,7 +1200,7 @@ def render_raw_output_tail(stdout: str, stderr: str):
         if not stream_lines:
             lines.extend(["", f"--- raw unittest {stream_name}: empty ---"])
             continue
-        tail = stream_lines[-RAW_OUTPUT_TAIL_LINE_COUNT:]
+        tail = stream_lines if tail_line_count == 0 else stream_lines[-tail_line_count:]
         header = f"--- raw unittest {stream_name}"
         if len(tail) < len(stream_lines):
             header += f" (last {len(tail)} of {len(stream_lines)} lines)"

--- a/scripts/ci/run_tests.py
+++ b/scripts/ci/run_tests.py
@@ -100,6 +100,7 @@ class FailureInfo:
     actual_result_lines: list[str]
     detail_lines: list[str]
     timeout_seconds: float | None
+    crash_signal: str | None
     reproduce_batch: list[str]
 
 
@@ -978,16 +979,35 @@ def extract_interesting_failure_block(lines: list[str]):
     return []
 
 
-def format_signal_summary(returncode: int | None):
+# signals the runner sends itself to stop a batch - those are not crashes
+NON_CRASH_SIGNALS = frozenset({"SIGINT", "SIGTERM", "SIGKILL", "SIGHUP"})
+
+
+def signal_name_from_returncode(returncode: int | None):
     if returncode is None or returncode >= 0:
         return None
     signal_number = -returncode
     try:
-        signal_name = signal.Signals(signal_number).name
+        return signal.Signals(signal_number).name
     except ValueError:
-        signal_name = f"SIG{signal_number}"
-    description = signal.strsignal(signal_number) or "terminated by signal"
+        return f"SIG{signal_number}"
+
+
+def format_signal_summary(returncode: int | None):
+    signal_name = signal_name_from_returncode(returncode)
+    if signal_name is None:
+        return None
+    description = signal.strsignal(-returncode) or "terminated by signal"
     return f"{signal_name} - {description}"
+
+
+def crash_signal_summary(returncode: int | None):
+    # a crash signal means the unittest process died mid-run - the parsed output only shows the crash site,
+    # while the raw output can hold the report that explains it (e.g. a ThreadSanitizer race report)
+    signal_name = signal_name_from_returncode(returncode)
+    if signal_name is None or signal_name in NON_CRASH_SIGNALS:
+        return None
+    return format_signal_summary(returncode)
 
 
 def retarget_failing_test(new_test_name: str | None, test_name: str | None, line_number: int | None):
@@ -1025,6 +1045,7 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
             actual_result_lines=[],
             detail_lines=[],
             timeout_seconds=float(re.search(r"after ([0-9]+(?:\.[0-9]+)?) seconds", message).group(1)),
+            crash_signal=None,
             reproduce_batch=reproduce_batch,
         )
 
@@ -1060,6 +1081,7 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
             actual_result_lines=stderr_info.actual_result_lines,
             detail_lines=[],
             timeout_seconds=None,
+            crash_signal=None,
             reproduce_batch=reproduce_batch,
         )
 
@@ -1132,6 +1154,7 @@ def parse_failure_info(message: str | None, stdout: str, stderr: str, batch, ret
         actual_result_lines=[],
         detail_lines=detail_lines,
         timeout_seconds=None,
+        crash_signal=crash_signal_summary(returncode),
         reproduce_batch=reproduce_batch,
     )
 
@@ -1210,7 +1233,9 @@ def render_raw_output_tail(stdout: str, stderr: str):
 
 def render_failure_lines_with_diagnostics(failure: FailureInfo, stdout: str, stderr: str):
     lines = render_failure_lines(failure)
-    if is_low_information_failure(failure):
+    # low-information failures have nothing useful parsed at all; a crash has a parsed crash site, but the
+    # raw output can still hold what explains it (e.g. a ThreadSanitizer race report printed before the crash)
+    if is_low_information_failure(failure) or failure.crash_signal is not None:
         lines = [*lines, *render_raw_output_tail(stdout, stderr)]
     return lines
 

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -1720,6 +1720,28 @@ assertions: 16 | 15 passed | 1 failed
         self.assertIn("assertions: 16 | 15 passed | 1 failed", stripped_lines)
         self.assertEqual(reproduce_batch, ["/tmp/a.test", "/tmp/b.test"])
 
+    def test_raw_output_tail_line_count_env(self):
+        # DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES controls how much of the raw unittest output is dumped:
+        # the default only shows the tail, while 0 dumps the full output (used by the ThreadSanitizer job)
+        stderr = "\n".join(f"stderr line {i}" for i in range(120)) + "\n"
+
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES", None)
+            lines = run_tests.render_raw_output_tail("", stderr)
+        default_lines = strip_ansi_lines(lines)
+        # by default only the last 100 lines are dumped, with a truncation header
+        self.assertIn("--- raw unittest stderr (last 100 of 120 lines) ---", default_lines)
+        self.assertIn("stderr line 20", default_lines)
+        self.assertNotIn("stderr line 0", default_lines)
+
+        with mock.patch.dict(os.environ, {"DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES": "0"}, clear=False):
+            lines = run_tests.render_raw_output_tail("", stderr)
+        full_lines = strip_ansi_lines(lines)
+        # with 0 the whole output is dumped, without a truncation header
+        self.assertIn("--- raw unittest stderr ---", full_lines)
+        self.assertIn("stderr line 0", full_lines)
+        self.assertIn("stderr line 119", full_lines)
+
     def test_informative_failures_do_not_dump_raw_output(self):
         batch = ["/tmp/fail.test"]
         stderr = """

--- a/scripts/ci/test_run_tests.py
+++ b/scripts/ci/test_run_tests.py
@@ -33,6 +33,18 @@ def strip_ansi_lines(lines: list[str]) -> list[str]:
     return [run_tests.strip_ansi(line) for line in lines]
 
 
+def parsed_failure_lines(lines: list[str]) -> list[str]:
+    # the parsed failure description, without the raw unittest output dump that may follow it
+    stripped = strip_ansi_lines(lines)
+    for idx, line in enumerate(stripped):
+        if line.startswith("--- raw unittest"):
+            stripped = stripped[:idx]
+            break
+    while stripped and not stripped[-1].strip():
+        stripped.pop()
+    return stripped
+
+
 class RunTestsScriptTest(unittest.TestCase):
     def test_line_buffering_escapes_unicode_for_non_utf8_streams(self):
         stdout_buffer = BytesIO()
@@ -1454,7 +1466,7 @@ test cases: 1 | 1 failed
 """
         lines, reproduce_batch = run_tests.summarize_failure_output(None, stdout, "", batch, returncode=-11)
         self.assertEqual(
-            strip_ansi_lines(lines)[1:],
+            parsed_failure_lines(lines)[1:],
             [
                 "error: FAIL test/sql/crash.test",
                 "",
@@ -1464,6 +1476,8 @@ test cases: 1 | 1 failed
                 "/duckdb/build/release/src/libduckdb.so(duckdb::Execute()+0x34) [0x5678]",
             ],
         )
+        # a crash kills the unittest process mid-run, so the raw output is dumped as well
+        self.assertIn("--- raw unittest stdout ---", strip_ansi_lines(lines))
         self.assertEqual(reproduce_batch, batch)
 
     def test_signal_only_failure_prefers_returncode_over_unrelated_stdout(self):
@@ -1476,13 +1490,17 @@ test cases: 1 | 1 failed
             returncode=-6,
         )
         self.assertEqual(
-            strip_ansi_lines(lines)[1:],
+            parsed_failure_lines(lines)[1:],
             [
                 "error: FAIL test/sql/crash.test",
                 "",
                 run_tests.format_signal_summary(-6),
             ],
         )
+        # the process died from a crash signal, so the raw output is dumped as well
+        stripped_lines = strip_ansi_lines(lines)
+        self.assertIn("--- raw unittest stdout ---", stripped_lines)
+        self.assertIn("before abort", stripped_lines)
         self.assertEqual(reproduce_batch, ["test/sql/crash.test"])
 
     def test_signal_only_failure_uses_last_started_test_for_reproduce(self):
@@ -1504,13 +1522,14 @@ test cases: 1 | 1 failed
             returncode=-11,
         )
         self.assertEqual(
-            strip_ansi_lines(lines)[1:],
+            parsed_failure_lines(lines)[1:],
             [
                 "error: FAIL /tmp/second.test",
                 "",
                 run_tests.format_signal_summary(-11),
             ],
         )
+        self.assertIn("--- raw unittest stdout ---", strip_ansi_lines(lines))
         self.assertEqual(reproduce_batch, ["/tmp/second.test"])
 
     def test_sanitizer_output_is_preferred_over_signal_summary(self):
@@ -1528,7 +1547,7 @@ READ of size 4 at 0xdeadbeef thread T0
             returncode=-6,
         )
         self.assertEqual(
-            strip_ansi_lines(lines)[1:],
+            parsed_failure_lines(lines)[1:],
             [
                 "error: FAIL test/sql/asan.test",
                 "",
@@ -1539,6 +1558,8 @@ READ of size 4 at 0xdeadbeef thread T0
         )
         self.assertEqual(reproduce_batch, ["test/sql/asan.test"])
         self.assertNotIn(run_tests.format_signal_summary(-6), lines)
+        # the sanitizer aborted the process, so the raw output is dumped as well
+        self.assertIn("--- raw unittest stderr ---", strip_ansi_lines(lines))
 
     def test_thread_sanitizer_output_is_not_truncated(self):
         batch = ["test/sql/threadsan.test"]
@@ -1753,9 +1774,46 @@ Wrong result in query! (/tmp/fail.test:25)!
 Mismatch on row 1, column 1
 [3, 1, 2] <> [1, 2, 3]
 """
-        lines, _ = run_tests.summarize_failure_output(None, "", stderr, batch)
+        lines, _ = run_tests.summarize_failure_output(None, "", stderr, batch, returncode=1)
         stripped_lines = strip_ansi_lines(lines)
         self.assertFalse(any(line.startswith("--- raw unittest") for line in stripped_lines))
+
+    def test_signal_crash_failure_dumps_raw_output(self):
+        # a crash signal kills the unittest process mid-run: the parsed output only shows the crash site,
+        # so the raw output (which can hold the report that explains the crash) is dumped as well
+        batch = ["test/sql/aggregate/aggregates/test_sem.test"]
+        stdout = """
+[0/1] (0%): test/sql/aggregate/aggregates/test_sem.test
+due to a fatal error condition:
+  SIGSEGV - Segmentation violation signal
+
+/duckdb/build/reldebug/src/libduckdb.so(duckdb::RowOperations::CombineStates()+0x12c) [0x1234]
+"""
+        stderr = """
+WARNING: ThreadSanitizer: data race (pid=123)
+  Read of size 8 by thread T2:
+    #0 duckdb::RowOperations::CombineStates()
+
+SUMMARY: ThreadSanitizer: data race in duckdb::RowOperations::CombineStates()
+"""
+        lines, reproduce_batch = run_tests.summarize_failure_output(None, stdout, stderr, batch, returncode=-11)
+        stripped_lines = strip_ansi_lines(lines)
+        self.assertIn("SIGSEGV - Segmentation violation signal", stripped_lines)
+        self.assertIn("--- raw unittest stdout ---", stripped_lines)
+        self.assertIn("--- raw unittest stderr ---", stripped_lines)
+        self.assertIn("SUMMARY: ThreadSanitizer: data race in duckdb::RowOperations::CombineStates()", stripped_lines)
+        self.assertEqual(reproduce_batch, batch)
+
+    def test_runner_stop_signals_are_not_crashes(self):
+        # SIGTERM/SIGINT/SIGKILL are sent by the runner to stop a batch - they must not dump raw output
+        for stop_signal in (-15, -2, -9, -1):
+            self.assertIsNone(run_tests.crash_signal_summary(stop_signal))
+        self.assertEqual(run_tests.crash_signal_summary(-11), run_tests.format_signal_summary(-11))
+        self.assertEqual(run_tests.crash_signal_summary(-6), run_tests.format_signal_summary(-6))
+        # a regular failed test exits normally, and so does a successful one
+        self.assertIsNone(run_tests.crash_signal_summary(1))
+        self.assertIsNone(run_tests.crash_signal_summary(0))
+        self.assertIsNone(run_tests.crash_signal_summary(None))
 
     def test_generic_failure_merges_query_diagnostics_with_assertion_failure(self):
         remote_optimizer_path = REPO_ROOT / "test" / "extension" / "test_remote_optimizer.cpp"


### PR DESCRIPTION
The test runner truncates the raw unittest stderr/stdout to the last 100 lines when reporting low-information failures. ThreadSanitizer race reports are often longer than that (for example https://github.com/duckdb/duckdb/actions/runs/34194844474/job/101960907679?pr=25277), so the full report never reaches the CI logs. Allow overriding the tail line count via
DUCKDB_TEST_RAW_OUTPUT_TAIL_LINES (0 = full output) and enable it in the ThreadSanitizer job and the unittest_threadsan targets.

I've tried to run TSAN locally and can not reproduce the same error. I think it will be helpful to investigate the root cause of TSAN failure if we can get the full report.