### PR TITLE
More Sqllogictest cleanup /2

### DIFF
--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -569,6 +569,18 @@ bool DeleteTestPath() {
 
 static bool emit_test_events = false;
 
+static std::function<void(DuckDB &)> static_extension_loader;
+
+void SetStaticExtensionLoader(std::function<void(DuckDB &)> loader) {
+	static_extension_loader = std::move(loader);
+}
+
+void LoadStaticExtensions(DuckDB &db) {
+	if (static_extension_loader) {
+		static_extension_loader(db);
+	}
+}
+
 void SetEmitTestEvents(bool emit) {
 	emit_test_events = emit;
 }

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -48,9 +48,17 @@ static string local_temp_dir_root_override; // --local-temp-dir-root ("" -> the 
 // set, not one per root: a remote root is env-var passthrough only -- unittest holds no credentials, so
 // it can never mkdir or reap one, and the local tree is the only thing with a lifecycle.
 static vector<string> run_created_levels;  // $ROOT..$RUN_ID
-static vector<string> test_created_levels; // $TEST_ID
 static vector<string> home_created_levels; // the HOME sandbox sibling
-static string active_test_leaf;            // currently-materialized $TEST_ID dir ("" when none)
+
+//! The $TEST_ID dir a test materialized, and the levels its path created. Keyed by TEST_ID rather
+//! than held in one global: test files can run concurrently, and every thread working on one test
+//! (a concurrentloop spawns several) has to find that test's entry.
+struct ActiveTestTempDir {
+	string leaf;
+	vector<string> created_levels;
+};
+static mutex active_test_lock;
+static unordered_map<string, ActiveTestTempDir> active_tests;
 
 bool NO_FAIL(QueryResult &result) {
 	if (result.HasError()) {
@@ -522,12 +530,20 @@ void DestroyTempDir(bool success) {
 // Fired at test end with THIS test's pass/fail. Only the $TEST_ID level is in scope -- $RUN_ID/$ROOT
 // were made by PrepareTempDir, so ReclaimLevels stops there.
 void DestroyTestTempDir(bool success) {
-	if (!active_test_leaf.empty() && DestroyFires(temp_dir_destroy, success)) {
-		duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-		ReclaimLevels(*fs, active_test_leaf, test_created_levels);
+	ActiveTestTempDir entry;
+	{
+		lock_guard<mutex> guard(active_test_lock);
+		auto it = active_tests.find(ResolveTestId());
+		if (it == active_tests.end()) {
+			return;
+		}
+		entry = std::move(it->second);
+		active_tests.erase(it);
 	}
-	active_test_leaf.clear();
-	test_created_levels.clear();
+	if (!entry.leaf.empty() && DestroyFires(temp_dir_destroy, success)) {
+		duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+		ReclaimLevels(*fs, entry.leaf, entry.created_levels);
+	}
 }
 
 // $ROOT/[RUN_ID]/[TEST_ID], materializing the $TEST_ID level on first request -- lazily, because the
@@ -535,14 +551,22 @@ void DestroyTestTempDir(bool success) {
 static string MaterializeLocalTestPath() {
 	string path = TreeTestPath(LocalRoot()).ToString();
 	string root = TreeRunIdRoot(LocalRoot()).ToString();
-	if (path != root && path != active_test_leaf) {
-		active_test_leaf = path;
-		test_created_levels.clear();
-		duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
-		if (!fs->DirectoryExists(path)) {
-			RecordAndCreateLevels(*fs, path, test_created_levels);
-		}
+	if (path == root) {
+		return path;
 	}
+	lock_guard<mutex> guard(active_test_lock);
+	auto test_id = ResolveTestId();
+	auto entry = active_tests.find(test_id);
+	if (entry != active_tests.end() && entry->second.leaf == path) {
+		return path;
+	}
+	ActiveTestTempDir active;
+	active.leaf = path;
+	duckdb::unique_ptr<FileSystem> fs = FileSystem::CreateLocal();
+	if (!fs->DirectoryExists(path)) {
+		RecordAndCreateLevels(*fs, path, active.created_levels);
+	}
+	active_tests[test_id] = std::move(active);
 	return path;
 }
 // -----------------------------------------------------------------------------

--- a/test/helpers/test_reporter.cpp
+++ b/test/helpers/test_reporter.cpp
@@ -5,9 +5,11 @@
 namespace duckdb {
 
 //! Reporter used when no driver installed one: failures become exceptions, everything else is
-//! tallied on the reporter itself. This is what the unittester extension runs on.
+//! tallied on the reporter itself.
 static TestReporter default_reporter;
-static TestReporter *active_reporter = &default_reporter;
+//! Per thread, so that test files running concurrently each report into their own reporter. A
+//! thread that spawns workers mid-test (concurrentloop) hands them its reporter explicitly.
+static thread_local TestReporter *active_reporter = nullptr;
 
 void TestReporter::Fail(const string &message, const string &file, idx_t line) {
 	throw TestFailureException(message, file, line);
@@ -34,7 +36,7 @@ void TestReporter::Require(bool condition, const char *expression) {
 }
 
 TestReporter &TestReporter::Get() {
-	return *active_reporter;
+	return active_reporter ? *active_reporter : default_reporter;
 }
 
 void TestReporter::Set(optional_ptr<TestReporter> reporter) {

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -65,6 +65,13 @@ string TestCreatePath(string suffix);
 //! ~/.duckdb, so a remote root resolves against the local tree.
 string GetTempDirHome();
 
+//! Extensions the driver has compiled into itself, installed into every database the runner
+//! creates. The unittest binary links debug_fs and registers it here; the sqllogictest extension
+//! links none, so tests needing one skip or fail rather than the runner depending on it.
+void SetStaticExtensionLoader(std::function<void(DuckDB &)> loader);
+
+void LoadStaticExtensions(DuckDB &db);
+
 void SetEmitTestEvents(bool emit);
 bool EmitTestEventsEnabled();
 

--- a/test/include/test_reporter.hpp
+++ b/test/include/test_reporter.hpp
@@ -33,7 +33,7 @@ struct TestFailureException {
 
 //! Sink for the verdicts the sqllogictest runner produces. The runner reports through this
 //! interface instead of calling a test framework directly, so the same runner can be driven by the
-//! Catch-based unittest binary or in-process (the unittester extension).
+//! Catch-based unittest binary or in-process (the sqllogictest extension).
 class TestReporter {
 public:
 	virtual ~TestReporter() = default;
@@ -64,6 +64,21 @@ public:
 	atomic<idx_t> assertion_count {0};
 	//! Reason passed to the last Skip call.
 	string skip_reason;
+};
+
+//! Installs a reporter for as long as it is in scope, restoring the previous one afterwards (a test
+//! run nested inside another one must not leave the outer driver without its reporter).
+class TestReporterScope {
+public:
+	explicit TestReporterScope(TestReporter &reporter) : previous(TestReporter::Get()) {
+		TestReporter::Set(reporter);
+	}
+	~TestReporterScope() {
+		TestReporter::Set(previous);
+	}
+
+private:
+	TestReporter &previous;
 };
 
 } // namespace duckdb

--- a/test/sql/copy/async_file_lifecycle.test
+++ b/test/sql/copy/async_file_lifecycle.test
@@ -2,6 +2,9 @@
 # description: test async COPY file open/finalize lifecycle paths
 # group: [copy]
 
+# simulates filesystem latency, which only a driver that links debug_fs can provide
+require debug_fs
+
 require parquet
 
 statement ok

--- a/test/sql/storage/external_file_cache/external_file_cache_async_toggle.test
+++ b/test/sql/storage/external_file_cache/external_file_cache_async_toggle.test
@@ -2,6 +2,9 @@
 # description: Concurrent cache toggles must not invalidate file handles used by async Parquet reads
 # group: [external_file_cache]
 
+# simulates filesystem latency, which only a driver that links debug_fs can provide
+require debug_fs
+
 require parquet
 
 statement ok

--- a/test/sqlite/catch_test_reporter.hpp
+++ b/test/sqlite/catch_test_reporter.hpp
@@ -13,7 +13,7 @@
 namespace duckdb {
 
 //! Routes the sqllogictest runner's verdicts into the Catch session that the unittest binary runs.
-//! Only the unittest binary links this; the unittester extension uses the default reporter.
+//! Only the unittest binary links this; the sqllogictest extension uses the default reporter.
 class CatchTestReporter : public TestReporter {
 public:
 	void Fail(const string &message, const string &file, idx_t line) override;

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -76,6 +76,7 @@ bool TestResultHelper::CheckQueryResult(const Query &query, ExecuteContext &cont
 			runner.finished_processing_file = true;
 			return true;
 		}
+		runner.last_error_message = result.GetError();
 		if (!FailureSummary::SkipLoggingSameError(context.error_file)) {
 			logger.UnexpectedFailure(result);
 		}
@@ -342,6 +343,7 @@ bool TestResultHelper::CheckStatementResult(const Statement &statement, ExecuteC
 			runner.finished_processing_file = true;
 			return true;
 		}
+		runner.last_error_message = result.GetError();
 		if (!FailureSummary::SkipLoggingSameError(statement.file_name)) {
 			logger.UnexpectedStatement(expected_result == ExpectedResult::RESULT_SUCCESS, result);
 		}

--- a/test/sqlite/sqllogic_command.cpp
+++ b/test/sqlite/sqllogic_command.cpp
@@ -673,11 +673,18 @@ void LoopCommand::ExecuteInternal(ExecuteContext &context) const {
 		std::list<std::thread> threads;
 		idx_t finished_thread_idx = 0;
 		auto context_it = contexts.begin();
+		// the reporter is per thread: hand this test's reporter to the workers it spawns
+		auto &reporter = TestReporter::Get();
 		while (context_it != contexts.end()) {
 			// launch threads
 			for (; context_it != contexts.end() && threads.size() - finished_thread_idx < max_threads; ++context_it) {
 				auto &execute_context = *context_it;
-				threads.emplace_back(ParallelExecuteLoop, &execute_context);
+				threads.emplace_back(
+				    [&reporter](ParallelExecuteContext *ctx) {
+					    TestReporter::Set(reporter);
+					    ParallelExecuteLoop(ctx);
+				    },
+				    &execute_context);
 			}
 			// wait for active threads to finish
 			for (auto it = std::next(threads.begin(), static_cast<int64_t>(finished_thread_idx)); it != threads.end();

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -10,8 +10,12 @@
 
 namespace duckdb {
 
+//! Process-wide: a failure report is a sequence of writes to stderr, and test files running
+//! concurrently would otherwise shred each other's output.
+mutex SQLLogicTestLogger::log_mutex;
+
 SQLLogicTestLogger::SQLLogicTestLogger(ExecuteContext &context, const Command &command)
-    : connection(command.CommandConnection(context)), log_lock(command.runner.log_lock), file_name(command.file_name),
+    : connection(command.CommandConnection(context)), log_lock(log_mutex), file_name(command.file_name),
       query_line(command.query_line), sql_query(context.sql_query) {
 }
 

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -66,6 +66,9 @@ public:
 	string ResultToString(MaterializedQueryResult &result);
 
 private:
+	static mutex log_mutex;
+
+private:
 	Connection &connection;
 	lock_guard<mutex> log_lock;
 	string file_name;

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -103,8 +103,9 @@ void SQLLogicTestRunner::AddSkipReason(const string &reason) {
 	skip_reason_counts[reason]++;
 }
 
-void SQLLogicTestRunner::SkipTest(const string &reason) {
+void SQLLogicTestRunner::SkipTest(const string &reason, TestSkipKind kind) {
 	AddSkipReason(reason);
+	test_skip_kind = kind;
 	// A whole-test skip is a terminal disposition, not a mid-stream event: record it and let the
 	// Catch wrapper emit the single end {status:"skip-requirement"} terminal.
 	test_skipped_requirement = true;
@@ -125,9 +126,6 @@ string SQLLogicTestRunner::GetSkipReasonSummary() {
 }
 
 void SQLLogicTestRunner::CountStatement(bool passed) {
-	if (!EmitTestEventsEnabled()) {
-		return; // feature off: no counting on the normal path
-	}
 	if (passed) {
 		test_stat_passes++;
 	} else {
@@ -136,9 +134,6 @@ void SQLLogicTestRunner::CountStatement(bool passed) {
 }
 
 void SQLLogicTestRunner::CountSkipMode() {
-	if (!EmitTestEventsEnabled()) {
-		return;
-	}
 	test_stat_skip_mode++;
 }
 
@@ -784,7 +779,7 @@ void SQLLogicTestRunner::ExecuteInternal(SQLLogicParser &parser, const string &s
 	file_name = script;
 	auto &test_config = TestConfiguration::Get();
 	if (test_config.ShouldSkipTest(script)) {
-		SkipTest("config skip_tests");
+		SkipTest("config skip_tests", TestSkipKind::EXCLUDED);
 		return;
 	}
 
@@ -862,7 +857,7 @@ void SQLLogicTestRunner::ExecuteScript(SQLLogicParser &parser, const string &scr
 		// Check tags first time we hit test statements, since all explicit & implicit tags now present
 		if (parser.IsTestCommand(token.type) && !test_expr_executed) {
 			if (test_config.GetPolicyForTagSet(file_tags) == TestConfiguration::SelectPolicy::SKIP) {
-				SkipTest("select tag-set");
+				SkipTest("select tag-set", TestSkipKind::EXCLUDED);
 				return;
 			}
 			test_expr_executed = true;
@@ -1248,7 +1243,7 @@ void SQLLogicTestRunner::ExecuteScript(SQLLogicParser &parser, const string &scr
 		} else if (token.type == SQLLogicTokenType::SQLLOGIC_LOAD) {
 			auto &test_config = TestConfiguration::Get();
 			if (test_config.OnLoadCommand() == "skip") {
-				SkipTest("config on_load skip");
+				SkipTest("config on_load skip", TestSkipKind::EXCLUDED);
 				return;
 			}
 			bool is_read_only = false;

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -9,7 +9,6 @@
 #include "duckdb/main/extension_entries.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/settings.hpp"
-#include "debug_fs_extension.hpp"
 #include "sqllogic_parser.hpp"
 #include "test_helpers.hpp"
 #include "test_reporter.hpp"
@@ -248,7 +247,7 @@ NewDatabaseConnection SQLLogicTestRunner::CreateDatabase(const string &db_path, 
 	NewDatabaseConnection result;
 	try {
 		result.db = make_uniq<DuckDB>(db_path, config.get());
-		result.db->LoadStaticExtension<DebugFsExtension>();
+		LoadStaticExtensions(*result.db);
 
 		// always load core functions
 		auto &test_config = TestConfiguration::Get();

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -94,7 +94,6 @@ public:
 
 	//! The map converting the labels to the hash values
 	HashLabelMap hash_label_map;
-	mutex log_lock;
 
 	//! Per-test statement tallies for --emit-test-events. Atomic: concurrent loops run the countable
 	//! commands on multiple threads; the begin/end events are emitted single-threaded at boundaries.

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -110,6 +110,9 @@ public:
 	bool test_skipped_requirement = false;
 	string test_skip_reason;
 	TestSkipKind test_skip_kind = TestSkipKind::REQUIREMENT;
+	//! Error text of the statement that failed, when it failed with one. The driver otherwise only
+	//! sees a file:line locator, and the text is what says why.
+	string last_error_message;
 	//! Locator for the failing command (file:line), stashed at the throw site for --emit-test-events.
 	//! A Catch FAIL carries no message; consumers get this anchor to correlate with captured output.
 	//! Written single-threaded: serial fails throw directly; concurrent fails are re-raised post-join.

--- a/test/sqlite/sqllogic_test_runner.hpp
+++ b/test/sqlite/sqllogic_test_runner.hpp
@@ -23,6 +23,14 @@ class SQLLogicParser;
 
 enum class RequireResult { PRESENT, MISSING };
 
+//! Why a whole test was skipped.
+enum class TestSkipKind : uint8_t {
+	//! the environment cannot run it: require / require-env
+	REQUIREMENT,
+	//! it was deliberately excluded: a skip list or a tag selection
+	EXCLUDED
+};
+
 struct CachedLabelData {
 public:
 	CachedLabelData(const string &hash, string result_str_p) : hash(hash), result_str(std::move(result_str_p)) {
@@ -101,6 +109,7 @@ public:
 	//! the terminal to emit end{status:"skip-requirement"}.
 	bool test_skipped_requirement = false;
 	string test_skip_reason;
+	TestSkipKind test_skip_kind = TestSkipKind::REQUIREMENT;
 	//! Locator for the failing command (file:line), stashed at the throw site for --emit-test-events.
 	//! A Catch FAIL carries no message; consumers get this anchor to correlate with captured output.
 	//! Written single-threaded: serial fails throw directly; concurrent fails are re-raised post-join.
@@ -124,9 +133,9 @@ public:
 	string ReplaceLoopIterator(string text, string loop_iterator_name, string replacement);
 	string LoopReplacement(string text, const vector<LoopDefinition> &loops);
 	static ExtensionLoadResult LoadExtension(DuckDB &db, const std::string &extension);
-	void SkipTest(const string &reason);
+	void SkipTest(const string &reason, TestSkipKind kind = TestSkipKind::REQUIREMENT);
 	static string GetSkipReasonSummary();
-	//! --emit-test-events: statement tallies (counted, not emitted) + the begin/end JSON events.
+	//! Statement tallies, plus the begin/end JSON events emitted under --emit-test-events.
 	void CountStatement(bool passed);
 	void CountSkipMode();
 	void EmitBegin(const string &test_name);

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -6,6 +6,7 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "debug_fs_extension.hpp"
 #include "sqlite/catch_test_reporter.hpp"
 #include "sqlite/sqllogic_test_logger.hpp"
 #include "sqlite/sqllogic_test_runner.hpp"
@@ -70,6 +71,8 @@ int main(int argc_in, char *argv[]) {
 	// route the sqllogictest runner's verdicts into the Catch session
 	static CatchTestReporter catch_reporter;
 	TestReporter::Set(catch_reporter);
+	// debug_fs is linked into this binary; hand it to every database the runner creates
+	SetStaticExtensionLoader([](DuckDB &db) { db.LoadStaticExtension<DebugFsExtension>(); });
 
 	auto &test_config = TestConfiguration::Get();
 	try {


### PR DESCRIPTION
Stacked on top of https://github.com/duckdb/duckdb/pull/25488, adds primitives to allow unittester to run in parallel in the same binary, by moving away from global into either class members or thread_local globals.

Minor refactor, should be a nop for unittester, but allows to reuse the same code as loadable extension.