### PR TITLE
Error on byte mismatch when writing to local file system

### DIFF
--- a/extension/parquet/parquet_writer.cpp
+++ b/extension/parquet/parquet_writer.cpp
@@ -1427,7 +1427,7 @@ void ParquetWriter::Finalize() {
 
 	Write(file_meta_data);
 
-	uint32_t footer_size = writer->GetTotalWritten() - metadata_start_offset;
+	auto footer_size = NumericCast<uint32_t>(writer->GetTotalWritten() - metadata_start_offset);
 	writer->Write<uint32_t>(footer_size);
 
 	if (options.encryption_config) {

--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -517,7 +517,7 @@ void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, 
 	while (bytes_to_write > 0) {
 		int64_t bytes_written = pwrite(fd, write_buffer, UnsafeNumericCast<size_t>(bytes_to_write),
 		                               UnsafeNumericCast<off_t>(current_location));
-		if (bytes_written < 0) {
+		if (bytes_written < 0 || bytes_written > bytes_to_write) {
 			throw IOException({{"errno", std::to_string(errno)}}, "Could not write file \"%s\": %s", handle.path,
 			                  strerror(errno));
 		}
@@ -543,7 +543,7 @@ int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_byte
 		auto bytes_to_write_this_call =
 		    MinValue<idx_t>(idx_t(NumericLimits<int32_t>::Maximum()), idx_t(bytes_to_write));
 		int64_t current_bytes_written = write(fd, buffer, bytes_to_write_this_call);
-		if (current_bytes_written <= 0) {
+		if (current_bytes_written <= 0 || idx_t(current_bytes_written) > bytes_to_write_this_call) {
 			throw IOException({{"errno", std::to_string(errno)}}, "Could not write file \"%s\": %s", handle.path,
 			                  strerror(errno));
 		}
@@ -1333,7 +1333,7 @@ static int64_t FSWrite(FileHandle &handle, HANDLE hFile, void *buffer, int64_t n
 	while (nr_bytes > 0) {
 		auto bytes_to_write = MinValue<idx_t>(idx_t(NumericLimits<int32_t>::Maximum()), idx_t(nr_bytes));
 		DWORD current_bytes_written = FSInternalWrite(handle, hFile, buffer, bytes_to_write, location);
-		if (current_bytes_written <= 0) {
+		if (current_bytes_written <= 0 || current_bytes_written > bytes_to_write) {
 			throw IOException({{"errno", std::to_string(errno)}}, "Could not write file \"%s\": %s", handle.path,
 			                  strerror(errno));
 		}

--- a/src/common/serializer/async_file_writer.cpp
+++ b/src/common/serializer/async_file_writer.cpp
@@ -404,6 +404,14 @@ void AsyncFileWriter::Close() {
 			SealCopiedBuffer(ScheduleMode::DEFER);
 		}
 		write_queue->Close();
+		if (handle->file_system.IsLocalFileSystem() && handle->GetFileCompressionType().IsUncompressed()) {
+			auto metadata = handle->Stats();
+			if (metadata.file_type == FileType::FILE_TYPE_REGULAR &&
+			    metadata.file_size != NumericCast<int64_t>(total_written)) {
+				throw IOException("File size mismatch for file \"%s\": expected %llu bytes, found %lld bytes", path,
+				                  total_written, metadata.file_size);
+			}
+		}
 	} catch (...) {
 		auto error = std::current_exception();
 		if (!first_error) {

--- a/test/common/test_async_file_writer.cpp
+++ b/test/common/test_async_file_writer.cpp
@@ -165,6 +165,20 @@ private:
 	atomic<idx_t> abort_count {0};
 };
 
+class SizeMismatchWriteFileSystem : public TrackingWriteFileSystem {
+public:
+	explicit SizeMismatchWriteFileSystem(int64_t size_difference_p) : size_difference(size_difference_p) {
+	}
+
+	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		TrackingWriteFileSystem::Write(handle, buffer, nr_bytes, location);
+		LocalFileSystem::Truncate(handle, NumericCast<int64_t>(location) + nr_bytes + size_difference);
+	}
+
+private:
+	int64_t size_difference;
+};
+
 class PublishingFileHandle : public FileHandle {
 public:
 	PublishingFileHandle(FileSystem &fs, const string &path, FileOpenFlags flags, atomic<idx_t> &publish_count_p,
@@ -1925,6 +1939,36 @@ TEST_CASE("AsyncFileWriter publishes only on successful explicit close", "[async
 	REQUIRE(fs.AbortCount() == 0);
 	REQUIRE(ReadFile(path) == "published");
 	fs.RemoveFile(path);
+}
+
+TEST_CASE("AsyncFileWriter rejects incorrect final file sizes", "[async_file_writer]") {
+	for (auto async_threads : {0, 2}) {
+		for (auto size_difference : {-32768, 32768}) {
+			for (auto exclusive_create : {false, true}) {
+				CAPTURE(async_threads, size_difference, exclusive_create);
+				DuckDB db(nullptr);
+				auto con = CreateConnectionWithAsyncThreads(db, async_threads);
+				SizeMismatchWriteFileSystem fs(size_difference);
+				auto path = TestCreatePath("async_file_writer_size_mismatch.tmp");
+				fs.TryRemoveFile(path);
+
+				auto flags = AsyncFileWriter::DEFAULT_OPEN_FLAGS;
+				if (exclusive_create) {
+					flags |= FileFlags::FILE_FLAGS_EXCLUSIVE_CREATE;
+				}
+				AsyncFileWriter writer(*con->context, fs, path, flags);
+				writer.WriteData(make_uniq<StringAsyncWriteBuffer>(string(65536, 'x')));
+				auto error = CaptureException([&]() { writer.Close(); });
+				REQUIRE(error.find("File size mismatch") != string::npos);
+				REQUIRE(error.find("expected 65536 bytes") != string::npos);
+				REQUIRE(error.find("found " + to_string(65536 + size_difference) + " bytes") != string::npos);
+				REQUIRE(CaptureException([&]() { writer.Close(); }) == error);
+				REQUIRE(fs.AbortCount() == 1);
+				REQUIRE(fs.FileExists(path) == !exclusive_create);
+				fs.TryRemoveFile(path);
+			}
+		}
+	}
 }
 
 TEST_CASE("AsyncFileWriter exclusive creation preserves existing files", "[async_file_writer]") {


### PR DESCRIPTION
If there is, for any reason, a byte mismatch here, the write should fail instead of silently succeeding with a wrong byte count.