### PR TITLE
Bind optimizer-introduced builtins through the catalog

### DIFF
--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -82,10 +82,6 @@ unique_ptr<FunctionData> ConstantOrNullBind(BindScalarFunctionInput &input) {
 
 } // namespace
 
-unique_ptr<FunctionData> ConstantOrNull::Bind(Value value) {
-	return make_uniq<ConstantOrNullBindData>(std::move(value));
-}
-
 bool ConstantOrNull::IsConstantOrNull(BoundFunctionExpression &expr, const Value &val) {
 	if (expr.Function().GetName() != "constant_or_null") {
 		return false;

--- a/src/include/duckdb/function/aggregate_function.hpp
+++ b/src/include/duckdb/function/aggregate_function.hpp
@@ -854,9 +854,14 @@ public:
 	const shared_ptr<const AggregateFunction> &GetDefinition() const {
 		return definition;
 	}
-	//! Restore the definition after the bound function has been replaced wholesale
+	//! Restore the definition after the bound function has been replaced wholesale, together with the
+	//! qualification it carries - the replacement is a specialized implementation, not a different function
 	void SetDefinition(shared_ptr<const AggregateFunction> definition_p) {
 		definition = std::move(definition_p);
+		if (definition) {
+			schema_name = definition->GetSchemaName();
+			catalog_name = definition->GetCatalogName();
+		}
 	}
 
 	AggregateStateLayout GetStateType(optional_ptr<FunctionData> bind_data) const {

--- a/src/include/duckdb/function/scalar/generic_common.hpp
+++ b/src/include/duckdb/function/scalar/generic_common.hpp
@@ -18,7 +18,6 @@ namespace duckdb {
 class BoundFunctionExpression;
 
 struct ConstantOrNull {
-	static unique_ptr<FunctionData> Bind(Value value);
 	static bool IsConstantOrNull(BoundFunctionExpression &expr, const Value &val);
 };
 

--- a/src/include/duckdb/function/scalar_function.hpp
+++ b/src/include/duckdb/function/scalar_function.hpp
@@ -575,9 +575,14 @@ public:
 	const shared_ptr<const ScalarFunction> &GetDefinition() const {
 		return definition;
 	}
-	//! Restore the definition after the bound function has been replaced wholesale
+	//! Restore the definition after the bound function has been replaced wholesale, together with the
+	//! qualification it carries - the replacement is a specialized implementation, not a different function
 	void SetDefinition(shared_ptr<const ScalarFunction> definition_p) {
 		definition = std::move(definition_p);
+		if (definition) {
+			schema_name = definition->GetSchemaName();
+			catalog_name = definition->GetCatalogName();
+		}
 	}
 
 private:

--- a/src/include/duckdb/function/window_function.hpp
+++ b/src/include/duckdb/function/window_function.hpp
@@ -378,9 +378,14 @@ public:
 	const shared_ptr<const WindowFunction> &GetDefinition() const {
 		return definition;
 	}
-	//! Restore the definition after the bound function has been replaced wholesale
+	//! Restore the definition after the bound function has been replaced wholesale, together with the
+	//! qualification it carries - the replacement is a specialized implementation, not a different function
 	void SetDefinition(shared_ptr<const WindowFunction> definition_p) {
 		definition = std::move(definition_p);
+		if (definition) {
+			schema_name = definition->GetSchemaName();
+			catalog_name = definition->GetCatalogName();
+		}
 	}
 
 public:

--- a/src/include/duckdb/optimizer/builtin_function_lookup.hpp
+++ b/src/include/duckdb/optimizer/builtin_function_lookup.hpp
@@ -28,6 +28,9 @@ shared_ptr<const ScalarFunction> GetBuiltinScalarFunction(ClientContext &context
 //! Aggregate counterpart of GetBuiltinScalarFunction
 shared_ptr<const AggregateFunction> GetBuiltinAggregateFunction(ClientContext &context, const Identifier &name,
                                                                 const vector<LogicalType> &arguments);
+//! Like GetBuiltinAggregateFunction, but returns nullptr instead of throwing when no overload matches
+shared_ptr<const AggregateFunction> TryGetBuiltinAggregateFunction(ClientContext &context, const Identifier &name,
+                                                                   const vector<LogicalType> &arguments);
 
 //! Look up a built-in scalar function as GetBuiltinScalarFunction does, and bind it to the given children
 unique_ptr<BoundFunctionExpression> BindBuiltinScalarFunction(ClientContext &context, const Identifier &name,

--- a/src/include/duckdb/optimizer/builtin_function_lookup.hpp
+++ b/src/include/duckdb/optimizer/builtin_function_lookup.hpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/optimizer/builtin_function_lookup.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/identifier.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+class AggregateFunction;
+class BoundFunctionExpression;
+class ClientContext;
+class Expression;
+class ScalarFunction;
+
+//! Look up a built-in scalar function in the system catalog and select the overload matching the given argument
+//! types. Rewrites that introduce a registered built-in resolve it this way so that the bound function keeps the
+//! catalog and schema name of its definition, like any function bound from SQL.
+shared_ptr<const ScalarFunction> GetBuiltinScalarFunction(ClientContext &context, const Identifier &name,
+                                                          const vector<LogicalType> &arguments);
+//! Aggregate counterpart of GetBuiltinScalarFunction
+shared_ptr<const AggregateFunction> GetBuiltinAggregateFunction(ClientContext &context, const Identifier &name,
+                                                                const vector<LogicalType> &arguments);
+
+//! Look up a built-in scalar function as GetBuiltinScalarFunction does, and bind it to the given children
+unique_ptr<BoundFunctionExpression> BindBuiltinScalarFunction(ClientContext &context, const Identifier &name,
+                                                              vector<unique_ptr<Expression>> children);
+
+} // namespace duckdb

--- a/src/include/duckdb/optimizer/expression_rewriter.hpp
+++ b/src/include/duckdb/optimizer/expression_rewriter.hpp
@@ -32,8 +32,9 @@ public:
 	void VisitExpression(unique_ptr<Expression> *expression) override;
 
 	// Generates either a constant_or_null(child) expression
-	static unique_ptr<Expression> ConstantOrNull(unique_ptr<Expression> child, Value value);
-	static unique_ptr<Expression> ConstantOrNull(vector<unique_ptr<Expression>> children, Value value);
+	static unique_ptr<Expression> ConstantOrNull(ClientContext &context, unique_ptr<Expression> child, Value value);
+	static unique_ptr<Expression> ConstantOrNull(ClientContext &context, vector<unique_ptr<Expression>> children,
+	                                             Value value);
 
 private:
 	//! Apply a set of rules to a specific expression

--- a/src/include/duckdb/optimizer/rule/like_optimizations.hpp
+++ b/src/include/duckdb/optimizer/rule/like_optimizations.hpp
@@ -23,7 +23,7 @@ public:
 	unique_ptr<Expression> Apply(LogicalOperator &op, vector<reference<Expression>> &bindings, bool &changes_made,
 	                             bool is_root) override;
 
-	unique_ptr<Expression> ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function, string pattern,
+	unique_ptr<Expression> ApplyRule(BoundFunctionExpression &expr, const Identifier &function_name, string pattern,
 	                                 bool is_not_like, PatternMatchType match_type) const;
 };
 

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library_unity(
   materialized_aggregate_reuse.cpp
   aggregate_rewrite_helper.cpp
   build_probe_side_optimizer.cpp
+  builtin_function_lookup.cpp
   column_binding_replacer.cpp
   column_lifetime_analyzer.cpp
   empty_result_pullup.cpp

--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/optimizer/matcher/expression_matcher.hpp"
 #include "duckdb/optimizer/aggregate_rewrite.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
@@ -354,15 +355,17 @@ private:
 			RewriteInfo rewrite_info;
 			auto count_arg = rule.Rewrite(expr, bindings, rewrite_info.additional_expressions);
 
-			// Add COUNT([x]) to the aggregate list
+			// Add COUNT([x]) to the aggregate list - the count set holds both the unary count and count_star
 			FunctionBinder function_binder(optimizer.context);
-			const auto count_fun = count_arg ? CountFunctionBase::GetFunction() : CountStarFun::GetFunction();
 			vector<unique_ptr<Expression>> count_args;
+			vector<LogicalType> count_arg_types;
 			if (count_arg) {
+				count_arg_types.push_back(count_arg->GetReturnType());
 				count_args.push_back(std::move(count_arg));
 			}
-			auto count_aggr = function_binder.BindAggregateFunction(count_fun, std::move(count_args), nullptr,
-			                                                        AggregateType::NON_DISTINCT);
+			auto count_fun = GetBuiltinAggregateFunction(optimizer.context, CountFun::Name, count_arg_types);
+			auto count_aggr = function_binder.BindAggregateFunction(std::move(count_fun), std::move(count_args),
+			                                                        nullptr, AggregateType::NON_DISTINCT);
 
 			rewrite_info.count_idx = aggr.expressions.size();
 			rewrites.emplace(i, std::move(rewrite_info));

--- a/src/optimizer/aggregate_function_rewriter.cpp
+++ b/src/optimizer/aggregate_function_rewriter.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/optimizer/aggregate_function_rewriter.hpp"
 
-#include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
@@ -92,21 +91,17 @@ public:
 
 	unique_ptr<Expression> Rewrite(unique_ptr<Expression> &expr, vector<reference<Expression>> &bindings,
 	                               vector<unique_ptr<Expression>> &additional_expressions) override {
-		auto &catalog = Catalog::GetSystemCatalog(optimizer.context);
 		FunctionBinder function_binder(optimizer.context);
 
 		// Move the child out of AVG(x)
 		auto avg_child = std::move(bindings[0].get().Cast<BoundAggregateExpression>().GetChildrenMutable()[0]);
 
 		// Replace AVG(x) with SUM(x)
-		auto &sum_entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(
-		    optimizer.context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "sum"));
-		const auto &sum_fun =
-		    sum_entry.functions.GetFunctionByArguments(optimizer.context, {avg_child->GetReturnType()});
+		auto sum_fun = GetBuiltinAggregateFunction(optimizer.context, "sum", {avg_child->GetReturnType()});
 		vector<unique_ptr<Expression>> args;
 		args.push_back(std::move(avg_child));
 		auto count_arg = args.back()->Copy();
-		expr = function_binder.BindAggregateFunction(sum_fun, std::move(args));
+		expr = function_binder.BindAggregateFunction(std::move(sum_fun), std::move(args));
 
 		return count_arg;
 	}

--- a/src/optimizer/aggregate_reuse.cpp
+++ b/src/optimizer/aggregate_reuse.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/optimizer/aggregate_rewrite_helper.hpp"
 #include "duckdb/optimizer/aggregate_reuse_internal.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
@@ -598,8 +599,9 @@ bool AggregateReuseOptimizer::TryReuseSemiAggregate(unique_ptr<LogicalOperator> 
 	FunctionBinder function_binder(optimizer.context);
 	vector<unique_ptr<Expression>> combine_arguments;
 	combine_arguments.push_back(make_uniq<BoundColumnRefExpression>(state_type, *planned_payload));
+	auto combine_function = GetBuiltinAggregateFunction(optimizer.context, CombineAggrFun::Name, {state_type});
 	auto combined_state =
-	    function_binder.BindAggregateFunction(CombineAggrFun::GetFunction(), std::move(combine_arguments));
+	    function_binder.BindAggregateFunction(std::move(combine_function), std::move(combine_arguments));
 	if (combined_state->GetReturnType() != state_type) {
 		throw InternalException("Aggregate state changed while binding aggregate reuse combination");
 	}

--- a/src/optimizer/aggregate_rewrite.cpp
+++ b/src/optimizer/aggregate_rewrite.cpp
@@ -1,6 +1,5 @@
 #include "duckdb/optimizer/aggregate_rewrite.hpp"
 
-#include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/optimizer/builtin_function_lookup.hpp"
@@ -72,14 +71,11 @@ FrequencyAggregateFinalizeInput::FrequencyAggregateFinalizeInput(
 }
 
 static unique_ptr<BoundAggregateExpression> BindMinAggregate(ClientContext &context, unique_ptr<Expression> child) {
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(
-	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "min"));
-	const auto &function = entry.functions.GetFunctionByArguments(context, {child->GetReturnType()});
+	auto function = GetBuiltinAggregateFunction(context, MinFun::Name, {child->GetReturnType()});
 	FunctionBinder function_binder(context);
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(child));
-	return function_binder.BindAggregateFunction(function, std::move(children));
+	return function_binder.BindAggregateFunction(std::move(function), std::move(children));
 }
 
 static unique_ptr<Expression> CreateAggregateSortKey(ClientContext &context, const BoundOrderModifier &order_bys) {

--- a/src/optimizer/aggregate_rewrite.cpp
+++ b/src/optimizer/aggregate_rewrite.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -126,7 +127,8 @@ unique_ptr<AggregateRewritePlan> FrequencyAggregateRewrite::Create(AggregateRewr
 	if (!input.aggregate.IsDistinct()) {
 		count_column = frequency_aggregates.size();
 		FunctionBinder function_binder(input.context);
-		frequency_aggregates.push_back(function_binder.BindAggregateFunction(CountStarFun::GetFunction(), {}));
+		auto count_star = GetBuiltinAggregateFunction(input.context, CountStarFun::Name, {});
+		frequency_aggregates.push_back(function_binder.BindAggregateFunction(std::move(count_star), {}));
 	}
 
 	optional_idx order_column;

--- a/src/optimizer/builtin_function_lookup.cpp
+++ b/src/optimizer/builtin_function_lookup.cpp
@@ -32,6 +32,20 @@ shared_ptr<const AggregateFunction> GetBuiltinAggregateFunction(ClientContext &c
 	return entry.functions.GetFunctionByArguments(context, arguments);
 }
 
+shared_ptr<const AggregateFunction> TryGetBuiltinAggregateFunction(ClientContext &context, const Identifier &name,
+                                                                   const vector<LogicalType> &arguments) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto &entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(context, BuiltinName(catalog, name));
+
+	ErrorData error;
+	FunctionBinder function_binder(context);
+	auto index = function_binder.BindFunction(entry.functions.name, entry.functions, arguments, error);
+	if (!index.IsValid()) {
+		return nullptr;
+	}
+	return entry.functions.GetFunctionByOffset(index.GetIndex());
+}
+
 unique_ptr<BoundFunctionExpression> BindBuiltinScalarFunction(ClientContext &context, const Identifier &name,
                                                               vector<unique_ptr<Expression>> children) {
 	vector<LogicalType> arguments;

--- a/src/optimizer/builtin_function_lookup.cpp
+++ b/src/optimizer/builtin_function_lookup.cpp
@@ -1,0 +1,52 @@
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+namespace duckdb {
+
+namespace {
+
+//! Built-ins are always looked up fully qualified in the system catalog, so a macro or user-defined function of the
+//! same name in the search path can never be selected instead.
+QualifiedName BuiltinName(Catalog &catalog, const Identifier &name) {
+	return QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), name);
+}
+
+} // namespace
+
+shared_ptr<const ScalarFunction> GetBuiltinScalarFunction(ClientContext &context, const Identifier &name,
+                                                          const vector<LogicalType> &arguments) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto &entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(context, BuiltinName(catalog, name));
+	return entry.functions.GetFunctionByArguments(context, arguments);
+}
+
+shared_ptr<const AggregateFunction> GetBuiltinAggregateFunction(ClientContext &context, const Identifier &name,
+                                                                const vector<LogicalType> &arguments) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+	auto &entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(context, BuiltinName(catalog, name));
+	return entry.functions.GetFunctionByArguments(context, arguments);
+}
+
+unique_ptr<BoundFunctionExpression> BindBuiltinScalarFunction(ClientContext &context, const Identifier &name,
+                                                              vector<unique_ptr<Expression>> children) {
+	vector<LogicalType> arguments;
+	arguments.reserve(children.size());
+	for (auto &child : children) {
+		arguments.push_back(child->GetReturnType());
+	}
+	auto function = GetBuiltinScalarFunction(context, name, arguments);
+
+	FunctionBinder function_binder(context);
+	auto result = function_binder.BindScalarFunction(std::move(function), std::move(children));
+	if (result->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		throw InternalException("Optimizer exception - binding built-in function %s did not return a function", name);
+	}
+	return unique_ptr_cast<Expression, BoundFunctionExpression>(std::move(result));
+}
+
+} // namespace duckdb

--- a/src/optimizer/builtin_function_lookup.cpp
+++ b/src/optimizer/builtin_function_lookup.cpp
@@ -53,14 +53,7 @@ unique_ptr<BoundFunctionExpression> BindBuiltinScalarFunction(ClientContext &con
 	for (auto &child : children) {
 		arguments.push_back(child->GetReturnType());
 	}
-	auto function = GetBuiltinScalarFunction(context, name, arguments);
-
-	FunctionBinder function_binder(context);
-	auto result = function_binder.BindScalarFunction(std::move(function), std::move(children));
-	if (result->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
-		throw InternalException("Optimizer exception - binding built-in function %s did not return a function", name);
-	}
-	return unique_ptr_cast<Expression, BoundFunctionExpression>(std::move(result));
+	return GetBuiltinScalarFunction(context, name, arguments)->Bind(context, std::move(children));
 }
 
 } // namespace duckdb

