### PR TITLE
Specify unary arg property for round_even function

### DIFF
--- a/extension/core_functions/scalar/math/numeric.cpp
+++ b/extension/core_functions/scalar/math/numeric.cpp
@@ -1223,6 +1223,7 @@ ScalarFunctionSet RoundEvenFun::GetFunctions() {
 		}
 		round_even.AddFunction(std::move(round_even_function));
 	}
+	round_even.SetUnaryArgProperties(ArgProperties().NonDecreasing());
 	return round_even;
 }
 

--- a/test/sql/optimizer/monotone_function_zonemap_pruning.test
+++ b/test/sql/optimizer/monotone_function_zonemap_pruning.test
@@ -131,3 +131,22 @@ FROM monotone_math
 WHERE tanh(x) > 0.5;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+# Rounding 10.2, 20.2, and 60.2 leaves only the third row group above 50.
+statement ok
+ATTACH '{TEST_DIR}/round_even_prune.duckdb' AS round_even_db (ROW_GROUP_SIZE 2048);
+
+statement ok
+CREATE TABLE round_even_db.t AS
+SELECT CASE WHEN range < 2048 THEN 10.2 WHEN range < 4096 THEN 20.2 ELSE 60.2 END::DOUBLE AS x
+FROM range(6144);
+
+query I
+SELECT count(*) FROM round_even_db.t WHERE round_even(x, 0) > 50;
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT x FROM round_even_db.t WHERE round_even(x, 0) > 50;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*


### PR DESCRIPTION
Hi team, I found row groups are not pruned as expected for `round_even` function, example
```sql
memory D ATTACH '/tmp/round_even_prune.duckdb' AS round_even_db (ROW_GROUP_SIZE 2048);
memory D CREATE TABLE round_even_db.t AS
         SELECT CASE WHEN range < 2048 THEN 10.2 WHEN range < 4096 THEN 20.2 ELSE 60.2 END::DOUBLE AS x
         FROM range(6144);

-- should access one row group, but access all
memory D EXPLAIN ANALYZE SELECT x FROM round_even_db.t WHERE round_even(x, 0) > 50;
╭─ Summary ───────────╮
│ Total Time: 0.0023s │
╰─────────────────────╯
╭─ Table Scan ─────────────────────╮
│ Table: round_even_db.main.t      │
│ Type: Sequential Scan            │
│ Projections: x                   │
│ Filters: round_even(x, 0) > 50.0 │
│ Row Groups Scanned: 3 / 3        │
│ 2,048 rows                   0µs │
╰──────────────────────────────────╯
```