### PR TITLE
Fix primary key accepting transaction-local NULL

### DIFF
--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -7,9 +7,11 @@
 #include "duckdb/execution/index/bound_index.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database_manager.hpp"
+#include "duckdb/planner/constraints/bound_not_null_constraint.hpp"
 #include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/storage_manager.hpp"
+#include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/execution/index/index_type.hpp"
 
 namespace duckdb {
@@ -136,6 +138,13 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 	if (!storage.IsMainTable()) {
 		throw TransactionException(
 		    "Transaction conflict: cannot add an index to a table that has been altered or dropped");
+	}
+	if (alter_table_info && info->constraint_type == IndexConstraintType::PRIMARY) {
+		auto &local_storage = LocalStorage::Get(context, storage.db);
+		for (const auto &column_id : storage_ids) {
+			BoundNotNullConstraint not_null {PhysicalIndex(column_id)};
+			local_storage.VerifyNewConstraint(storage, not_null);
+		}
 	}
 
 	auto &schema = table.schema;

--- a/src/execution/operator/schema/physical_create_index.cpp
+++ b/src/execution/operator/schema/physical_create_index.cpp
@@ -139,13 +139,6 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 		throw TransactionException(
 		    "Transaction conflict: cannot add an index to a table that has been altered or dropped");
 	}
-	if (alter_table_info && info->constraint_type == IndexConstraintType::PRIMARY) {
-		auto &local_storage = LocalStorage::Get(context, storage.db);
-		for (const auto &column_id : storage_ids) {
-			BoundNotNullConstraint not_null {PhysicalIndex(column_id)};
-			local_storage.VerifyNewConstraint(storage, not_null);
-		}
-	}
 
 	auto &schema = table.schema;
 	info->column_ids = storage_ids;