--- a/src/optimizer/compressed_materialization.cpp
+++ b/src/optimizer/compressed_materialization.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar/operators.hpp"
 #include "duckdb/function/scalar/variant_functions.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/topn_optimizer.hpp"
@@ -330,6 +331,8 @@ unique_ptr<CompressExpression> CMHelper::CreateIntegralFunctionCompress(unique_p
                                                                         const LogicalType &target_type,
                                                                         const Value &min, const Value &range_value,
                                                                         const BaseStatistics &stats) {
+	// the compression functions are registered for (de)serialization only - their bind throws, so they are
+	// constructed and specialized here rather than resolved through the catalog
 	auto compress_function = CMIntegralCompressFun::GetFunction(source_type, target_type);
 	vector<unique_ptr<Expression>> arguments;
 	arguments.emplace_back(std::move(input));
@@ -961,12 +964,9 @@ unique_ptr<Expression> CompressedMaterialization::GetDecompressExpression(unique
 	}
 	if (type.id() == LogicalTypeId::BLOB && stats.GetType().id() == LogicalTypeId::VARIANT) {
 		auto variant = GetVariantDecompress(std::move(input), LogicalType::VARIANT(), stats);
-		auto comparator_function = VariantComparatorFun::GetFunction();
-		BoundScalarFunction bound_function(comparator_function);
-		bound_function.SetReturnType(LogicalType::BLOB);
 		vector<unique_ptr<Expression>> arguments;
 		arguments.push_back(std::move(variant));
-		return make_uniq<BoundFunctionExpression>(std::move(bound_function), std::move(arguments), nullptr);
+		return BindBuiltinScalarFunction(context, VariantComparatorFun::Name, std::move(arguments));
 	}
 	if (type.id() == LogicalTypeId::GEOMETRY) {
 		return GetGeometryDecompress(std::move(input), result_type, stats);

--- a/src/optimizer/expression_rewriter.cpp
+++ b/src/optimizer/expression_rewriter.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/expression_rewriter.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
@@ -79,23 +80,18 @@ unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const
 	return expr;
 }
 
-unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(unique_ptr<Expression> child, Value value) {
+unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(ClientContext &context, unique_ptr<Expression> child,
+                                                          Value value) {
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(child));
-	return ConstantOrNull(std::move(children), std::move(value));
+	return ConstantOrNull(context, std::move(children), std::move(value));
 }
 
-unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(vector<unique_ptr<Expression>> children, Value value) {
-	auto type = value.type();
-	auto func = ConstantOrNullFun::GetFunction();
-	func.GetSignature().GetParameter(0).SetType(type);
-	func.SetReturnType(type);
-	children.insert(children.begin(), make_uniq<BoundConstantExpression>(value));
-
-	BoundScalarFunction bound_func(func);
-
-	return make_uniq<BoundFunctionExpression>(std::move(bound_func), std::move(children),
-	                                          ConstantOrNull::Bind(std::move(value)));
+unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(ClientContext &context,
+                                                          vector<unique_ptr<Expression>> children, Value value) {
+	children.insert(children.begin(), make_uniq<BoundConstantExpression>(std::move(value)));
+	// the bind of constant_or_null derives the return type and the bind data from the leading constant
+	return BindBuiltinScalarFunction(context, ConstantOrNullFun::Name, std::move(children));
 }
 
 void ExpressionRewriter::VisitOperator(LogicalOperator &op) {

--- a/src/optimizer/grouping_sets_optimizer.cpp
+++ b/src/optimizer/grouping_sets_optimizer.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/generic_common.hpp"
 #include "duckdb/optimizer/aggregate_rewrite_helper.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -258,7 +259,6 @@ bool GroupingSetsOptimizer::TryRewriteGroupingSets(unique_ptr<LogicalOperator> &
 	const idx_t aggregate_count = aggr.expressions.size();
 
 	// build the per-level aggregates
-	auto combine_function = CombineAggrFun::GetFunction();
 	FunctionBinder function_binder(optimizer.context);
 	vector<LogicalType> state_types;
 	for (idx_t level_idx = 0; level_idx < levels.size(); level_idx++) {
@@ -301,7 +301,10 @@ bool GroupingSetsOptimizer::TryRewriteGroupingSets(unique_ptr<LogicalOperator> &
 				vector<unique_ptr<Expression>> arguments;
 				arguments.push_back(make_uniq<BoundColumnRefExpression>(
 				    state_types[aggr_idx], ColumnBinding(cte_ref_index, ProjectionIndex(state_pos))));
-				auto combine_aggregate = function_binder.BindAggregateFunction(combine_function, std::move(arguments));
+				auto combine_function =
+				    GetBuiltinAggregateFunction(optimizer.context, CombineAggrFun::Name, {state_types[aggr_idx]});
+				auto combine_aggregate =
+				    function_binder.BindAggregateFunction(std::move(combine_function), std::move(arguments));
 				if (combine_aggregate->GetReturnType() != state_types[aggr_idx]) {
 					return false;
 				}

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -2,7 +2,7 @@
 
 #include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/execution/operator/join/physical_comparison_join.hpp"
-#include "duckdb/function/aggregate/distributive_function_utils.hpp"
+#include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/optimizer.hpp"

--- a/src/optimizer/join_filter_pushdown_optimizer.cpp
+++ b/src/optimizer/join_filter_pushdown_optimizer.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/execution/operator/join/physical_comparison_join.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
@@ -383,15 +384,15 @@ void JoinFilterPushdownOptimizer::GenerateJoinFilters(LogicalComparisonJoin &joi
 	}
 
 	// set up the min/max aggregates for each of the filters
-	vector<AggregateFunction> aggr_functions;
-	aggr_functions.push_back(MinFunction::GetFunction());
-	aggr_functions.push_back(MaxFunction::GetFunction());
+	auto &context = optimizer.GetContext();
 	for (auto &join_condition : pushdown_info->join_condition) {
-		for (auto &aggr : aggr_functions) {
-			FunctionBinder function_binder(optimizer.GetContext());
+		for (const auto &aggr_name : {MinFun::Name, MaxFun::Name}) {
+			FunctionBinder function_binder(context);
 			vector<unique_ptr<Expression>> aggr_children;
 			aggr_children.push_back(join.conditions[join_condition].GetRHS().Copy());
-			auto aggr_expr = function_binder.BindAggregateFunction(aggr, std::move(aggr_children), nullptr,
+			// the one-argument overload of the min/max set is the plain aggregate, min(x, n) takes two
+			auto aggr = GetBuiltinAggregateFunction(context, aggr_name, {aggr_children[0]->GetReturnType()});
+			auto aggr_expr = function_binder.BindAggregateFunction(std::move(aggr), std::move(aggr_children), nullptr,
 			                                                       AggregateType::NON_DISTINCT);
 			if (aggr_expr->GetChildren().size() != 1) {
 				// min/max with collation - not supported

--- a/src/optimizer/partial_aggregate_pushdown.cpp
+++ b/src/optimizer/partial_aggregate_pushdown.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/generic_common.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/relation_statistics/relation_statistics_extractor.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -385,7 +386,6 @@ static bool PassesLowerGroupHeuristic(const LogicalAggregate &aggr, const Partia
 static bool BindPushdownAggregates(ClientContext &context, LogicalAggregate &aggr, TableIndex lower_aggregate_index,
                                    vector<unique_ptr<Expression>> &lower_aggregates,
                                    vector<unique_ptr<Expression>> &upper_aggregates) {
-	auto combine_function = CombineAggrFun::GetFunction();
 	FunctionBinder function_binder(context);
 
 	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
@@ -399,7 +399,8 @@ static bool BindPushdownAggregates(ClientContext &context, LogicalAggregate &agg
 		vector<unique_ptr<Expression>> arguments;
 		auto lower_binding = ColumnBinding(lower_aggregate_index, ProjectionIndex(i));
 		arguments.push_back(make_uniq<BoundColumnRefExpression>(lower_type, lower_binding));
-		auto upper_aggregate = function_binder.BindAggregateFunction(combine_function, std::move(arguments));
+		auto combine_function = GetBuiltinAggregateFunction(context, CombineAggrFun::Name, {lower_type});
+		auto upper_aggregate = function_binder.BindAggregateFunction(std::move(combine_function), std::move(arguments));
 		if (!upper_aggregate->GetReturnType().IsAggregateState()) {
 			return false;
 		}
@@ -575,19 +576,13 @@ static unique_ptr<BoundAggregateExpression> DEBindAggregate(ClientContext &conte
 
 static unique_ptr<BoundAggregateExpression> DEBindCombineAggr(ClientContext &context,
                                                               vector<unique_ptr<Expression>> children) {
-	auto functions = CombineAggrFun::GetFunctions();
 	vector<LogicalType> types;
 	for (auto &child : children) {
 		types.push_back(child->GetReturnType());
 	}
-	ErrorData error;
 	FunctionBinder function_binder(context);
-	auto best = function_binder.BindFunction(functions.name, functions, types, error);
-	if (!best.IsValid()) {
-		return nullptr;
-	}
-	auto &func = functions.GetFunctionByOffset(best.GetIndex());
-	return function_binder.BindAggregateFunction(func, std::move(children));
+	auto func = GetBuiltinAggregateFunction(context, CombineAggrFun::Name, types);
+	return function_binder.BindAggregateFunction(std::move(func), std::move(children));
 }
 
 struct DoubleEagerHeuristics {

--- a/src/optimizer/partial_aggregate_pushdown.cpp
+++ b/src/optimizer/partial_aggregate_pushdown.cpp
@@ -570,16 +570,7 @@ static unique_ptr<BoundAggregateExpression> DEBindAggregate(ClientContext &conte
 
 static unique_ptr<BoundAggregateExpression> DEBindCombineAggr(ClientContext &context,
                                                               vector<unique_ptr<Expression>> children) {
-	vector<LogicalType> types;
-	for (auto &child : children) {
-		types.push_back(child->GetReturnType());
-	}
-	auto func = TryGetBuiltinAggregateFunction(context, CombineAggrFun::Name, types);
-	if (!func) {
-		return nullptr;
-	}
-	FunctionBinder function_binder(context);
-	return function_binder.BindAggregateFunction(std::move(func), std::move(children));
+	return DEBindAggregate(context, CombineAggrFun::Name, std::move(children));
 }
 
 struct DoubleEagerHeuristics {

--- a/src/optimizer/partial_aggregate_pushdown.cpp
+++ b/src/optimizer/partial_aggregate_pushdown.cpp
@@ -580,8 +580,11 @@ static unique_ptr<BoundAggregateExpression> DEBindCombineAggr(ClientContext &con
 	for (auto &child : children) {
 		types.push_back(child->GetReturnType());
 	}
+	auto func = TryGetBuiltinAggregateFunction(context, CombineAggrFun::Name, types);
+	if (!func) {
+		return nullptr;
+	}
 	FunctionBinder function_binder(context);
-	auto func = GetBuiltinAggregateFunction(context, CombineAggrFun::Name, types);
 	return function_binder.BindAggregateFunction(std::move(func), std::move(children));
 }
 

--- a/src/optimizer/partial_aggregate_pushdown.cpp
+++ b/src/optimizer/partial_aggregate_pushdown.cpp
@@ -1,7 +1,5 @@
 #include "duckdb/optimizer/partial_aggregate_pushdown.hpp"
 
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/common/extension_type_info.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
@@ -558,20 +556,16 @@ struct DoubleEagerSide {
 
 static unique_ptr<BoundAggregateExpression> DEBindAggregate(ClientContext &context, const string &name,
                                                             vector<unique_ptr<Expression>> children) {
-	auto &entry = Catalog::GetEntry<AggregateFunctionCatalogEntry>(
-	    context, QualifiedName(Identifier::SystemCatalog(), Identifier::DefaultSchema(), Identifier(name)));
 	vector<LogicalType> types;
 	for (auto &child : children) {
 		types.push_back(child->GetReturnType());
 	}
-	ErrorData error;
-	FunctionBinder function_binder(context);
-	auto best = function_binder.BindFunction(entry.name, entry.functions, types, error);
-	if (!best.IsValid()) {
+	auto func = TryGetBuiltinAggregateFunction(context, Identifier(name), types);
+	if (!func) {
 		return nullptr;
 	}
-	auto &func = entry.functions.GetFunctionByOffset(best.GetIndex());
-	return function_binder.BindAggregateFunction(func, std::move(children));
+	FunctionBinder function_binder(context);
+	return function_binder.BindAggregateFunction(std::move(func), std::move(children));
 }
 
 static unique_ptr<BoundAggregateExpression> DEBindCombineAggr(ClientContext &context,

--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/scalar/struct_functions.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/parser/parsed_data/vacuum_info.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
@@ -373,10 +375,10 @@ void RemoveUnusedColumns::VisitOperator(unique_ptr<LogicalOperator> &op_ref) {
 			ClearUnusedExpressions(aggr.expressions, aggr.aggregate_index);
 			if (aggr.expressions.empty() && aggr.groups.empty()) {
 				// removed all expressions from the aggregate: push a COUNT(*)
-				auto count_star_fun = CountStarFun::GetFunction();
+				auto count_star_fun = GetBuiltinAggregateFunction(context, CountStarFun::Name, {});
 				FunctionBinder function_binder(context);
-				aggr.expressions.push_back(
-				    function_binder.BindAggregateFunction(count_star_fun, {}, nullptr, AggregateType::NON_DISTINCT));
+				aggr.expressions.push_back(function_binder.BindAggregateFunction(std::move(count_star_fun), {}, nullptr,
+				                                                                 AggregateType::NON_DISTINCT));
 			}
 		}
 
@@ -918,7 +920,6 @@ static unique_ptr<Expression> ConstructStructExtractFromPath(ClientContext &cont
 		auto &child_types = StructType::GetChildTypes(type_iter.get());
 		D_ASSERT(child_index < child_types.size());
 		auto is_unnamed = StructType::IsUnnamed(type_iter.get());
-		auto function = is_unnamed ? GetIndexExtractFunction() : GetKeyExtractFunction();
 
 		type_iter = child_types[child_index].second;
 
@@ -929,7 +930,8 @@ static unique_ptr<Expression> ConstructStructExtractFromPath(ClientContext &cont
 		} else {
 			arguments[1] = make_uniq<BoundConstantExpression>(Value(child_types[child_index].first));
 		}
-		target = function.Bind(context, std::move(arguments));
+		// the struct_extract set holds both the key and the index overload, the constant argument selects between them
+		target = BindBuiltinScalarFunction(context, StructExtractFun::Name, std::move(arguments));
 		if (!path_iter.get().HasChildren()) {
 			break;
 		}

--- a/src/optimizer/rule/arithmetic_simplification.cpp
+++ b/src/optimizer/rule/arithmetic_simplification.cpp
@@ -54,7 +54,8 @@ unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, 
 			return std::move(root.GetChildrenMutable()[1 - constant_child]);
 		} else if (constant.GetValue() == 0) {
 			// multiply by zero: replace with constant or null
-			return ExpressionRewriter::ConstantOrNull(std::move(root.GetChildrenMutable()[1 - constant_child]),
+			return ExpressionRewriter::ConstantOrNull(GetContext(),
+			                                          std::move(root.GetChildrenMutable()[1 - constant_child]),
 			                                          Value::Numeric(root.GetReturnType(), 0));
 		}
 	} else if (func_name == "//") {

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -12,8 +12,9 @@
 
 namespace duckdb {
 
-static bool DateTimestampComparisonIsInvertible(BoundFunctionExpression &expr, BoundFunctionExpression &cast_expression,
-                                                const Value &constant_value, Value &cast_constant, bool column_ref_left,
+static bool DateTimestampComparisonIsInvertible(ClientContext &context, BoundFunctionExpression &expr,
+                                                BoundFunctionExpression &cast_expression, const Value &constant_value,
+                                                Value &cast_constant, bool column_ref_left,
                                                 unique_ptr<Expression> &replacement) {
 	if (Timestamp::GetTime(constant_value.GetValue<timestamp_t>()) == dtime_t(0)) {
 		return true; // it's midnight: no replacement needed
@@ -24,13 +25,13 @@ static bool DateTimestampComparisonIsInvertible(BoundFunctionExpression &expr, B
 	switch (op) {
 	case ExpressionType::COMPARE_EQUAL:
 		// d =  T   -> false, preserving NULL
-		replacement = ExpressionRewriter::ConstantOrNull(std::move(BoundCastExpression::ChildMutable(cast_expression)),
-		                                                 Value::BOOLEAN(false));
+		replacement = ExpressionRewriter::ConstantOrNull(
+		    context, std::move(BoundCastExpression::ChildMutable(cast_expression)), Value::BOOLEAN(false));
 		return true;
 	case ExpressionType::COMPARE_NOTEQUAL:
 		// d != T   -> true, preserving NULL
-		replacement = ExpressionRewriter::ConstantOrNull(std::move(BoundCastExpression::ChildMutable(cast_expression)),
-		                                                 Value::BOOLEAN(true));
+		replacement = ExpressionRewriter::ConstantOrNull(
+		    context, std::move(BoundCastExpression::ChildMutable(cast_expression)), Value::BOOLEAN(true));
 		return true;
 	case ExpressionType::COMPARE_DISTINCT_FROM:
 		// d IS DISTINCT FROM T     -> true
@@ -72,17 +73,18 @@ static bool DateTimestampComparisonIsInvertible(BoundFunctionExpression &expr, B
 	return true;
 }
 
-static bool ConstantCastIsInvertible(BoundFunctionExpression &expr, BoundFunctionExpression &cast_expression,
-                                     const Value &constant_value, Value &cast_constant, const LogicalType &target_type,
-                                     bool column_ref_left, unique_ptr<Expression> &replacement) {
+static bool ConstantCastIsInvertible(ClientContext &context, BoundFunctionExpression &expr,
+                                     BoundFunctionExpression &cast_expression, const Value &constant_value,
+                                     Value &cast_constant, const LogicalType &target_type, bool column_ref_left,
+                                     unique_ptr<Expression> &replacement) {
 	if (cast_constant.IsNull() || BoundCastExpression::CastIsInvertible(cast_expression.GetReturnType(), target_type)) {
 		return true;
 	}
 	if (target_type.id() != LogicalTypeId::DATE || cast_expression.GetReturnType().id() != LogicalTypeId::TIMESTAMP) {
 		return false;
 	}
-	return DateTimestampComparisonIsInvertible(expr, cast_expression, constant_value, cast_constant, column_ref_left,
-	                                           replacement);
+	return DateTimestampComparisonIsInvertible(context, expr, cast_expression, constant_value, cast_constant,
+	                                           column_ref_left, replacement);
 }
 
 static unique_ptr<Expression> CreateNullCheckExpression(ExpressionType expression_type, unique_ptr<Expression> child) {
@@ -207,7 +209,7 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 
 		// Is the constant cast invertible?
 		unique_ptr<Expression> replacement;
-		if (!ConstantCastIsInvertible(expr, cast_expression, constant_value, cast_constant, target_type,
+		if (!ConstantCastIsInvertible(GetContext(), expr, cast_expression, constant_value, cast_constant, target_type,
 		                              column_ref_left, replacement)) {
 			return nullptr;
 		}

--- a/src/optimizer/rule/contains_to_in_clause.cpp
+++ b/src/optimizer/rule/contains_to_in_clause.cpp
@@ -51,7 +51,7 @@ unique_ptr<Expression> ContainsToInClauseRule::Apply(LogicalOperator &op, vector
 	// No non-NULL elements: never contains any value.
 	if (non_null_elements.empty()) {
 		changes_made = true;
-		return ExpressionRewriter::ConstantOrNull(probe_arg->Copy(), Value::BOOLEAN(false));
+		return ExpressionRewriter::ConstantOrNull(GetContext(), probe_arg->Copy(), Value::BOOLEAN(false));
 	}
 
 	// Fully constant probe: let constant folding handle it.

--- a/src/optimizer/rule/date_trunc_simplification.cpp
+++ b/src/optimizer/rule/date_trunc_simplification.cpp
@@ -113,7 +113,7 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 					if (rhs_comparison_type == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 						return make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
 					}
-					return ExpressionRewriter::ConstantOrNull(column_part.Copy(), Value::BOOLEAN(false));
+					return ExpressionRewriter::ConstantOrNull(GetContext(), column_part.Copy(), Value::BOOLEAN(false));
 				}
 
 				auto trunc = CreateTrunc(date_part, rhs, column_part.GetReturnType());
@@ -186,7 +186,7 @@ unique_ptr<Expression> DateTruncSimplificationRule::Apply(LogicalOperator &op, v
 					if (rhs_comparison_type == ExpressionType::COMPARE_DISTINCT_FROM) {
 						return make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
 					}
-					return ExpressionRewriter::ConstantOrNull(column_part.Copy(), Value::BOOLEAN(true));
+					return ExpressionRewriter::ConstantOrNull(GetContext(), column_part.Copy(), Value::BOOLEAN(true));
 				}
 
 				auto trunc = CreateTrunc(date_part, rhs, column_part.GetReturnType());

--- a/src/optimizer/rule/empty_needle_removal.cpp
+++ b/src/optimizer/rule/empty_needle_removal.cpp
@@ -71,7 +71,8 @@ unique_ptr<Expression> EmptyNeedleRemovalRule::Apply(LogicalOperator &op, vector
 	// PREFIX(NULL, '') is NULL
 	// so rewrite PREFIX(x, '') to TRUE_OR_NULL(x)
 	if (needle_string.empty()) {
-		return ExpressionRewriter::ConstantOrNull(std::move(root.GetChildrenMutable()[0]), Value::BOOLEAN(true));
+		return ExpressionRewriter::ConstantOrNull(GetContext(), std::move(root.GetChildrenMutable()[0]),
+		                                          Value::BOOLEAN(true));
 	}
 	return nullptr;
 }

--- a/src/optimizer/rule/enum_comparison.cpp
+++ b/src/optimizer/rule/enum_comparison.cpp
@@ -57,7 +57,7 @@ unique_ptr<Expression> EnumComparisonRule::Apply(LogicalOperator &op, vector<ref
 		vector<unique_ptr<Expression>> children;
 		children.push_back(std::move(BoundComparisonExpression::LeftMutable(root)));
 		children.push_back(std::move(BoundComparisonExpression::RightMutable(root)));
-		return ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(false));
+		return ExpressionRewriter::ConstantOrNull(GetContext(), std::move(children), Value::BOOLEAN(false));
 	}
 
 	if (!is_root || op.type != LogicalOperatorType::LOGICAL_FILTER) {

--- a/src/optimizer/rule/in_clause_simplification_rule.cpp
+++ b/src/optimizer/rule/in_clause_simplification_rule.cpp
@@ -126,7 +126,7 @@ unique_ptr<Expression> InEnumSimplificationRule::Apply(LogicalOperator &op, vect
 	} else {
 		// constant_or_null(not_in, child[0])
 		const bool not_in = (expr.GetExpressionType() == ExpressionType::COMPARE_NOT_IN);
-		return rewriter.ConstantOrNull(in_children[0]->Copy(), Value::BOOLEAN(not_in));
+		return rewriter.ConstantOrNull(GetContext(), in_children[0]->Copy(), Value::BOOLEAN(not_in));
 	}
 
 	return nullptr;
@@ -212,11 +212,11 @@ unique_ptr<Expression> EnumCompareSimplificationRule::Apply(LogicalOperator &op,
 		//	Not in the domain, so rewrite as ConstantOrNull(enum, ne)
 		switch (expr.GetExpressionType()) {
 		case ExpressionType::COMPARE_EQUAL:
-			return rewriter.ConstantOrNull(std::move(cmp_children[0]), Value::BOOLEAN(false));
+			return rewriter.ConstantOrNull(GetContext(), std::move(cmp_children[0]), Value::BOOLEAN(false));
 		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
 			return make_uniq<BoundConstantExpression>(Value::BOOLEAN(false));
 		case ExpressionType::COMPARE_NOTEQUAL:
-			return rewriter.ConstantOrNull(std::move(cmp_children[0]), Value::BOOLEAN(true));
+			return rewriter.ConstantOrNull(GetContext(), std::move(cmp_children[0]), Value::BOOLEAN(true));
 		case ExpressionType::COMPARE_DISTINCT_FROM:
 			return make_uniq<BoundConstantExpression>(Value::BOOLEAN(true));
 		default:

--- a/src/optimizer/rule/like_optimizations.cpp
+++ b/src/optimizer/rule/like_optimizations.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/rule/like_optimizations.hpp"
 
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -158,22 +159,22 @@ unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<r
 		    std::move(root.GetChildrenMutable()[0]), std::move(root.GetChildrenMutable()[1]));
 	} else if (PatternIsPrefix(patt_str, match_type)) {
 		// Prefix LIKE pattern : [^%_]*[%]+, ignoring underscore
-		return ApplyRule(root, PrefixFun::GetFunction(), patt_str, is_not_like, match_type);
+		return ApplyRule(root, "prefix", patt_str, is_not_like, match_type);
 	} else if (PatternIsSuffix(patt_str, match_type)) {
 		// Suffix LIKE pattern: [%]+[^%_]*, ignoring underscore
-		return ApplyRule(root, SuffixFun::GetFunction(), patt_str, is_not_like, match_type);
+		return ApplyRule(root, "suffix", patt_str, is_not_like, match_type);
 	} else if (PatternIsContains(patt_str, match_type)) {
 		// Contains LIKE pattern: [%]+[^%_]*[%]+, ignoring underscore
-		return ApplyRule(root, GetStringContains(), patt_str, is_not_like, match_type);
+		return ApplyRule(root, "contains", patt_str, is_not_like, match_type);
 	}
 	return nullptr;
 }
 
-unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &expr, const ScalarFunction &function,
+unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression &expr, const Identifier &function_name,
                                                        string pattern, bool is_not_like,
                                                        PatternMatchType match_type) const {
 	// replace LIKE by an optimized function
-	auto result = function.Bind(GetContext(), std::move(expr.GetChildrenMutable()));
+	auto result = BindBuiltinScalarFunction(GetContext(), function_name, std::move(expr.GetChildrenMutable()));
 
 	// removing wildcard from the pattern
 	char wildcard_any = match_type == PatternMatchType::GLOB ? '*' : '%';

--- a/src/optimizer/rule/monotone_preimage.cpp
+++ b/src/optimizer/rule/monotone_preimage.cpp
@@ -310,7 +310,7 @@ unique_ptr<Expression> MonotonePreimageRule::Apply(LogicalOperator &op, vector<r
 		if (has_infinity) {
 			return nullptr;
 		}
-		return ExpressionRewriter::ConstantOrNull(col.Copy(), Value::BOOLEAN(false));
+		return ExpressionRewriter::ConstantOrNull(GetContext(), col.Copy(), Value::BOOLEAN(false));
 	}
 
 	// emit finite-domain bounds. On infinity types both bounds are always kept so ±infinity (whose f is

--- a/src/optimizer/rule/move_constants.cpp
+++ b/src/optimizer/rule/move_constants.cpp
@@ -88,7 +88,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 			// for example, if we have x + 5 = 3, where x is an unsigned number, we will get x = -2
 			// since this is not possible we can remove the entire branch here
 			return ExpressionRewriter::ConstantOrNull(
-			    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
+			    GetContext(), std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]),
+			    Value::BOOLEAN(false));
 		}
 		outer_constant.GetValueMutable() = std::move(*result_value);
 	} else if (op_type == "-") {
@@ -107,7 +108,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 					return nullptr;
 				}
 				return ExpressionRewriter::ConstantOrNull(
-				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
+				    GetContext(), std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]),
+				    Value::BOOLEAN(false));
 			}
 			outer_constant.GetValueMutable() = std::move(*result_value);
 		} else {
@@ -123,7 +125,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 					return nullptr;
 				}
 				return ExpressionRewriter::ConstantOrNull(
-				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(false));
+				    GetContext(), std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]),
+				    Value::BOOLEAN(false));
 			}
 			outer_constant.GetValueMutable() = std::move(*result_value);
 			// in this case, we should also flip the comparison
@@ -152,7 +155,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 				// the result will be either FALSE or NULL (if COMPARE_EQUAL)
 				// or TRUE or NULL (if COMPARE_NOTEQUAL)
 				return ExpressionRewriter::ConstantOrNull(
-				    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(is_inequality));
+				    GetContext(), std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]),
+				    Value::BOOLEAN(is_inequality));
 			} else {
 				// not cleanly divisible and we are doing > >= < <=, skip the simplification for now
 				return nullptr;
@@ -169,7 +173,8 @@ unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<refe
 				return nullptr;
 			}
 			return ExpressionRewriter::ConstantOrNull(
-			    std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]), Value::BOOLEAN(comparison_result));
+			    GetContext(), std::move(arithmetic.GetChildrenMutable()[arithmetic_child_index]),
+			    Value::BOOLEAN(comparison_result));
 		}
 		if (inner_value < 0) {
 			// multiply by negative value, need to flip expression
@@ -339,7 +344,7 @@ unique_ptr<Expression> MoveUnaryMinusRule::Apply(LogicalOperator &op, vector<ref
 			if (!TryOutOfRangeComparisonResult(comparison.GetExpressionType(), comparison_result)) {
 				return nullptr;
 			}
-			return ExpressionRewriter::ConstantOrNull(std::move(negation.GetChildrenMutable()[0]),
+			return ExpressionRewriter::ConstantOrNull(GetContext(), std::move(negation.GetChildrenMutable()[0]),
 			                                          Value::BOOLEAN(comparison_result));
 		}
 		outer_constant.GetValueMutable() = std::move(*result_value);

--- a/src/optimizer/rule/regex_optimizations.cpp
+++ b/src/optimizer/rule/regex_optimizations.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
@@ -200,7 +201,7 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 		}
 
 		auto parameter = make_uniq<BoundConstantExpression>(Value(std::move(escaped_like_string.like_string)));
-		auto contains = GetStringContains().Bind(GetContext(), std::move(root.GetChildrenMutable()));
+		auto contains = BindBuiltinScalarFunction(GetContext(), "contains", std::move(root.GetChildrenMutable()));
 
 		contains->GetChildrenMutable()[1] = std::move(parameter);
 
@@ -221,7 +222,7 @@ unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<
 		D_ASSERT(root.GetChildrenMutable().size() == 2);
 	}
 
-	auto like_expression = LikeFun::GetFunction().Bind(GetContext(), std::move(root.GetChildrenMutable()));
+	auto like_expression = BindBuiltinScalarFunction(GetContext(), LikeFun::Name, std::move(root.GetChildrenMutable()));
 
 	// Clear the bind info, as the LikeFun bind info is not valid for this new expression.
 	like_expression->BindInfoMutable().reset();

--- a/src/optimizer/rule/string_prefix.cpp
+++ b/src/optimizer/rule/string_prefix.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/limits.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/expression_rewriter.hpp"
 #include "duckdb/optimizer/matcher/expression_matcher.hpp"
 #include "duckdb/optimizer/matcher/type_matcher_id.hpp"
@@ -151,7 +152,7 @@ unique_ptr<Expression> StringPrefixRule::Apply(LogicalOperator &op, vector<refer
 
 	// The constant is longer than the extracted prefix, so the comparison can only be FALSE
 	if (constant_length > num_characters) {
-		return ExpressionRewriter::ConstantOrNull(std::move(children[0]), Value::BOOLEAN(false));
+		return ExpressionRewriter::ConstantOrNull(GetContext(), std::move(children[0]), Value::BOOLEAN(false));
 	}
 
 	// A prefix extraction can only return fewer than n characters if it returns the entire string.
@@ -163,8 +164,7 @@ unique_ptr<Expression> StringPrefixRule::Apply(LogicalOperator &op, vector<refer
 	vector<unique_ptr<Expression>> prefix_children;
 	prefix_children.emplace_back(std::move(children[0]));
 	prefix_children.emplace_back(make_uniq<BoundConstantExpression>(constant.GetValue()));
-	auto prefix_expr = PrefixFun::GetFunction().Bind(GetContext(), std::move(prefix_children));
-	return std::move(prefix_expr);
+	return BindBuiltinScalarFunction(GetContext(), PrefixFun::Name, std::move(prefix_children));
 }
 
 unique_ptr<Expression> InstrPrefixRule::Apply(LogicalOperator &op, vector<reference<Expression>> &bindings,
@@ -183,7 +183,7 @@ unique_ptr<Expression> InstrPrefixRule::Apply(LogicalOperator &op, vector<refere
 	vector<unique_ptr<Expression>> prefix_children;
 	prefix_children.emplace_back(std::move(children[0]));
 	prefix_children.emplace_back(make_uniq<BoundConstantExpression>(needle.GetValue()));
-	return PrefixFun::GetFunction().Bind(GetContext(), std::move(prefix_children));
+	return BindBuiltinScalarFunction(GetContext(), PrefixFun::Name, std::move(prefix_children));
 }
 
 } // namespace duckdb

--- a/src/optimizer/statistics/expression/propagate_between.cpp
+++ b/src/optimizer/statistics/expression/propagate_between.cpp
@@ -48,7 +48,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateBetween(BoundFunctionE
 			vector<unique_ptr<Expression>> children;
 			children.push_back(std::move(input));
 			children.push_back(std::move(false_bound));
-			expr_ptr = ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(false));
+			expr_ptr = ExpressionRewriter::ConstantOrNull(context, std::move(children), Value::BOOLEAN(false));
 		}
 	} else if (lower_prune == FilterPropagateResult::FILTER_TRUE_OR_NULL &&
 	           upper_prune == FilterPropagateResult::FILTER_TRUE_OR_NULL) {
@@ -57,7 +57,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateBetween(BoundFunctionE
 		children.push_back(std::move(input));
 		children.push_back(std::move(lower_bound));
 		children.push_back(std::move(upper_bound));
-		expr_ptr = ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(true));
+		expr_ptr = ExpressionRewriter::ConstantOrNull(context, std::move(children), Value::BOOLEAN(true));
 	} else if (lower_prune == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
 		// lower filter is always true: replace with upper comparison
 		expr_ptr = BoundComparisonExpression::Create(upper_comparison, std::move(input), std::move(upper_bound));

--- a/src/optimizer/statistics/expression/propagate_comparison.cpp
+++ b/src/optimizer/statistics/expression/propagate_comparison.cpp
@@ -168,14 +168,14 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateComparison(BoundFuncti
 		vector<unique_ptr<Expression>> children;
 		children.push_back(std::move(left));
 		children.push_back(std::move(right));
-		expr_ptr = ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(true));
+		expr_ptr = ExpressionRewriter::ConstantOrNull(context, std::move(children), Value::BOOLEAN(true));
 		return nullptr;
 	}
 	case FilterPropagateResult::FILTER_FALSE_OR_NULL: {
 		vector<unique_ptr<Expression>> children;
 		children.push_back(std::move(left));
 		children.push_back(std::move(right));
-		expr_ptr = ExpressionRewriter::ConstantOrNull(std::move(children), Value::BOOLEAN(false));
+		expr_ptr = ExpressionRewriter::ConstantOrNull(context, std::move(children), Value::BOOLEAN(false));
 		return nullptr;
 	}
 	default:

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -1,12 +1,11 @@
 #include "duckdb/optimizer/topn_window_elimination.hpp"
 
-#include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
-#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/optimizer/builtin_function_lookup.hpp"
 #include "duckdb/optimizer/late_materialization_helper.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression_nullability.hpp"
@@ -331,7 +330,6 @@ unique_ptr<Expression>
 TopNWindowElimination::CreateAggregateExpression(vector<unique_ptr<Expression>> aggregate_params,
                                                  const bool requires_arg,
                                                  const TopNWindowEliminationParameters &params) const {
-	auto &catalog = Catalog::GetSystemCatalog(context);
 	FunctionBinder function_binder(context);
 
 	// If the value column can be null, we must use the nulls_last function to follow null ordering semantics
@@ -346,10 +344,8 @@ TopNWindowElimination::CreateAggregateExpression(vector<unique_ptr<Expression>> 
 	fun_name += params.order_type == OrderType::ASCENDING ? "min" : "max";
 	fun_name += params.can_be_null && (requires_arg || change_to_arg) ? "_nulls_last" : "";
 
-	auto &fun_entry = catalog.GetEntry<AggregateFunctionCatalogEntry>(
-	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), Identifier(fun_name)));
-	const auto &fun = fun_entry.functions.GetFunctionByArguments(context, ExtractReturnTypes(aggregate_params));
-	return function_binder.BindAggregateFunction(fun, std::move(aggregate_params));
+	auto fun = GetBuiltinAggregateFunction(context, Identifier(fun_name), ExtractReturnTypes(aggregate_params));
+	return function_binder.BindAggregateFunction(std::move(fun), std::move(aggregate_params));
 }
 
 unique_ptr<LogicalOperator>
@@ -366,14 +362,7 @@ TopNWindowElimination::CreateAggregateOperator(LogicalWindow &window, vector<uni
 		aggregate_params.push_back(std::move(args[0]));
 	} else if (args.size() > 1) {
 		// For more than one arg, we must use struct pack
-		auto &catalog = Catalog::GetSystemCatalog(context);
-		FunctionBinder function_binder(context);
-		auto &struct_pack_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
-		    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "struct_pack"));
-		const auto &struct_pack_fun =
-		    struct_pack_entry.functions.GetFunctionByArguments(context, ExtractReturnTypes(args));
-		auto struct_pack_expr = function_binder.BindScalarFunction(struct_pack_fun, std::move(args));
-		aggregate_params.push_back(std::move(struct_pack_expr));
+		aggregate_params.push_back(BindBuiltinScalarFunction(context, "struct_pack", std::move(args)));
 	}
 
 	aggregate_params.push_back(std::move(window_expr.OrderByMutable()[0].expression));
@@ -415,32 +404,18 @@ TopNWindowElimination::CreateAggregateOperator(LogicalWindow &window, vector<uni
 unique_ptr<Expression>
 TopNWindowElimination::CreateRowNumberGenerator(unique_ptr<Expression> aggregate_column_ref) const {
 	// Create unnest(generate_series(1, array_length(column_ref, 1))) function to generate row ids
-	FunctionBinder function_binder(context);
-	auto &catalog = Catalog::GetSystemCatalog(context);
-
 	// array_length
-	auto &array_length_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
-	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "array_length"));
 	vector<unique_ptr<Expression>> array_length_exprs;
 	array_length_exprs.push_back(std::move(aggregate_column_ref));
 	array_length_exprs.push_back(make_uniq<BoundConstantExpression>(1));
-
-	const auto &array_length_fun = array_length_entry.functions.GetFunctionByArguments(
-	    context, {array_length_exprs[0]->GetReturnType(), array_length_exprs[1]->GetReturnType()});
-	auto bound_array_length_fun = function_binder.BindScalarFunction(array_length_fun, std::move(array_length_exprs));
+	auto bound_array_length_fun = BindBuiltinScalarFunction(context, "array_length", std::move(array_length_exprs));
 
 	// generate_series
-	auto &generate_series_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
-	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "generate_series"));
-
 	vector<unique_ptr<Expression>> generate_series_exprs;
 	generate_series_exprs.push_back(make_uniq<BoundConstantExpression>(1));
 	generate_series_exprs.push_back(std::move(bound_array_length_fun));
-
-	const auto &generate_series_fun = generate_series_entry.functions.GetFunctionByArguments(
-	    context, {generate_series_exprs[0]->GetReturnType(), generate_series_exprs[1]->GetReturnType()});
 	auto bound_generate_series_fun =
-	    function_binder.BindScalarFunction(generate_series_fun, std::move(generate_series_exprs));
+	    BindBuiltinScalarFunction(context, "generate_series", std::move(generate_series_exprs));
 
 	// unnest
 	auto unnest_row_number_expr = make_uniq<BoundUnnestExpression>(LogicalType::BIGINT);
@@ -492,11 +467,8 @@ void TopNWindowElimination::AddStructExtractExprs(
     vector<unique_ptr<Expression>> &exprs, const LogicalType &struct_type,
     const unique_ptr<BoundColumnRefExpression> &aggregate_column_ref) const {
 	FunctionBinder function_binder(context);
-	auto &catalog = Catalog::GetSystemCatalog(context);
-	auto &struct_extract_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(
-	    context, QualifiedName(catalog.GetName(), Identifier::DefaultSchema(), "struct_extract"));
-	const auto &struct_extract_fun =
-	    struct_extract_entry.functions.GetFunctionByArguments(context, {struct_type, LogicalType::VARCHAR});
+	// resolved once - the same overload binds for every field of the struct
+	auto struct_extract_fun = GetBuiltinScalarFunction(context, "struct_extract", {struct_type, LogicalType::VARCHAR});
 
 	const auto &child_types = StructType::GetChildTypes(struct_type);
 	for (idx_t i = 0; i < child_types.size(); i++) {

--- a/test/optimizer/CMakeLists.txt
+++ b/test/optimizer/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library_unity(
   test_optimizer
   OBJECT
   aggregate_rewrite.cpp
+  bound_function_identity.cpp
   build_probe_side_optimizer.cpp
   column_binding_rewrite.cpp
   common_subplan_nonserializable.cpp

--- a/test/optimizer/bound_function_identity.cpp
+++ b/test/optimizer/bound_function_identity.cpp
@@ -7,7 +7,9 @@
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/planner.hpp"
 
 using namespace duckdb;
@@ -53,6 +55,22 @@ void CollectIdentityFunctions(const LogicalOperator &op, vector<BoundFunctionInf
 	    op, [&](const unique_ptr<Expression> *expr) { CollectIdentityFunctions(**expr, result); });
 	for (auto &child : op.children) {
 		CollectIdentityFunctions(*child, result);
+	}
+}
+
+//! The join filter pushdown aggregates hang off the join rather than being plan expressions, so
+//! EnumerateExpressions does not reach them
+void CollectJoinFilterAggregates(const LogicalOperator &op, vector<BoundFunctionInfo> &result) {
+	if (op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = op.Cast<LogicalComparisonJoin>();
+		if (join.filter_pushdown) {
+			for (auto &aggregate : join.filter_pushdown->min_max_aggregates) {
+				CollectIdentityFunctions(*aggregate, result);
+			}
+		}
+	}
+	for (auto &child : op.children) {
+		CollectJoinFilterAggregates(*child, result);
 	}
 }
 
@@ -193,14 +211,17 @@ TEST_CASE("Aggregate rewrites keep the definition of the aggregates they introdu
 TEST_CASE("Column pruning keeps the definition of count_star()", "[optimizer][function_identity]") {
 	DuckDB db(nullptr);
 	Connection con(db);
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE structs AS SELECT i AS id, {'a': i, 'b': i::VARCHAR} AS s "
-	                          "FROM range(100) _(i)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers AS SELECT i::INTEGER AS i FROM range(100) t(i)"));
 
 	con.BeginTransaction();
-	// pushing the referenced fields down through a projection rebuilds them as struct_extract calls, but those
-	// are consumed again by the pushdown, so only the aggregate side is observable in the final plan
-	RequireIdentityFunction(PlanIdentityFunctions(con, "SELECT id % 10, count(*) FROM structs GROUP BY 1"),
-	                        "count_star");
+	// pruning the unreferenced sum leaves an aggregate with no expressions, which the optimizer replaces with a
+	// count_star of its own. The filter keeps the aggregate from being folded away before that happens.
+	auto functions = PlanIdentityFunctions(con, "SELECT 1 FROM (SELECT sum(i) FROM integers WHERE random() > 0.5) t");
+	auto &count_star = RequireIdentityFunction(functions, "count_star");
+	REQUIRE(count_star.is_aggregate);
+	REQUIRE(count_star.return_type == LogicalType::BIGINT);
+	REQUIRE(count_star.arguments.empty());
+	REQUIRE(FindIdentityFunction(functions, "sum").IsValid() == false);
 	con.Rollback();
 }
 
@@ -263,5 +284,23 @@ TEST_CASE("Compressed materialization keeps its internal functions unqualified",
 	REQUIRE(compression_functions > 0);
 	// count_star is introduced by the planner here, and is qualified like any catalog-bound aggregate
 	RequireIdentityFunction(functions, "count_star");
+	con.Rollback();
+}
+
+TEST_CASE("Join filter pushdown keeps the definition of min() and max()", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	// the build side keys are spread out, so the min/max filters cannot be resolved from statistics alone
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE big AS SELECT i::INTEGER AS k FROM range(100000) t(i)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE small AS SELECT (i * 7)::INTEGER AS k FROM range(50) t(i)"));
+
+	con.BeginTransaction();
+	auto plan = OptimizeIdentityQuery(con, "SELECT count(*) FROM big JOIN small USING (k)");
+
+	vector<BoundFunctionInfo> functions;
+	CollectJoinFilterAggregates(*plan, functions);
+	auto &min_function = RequireIdentityFunction(functions, "min");
+	REQUIRE(min_function.is_aggregate);
+	RequireIdentityFunction(functions, "max");
 	con.Rollback();
 }

--- a/test/optimizer/bound_function_identity.cpp
+++ b/test/optimizer/bound_function_identity.cpp
@@ -190,19 +190,17 @@ TEST_CASE("Aggregate rewrites keep the definition of the aggregates they introdu
 	con.Rollback();
 }
 
-TEST_CASE("Column pruning keeps the definition of struct_extract() and count_star()",
-          "[optimizer][function_identity]") {
+TEST_CASE("Column pruning keeps the definition of count_star()", "[optimizer][function_identity]") {
 	DuckDB db(nullptr);
 	Connection con(db);
-	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE structs AS SELECT i AS id, {'a': i, 'b': i::VARCHAR} AS s "
+	                          "FROM range(100) _(i)"));
 
 	con.BeginTransaction();
-	// pulling the field accesses up over the projection reconstructs them as struct_extract calls
-	RequireIdentityFunction(
-	    PlanIdentityFunctions(con, "SELECT p.s.a, p.s.b FROM (SELECT {'a': i, 'b': i::VARCHAR} AS s FROM integers) p "
-	                               "WHERE p.s.a > 0"),
-	    "struct_extract");
-	RequireIdentityFunction(PlanIdentityFunctions(con, "SELECT count(*) FROM integers"), "count_star");
+	// pushing the referenced fields down through a projection rebuilds them as struct_extract calls, but those
+	// are consumed again by the pushdown, so only the aggregate side is observable in the final plan
+	RequireIdentityFunction(PlanIdentityFunctions(con, "SELECT id % 10, count(*) FROM structs GROUP BY 1"),
+	                        "count_star");
 	con.Rollback();
 }
 

--- a/test/optimizer/bound_function_identity.cpp
+++ b/test/optimizer/bound_function_identity.cpp
@@ -1,0 +1,269 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/expression/bound_aggregate_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/logical_operator_visitor.hpp"
+#include "duckdb/planner/planner.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+//! One bound function found in an optimized plan
+struct BoundFunctionInfo {
+	Identifier catalog_name;
+	Identifier schema_name;
+	Identifier name;
+	vector<LogicalType> arguments;
+	LogicalType return_type;
+	bool is_aggregate;
+};
+
+unique_ptr<LogicalOperator> OptimizeIdentityQuery(Connection &con, const string &query) {
+	Parser parser(con.context->GetParserOptions());
+	parser.ParseQuery(query);
+	REQUIRE(parser.statements.size() == 1);
+	Planner planner(*con.context);
+	planner.CreatePlan(std::move(parser.statements[0]));
+	Optimizer optimizer(*planner.binder, *con.context);
+	return optimizer.Optimize(std::move(planner.plan));
+}
+
+void CollectIdentityFunctions(const Expression &expr, vector<BoundFunctionInfo> &result) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+		auto &fun = expr.Cast<BoundFunctionExpression>().Function();
+		result.push_back(
+		    {fun.GetCatalogName(), fun.GetSchemaName(), fun.GetName(), fun.GetArguments(), fun.GetReturnType(), false});
+	} else if (expr.GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE) {
+		auto &fun = expr.Cast<BoundAggregateExpression>().Function();
+		result.push_back(
+		    {fun.GetCatalogName(), fun.GetSchemaName(), fun.GetName(), fun.GetArguments(), fun.GetReturnType(), true});
+	}
+	ExpressionIterator::EnumerateChildren(expr,
+	                                      [&](const Expression &child) { CollectIdentityFunctions(child, result); });
+}
+
+void CollectIdentityFunctions(const LogicalOperator &op, vector<BoundFunctionInfo> &result) {
+	LogicalOperatorVisitor::EnumerateExpressions(
+	    op, [&](const unique_ptr<Expression> *expr) { CollectIdentityFunctions(**expr, result); });
+	for (auto &child : op.children) {
+		CollectIdentityFunctions(*child, result);
+	}
+}
+
+vector<BoundFunctionInfo> PlanIdentityFunctions(Connection &con, const string &query) {
+	vector<BoundFunctionInfo> result;
+	auto plan = OptimizeIdentityQuery(con, query);
+	CollectIdentityFunctions(*plan, result);
+	return result;
+}
+
+//! Compressed materialization functions are registered so that plans containing them can be (de)serialized, but
+//! their bind throws - they are constructed directly, and so carry no qualification.
+bool IsInternalCompressionFunction(const Identifier &name) {
+	return StringUtil::StartsWith(name.GetIdentifierName(), "__internal_compress_") ||
+	       StringUtil::StartsWith(name.GetIdentifierName(), "__internal_decompress_");
+}
+
+optional_idx FindIdentityFunction(const vector<BoundFunctionInfo> &functions, const Identifier &name) {
+	for (idx_t i = 0; i < functions.size(); i++) {
+		if (functions[i].name == name) {
+			return i;
+		}
+	}
+	return optional_idx();
+}
+
+//! Assert that the named function was introduced, and that every instance of it kept the catalog and schema name
+//! of its definition - the same qualification the binder gives the function when it is written in SQL
+const BoundFunctionInfo &RequireIdentityFunction(const vector<BoundFunctionInfo> &functions, const Identifier &name) {
+	auto index = FindIdentityFunction(functions, name);
+	INFO("expected function " << name.GetIdentifierName() << " in the optimized plan");
+	REQUIRE(index.IsValid());
+	for (auto &fun : functions) {
+		if (fun.name != name) {
+			continue;
+		}
+		REQUIRE(fun.catalog_name == Identifier::SystemCatalog());
+		REQUIRE(fun.schema_name == Identifier::DefaultSchema());
+	}
+	return functions[index.GetIndex()];
+}
+
+} // namespace
+
+TEST_CASE("LIKE rewrites keep the definition of the built-in they introduce", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE strings(s VARCHAR)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO strings VALUES ('abc'), ('cab'), (NULL)"));
+
+	con.BeginTransaction();
+	for (auto &entry : vector<pair<string, string>> {{"SELECT s LIKE 'abc%' FROM strings", "prefix"},
+	                                                 {"SELECT s LIKE '%abc' FROM strings", "suffix"},
+	                                                 {"SELECT s LIKE '%abc%' FROM strings", "contains"},
+	                                                 {"SELECT s NOT LIKE 'abc%' FROM strings", "prefix"},
+	                                                 {"SELECT s GLOB 'abc*' FROM strings", "prefix"}}) {
+		INFO(entry.first);
+		auto functions = PlanIdentityFunctions(con, entry.first);
+		auto &fun = RequireIdentityFunction(functions, Identifier(entry.second));
+		REQUIRE(fun.arguments == vector<LogicalType> {LogicalType::VARCHAR, LogicalType::VARCHAR});
+		REQUIRE(fun.return_type == LogicalType::BOOLEAN);
+		REQUIRE(!fun.is_aggregate);
+	}
+	con.Rollback();
+}
+
+TEST_CASE("Regex rewrites keep the definition of the built-in they introduce", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE strings(s VARCHAR)"));
+
+	con.BeginTransaction();
+	// a literal regex becomes contains()
+	RequireIdentityFunction(PlanIdentityFunctions(con, "SELECT regexp_matches(s, 'abc') FROM strings"), "contains");
+	// an anchored regex becomes a LIKE, which the LIKE rule then turns into prefix()
+	RequireIdentityFunction(PlanIdentityFunctions(con, "SELECT regexp_matches(s, '^abc') FROM strings"), "prefix");
+	con.Rollback();
+}
+
+TEST_CASE("String prefix rewrites keep the definition of prefix()", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE strings(s VARCHAR)"));
+
+	con.BeginTransaction();
+	RequireIdentityFunction(PlanIdentityFunctions(con, "SELECT left(s, 3) = 'abc' FROM strings"), "prefix");
+	RequireIdentityFunction(PlanIdentityFunctions(con, "SELECT instr(s, 'abc') = 1 FROM strings"), "prefix");
+	con.Rollback();
+}
+
+TEST_CASE("Optimizer-introduced constant_or_null keeps its definition", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+
+	con.BeginTransaction();
+	auto functions = PlanIdentityFunctions(con, "SELECT i * 0 FROM integers");
+	auto &fun = RequireIdentityFunction(functions, "constant_or_null");
+	// the bind derives the return type from the leading constant
+	REQUIRE(fun.return_type == LogicalType::INTEGER);
+	REQUIRE(fun.arguments.size() == 2);
+	con.Rollback();
+}
+
+TEST_CASE("Aggregate rewrites keep the definition of the aggregates they introduce", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(g INTEGER, i INTEGER)"));
+	// a NULL keeps the count over i from being turned into a count_star by statistics propagation
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (1, 1), (1, NULL), (2, 3)"));
+
+	con.BeginTransaction();
+	// avg(x) is rewritten into sum(x) / count(x)
+	{
+		auto functions = PlanIdentityFunctions(con, "SELECT g, avg(i) FROM integers GROUP BY g");
+		auto &count = RequireIdentityFunction(functions, "count");
+		REQUIRE(count.is_aggregate);
+		REQUIRE(count.return_type == LogicalType::BIGINT);
+		REQUIRE(FindIdentityFunction(functions, "avg").IsValid() == false);
+		// statistics propagation may swap sum for its no-overflow implementation
+		REQUIRE((FindIdentityFunction(functions, "sum").IsValid() ||
+		         FindIdentityFunction(functions, "sum_no_overflow").IsValid()));
+	}
+	// over a column without NULLs, statistics propagation turns the introduced count into a count_star
+	{
+		auto functions = PlanIdentityFunctions(con, "SELECT g, avg(g) FROM integers GROUP BY g");
+		REQUIRE(FindIdentityFunction(functions, "count_star").IsValid());
+	}
+	// ROLLUP is cascaded through exported aggregate states combined by combine_aggr()
+	{
+		auto functions = PlanIdentityFunctions(con, "SELECT g, i, sum(i) FROM integers GROUP BY ROLLUP(g, i)");
+		auto &combine = RequireIdentityFunction(functions, "combine_aggr");
+		REQUIRE(combine.is_aggregate);
+	}
+	con.Rollback();
+}
+
+TEST_CASE("Column pruning keeps the definition of struct_extract() and count_star()",
+          "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+
+	con.BeginTransaction();
+	// pulling the field accesses up over the projection reconstructs them as struct_extract calls
+	RequireIdentityFunction(
+	    PlanIdentityFunctions(con, "SELECT p.s.a, p.s.b FROM (SELECT {'a': i, 'b': i::VARCHAR} AS s FROM integers) p "
+	                               "WHERE p.s.a > 0"),
+	    "struct_extract");
+	RequireIdentityFunction(PlanIdentityFunctions(con, "SELECT count(*) FROM integers"), "count_star");
+	con.Rollback();
+}
+
+TEST_CASE("Aggregate reuse keeps the definition of combine_aggr()", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE reuse_dim(id INTEGER, label VARCHAR)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO reuse_dim VALUES (10, 'x'), (20, 'b'), (30, 'x'), (40, 'd')"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE reuse_owner(k INTEGER, dim_id INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO reuse_owner VALUES (1, 10), (2, 20), (3, 30), (4, 40)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE reuse_fact(k INTEGER, v INTEGER, w INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query(
+	    "INSERT INTO reuse_fact VALUES (1, 10, 1), (1, 20, 2), (2, 5, 3), (3, 40, 4), (3, 50, 5), (4, NULL, 6)"));
+
+	con.BeginTransaction();
+	auto functions = PlanIdentityFunctions(con, "SELECT o.k, d.label, sum(f.v) "
+	                                            "FROM reuse_owner o JOIN reuse_dim d ON o.dim_id = d.id "
+	                                            "JOIN reuse_fact f USING (k) "
+	                                            "WHERE o.k IN (SELECT k FROM reuse_fact GROUP BY k HAVING sum(v) > 25) "
+	                                            "GROUP BY o.k, d.label");
+	RequireIdentityFunction(functions, "combine_aggr");
+	con.Rollback();
+}
+
+TEST_CASE("Partial aggregate pushdown keeps the definition of combine_aggr()", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE fact AS SELECT i % 1000 AS dim_key, (i * 17) % 100 AS measure "
+	                          "FROM range(100000) _(i)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE dim AS SELECT i AS dim_key, (i % 7) AS d_a, (i % 11) AS d_b, "
+	                          "(i % 13) AS d_c, (i % 17) AS d_d FROM range(1000) _(i)"));
+	REQUIRE_NO_FAIL(con.Query("ANALYZE"));
+
+	con.BeginTransaction();
+	auto functions = PlanIdentityFunctions(con, "SELECT d_a, d_b, d_c, d_d, sum(measure) AS s "
+	                                            "FROM fact JOIN dim USING (dim_key) GROUP BY d_a, d_b, d_c, d_d");
+	RequireIdentityFunction(functions, "combine_aggr");
+	con.Rollback();
+}
+
+TEST_CASE("Compressed materialization keeps its internal functions unqualified", "[optimizer][function_identity]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE cm AS SELECT (i % 100) + 1000 AS a, (i % 7)::VARCHAR AS b "
+	                          "FROM range(10000) _(i)"));
+	REQUIRE_NO_FAIL(con.Query("ANALYZE"));
+
+	con.BeginTransaction();
+	auto functions = PlanIdentityFunctions(con, "SELECT a, b, count(*) FROM cm GROUP BY a, b");
+	idx_t compression_functions = 0;
+	for (auto &fun : functions) {
+		if (!IsInternalCompressionFunction(fun.name)) {
+			continue;
+		}
+		compression_functions++;
+		// these are not bindable through the catalog, so they stay unqualified
+		REQUIRE(fun.catalog_name.empty());
+		REQUIRE(fun.schema_name.empty());
+	}
+	REQUIRE(compression_functions > 0);
+	// count_star is introduced by the planner here, and is qualified like any catalog-bound aggregate
+	RequireIdentityFunction(functions, "count_star");
+	con.Rollback();
+}

