### PR TITLE
Fix correlated HAVING empty input handling

### DIFF
--- a/src/include/duckdb/planner/expression_nullability.hpp
+++ b/src/include/duckdb/planner/expression_nullability.hpp
@@ -12,12 +12,19 @@
 #include "duckdb/common/table_index.hpp"
 #include "duckdb/common/vector.hpp"
 
+#include <functional>
+
 namespace duckdb {
 
 class ClientContext;
+class BoundColumnRefExpression;
 class Expression;
 class LogicalCTE;
 class LogicalOperator;
+
+//! Returns whether an expression becomes NULL when the provided column reference becomes NULL.
+bool ExpressionBecomesNull(const Expression &expr,
+                           const std::function<bool(const BoundColumnRefExpression &)> &column_becomes_null);
 
 //! Conservatively proves that an expression cannot be NULL at a logical operator's output.
 class NotNullExpressionAnalyzer {

--- a/src/optimizer/join_order/join_order_operator.cpp
+++ b/src/optimizer/join_order/join_order_operator.cpp
@@ -1,13 +1,12 @@
 #include "duckdb/optimizer/join_order/join_order_operator.hpp"
 
 #include "duckdb/common/assert.hpp"
-#include "duckdb/function/function.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
-#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/expression_nullability.hpp"
 
 namespace duckdb {
 
@@ -86,29 +85,8 @@ static bool ColumnBecomesNull(const BoundColumnRefExpression &column, const Join
 	return entry != relation_mapping.end() && ContainsRelation(null_relations, entry->second);
 }
 
-static bool ExpressionBecomesNull(const Expression &expression, const JoinRelationSet &null_relations,
-                                  const unordered_map<TableIndex, RelationIndex> &relation_mapping) {
-	if (expression.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
-		return ColumnBecomesNull(expression.Cast<BoundColumnRefExpression>(), null_relations, relation_mapping);
-	}
-	if (expression.GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
-		auto &function = expression.Cast<BoundFunctionExpression>();
-		if (function.Function().GetNullHandling() == FunctionNullHandling::SPECIAL_HANDLING) {
-			return false;
-		}
-	}
-	if (!expression.PropagatesNullValues()) {
-		return false;
-	}
-	bool child_becomes_null = false;
-	ExpressionIterator::EnumerateChildren(expression, [&](const Expression &child) {
-		child_becomes_null |= ExpressionBecomesNull(child, null_relations, relation_mapping);
-	});
-	return child_becomes_null;
-}
-
-static bool ExpressionRejectsNulls(const Expression &expression, const JoinRelationSet &null_relations,
-                                   const unordered_map<TableIndex, RelationIndex> &relation_mapping) {
+static bool ExpressionRejectsNulls(const Expression &expression,
+                                   const std::function<bool(const BoundColumnRefExpression &)> &column_becomes_null) {
 	if (expression.GetExpressionType() == ExpressionType::CONJUNCTION_AND ||
 	    expression.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
 		auto &conjunction = expression.Cast<BoundConjunctionExpression>();
@@ -118,17 +96,16 @@ static bool ExpressionRejectsNulls(const Expression &expression, const JoinRelat
 		auto rejects = expression.GetExpressionType() == ExpressionType::CONJUNCTION_OR;
 		for (auto &child : conjunction.GetChildren()) {
 			if (expression.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
-				rejects |= ExpressionRejectsNulls(*child, null_relations, relation_mapping);
+				rejects |= ExpressionRejectsNulls(*child, column_becomes_null);
 			} else {
-				rejects &= ExpressionRejectsNulls(*child, null_relations, relation_mapping);
+				rejects &= ExpressionRejectsNulls(*child, column_becomes_null);
 			}
 		}
 		return rejects;
 	}
 	if (expression.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
 		auto &op = expression.Cast<BoundOperatorExpression>();
-		return !op.GetChildren().empty() &&
-		       ExpressionBecomesNull(*op.GetChildren()[0], null_relations, relation_mapping);
+		return !op.GetChildren().empty() && ExpressionBecomesNull(*op.GetChildren()[0], column_becomes_null);
 	}
 	if (BoundComparisonExpression::IsComparison(expression)) {
 		if (expression.GetExpressionType() == ExpressionType::COMPARE_DISTINCT_FROM ||
@@ -136,26 +113,29 @@ static bool ExpressionRejectsNulls(const Expression &expression, const JoinRelat
 			return false;
 		}
 		auto &comparison = expression.Cast<BoundFunctionExpression>();
-		return ExpressionBecomesNull(BoundComparisonExpression::Left(comparison), null_relations, relation_mapping) ||
-		       ExpressionBecomesNull(BoundComparisonExpression::Right(comparison), null_relations, relation_mapping);
+		return ExpressionBecomesNull(BoundComparisonExpression::Left(comparison), column_becomes_null) ||
+		       ExpressionBecomesNull(BoundComparisonExpression::Right(comparison), column_becomes_null);
 	}
 	return expression.GetReturnType().id() == LogicalTypeId::BOOLEAN &&
-	       ExpressionBecomesNull(expression, null_relations, relation_mapping);
+	       ExpressionBecomesNull(expression, column_becomes_null);
 }
 
 static bool PredicateRejectsNulls(const vector<JoinCondition> &conditions, const JoinRelationSet &null_relations,
                                   const unordered_map<TableIndex, RelationIndex> &relation_mapping) {
+	auto column_becomes_null = [&](const BoundColumnRefExpression &column) {
+		return ColumnBecomesNull(column, null_relations, relation_mapping);
+	};
 	for (auto &condition : conditions) {
 		if (condition.IsComparison()) {
 			if (condition.GetComparisonType() == ExpressionType::COMPARE_DISTINCT_FROM ||
 			    condition.GetComparisonType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
 				continue;
 			}
-			if (ExpressionBecomesNull(condition.GetLHS(), null_relations, relation_mapping) ||
-			    ExpressionBecomesNull(condition.GetRHS(), null_relations, relation_mapping)) {
+			if (ExpressionBecomesNull(condition.GetLHS(), column_becomes_null) ||
+			    ExpressionBecomesNull(condition.GetRHS(), column_becomes_null)) {
 				return true;
 			}
-		} else if (ExpressionRejectsNulls(condition.GetJoinExpression(), null_relations, relation_mapping)) {
+		} else if (ExpressionRejectsNulls(condition.GetJoinExpression(), column_becomes_null)) {
 			return true;
 		}
 	}

--- a/src/planner/expression_nullability.cpp
+++ b/src/planner/expression_nullability.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/operator/list.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
@@ -12,6 +13,22 @@
 #include <algorithm>
 
 namespace duckdb {
+
+bool ExpressionBecomesNull(const Expression &expr,
+                           const std::function<bool(const BoundColumnRefExpression &)> &column_becomes_null) {
+	if (expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+		auto &column = expr.Cast<BoundColumnRefExpression>();
+		return column_becomes_null(column);
+	}
+	if (!expr.PropagatesNullValues()) {
+		return false;
+	}
+	bool child_becomes_null = false;
+	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+		child_becomes_null |= ExpressionBecomesNull(child, column_becomes_null);
+	});
+	return child_becomes_null;
+}
 
 NotNullExpressionAnalyzer::NotNullExpressionAnalyzer(ClientContext &context_p,
                                                      optional_ptr<LogicalOperator> plan_root_p)

--- a/src/planner/subquery/delim_join_cte_rewriter.cpp
+++ b/src/planner/subquery/delim_join_cte_rewriter.cpp
@@ -179,10 +179,6 @@ static bool ExpressionReferencesChild(Expression &expr, LogicalOperator &child) 
 	return false;
 }
 
-static bool ExpressionNullPropagatesForChild(Expression &expr, LogicalOperator &child) {
-	return ExpressionReferencesChild(expr, child) && expr.PropagatesNullValues();
-}
-
 static bool ExpressionNullRejectsDelimJoinRHS(Expression &expr, LogicalComparisonJoin &delim_join) {
 	auto &rhs = *delim_join.children[1];
 	if (!ExpressionReferencesChild(expr, rhs)) {
@@ -193,9 +189,14 @@ static bool ExpressionNullRejectsDelimJoinRHS(Expression &expr, LogicalCompariso
 	}
 	if (expr.GetExpressionClass() == ExpressionClass::BOUND_OPERATOR &&
 	    expr.GetExpressionType() == ExpressionType::OPERATOR_IS_NOT_NULL) {
+		auto rhs_output = rhs.GetColumnBindings();
+		column_binding_set_t rhs_bindings(rhs_output.begin(), rhs_output.end());
+		auto column_becomes_null = [&](const BoundColumnRefExpression &column) {
+			return column.Depth() == 0 && rhs_bindings.find(column.Binding()) != rhs_bindings.end();
+		};
 		bool null_propagating_child = false;
 		ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) {
-			null_propagating_child = null_propagating_child || ExpressionNullPropagatesForChild(child, rhs);
+			null_propagating_child |= ExpressionBecomesNull(child, column_becomes_null);
 		});
 		return null_propagating_child;
 	}

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -4,6 +4,7 @@
 
 #include "duckdb/common/operator/add.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
 #include "duckdb/function/function_binder.hpp"
@@ -17,6 +18,7 @@
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/list.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/expression_nullability.hpp"
 #include "duckdb/planner/operator/list.hpp"
 #include "duckdb/planner/logical_plan_verifier.hpp"
 #include "duckdb/planner/subquery/rewrite_correlated_expressions.hpp"
@@ -782,11 +784,45 @@ void FlattenDependentJoins::AddCorrelatedFirstAggregates(LogicalAggregate &aggr,
 	}
 }
 
+static bool
+ExpressionCanThrowOnNullInput(ClientContext &context, const Expression &expr,
+                              const std::function<bool(const BoundColumnRefExpression &)> &column_becomes_null) {
+	bool can_throw = false;
+	ExpressionIterator::EnumerateChildren(expr, [&](const Expression &child) {
+		if (can_throw || !child.CanThrow()) {
+			return;
+		}
+		// CanThrow is conservative for foldable children such as implicit constant casts.
+		Value constant_value;
+		if (child.IsConsistent() && child.IsFoldable() &&
+		    ExpressionExecutor::TryEvaluateScalar(context, child, constant_value)) {
+			return;
+		}
+		if (!ExpressionBecomesNull(child, column_becomes_null) ||
+		    ExpressionCanThrowOnNullInput(context, child, column_becomes_null)) {
+			// Independent children are evaluated before the parent can propagate NULL.
+			can_throw = true;
+		}
+	});
+	return can_throw;
+}
+
 FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownProjection(unique_ptr<LogicalOperator> &plan,
                                                                                 bool propagate_null_values,
                                                                                 vector<ColumnBinding> state) {
-	for (auto &expr : plan->expressions) {
-		propagate_null_values &= expr->PropagatesNullValues();
+	if (propagate_null_values) {
+		auto child_output = plan->children[0]->GetColumnBindings();
+		column_binding_set_t child_bindings(child_output.begin(), child_output.end());
+		auto column_becomes_null = [&](const BoundColumnRefExpression &column) {
+			return column.Depth() == 0 && child_bindings.find(column.Binding()) != child_bindings.end();
+		};
+		for (auto &expr : plan->expressions) {
+			if (expr->IsVolatile() || !ExpressionBecomesNull(*expr, column_becomes_null) ||
+			    ExpressionCanThrowOnNullInput(binder.context, *expr, column_becomes_null)) {
+				propagate_null_values = false;
+				break;
+			}
+		}
 	}
 
 	propagate_null_values &= plan->children[0]->type != LogicalOperatorType::LOGICAL_DEPENDENT_JOIN;
@@ -806,7 +842,8 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownAggregate(u
                                                                                vector<ColumnBinding> state) {
 	auto &aggr = plan->Cast<LogicalAggregate>();
 	for (auto &expr : plan->expressions) {
-		propagate_null_values &= expr->PropagatesNullValues();
+		auto &aggr_expr = expr->Cast<BoundAggregateExpression>();
+		propagate_null_values &= !aggr_expr.IsVolatile() && aggr_expr.PropagatesNullValues();
 	}
 	auto result = PushDownChild(plan, propagate_null_values, std::move(state));
 
@@ -835,17 +872,7 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownAggregate(u
 		return result;
 	}
 
-	JoinType join_type = JoinType::INNER;
-	if (any_join || !propagate_null_values) {
-		join_type = JoinType::LEFT;
-	}
-	for (auto &aggr_exp : aggr.expressions) {
-		auto &b_aggr_exp = aggr_exp->Cast<BoundAggregateExpression>();
-		if (!b_aggr_exp.PropagatesNullValues()) {
-			join_type = JoinType::LEFT;
-			break;
-		}
-	}
+	auto join_type = !any_join && propagate_null_values ? JoinType::INNER : JoinType::LEFT;
 
 	unique_ptr<LogicalComparisonJoin> join = make_uniq<LogicalComparisonJoin>(join_type);
 	auto left_index = binder.GenerateTableIndex();
@@ -1458,8 +1485,16 @@ FlattenDependentJoins::PushDownCorrelatedNodeInternal(unique_ptr<LogicalOperator
 		return AttachDomainToIndependentSubtree(plan, propagate_null_values);
 	}
 	switch (plan->type) {
-	case LogicalOperatorType::LOGICAL_UNNEST:
 	case LogicalOperatorType::LOGICAL_FILTER: {
+		for (auto &expr : plan->expressions) {
+			if (expr->IsVolatile() || expr->CanThrow()) {
+				propagate_null_values = false;
+				break;
+			}
+		}
+		return PushDownChild(plan, propagate_null_values, std::move(state));
+	}
+	case LogicalOperatorType::LOGICAL_UNNEST: {
 		return PushDownChild(plan, propagate_null_values, std::move(state));
 	}
 	case LogicalOperatorType::LOGICAL_PROJECTION: {

--- a/test/sql/subquery/scalar/test_correlated_having.test
+++ b/test/sql/subquery/scalar/test_correlated_having.test
@@ -1,0 +1,127 @@
+# name: test/sql/subquery/scalar/test_correlated_having.test
+# description: Test correlated subqueries with HAVING without GROUP BY
+# group: [scalar]
+
+statement ok
+CREATE TABLE outer_values(i INTEGER);
+
+statement ok
+INSERT INTO outer_values VALUES (1), (2);
+
+statement ok
+CREATE TABLE inner_values(i INTEGER);
+
+statement ok
+INSERT INTO inner_values VALUES (1);
+
+query ITITI
+SELECT outer_values.i,
+       EXISTS (SELECT 1 FROM inner_values WHERE inner_values.i = outer_values.i HAVING true),
+       (SELECT 1 FROM inner_values WHERE inner_values.i = outer_values.i HAVING true),
+       EXISTS (SELECT 1 FROM inner_values WHERE inner_values.i = outer_values.i HAVING false),
+       (SELECT 1 FROM inner_values WHERE inner_values.i = outer_values.i HAVING false)
+FROM outer_values
+ORDER BY outer_values.i;
+----
+1	1	1	0	NULL
+2	1	1	0	NULL
+
+query IIIIIT
+SELECT outer_values.i,
+       (SELECT 7 FROM inner_values WHERE inner_values.i = outer_values.i HAVING sum(inner_values.i) IS NULL),
+       (SELECT outer_values.i FROM inner_values WHERE inner_values.i = outer_values.i HAVING true),
+       (SELECT sum(inner_values.i) FROM inner_values WHERE inner_values.i = outer_values.i),
+       (SELECT coalesce(sum(inner_values.i), 42)
+        FROM inner_values WHERE inner_values.i = outer_values.i HAVING true),
+       (SELECT sum(inner_values.i) IS NULL
+        FROM inner_values WHERE inner_values.i = outer_values.i HAVING true)
+FROM outer_values
+ORDER BY outer_values.i;
+----
+1	NULL	1	1	1	0
+2	7	2	NULL	42	1
+
+query ITT
+SELECT outer_values.i,
+       EXISTS (SELECT sum(inner_values.i) FROM inner_values WHERE inner_values.i = outer_values.i HAVING true),
+       1 IN (SELECT sum(inner_values.i) FROM inner_values WHERE inner_values.i = outer_values.i HAVING true)
+FROM outer_values
+ORDER BY outer_values.i;
+----
+1	1	1
+2	1	NULL
+
+query IT
+SELECT outer_values.i,
+       (SELECT random() FROM inner_values WHERE inner_values.i = outer_values.i HAVING true) IS NOT NULL
+FROM outer_values
+ORDER BY outer_values.i;
+----
+1	1
+2	1
+
+statement ok
+CREATE SEQUENCE having_effect_seq START 1;
+
+query II
+SELECT outer_values.i,
+       (SELECT sum(inner_values.i)
+        FROM inner_values
+        WHERE inner_values.i = outer_values.i
+        HAVING nextval('having_effect_seq') > 0)
+FROM outer_values
+ORDER BY outer_values.i;
+----
+1	1
+2	NULL
+
+query I
+SELECT currval('having_effect_seq');
+----
+2
+
+statement error
+SELECT (SELECT sum(inner_values.i) + CAST('invalid' AS INTEGER)
+        FROM inner_values
+        WHERE inner_values.i = outer_values.i)
+FROM outer_values
+WHERE outer_values.i = 2;
+----
+Could not convert string
+
+statement error
+SELECT (SELECT sum(inner_values.i)
+        FROM inner_values
+        WHERE inner_values.i = outer_values.i
+        HAVING CAST('invalid' AS BOOLEAN))
+FROM outer_values
+WHERE outer_values.i = 2;
+----
+Could not convert string
+
+statement ok
+SET disabled_optimizers='deliminator';
+
+statement ok
+SET explain_output='optimized_only';
+
+query II
+EXPLAIN SELECT (SELECT avg(inner_values.i) * 0.2
+                FROM inner_values
+                WHERE inner_values.i = outer_values.i
+                HAVING true)
+FROM outer_values;
+----
+logical_opt	<REGEX>:.*Join Type: INNER.*Conditions: i IS NOT DISTINCT FROM #0.*
+
+query II
+EXPLAIN SELECT (SELECT coalesce(avg(inner_values.i), 0)
+                FROM inner_values
+                WHERE inner_values.i = outer_values.i
+                HAVING true)
+FROM outer_values;
+----
+logical_opt	<REGEX>:.*Join Type: LEFT.*Conditions: i IS NOT DISTINCT FROM #0.*
+
+statement ok
+SET disabled_optimizers='';

--- a/test/sql/subquery/scalar/test_correlated_having.test
+++ b/test/sql/subquery/scalar/test_correlated_having.test
@@ -1,5 +1,5 @@
 # name: test/sql/subquery/scalar/test_correlated_having.test
-# description: Test correlated subqueries with HAVING without GROUP BY
+# description: Issue #24563: Test correlated subqueries with HAVING without GROUP BY
 # group: [scalar]
 
 statement ok

--- a/test/sql/subquery/scalar/test_correlated_having.test
+++ b/test/sql/subquery/scalar/test_correlated_having.test
@@ -81,7 +81,7 @@ SELECT currval('having_effect_seq');
 2
 
 statement error
-SELECT (SELECT sum(inner_values.i) + CAST('invalid' AS INTEGER)
+SELECT (SELECT CAST(CASE WHEN sum(inner_values.i) IS NULL THEN 'invalid' ELSE '1' END AS INTEGER)
         FROM inner_values
         WHERE inner_values.i = outer_values.i)
 FROM outer_values
@@ -112,7 +112,7 @@ EXPLAIN SELECT (SELECT avg(inner_values.i) * 0.2
                 HAVING true)
 FROM outer_values;
 ----
-logical_opt	<REGEX>:.*Join Type: INNER.*Conditions: i IS NOT DISTINCT FROM #0.*
+logical_opt	<REGEX>:.*Join Type: INNER.*Conditions: i IS NOT DISTINCT FROM .*
 
 query II
 EXPLAIN SELECT (SELECT coalesce(avg(inner_values.i), 0)
@@ -121,7 +121,7 @@ EXPLAIN SELECT (SELECT coalesce(avg(inner_values.i), 0)
                 HAVING true)
 FROM outer_values;
 ----
-logical_opt	<REGEX>:.*Join Type: LEFT.*Conditions: i IS NOT DISTINCT FROM #0.*
+logical_opt	<REGEX>:.*Join Type: LEFT.*Conditions: i IS NOT DISTINCT FROM .*
 
 statement ok
 SET disabled_optimizers='';


### PR DESCRIPTION
Fixes #24563.

When flattening a correlated subquery with an ungrouped aggregate, correlated columns are added as grouping keys. For an empty input, the grouped RHS may produce no row, so reconnecting it with an `INNER JOIN` can be semantically different from the original ungrouped aggregate.

Using a `LEFT JOIN` is always safe, but may be less efficient. This PR keeps the `INNER JOIN` optimization only when the expressions above the aggregate guarantee that removing the empty-input row is unobservable; otherwise it falls back to `LEFT JOIN`.

Regression tests cover the original issue, join selection, volatile side effects, and throwing expressions.