### PR TITLE
Reject SET/DROP NOT NULL,SET DEFAULT,ALTER TYPE on nested struct fields

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -1196,9 +1196,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::DropNotNull(ClientContext &context, Dro
 
 unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context, ChangeColumnTypeInfo &info,
                                                           AlterTableType alter_table_type) {
-	// 'ChangeColumnType' is also called internally to implement ADD_FIELD/REMOVE_FIELD/RENAME_FIELD, whose
-	// locally-constructed ChangeColumnTypeInfo never sets 'column_path' - only reject a user-issued
-	// "ALTER ... TYPE" that directly targets a nested field.
+	// Only reject a user-issued ALTER TYPE; ADD/REMOVE/RENAME_FIELD's internal calls leave column_path empty.
 	if (alter_table_type == AlterTableType::ALTER_COLUMN_TYPE && info.column_path.size() > 1) {
 		throw NotImplementedException("Changing the type of a nested field is not yet supported");
 	}

--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -1093,6 +1093,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::RenameField(ClientContext &context, Ren
 }
 
 unique_ptr<CatalogEntry> DuckTableEntry::SetDefault(ClientContext &context, SetDefaultInfo &info) {
+	if (info.column_path.size() > 1) {
+		throw NotImplementedException("Setting a default value on a nested field is not yet supported");
+	}
 	auto default_idx = GetColumnIndex(info.column_name);
 	if (default_idx.index == COLUMN_IDENTIFIER_ROW_ID) {
 		throw CatalogException("Cannot SET DEFAULT for rowid column");
@@ -1115,6 +1118,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::SetDefault(ClientContext &context, SetD
 }
 
 unique_ptr<CatalogEntry> DuckTableEntry::SetNotNull(ClientContext &context, SetNotNullInfo &info) {
+	if (info.column_path.size() > 1) {
+		throw NotImplementedException("Setting a NOT NULL constraint on a nested field is not yet supported");
+	}
 	auto not_null_idx = GetColumnIndex(info.column_name);
 	if (columns.GetColumn(LogicalIndex(not_null_idx)).Generated()) {
 		throw BinderException("Unsupported constraint for generated column!");
@@ -1154,6 +1160,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::SetNotNull(ClientContext &context, SetN
 }
 
 unique_ptr<CatalogEntry> DuckTableEntry::DropNotNull(ClientContext &context, DropNotNullInfo &info) {
+	if (info.column_path.size() > 1) {
+		throw NotImplementedException("Dropping a NOT NULL constraint on a nested field is not yet supported");
+	}
 	auto not_null_idx = GetColumnIndex(info.column_name);
 	if (const auto pk = GetPrimaryKey()) {
 		auto &unique = pk->Cast<UniqueConstraint>();
@@ -1187,6 +1196,12 @@ unique_ptr<CatalogEntry> DuckTableEntry::DropNotNull(ClientContext &context, Dro
 
 unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context, ChangeColumnTypeInfo &info,
                                                           AlterTableType alter_table_type) {
+	// 'ChangeColumnType' is also called internally to implement ADD_FIELD/REMOVE_FIELD/RENAME_FIELD, whose
+	// locally-constructed ChangeColumnTypeInfo never sets 'column_path' - only reject a user-issued
+	// "ALTER ... TYPE" that directly targets a nested field.
+	if (alter_table_type == AlterTableType::ALTER_COLUMN_TYPE && info.column_path.size() > 1) {
+		throw NotImplementedException("Changing the type of a nested field is not yet supported");
+	}
 	// Bind type
 	auto type_binder = Binder::CreateBinder(context);
 	type_binder->SetSearchPath(catalog, schema.name);

--- a/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
@@ -297,8 +297,7 @@ struct ChangeColumnTypeInfo : public AlterTableInfo {
 	LogicalType target_type;
 	//! The expression used for data conversion
 	unique_ptr<ParsedExpression> expression;
-	//! The full dotted column path as written (e.g. ["s", "a"] for "s.a"); empty when not a nested-field target.
-	//! Used only to detect (and reject) a nested-field target - 'column_name' remains the operative field.
+	//! Full dotted column path, e.g. ["s", "a"] for "s.a"
 	vector<Identifier> column_path;
 
 public:
@@ -325,8 +324,7 @@ struct SetDefaultInfo : public AlterTableInfo {
 	Identifier column_name;
 	//! The expression used for data conversion
 	unique_ptr<ParsedExpression> expression;
-	//! The full dotted column path as written (e.g. ["s", "a"] for "s.a"); empty when not a nested-field target.
-	//! Used only to detect (and reject) a nested-field target - 'column_name' remains the operative field.
+	//! Full dotted column path, e.g. ["s", "a"] for "s.a"
 	vector<Identifier> column_path;
 
 public:
@@ -374,8 +372,7 @@ struct SetNotNullInfo : public AlterTableInfo {
 
 	//! The column name to alter
 	Identifier column_name;
-	//! The full dotted column path as written (e.g. ["s", "a"] for "s.a"); empty when not a nested-field target.
-	//! Used only to detect (and reject) a nested-field target - 'column_name' remains the operative field.
+	//! Full dotted column path, e.g. ["s", "a"] for "s.a"
 	vector<Identifier> column_path;
 
 public:
@@ -397,8 +394,7 @@ struct DropNotNullInfo : public AlterTableInfo {
 
 	//! The column name to alter
 	Identifier column_name;
-	//! The full dotted column path as written (e.g. ["s", "a"] for "s.a"); empty when not a nested-field target.
-	//! Used only to detect (and reject) a nested-field target - 'column_name' remains the operative field.
+	//! Full dotted column path, e.g. ["s", "a"] for "s.a"
 	vector<Identifier> column_path;
 
 public:

--- a/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
+++ b/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
@@ -297,6 +297,9 @@ struct ChangeColumnTypeInfo : public AlterTableInfo {
 	LogicalType target_type;
 	//! The expression used for data conversion
 	unique_ptr<ParsedExpression> expression;
+	//! The full dotted column path as written (e.g. ["s", "a"] for "s.a"); empty when not a nested-field target.
+	//! Used only to detect (and reject) a nested-field target - 'column_name' remains the operative field.
+	vector<Identifier> column_path;
 
 public:
 	unique_ptr<AlterInfo> Copy() const override;
@@ -322,6 +325,9 @@ struct SetDefaultInfo : public AlterTableInfo {
 	Identifier column_name;
 	//! The expression used for data conversion
 	unique_ptr<ParsedExpression> expression;
+	//! The full dotted column path as written (e.g. ["s", "a"] for "s.a"); empty when not a nested-field target.
+	//! Used only to detect (and reject) a nested-field target - 'column_name' remains the operative field.
+	vector<Identifier> column_path;
 
 public:
 	unique_ptr<AlterInfo> Copy() const override;
@@ -368,6 +374,9 @@ struct SetNotNullInfo : public AlterTableInfo {
 
 	//! The column name to alter
 	Identifier column_name;
+	//! The full dotted column path as written (e.g. ["s", "a"] for "s.a"); empty when not a nested-field target.
+	//! Used only to detect (and reject) a nested-field target - 'column_name' remains the operative field.
+	vector<Identifier> column_path;
 
 public:
 	unique_ptr<AlterInfo> Copy() const override;
@@ -388,6 +397,9 @@ struct DropNotNullInfo : public AlterTableInfo {
 
 	//! The column name to alter
 	Identifier column_name;
+	//! The full dotted column path as written (e.g. ["s", "a"] for "s.a"); empty when not a nested-field target.
+	//! Used only to detect (and reject) a nested-field target - 'column_name' remains the operative field.
+	vector<Identifier> column_path;
 
 public:
 	unique_ptr<AlterInfo> Copy() const override;

--- a/src/include/duckdb/storage/serialization/parse_info.json
+++ b/src/include/duckdb/storage/serialization/parse_info.json
@@ -250,6 +250,12 @@
         "id": 402,
         "name": "expression",
         "type": "ParsedExpression*"
+      },
+      {
+        "id": 403,
+        "name": "column_path",
+        "type": "vector<Identifier>",
+        "default": "{}"
       }
     ]
   },
@@ -267,6 +273,12 @@
         "id": 401,
         "name": "expression",
         "type": "ParsedExpression*"
+      },
+      {
+        "id": 402,
+        "name": "column_path",
+        "type": "vector<Identifier>",
+        "default": "{}"
       }
     ]
   },
@@ -317,6 +329,12 @@
         "id": 400,
         "name": "column_name",
         "type": "Identifier"
+      },
+      {
+        "id": 401,
+        "name": "column_path",
+        "type": "vector<Identifier>",
+        "default": "{}"
       }
     ]
   },
@@ -329,6 +347,12 @@
         "id": 400,
         "name": "column_name",
         "type": "Identifier"
+      },
+      {
+        "id": 401,
+        "name": "column_path",
+        "type": "vector<Identifier>",
+        "default": "{}"
       }
     ]
   },

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -393,7 +393,16 @@ string ChangeColumnTypeInfo::ToString() const {
 	}
 	result += GetQualifiedName().ToString(QualifiedNameToStringMode::HIDE_DEFAULT_SCHEMA);
 	result += " ALTER COLUMN ";
-	result += SQLIdentifier(column_name);
+	if (column_path.empty()) {
+		result += SQLIdentifier(column_name);
+	} else {
+		for (idx_t i = 0; i < column_path.size(); i++) {
+			if (i > 0) {
+				result += ".";
+			}
+			result += SQLIdentifier(column_path[i]);
+		}
+	}
 	result += " TYPE ";
 	if (target_type.IsValid()) {
 		result += target_type.ToString();
@@ -442,7 +451,16 @@ string SetDefaultInfo::ToString() const {
 	}
 	result += GetQualifiedName().ToString(QualifiedNameToStringMode::HIDE_DEFAULT_SCHEMA);
 	result += " ALTER COLUMN ";
-	result += SQLIdentifier(column_name);
+	if (column_path.empty()) {
+		result += SQLIdentifier(column_name);
+	} else {
+		for (idx_t i = 0; i < column_path.size(); i++) {
+			if (i > 0) {
+				result += ".";
+			}
+			result += SQLIdentifier(column_path[i]);
+		}
+	}
 	if (expression) {
 		result += " SET DEFAULT ";
 		result += expression->ToString();
@@ -479,7 +497,16 @@ string SetNotNullInfo::ToString() const {
 	}
 	result += GetQualifiedName().ToString(QualifiedNameToStringMode::HIDE_DEFAULT_SCHEMA);
 	result += " ALTER COLUMN ";
-	result += SQLIdentifier(column_name);
+	if (column_path.empty()) {
+		result += SQLIdentifier(column_name);
+	} else {
+		for (idx_t i = 0; i < column_path.size(); i++) {
+			if (i > 0) {
+				result += ".";
+			}
+			result += SQLIdentifier(column_path[i]);
+		}
+	}
 	result += " SET NOT NULL";
 	result += ";";
 	return result;
@@ -511,7 +538,16 @@ string DropNotNullInfo::ToString() const {
 	}
 	result += GetQualifiedName().ToString(QualifiedNameToStringMode::HIDE_DEFAULT_SCHEMA);
 	result += " ALTER COLUMN ";
-	result += SQLIdentifier(column_name);
+	if (column_path.empty()) {
+		result += SQLIdentifier(column_name);
+	} else {
+		for (idx_t i = 0; i < column_path.size(); i++) {
+			if (i > 0) {
+				result += ".";
+			}
+			result += SQLIdentifier(column_path[i]);
+		}
+	}
 	result += " DROP NOT NULL";
 	result += ";";
 	return result;

--- a/src/parser/parsed_data/alter_table_info.cpp
+++ b/src/parser/parsed_data/alter_table_info.cpp
@@ -379,8 +379,10 @@ ChangeColumnTypeInfo::~ChangeColumnTypeInfo() {
 }
 
 unique_ptr<AlterInfo> ChangeColumnTypeInfo::Copy() const {
-	return make_uniq_base<AlterInfo, ChangeColumnTypeInfo>(GetAlterEntryData(), column_name, target_type,
-	                                                       expression->Copy());
+	auto result = make_uniq_base<AlterInfo, ChangeColumnTypeInfo>(GetAlterEntryData(), column_name, target_type,
+	                                                              expression->Copy());
+	result->Cast<ChangeColumnTypeInfo>().column_path = column_path;
+	return result;
 }
 
 string ChangeColumnTypeInfo::ToString() const {
@@ -426,8 +428,10 @@ SetDefaultInfo::~SetDefaultInfo() {
 }
 
 unique_ptr<AlterInfo> SetDefaultInfo::Copy() const {
-	return make_uniq_base<AlterInfo, SetDefaultInfo>(GetAlterEntryData(), column_name,
-	                                                 expression ? expression->Copy() : nullptr);
+	auto result = make_uniq_base<AlterInfo, SetDefaultInfo>(GetAlterEntryData(), column_name,
+	                                                        expression ? expression->Copy() : nullptr);
+	result->Cast<SetDefaultInfo>().column_path = column_path;
+	return result;
 }
 
 string SetDefaultInfo::ToString() const {
@@ -462,7 +466,9 @@ SetNotNullInfo::~SetNotNullInfo() {
 }
 
 unique_ptr<AlterInfo> SetNotNullInfo::Copy() const {
-	return make_uniq_base<AlterInfo, SetNotNullInfo>(GetAlterEntryData(), column_name);
+	auto result = make_uniq_base<AlterInfo, SetNotNullInfo>(GetAlterEntryData(), column_name);
+	result->Cast<SetNotNullInfo>().column_path = column_path;
+	return result;
 }
 
 string SetNotNullInfo::ToString() const {
@@ -492,7 +498,9 @@ DropNotNullInfo::~DropNotNullInfo() {
 }
 
 unique_ptr<AlterInfo> DropNotNullInfo::Copy() const {
-	return make_uniq_base<AlterInfo, DropNotNullInfo>(GetAlterEntryData(), column_name);
+	auto result = make_uniq_base<AlterInfo, DropNotNullInfo>(GetAlterEntryData(), column_name);
+	result->Cast<DropNotNullInfo>().column_path = column_path;
+	return result;
 }
 
 string DropNotNullInfo::ToString() const {

--- a/src/parser/peg/transformer/transform_alter.cpp
+++ b/src/parser/peg/transformer/transform_alter.cpp
@@ -298,9 +298,7 @@ unique_ptr<AlterTableInfo>
 PEGTransformerFactory::TransformAlterColumn(PEGTransformer &transformer, const bool &has_result,
                                             unique_ptr<ColumnRefExpression> nested_column_name,
                                             unique_ptr<AlterTableInfo> alter_column_entry) {
-	//! The full dotted path as written (e.g. ["s", "a"] for "s.a") - preserved on the AlterTableInfo so the
-	//! catalog entry that actually executes the ALTER (e.g. DuckTableEntry) can detect and reject a nested-field
-	//! target; this transformer only captures parse-time info, it doesn't decide what's supported.
+	//! Preserved so DuckTableEntry can detect a nested-field target; not interpreted here.
 	auto column_path = nested_column_name->ColumnNames();
 	if (alter_column_entry->alter_table_type == AlterTableType::SET_DEFAULT) {
 		auto set_default_entry = unique_ptr_cast<AlterTableInfo, SetDefaultInfo>(std::move(alter_column_entry));

--- a/src/parser/peg/transformer/transform_alter.cpp
+++ b/src/parser/peg/transformer/transform_alter.cpp
@@ -299,19 +299,30 @@ PEGTransformerFactory::TransformAlterColumn(PEGTransformer &transformer, const b
                                             unique_ptr<ColumnRefExpression> nested_column_name,
                                             unique_ptr<AlterTableInfo> alter_column_entry) {
 	if (alter_column_entry->alter_table_type == AlterTableType::SET_DEFAULT) {
+		if (nested_column_name->ColumnNames().size() > 1) {
+			throw NotImplementedException("Setting a default value on a nested field is not yet supported");
+		}
 		auto set_default_entry = unique_ptr_cast<AlterTableInfo, SetDefaultInfo>(std::move(alter_column_entry));
-		// TODO(Dtenwolde) Figure out with nested names;
 		set_default_entry->column_name = nested_column_name->ColumnNames()[0];
 		return std::move(set_default_entry);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::DROP_NOT_NULL) {
+		if (nested_column_name->ColumnNames().size() > 1) {
+			throw NotImplementedException("Dropping a NOT NULL constraint on a nested field is not yet supported");
+		}
 		auto drop_not_null = unique_ptr_cast<AlterTableInfo, DropNotNullInfo>(std::move(alter_column_entry));
 		drop_not_null->column_name = nested_column_name->ColumnNames()[0];
 		return std::move(drop_not_null);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::SET_NOT_NULL) {
+		if (nested_column_name->ColumnNames().size() > 1) {
+			throw NotImplementedException("Setting a NOT NULL constraint on a nested field is not yet supported");
+		}
 		auto set_not_null = unique_ptr_cast<AlterTableInfo, SetNotNullInfo>(std::move(alter_column_entry));
 		set_not_null->column_name = nested_column_name->ColumnNames()[0];
 		return std::move(set_not_null);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::ALTER_COLUMN_TYPE) {
+		if (nested_column_name->ColumnNames().size() > 1) {
+			throw NotImplementedException("Changing the type of a nested field is not yet supported");
+		}
 		auto change_column_type = unique_ptr_cast<AlterTableInfo, ChangeColumnTypeInfo>(std::move(alter_column_entry));
 		change_column_type->column_name = nested_column_name->ColumnNames()[0];
 		if (!change_column_type->expression) {

--- a/src/parser/peg/transformer/transform_alter.cpp
+++ b/src/parser/peg/transformer/transform_alter.cpp
@@ -298,36 +298,26 @@ unique_ptr<AlterTableInfo>
 PEGTransformerFactory::TransformAlterColumn(PEGTransformer &transformer, const bool &has_result,
                                             unique_ptr<ColumnRefExpression> nested_column_name,
                                             unique_ptr<AlterTableInfo> alter_column_entry) {
-	//! The full dotted path as written (e.g. ["s", "a"] for "s.a")
+	//! The full dotted path as written (e.g. ["s", "a"] for "s.a") - preserved on the AlterTableInfo so the
+	//! catalog entry that actually executes the ALTER (e.g. DuckTableEntry) can detect and reject a nested-field
+	//! target; this transformer only captures parse-time info, it doesn't decide what's supported.
 	auto column_path = nested_column_name->ColumnNames();
 	if (alter_column_entry->alter_table_type == AlterTableType::SET_DEFAULT) {
-		if (column_path.size() > 1) {
-			throw NotImplementedException("Setting a default value on a nested field is not yet supported");
-		}
 		auto set_default_entry = unique_ptr_cast<AlterTableInfo, SetDefaultInfo>(std::move(alter_column_entry));
 		set_default_entry->column_name = column_path[0];
 		set_default_entry->column_path = column_path;
 		return std::move(set_default_entry);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::DROP_NOT_NULL) {
-		if (column_path.size() > 1) {
-			throw NotImplementedException("Dropping a NOT NULL constraint on a nested field is not yet supported");
-		}
 		auto drop_not_null = unique_ptr_cast<AlterTableInfo, DropNotNullInfo>(std::move(alter_column_entry));
 		drop_not_null->column_name = column_path[0];
 		drop_not_null->column_path = column_path;
 		return std::move(drop_not_null);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::SET_NOT_NULL) {
-		if (column_path.size() > 1) {
-			throw NotImplementedException("Setting a NOT NULL constraint on a nested field is not yet supported");
-		}
 		auto set_not_null = unique_ptr_cast<AlterTableInfo, SetNotNullInfo>(std::move(alter_column_entry));
 		set_not_null->column_name = column_path[0];
 		set_not_null->column_path = column_path;
 		return std::move(set_not_null);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::ALTER_COLUMN_TYPE) {
-		if (column_path.size() > 1) {
-			throw NotImplementedException("Changing the type of a nested field is not yet supported");
-		}
 		auto change_column_type = unique_ptr_cast<AlterTableInfo, ChangeColumnTypeInfo>(std::move(alter_column_entry));
 		change_column_type->column_name = column_path[0];
 		change_column_type->column_path = column_path;

--- a/src/parser/peg/transformer/transform_alter.cpp
+++ b/src/parser/peg/transformer/transform_alter.cpp
@@ -298,33 +298,39 @@ unique_ptr<AlterTableInfo>
 PEGTransformerFactory::TransformAlterColumn(PEGTransformer &transformer, const bool &has_result,
                                             unique_ptr<ColumnRefExpression> nested_column_name,
                                             unique_ptr<AlterTableInfo> alter_column_entry) {
+	//! The full dotted path as written (e.g. ["s", "a"] for "s.a")
+	auto column_path = nested_column_name->ColumnNames();
 	if (alter_column_entry->alter_table_type == AlterTableType::SET_DEFAULT) {
-		if (nested_column_name->ColumnNames().size() > 1) {
+		if (column_path.size() > 1) {
 			throw NotImplementedException("Setting a default value on a nested field is not yet supported");
 		}
 		auto set_default_entry = unique_ptr_cast<AlterTableInfo, SetDefaultInfo>(std::move(alter_column_entry));
-		set_default_entry->column_name = nested_column_name->ColumnNames()[0];
+		set_default_entry->column_name = column_path[0];
+		set_default_entry->column_path = column_path;
 		return std::move(set_default_entry);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::DROP_NOT_NULL) {
-		if (nested_column_name->ColumnNames().size() > 1) {
+		if (column_path.size() > 1) {
 			throw NotImplementedException("Dropping a NOT NULL constraint on a nested field is not yet supported");
 		}
 		auto drop_not_null = unique_ptr_cast<AlterTableInfo, DropNotNullInfo>(std::move(alter_column_entry));
-		drop_not_null->column_name = nested_column_name->ColumnNames()[0];
+		drop_not_null->column_name = column_path[0];
+		drop_not_null->column_path = column_path;
 		return std::move(drop_not_null);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::SET_NOT_NULL) {
-		if (nested_column_name->ColumnNames().size() > 1) {
+		if (column_path.size() > 1) {
 			throw NotImplementedException("Setting a NOT NULL constraint on a nested field is not yet supported");
 		}
 		auto set_not_null = unique_ptr_cast<AlterTableInfo, SetNotNullInfo>(std::move(alter_column_entry));
-		set_not_null->column_name = nested_column_name->ColumnNames()[0];
+		set_not_null->column_name = column_path[0];
+		set_not_null->column_path = column_path;
 		return std::move(set_not_null);
 	} else if (alter_column_entry->alter_table_type == AlterTableType::ALTER_COLUMN_TYPE) {
-		if (nested_column_name->ColumnNames().size() > 1) {
+		if (column_path.size() > 1) {
 			throw NotImplementedException("Changing the type of a nested field is not yet supported");
 		}
 		auto change_column_type = unique_ptr_cast<AlterTableInfo, ChangeColumnTypeInfo>(std::move(alter_column_entry));
-		change_column_type->column_name = nested_column_name->ColumnNames()[0];
+		change_column_type->column_name = column_path[0];
+		change_column_type->column_path = column_path;
 		if (!change_column_type->expression) {
 			change_column_type->expression =
 			    make_uniq<CastExpression>(change_column_type->target_type, std::move(nested_column_name));

--- a/src/storage/serialization/serialize_parse_info.cpp
+++ b/src/storage/serialization/serialize_parse_info.cpp
@@ -330,6 +330,7 @@ void ChangeColumnTypeInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<Identifier>(400, "column_name", column_name);
 	serializer.WriteProperty<LogicalType>(401, "target_type", target_type);
 	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(402, "expression", expression);
+	serializer.WritePropertyWithDefault<vector<Identifier>>(403, "column_path", column_path, {});
 }
 
 unique_ptr<AlterTableInfo> ChangeColumnTypeInfo::Deserialize(Deserializer &deserializer) {
@@ -337,6 +338,7 @@ unique_ptr<AlterTableInfo> ChangeColumnTypeInfo::Deserialize(Deserializer &deser
 	deserializer.ReadPropertyWithDefault<Identifier>(400, "column_name", result->column_name);
 	deserializer.ReadProperty<LogicalType>(401, "target_type", result->target_type);
 	deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(402, "expression", result->expression);
+	deserializer.ReadPropertyWithExplicitDefault<vector<Identifier>>(403, "column_path", result->column_path, {});
 	return std::move(result);
 }
 
@@ -484,11 +486,13 @@ unique_ptr<ParseInfo> DropInfo::Deserialize(Deserializer &deserializer) {
 void DropNotNullInfo::Serialize(Serializer &serializer) const {
 	AlterTableInfo::Serialize(serializer);
 	serializer.WritePropertyWithDefault<Identifier>(400, "column_name", column_name);
+	serializer.WritePropertyWithDefault<vector<Identifier>>(401, "column_path", column_path, {});
 }
 
 unique_ptr<AlterTableInfo> DropNotNullInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<DropNotNullInfo>(new DropNotNullInfo());
 	deserializer.ReadPropertyWithDefault<Identifier>(400, "column_name", result->column_name);
+	deserializer.ReadPropertyWithExplicitDefault<vector<Identifier>>(401, "column_path", result->column_path, {});
 	return std::move(result);
 }
 
@@ -674,23 +678,27 @@ void SetDefaultInfo::Serialize(Serializer &serializer) const {
 	AlterTableInfo::Serialize(serializer);
 	serializer.WritePropertyWithDefault<Identifier>(400, "column_name", column_name);
 	serializer.WritePropertyWithDefault<unique_ptr<ParsedExpression>>(401, "expression", expression);
+	serializer.WritePropertyWithDefault<vector<Identifier>>(402, "column_path", column_path, {});
 }
 
 unique_ptr<AlterTableInfo> SetDefaultInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<SetDefaultInfo>(new SetDefaultInfo());
 	deserializer.ReadPropertyWithDefault<Identifier>(400, "column_name", result->column_name);
 	deserializer.ReadPropertyWithDefault<unique_ptr<ParsedExpression>>(401, "expression", result->expression);
+	deserializer.ReadPropertyWithExplicitDefault<vector<Identifier>>(402, "column_path", result->column_path, {});
 	return std::move(result);
 }
 
 void SetNotNullInfo::Serialize(Serializer &serializer) const {
 	AlterTableInfo::Serialize(serializer);
 	serializer.WritePropertyWithDefault<Identifier>(400, "column_name", column_name);
+	serializer.WritePropertyWithDefault<vector<Identifier>>(401, "column_path", column_path, {});
 }
 
 unique_ptr<AlterTableInfo> SetNotNullInfo::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<SetNotNullInfo>(new SetNotNullInfo());
 	deserializer.ReadPropertyWithDefault<Identifier>(400, "column_name", result->column_name);
+	deserializer.ReadPropertyWithExplicitDefault<vector<Identifier>>(401, "column_path", result->column_path, {});
 	return std::move(result);
 }
 

--- a/test/sql/alter/struct/alter_nested_struct_field_not_implemented.test
+++ b/test/sql/alter/struct/alter_nested_struct_field_not_implemented.test
@@ -1,0 +1,64 @@
+# name: test/sql/alter/struct/alter_nested_struct_field_not_implemented.test
+# description: ALTER on a nested struct field must not silently target the top-level column
+# group: [struct]
+
+statement ok
+CREATE TABLE test(s STRUCT(a INTEGER, b INTEGER))
+
+statement ok
+INSERT INTO test VALUES ({'a': NULL, 'b': 1})
+
+# https://github.com/duckdb/duckdb/issues/25456 - this used to silently set NOT NULL on the
+# top-level column "s" instead of the nested field "s.a", leaving the NULL field unenforced
+statement error
+ALTER TABLE test ALTER s.a SET NOT NULL
+----
+Setting a NOT NULL constraint on a nested field is not yet supported
+
+statement error
+ALTER TABLE test ALTER s.a DROP NOT NULL
+----
+Dropping a NOT NULL constraint on a nested field is not yet supported
+
+statement error
+ALTER TABLE test ALTER s.a SET DEFAULT 5
+----
+Setting a default value on a nested field is not yet supported
+
+statement error
+ALTER TABLE test ALTER s.a TYPE BIGINT
+----
+Changing the type of a nested field is not yet supported
+
+# the row is untouched. none of the above silently applied to the wrong column
+query I
+SELECT * FROM test
+----
+{'a': NULL, 'b': 1}
+
+# simple (non-nested) columns are unaffected by the guard
+statement ok
+CREATE TABLE simple(a INTEGER, b INTEGER)
+
+statement ok
+INSERT INTO simple VALUES (1, 1)
+
+statement ok
+ALTER TABLE simple ALTER a SET NOT NULL
+
+statement error
+INSERT INTO simple VALUES (NULL, 2)
+----
+NOT NULL constraint failed
+
+statement ok
+ALTER TABLE simple ALTER a DROP NOT NULL
+
+statement ok
+INSERT INTO simple VALUES (NULL, 2)
+
+statement ok
+ALTER TABLE simple ALTER a SET DEFAULT 42
+
+statement ok
+ALTER TABLE simple ALTER a TYPE BIGINT


### PR DESCRIPTION
## Summary
`ALTER TABLE ... ALTER <col>.<field>` silently applied `SET/DROP NOT NULL`, `SET DEFAULT`, and `ALTER COLUMN TYPE` to the top-level column instead of the nested field, since the transformer only ever read the first path segment of the dotted column name.

## Fix
Throw a clear `NotImplementedException` instead of silently misapplying the operation to the wrong column, for all four affected operations, until real nested-field support exists for them.

The check lives in `DuckTableEntry` (where these operations actually execute), not the parser transformer, which only captures the full dotted path (`column_path`) onto the relevant `AlterTableInfo` classes and leaves the decision of what's supported to the catalog layer.

## Tests
`test/sql/alter/struct/alter_nested_struct_field_not_implemented.test` - covers all four operations erroring on a nested field, confirms the underlying row is left untouched, and confirms simple (non-nested) columns are unaffected by the guard.

Fixes #25456 