--- a/test/optimizer/catalog_function_binding.test
+++ b/test/optimizer/catalog_function_binding.test
@@ -197,3 +197,65 @@ physical_plan	<REGEX>:.*prefix\(s, 'abc'\).*
 
 statement ok
 DROP MACRO prefix
+
+# the rewrites only ever look in the system catalog, so they never trigger extension loading
+
+statement ok
+SET autoinstall_known_extensions = false
+
+statement ok
+SET autoload_known_extensions = false
+
+query I
+SELECT count(*) FROM duckdb_extensions() WHERE loaded AND extension_name = 'icu'
+----
+0
+
+query I
+SELECT s LIKE 'abc%' FROM strings ORDER BY ALL
+----
+0
+1
+NULL
+
+query I
+SELECT s LIKE '%b%' FROM strings ORDER BY ALL
+----
+1
+1
+NULL
+
+query I
+SELECT i * 0 FROM integers ORDER BY ALL
+----
+0
+0
+0
+NULL
+
+query II
+SELECT g, avg(i) FROM integers GROUP BY g ORDER BY ALL
+----
+1	1.0
+2	3.0
+
+query III
+SELECT g, i, sum(i) FROM integers GROUP BY ROLLUP(g, i) ORDER BY ALL
+----
+1	1	1
+1	NULL	1
+1	NULL	NULL
+2	3	6
+2	NULL	6
+NULL	NULL	7
+
+query I
+SELECT count(*) FROM duckdb_extensions() WHERE loaded AND extension_name = 'icu'
+----
+0
+
+statement ok
+RESET autoload_known_extensions
+
+statement ok
+RESET autoinstall_known_extensions