@@ -173,6 +166,15 @@ SinkFinalizeType PhysicalCreateIndex::Finalize(Pipeline &pipeline, Event &event,
 		if (indexes.Contains(info->GetIndexName())) {
 			throw CatalogException("an index with that name already exists for this table: %s",
 			                       SQLIdentifier(info->GetIndexName()));
+		}
+
+		// PRIMARY KEY columns cannot be NULL.
+		if (info->constraint_type == IndexConstraintType::PRIMARY) {
+			auto &local_storage = LocalStorage::Get(context, storage.db);
+			for (const auto &column_id : storage_ids) {
+				BoundNotNullConstraint not_null {PhysicalIndex(column_id)};
+				local_storage.VerifyNewConstraint(storage, not_null);
+			}
 		}
 
 		auto &catalog = Catalog::GetCatalog(context, info->GetQualifiedName().Catalog());

--- a/test/sql/alter/add_pk/test_add_pk_local_null.test
+++ b/test/sql/alter/add_pk/test_add_pk_local_null.test
@@ -2,9 +2,6 @@
 # description: ADD PRIMARY KEY must reject transaction-local NULLs
 # group: [add_pk]
 
-# Persistent NULLs are already rejected in test_add_pk_invalid_data.test.
-# Transaction-local inserts are not visible to the create-index scan.
-
 statement ok
 CREATE TABLE t(a INTEGER);
 
@@ -21,77 +18,3 @@ ALTER TABLE t ADD PRIMARY KEY (a);
 
 statement ok
 ROLLBACK;
-
-statement ok
-INSERT INTO t VALUES (NULL);
-
-query I
-SELECT a FROM t
-----
-NULL
-
-# Committed row plus a local NULL.
-
-statement ok
-DROP TABLE t;
-
-statement ok
-CREATE TABLE t(a INTEGER);
-
-statement ok
-INSERT INTO t VALUES (1);
-
-statement ok
-BEGIN;
-
-statement ok
-INSERT INTO t VALUES (NULL);
-
-statement error
-ALTER TABLE t ADD PRIMARY KEY (a);
-----
-<REGEX>:Constraint Error.*NOT NULL constraint failed.*
-
-statement ok
-ROLLBACK;
-
-# Compound PRIMARY KEY: NULL in one key column.
-
-statement ok
-CREATE TABLE t2(a INTEGER, b INTEGER);
-
-statement ok
-BEGIN;
-
-statement ok
-INSERT INTO t2 VALUES (1, NULL);
-
-statement error
-ALTER TABLE t2 ADD PRIMARY KEY (a, b);
-----
-<REGEX>:Constraint Error.*NOT NULL constraint failed.*
-
-statement ok
-ROLLBACK;
-
-# UNIQUE allows NULL, including a local NULL.
-
-statement ok
-CREATE TABLE t3(a INTEGER);
-
-statement ok
-BEGIN;
-
-statement ok
-INSERT INTO t3 VALUES (NULL);
-
-statement ok
-ALTER TABLE t3 ADD UNIQUE (a);
-
-statement ok
-COMMIT;
-
-query I
-SELECT a FROM t3
-----
-NULL

--- a/test/sql/alter/add_pk/test_add_pk_local_null.test
+++ b/test/sql/alter/add_pk/test_add_pk_local_null.test
@@ -1,0 +1,97 @@
+# name: test/sql/alter/add_pk/test_add_pk_local_null.test
+# description: ADD PRIMARY KEY must reject transaction-local NULLs
+# group: [add_pk]
+
+# Persistent NULLs are already rejected in test_add_pk_invalid_data.test.
+# Transaction-local inserts are not visible to the create-index scan.
+
+statement ok
+CREATE TABLE t(a INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t VALUES (NULL);
+
+statement error
+ALTER TABLE t ADD PRIMARY KEY (a);
+----
+<REGEX>:Constraint Error.*NOT NULL constraint failed.*
+
+statement ok
+ROLLBACK;
+
+statement ok
+INSERT INTO t VALUES (NULL);
+
+query I
+SELECT a FROM t
+----
+NULL
+
+# Committed row plus a local NULL.
+
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(a INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t VALUES (NULL);
+
+statement error
+ALTER TABLE t ADD PRIMARY KEY (a);
+----
+<REGEX>:Constraint Error.*NOT NULL constraint failed.*
+
+statement ok
+ROLLBACK;
+
+# Compound PRIMARY KEY: NULL in one key column.
+
+statement ok
+CREATE TABLE t2(a INTEGER, b INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t2 VALUES (1, NULL);
+
+statement error
+ALTER TABLE t2 ADD PRIMARY KEY (a, b);
+----
+<REGEX>:Constraint Error.*NOT NULL constraint failed.*
+
+statement ok
+ROLLBACK;
+
+# UNIQUE allows NULL, including a local NULL.
+
+statement ok
+CREATE TABLE t3(a INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t3 VALUES (NULL);
+
+statement ok
+ALTER TABLE t3 ADD UNIQUE (a);
+
+statement ok
+COMMIT;
+
+query I
+SELECT a FROM t3
+----
+NULL


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25467

Primary key construction needs to ensure two constraints: uniqueness and NOT NULL; the former is guaranteed by ART index, while the later is not properly validated for transaction-local changes.

The root cause is
- Before index construction, unique constraint is [skipped completely](https://github.com/duckdb/duckdb/blob/9849add833a58a1e0d084ab7132b4ebf7d8f6041/src/storage/data_table.cpp#L174-L176)
- physical index operator only check NULL at [sink](https://github.com/duckdb/duckdb/blob/9849add833a58a1e0d084ab7132b4ebf7d8f6041/src/execution/operator/schema/physical_create_index.cpp#L92-L99) stage for persisted rows, but not transaction-local ones
- physical index operator doesn't validate NOT NULL constraint at [finalization stage](https://github.com/duckdb/duckdb/blob/9849add833a58a1e0d084ab7132b4ebf7d8f6041/src/execution/operator/schema/physical_create_index.cpp#L118)
- ART is a general-purpose data structure, not specific for primary key, so it [skips empty keys on insertion](https://github.com/duckdb/duckdb/blob/9849add833a58a1e0d084ab7132b4ebf7d8f6041/src/execution/index/art/art.cpp#L546-L548)

This PR adds check at physical operator finalization stage, alternatives I considered
- Add check in the sink stage, so we could have one single place to check not null; but sink is executed in a parallel style, so we could duplicate and waste local rows validation for all chunks