### PR TITLE
Fix row-group pruning for string NOT IN predicates

### DIFF
--- a/src/storage/statistics/string_stats.cpp
+++ b/src/storage/statistics/string_stats.cpp
@@ -751,11 +751,14 @@ FilterPropagateResult StringStats::CheckZonemap(string_t min, StringStatsType mi
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		if (min_comp == 0 && max_comp == 0 && min_type == StringStatsType::EXACT_STATS &&
+		    max_type == StringStatsType::EXACT_STATS) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		}
 		if (min_comp >= 0 && max_comp <= 0) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-		} else {
-			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 		}
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	case ExpressionType::COMPARE_NOTEQUAL:
 	case ExpressionType::COMPARE_DISTINCT_FROM:
 		if (min_comp < 0 || max_comp > 0) {

--- a/test/sql/index/art/issues/test_art_view_col_binding.test
+++ b/test/sql/index/art/issues/test_art_view_col_binding.test
@@ -52,7 +52,7 @@ statement ok
 CREATE TABLE t(a INTEGER, b VARCHAR);
 
 statement ok
-INSERT INTO t VALUES (1, 'x');
+INSERT INTO t VALUES (1, 'x'), (2, 'y');
 
 statement ok
 CREATE VIEW v AS SELECT a, b FROM t;

--- a/test/sql/optimizer/in_list_row_group_pruning.test
+++ b/test/sql/optimizer/in_list_row_group_pruning.test
@@ -91,3 +91,53 @@ query II
 EXPLAIN ANALYZE SELECT sum(payload) FROM strings WHERE s NOT IN ('v000000', 'v000010');
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+# A listed string mixed with NULLs can be pruned, but a mixed string range must remain eligible.
+statement ok
+CREATE TABLE nullable_strings AS
+SELECT CASE range // 2048
+    WHEN 0 THEN CASE WHEN range % 2 = 0 THEN NULL ELSE 'a' END
+    WHEN 1 THEN CASE WHEN range % 2 = 0 THEN 'a' ELSE 'b' END
+    WHEN 2 THEN 'z'
+    ELSE 'c'
+END AS s, 1 AS payload
+FROM range(8192);
+
+query I
+SELECT sum(payload) FROM nullable_strings WHERE s NOT IN ('a', 'z');
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT sum(payload) FROM nullable_strings WHERE s NOT IN ('a', 'z');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+query I
+SELECT sum(payload) FROM nullable_strings WHERE s IN ('a', 'z', NULL);
+----
+4096
+
+query I
+SELECT count(*) FROM nullable_strings WHERE s NOT IN ('a', 'z', NULL);
+----
+0
+
+# Equal truncated prefixes do not prove that every string is an IN-list member.
+statement ok
+CREATE TABLE long_strings AS
+SELECT CASE WHEN range < 2048 THEN 'abcdefghijkl'
+    WHEN range % 2 = 0 THEN 'abcdefghijkla'
+    ELSE 'abcdefghijklb'
+END AS s, 1 AS payload
+FROM range(4096);
+
+query I
+SELECT sum(payload) FROM long_strings WHERE s NOT IN ('abcdefghijkla', 'abcdefghijklc');
+----
+3072
+
+query II
+EXPLAIN ANALYZE SELECT sum(payload) FROM long_strings WHERE s NOT IN ('abcdefghijkla', 'abcdefghijklc');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 2.*

--- a/test/sql/optimizer/in_list_row_group_pruning.test
+++ b/test/sql/optimizer/in_list_row_group_pruning.test
@@ -60,3 +60,34 @@ query I
 SELECT count(*) FROM doubles WHERE i NOT IN (1, 2, 3);
 ----
 1
+
+# Each row group contains one string; NOT IN excludes the first and third groups.
+statement ok
+CREATE TABLE strings AS
+SELECT CASE range // 2048
+    WHEN 0 THEN 'v000000'
+    WHEN 1 THEN 'v000001'
+    WHEN 2 THEN 'v000010'
+    ELSE 'v999999'
+END AS s, 1 AS payload
+FROM range(8192);
+
+query I
+SELECT sum(payload) FROM strings WHERE s NOT IN ('v000000', 'v000010');
+----
+4096
+
+query I
+SELECT sum(payload) FROM strings WHERE s <> 'v000000' AND s <> 'v000010';
+----
+4096
+
+query II
+EXPLAIN ANALYZE SELECT sum(payload) FROM strings WHERE s <> 'v000000' AND s <> 'v000010';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+query II
+EXPLAIN ANALYZE SELECT sum(payload) FROM strings WHERE s NOT IN ('v000000', 'v000010');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*

--- a/test/sql/optimizer/upper_lower_zonemap_pruning.test
+++ b/test/sql/optimizer/upper_lower_zonemap_pruning.test
@@ -17,7 +17,7 @@ FROM range(6144) r(i);
 
 # When min == max, upper() of the row group is a single known value: only the 'Beta' row group can match.
 query II
-EXPLAIN ANALYZE SELECT count(*) FROM case_pruning WHERE upper(s) = 'BETA';
+EXPLAIN ANALYZE SELECT sum(i) FROM case_pruning WHERE upper(s) = 'BETA';
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 
@@ -28,7 +28,7 @@ SELECT count(*) FROM case_pruning WHERE upper(s) = 'BETA';
 
 # lower() shares the same propagation.
 query II
-EXPLAIN ANALYZE SELECT count(*) FROM case_pruning WHERE lower(s) = 'gamma';
+EXPLAIN ANALYZE SELECT sum(i) FROM case_pruning WHERE lower(s) = 'gamma';
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 


### PR DESCRIPTION
Hi team, I found `NOT IN` operator doesn't properly prune row group for string type; for example,
```sql
memory D ATTACH '/tmp/in_list_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE strings AS
     SELECT CASE range // 2048
         WHEN 0 THEN 'v000000'
         WHEN 1 THEN 'v000001'
         WHEN 2 THEN 'v000010'
         ELSE 'v999999'
     END AS s, 1 AS payload
     FROM range(8192);

-- prunes correctly
db D EXPLAIN ANALYZE SELECT sum(payload) FROM strings WHERE s <> 'v000000' AND s <> 'v000010';
╭─ Summary ───────────╮
│ Total Time: 0.0021s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────────────╮
│ Aggregates: sum_no_overflow(#0)       │
│ 1 row                             0µs │
╰───────────────────┒┎──────────────────╯
╭─ Projection ──────┚┖──────────────────╮
│ Projections: payload                  │
│ 4,096 rows                        0µs │
╰───────────────────┒┎──────────────────╯
╭─ Table Scan ──────┚┖──────────────────╮
│ Table: db.main.strings                │
│ Type: Sequential Scan                 │
│ Projections: payload                  │
│ Filters:                              │
│ (s != 'v000000') AND (s != 'v000010') │
│ Row Groups Scanned: 2 / 4             │
│ 4,096 rows                        0µs │
╰───────────────────────────────────────╯

-- should only access two row groups, but in reality access four
db D EXPLAIN ANALYZE SELECT sum(payload) FROM strings WHERE s NOT IN ('v000000', 'v000010');
╭─ Summary ───────────╮
│ Total Time: 0.0027s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────────╮
│ Aggregates: sum_no_overflow(#0)   │
│ 1 row                         0µs │
╰─────────────────┒┎────────────────╯
╭─ Projection ────┚┖────────────────╮
│ Projections: payload              │
│ 4,096 rows                    0µs │
╰─────────────────┒┎────────────────╯
╭─ Table Scan ────┚┖────────────────╮
│ Table: db.main.strings            │
│ Type: Sequential Scan             │
│ Projections: payload              │
│ Filters:                          │
│ NOT (s IN ('v000000', 'v000010')) │
│ Row Groups Scanned: 4 / 4         │
│ 4,096 rows                    0µs │
╰───────────────────────────────────╯
```
The reason is, 
- Not equal operator has implemented the zonemap check [here](https://github.com/duckdb/duckdb/blob/8c061ed3daf0b992ba1597007074627240871962/src/storage/statistics/string_stats.cpp#L764)
- But we miss the counterpart logic at [equality check](https://github.com/duckdb/duckdb/blob/8c061ed3daf0b992ba1597007074627240871962/src/storage/statistics/string_stats.cpp#L752-L758) 