--- a/test/optimizer/catalog_function_binding.test
+++ b/test/optimizer/catalog_function_binding.test
@@ -253,8 +253,14 @@ SELECT avg(i) FROM integers WHERE i IS NULL
 ----
 NULL
 
-# pruning every aggregate expression makes the optimizer push a count_star of its own
+# pruning the unreferenced sum leaves an aggregate with no expressions, and the optimizer replaces it
+# with a count_star of its own - the filter keeps it from being folded away first
 query I
-SELECT 1 FROM (SELECT sum(i) FROM integers) t
+SELECT 1 FROM (SELECT sum(i) FROM integers WHERE random() > 0.5) t
 ----
 1
+
+query II
+EXPLAIN SELECT 1 FROM (SELECT sum(i) FROM integers WHERE random() > 0.5) t
+----
+physical_plan	<REGEX>:.*count_star\(\).*

--- a/test/optimizer/catalog_function_binding.test
+++ b/test/optimizer/catalog_function_binding.test
@@ -1,0 +1,199 @@
+# name: test/optimizer/catalog_function_binding.test
+# description: Optimizer rewrites resolve the built-ins they introduce in the system catalog
+# group: [optimizer]
+
+statement ok
+CREATE TABLE strings(s VARCHAR)
+
+statement ok
+INSERT INTO strings VALUES ('abc'), ('cab'), (NULL)
+
+statement ok
+CREATE TABLE integers(g INTEGER, i INTEGER)
+
+statement ok
+INSERT INTO integers VALUES (1, 1), (1, NULL), (2, 3), (2, 3)
+
+# baseline results, before anything shadows the built-ins
+query I
+SELECT s LIKE 'abc%' FROM strings ORDER BY ALL
+----
+0
+1
+NULL
+
+query I
+SELECT s LIKE '%abc' FROM strings ORDER BY ALL
+----
+0
+1
+NULL
+
+query I
+SELECT s LIKE '%b%' FROM strings ORDER BY ALL
+----
+1
+1
+NULL
+
+# a shadowing macro in another schema on the search path must not be picked up
+
+statement ok
+CREATE SCHEMA shadow
+
+statement ok
+CREATE MACRO shadow.prefix(a, b) AS false
+
+statement ok
+CREATE MACRO shadow.suffix(a, b) AS false
+
+statement ok
+CREATE MACRO shadow.contains(a, b) AS false
+
+statement ok
+CREATE MACRO shadow.constant_or_null(a, b) AS false
+
+statement ok
+CREATE MACRO shadow.count_star() AS 0
+
+statement ok
+CREATE MACRO shadow.combine_aggr(a) AS false
+
+statement ok
+SET search_path = 'shadow,main'
+
+query I
+SELECT s LIKE 'abc%' FROM strings ORDER BY ALL
+----
+0
+1
+NULL
+
+query I
+SELECT s LIKE '%abc' FROM strings ORDER BY ALL
+----
+0
+1
+NULL
+
+query I
+SELECT s LIKE '%b%' FROM strings ORDER BY ALL
+----
+1
+1
+NULL
+
+# the rewrite still fires, and still introduces the built-in
+query II
+EXPLAIN SELECT s LIKE 'abc%' FROM strings
+----
+physical_plan	<REGEX>:.*prefix\(s, 'abc'\).*
+
+query II
+EXPLAIN SELECT s LIKE '%abc' FROM strings
+----
+physical_plan	<REGEX>:.*suffix\(s, 'abc'\).*
+
+query II
+EXPLAIN SELECT s LIKE '%b%' FROM strings
+----
+physical_plan	<REGEX>:.*contains\(s, 'b'\).*
+
+# left(s, n) = constant rewrites to prefix() as well
+query II
+EXPLAIN SELECT left(s, 3) = 'abc' FROM strings
+----
+physical_plan	<REGEX>:.*prefix\(.*
+
+# x * 0 rewrites to constant_or_null(0, x)
+query I
+SELECT i * 0 FROM integers ORDER BY ALL
+----
+0
+0
+0
+NULL
+
+query II
+EXPLAIN SELECT i * 0 FROM integers
+----
+physical_plan	<REGEX>:.*constant_or_null\(0, i\).*
+
+# avg is decomposed into a sum and a count
+query II
+SELECT g, avg(i) FROM integers GROUP BY g ORDER BY ALL
+----
+1	1.0
+2	3.0
+
+# ROLLUP cascades through exported aggregate states combined by combine_aggr.
+# The oracle is the same query with the rewrite disabled.
+statement ok
+SET disabled_optimizers = 'grouping_sets'
+
+query III nosort rollup_result
+SELECT g, i, sum(i) FROM integers GROUP BY ROLLUP(g, i) ORDER BY ALL
+----
+
+statement ok
+RESET disabled_optimizers
+
+query III nosort rollup_result
+SELECT g, i, sum(i) FROM integers GROUP BY ROLLUP(g, i) ORDER BY ALL
+----
+
+query III
+SELECT g, i, sum(i) FROM integers GROUP BY ROLLUP(g, i) ORDER BY ALL
+----
+1	1	1
+1	NULL	1
+1	NULL	NULL
+2	3	6
+2	NULL	6
+NULL	NULL	7
+
+query II
+EXPLAIN SELECT g, i, sum(i) FROM integers GROUP BY ROLLUP(g, i)
+----
+physical_plan	<REGEX>:.*combine_aggr.*
+
+# aggregate modifiers keep working over the rewritten aggregates
+query III
+SELECT g, avg(DISTINCT i), avg(i) FILTER (WHERE i > 1) FROM integers GROUP BY g ORDER BY ALL
+----
+1	1.0	NULL
+2	3.0	3.0
+
+query I
+SELECT avg(i) FROM integers WHERE i IS NULL
+----
+NULL
+
+# pruning every aggregate expression makes the optimizer push a count_star of its own
+query I
+SELECT 1 FROM (SELECT sum(i) FROM integers) t
+----
+1
+
+statement ok
+RESET search_path
+
+# a macro shadowing the built-in in the default schema is not picked up either
+
+statement ok
+CREATE MACRO prefix(a, b) AS false
+
+query I
+SELECT s LIKE 'abc%' FROM strings ORDER BY ALL
+----
+0
+1
+NULL
+
+query II
+EXPLAIN SELECT s LIKE 'abc%' FROM strings
+----
+physical_plan	<REGEX>:.*prefix\(s, 'abc'\).*
+
+statement ok
+DROP MACRO prefix

--- a/test/optimizer/catalog_function_binding.test
+++ b/test/optimizer/catalog_function_binding.test
@@ -36,7 +36,91 @@ SELECT s LIKE '%b%' FROM strings ORDER BY ALL
 1
 NULL
 
-# a shadowing macro in another schema on the search path must not be picked up
+# a macro shadowing the built-in in the default schema is not picked up either
+
+statement ok
+CREATE MACRO prefix(a, b) AS false
+
+query I
+SELECT s LIKE 'abc%' FROM strings ORDER BY ALL
+----
+0
+1
+NULL
+
+query II
+EXPLAIN SELECT s LIKE 'abc%' FROM strings
+----
+physical_plan	<REGEX>:.*prefix\(s, 'abc'\).*
+
+statement ok
+DROP MACRO prefix
+
+# the rewrites only ever look in the system catalog, so they never trigger extension loading
+
+statement ok
+SET autoinstall_known_extensions = false
+
+statement ok
+SET autoload_known_extensions = false
+
+query I
+SELECT count(*) FROM duckdb_extensions() WHERE loaded AND extension_name = 'icu'
+----
+0
+
+query I
+SELECT s LIKE 'abc%' FROM strings ORDER BY ALL
+----
+0
+1
+NULL
+
+query I
+SELECT s LIKE '%b%' FROM strings ORDER BY ALL
+----
+1
+1
+NULL
+
+query I
+SELECT i * 0 FROM integers ORDER BY ALL
+----
+0
+0
+0
+NULL
+
+query II
+SELECT g, avg(i) FROM integers GROUP BY g ORDER BY ALL
+----
+1	1.0
+2	3.0
+
+query III
+SELECT g, i, sum(i) FROM integers GROUP BY ROLLUP(g, i) ORDER BY ALL
+----
+1	1	1
+1	NULL	1
+1	NULL	NULL
+2	3	6
+2	NULL	6
+NULL	NULL	7
+
+query I
+SELECT count(*) FROM duckdb_extensions() WHERE loaded AND extension_name = 'icu'
+----
+0
+
+statement ok
+RESET autoload_known_extensions
+
+statement ok
+RESET autoinstall_known_extensions
+
+# a shadowing macro in another schema on the search path must not be picked up.
+# This section stays last and never resets the search path: a test config may point the default
+# catalog somewhere else with USE, and RESET would drop that along with the schema.
 
 statement ok
 CREATE SCHEMA shadow
@@ -174,88 +258,3 @@ query I
 SELECT 1 FROM (SELECT sum(i) FROM integers) t
 ----
 1
-
-statement ok
-RESET search_path
-
-# a macro shadowing the built-in in the default schema is not picked up either
-
-statement ok
-CREATE MACRO prefix(a, b) AS false
-
-query I
-SELECT s LIKE 'abc%' FROM strings ORDER BY ALL
-----
-0
-1
-NULL
-
-query II
-EXPLAIN SELECT s LIKE 'abc%' FROM strings
-----
-physical_plan	<REGEX>:.*prefix\(s, 'abc'\).*
-
-statement ok
-DROP MACRO prefix
-
-# the rewrites only ever look in the system catalog, so they never trigger extension loading
-
-statement ok
-SET autoinstall_known_extensions = false
-
-statement ok
-SET autoload_known_extensions = false
-
-query I
-SELECT count(*) FROM duckdb_extensions() WHERE loaded AND extension_name = 'icu'
-----
-0
-
-query I
-SELECT s LIKE 'abc%' FROM strings ORDER BY ALL
-----
-0
-1
-NULL
-
-query I
-SELECT s LIKE '%b%' FROM strings ORDER BY ALL
-----
-1
-1
-NULL
-
-query I
-SELECT i * 0 FROM integers ORDER BY ALL
-----
-0
-0
-0
-NULL
-
-query II
-SELECT g, avg(i) FROM integers GROUP BY g ORDER BY ALL
-----
-1	1.0
-2	3.0
-
-query III
-SELECT g, i, sum(i) FROM integers GROUP BY ROLLUP(g, i) ORDER BY ALL
-----
-1	1	1
-1	NULL	1
-1	NULL	NULL
-2	3	6
-2	NULL	6
-NULL	NULL	7
-
-query I
-SELECT count(*) FROM duckdb_extensions() WHERE loaded AND extension_name = 'icu'
-----
-0
-
-statement ok
-RESET autoload_known_extensions
-
-statement ok
-RESET autoinstall_known_extensions


### PR DESCRIPTION
I'm following up on [@Maxxen's suggestion in #25260](https://github.com/duckdb/duckdb/pull/25260#discussion_r3914898469) to resolve functions introduced by optimizer rewrites through the catalog. Currently, `s LIKE 'abc%'` and `prefix(s, 'abc')` can produce the same function call with different definition metadata: the explicitly bound call carries its catalog and schema, while the optimizer-generated call comes from `PrefixFun::GetFunction()` and has neither.

The catalog entry sets this qualification on the function definitions in its overload set, and bound functions inherit it from their definition. Several optimizer rewrites bypass that path by binding functions obtained directly from C++ factories. This affects string rewrites, introduced counts and aggregate-state combinations, struct extraction, and the manually constructed `constant_or_null` expressions.

I added shared helpers to resolve scalar and aggregate builtins in `system.main`, select an overload from the argument types, and bind the resulting definition. The fully qualified lookup keeps optimizer-generated calls independent of macros or user-defined functions on the search path. Partial aggregate pushdown also has a lookup variant that returns `nullptr` when no overload matches, preserving its existing fallback behavior.

`ExpressionRewriter::ConstantOrNull` now takes a `ClientContext` and uses the registered function's bind callback to derive the return type and bind data from the leading constant. This replaces the manual construction in the rewriter. The declared parameter types remain `ANY`; the bound return type still comes from the constant.

I kept the internal compression and decompression functions constructed directly. They are registered for serialization, but their bind callback rejects ordinary binding, so they cannot use this path. `variant_comparator`, which has no such restriction, now goes through the catalog.

There is still a separate qualification problem in `BoundAggregateFunction::ReplaceImplementation`: it copies the catalog and schema from the replacement function, which can itself come from a factory. For example, statistics propagation can replace `count` with an unqualified `count_star` even when the original call was bound through the catalog. This PR addresses the optimizer's initial construction of registered builtins; implementation replacement and factory binding elsewhere in the planner and executor remain follow-up work.