### PR TITLE
Prevent out-of-bounds check for empty map in `PIVOT`

### DIFF
--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -348,6 +348,9 @@ bool PEGTransformerFactory::ConstructConstantFromExpression(const ParsedExpressi
 			value = Value::LIST(child_type, values);
 			return true;
 		} else if (function.FunctionName() == "map") {
+			if (function.GetArguments().size() != 2) {
+				return false;
+			}
 			Value keys;
 			if (!ConstructConstantFromExpression(function.GetArguments()[0].GetExpression(), keys)) {
 				return false;

--- a/src/parser/tableref/pivotref.cpp
+++ b/src/parser/tableref/pivotref.cpp
@@ -179,6 +179,9 @@ static bool TryFoldConstantForBackwardsCompatibility(const ParsedExpression &exp
 			value = Value::LIST(child_type, values);
 			return true;
 		} else if (function.FunctionName() == "map") {
+			if (function.GetArguments().size() != 2) {
+				return false;
+			}
 			Value keys;
 			if (!TryFoldConstantForBackwardsCompatibility(function.GetArguments()[0].GetExpression(), keys)) {
 				return false;

--- a/test/sql/pivot/pivot_errors.test
+++ b/test/sql/pivot/pivot_errors.test
@@ -45,4 +45,4 @@ Parser Error
 statement error
 SELECT * FROM (SELECT 1 AS a, 'x' AS b) t PIVOT (sum(a) FOR b IN (CAST(map() AS INTEGER)));
 ----
-Unimplemented type for cast
+Conversion Error: Unimplemented type for cast

--- a/test/sql/pivot/pivot_errors.test
+++ b/test/sql/pivot/pivot_errors.test
@@ -41,3 +41,8 @@ statement error
 FROM tbl PIVOT (c FOR IN enum_val);
 ----
 Parser Error
+
+statement error
+SELECT * FROM (SELECT 1 AS a, 'x' AS b) t PIVOT (sum(a) FOR b IN (CAST(map() AS INTEGER)));
+----
+Unimplemented type for cast


### PR DESCRIPTION
Fix https://github.com/duckdblabs/duckdb-internal/issues/10631

Prevent an out-of-bounds check when `PIVOT IN` contains an empty `map()`