### PR TITLE
Close the main WAL handle before renaming over it during WAL recovery

### DIFF
--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -382,6 +382,8 @@ void WriteAheadLogReplayer::MergeIntoRecoveryWAL(Connection &con, const ReplaySt
 	// move over the recovery WAL over the main WAL
 	recovery_handle->Sync();
 	recovery_handle.reset();
+	// the main WAL is the target of the move - Windows refuses to replace a file that is still open
+	main_wal_reader.handle.reset();
 
 	if (debug_checkpoint_abort == CheckpointAbort::DEBUG_ABORT_BEFORE_MOVING_RECOVERY) {
 		throw FatalException("Checkpoint aborted before moving recovery file because of PRAGMA checkpoint_abort flag");
@@ -496,7 +498,10 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 				}
 				// if this is not a read-only connection we need to finish the checkpoint
 				// overwrite the current WAL with the checkpoint WAL
+				// both files must be closed - Windows refuses to move a file that is still open, and refuses to
+				// replace a target that is still open
 				checkpoint_handle.reset();
+				reader.handle.reset();
 
 				fs.MoveFile(checkpoint_wal, wal_path);
 


### PR DESCRIPTION
Fixes #24767.

After a crash mid-checkpoint the database is left with both <db>.wal and <db>.wal.checkpoint. Recovery merges them into <db>.wal.recovery and renames that over the main WAL, but WriteAheadLogReplayer::ReplayLog still holds the main WAL open through its BufferedFileReader while MergeIntoRecoveryWAL calls MoveFile(recovery_path, main_wal_path). POSIX rename(2) replaces an open file, so this never surfaces in CI; Windows MoveFileExW refuses, and because nothing has changed when it fails, every retry fails identically - the database can never be opened read-write again without manual repair.

The "checkpoint was successful" branch of ReplayLog has the same defect: it closes the source checkpoint handle before MoveFile(checkpoint_wal, wal_path) but leaves the target, the main WAL, open through the same reader.

Close the reader's handle at both moves. It is only needed again after the rename, and both paths reopen the WAL from its path anyway.