### PR TITLE
Simplify boolean comparisons with FALSE

### DIFF
--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -175,10 +175,15 @@ unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, 
 		return make_uniq<BoundConstantExpression>(Value(LogicalType::BOOLEAN));
 	}
 	if (BoundComparisonExpression::IsComparison(column_ref_expr) && !constant_value.IsNull() &&
-	    constant_value.type().id() == LogicalTypeId::BOOLEAN && BooleanValue::Get(constant_value)) {
+	    constant_value.type().id() == LogicalTypeId::BOOLEAN) {
 		if (expr.GetExpressionType() == ExpressionType::COMPARE_EQUAL ||
 		    (expr.GetExpressionType() == ExpressionType::COMPARE_NOT_DISTINCT_FROM && is_root &&
 		     op.type == LogicalOperatorType::LOGICAL_FILTER)) {
+			if (!BooleanValue::Get(constant_value)) {
+				auto &comparison = column_ref_expr.Cast<BoundFunctionExpression>();
+				auto negated_type = NegateComparisonExpression(comparison.GetExpressionType());
+				BoundComparisonExpression::SetType(comparison, negated_type);
+			}
 			return column_ref_left ? std::move(left) : std::move(right);
 		}
 	}

--- a/test/sql/optimizer/boolean_wrapper_pushdown.test
+++ b/test/sql/optimizer/boolean_wrapper_pushdown.test
@@ -18,6 +18,25 @@ EXPLAIN ANALYZE SELECT sum(rowid) FROM integers WHERE (x > 3000) = true;
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
 
+foreach wrapper = IS
+
+query I
+SELECT count(*) FROM integers WHERE (x < 3000) {wrapper} FALSE;
+----
+1096
+
+query II
+EXPLAIN ANALYZE SELECT sum(rowid) FROM integers WHERE (x < 3000) {wrapper} FALSE;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 2.*
+
+endloop
+
+query I
+SELECT count(*) FROM integers WHERE FALSE = (x < 3000);
+----
+1096
+
 query II
 EXPLAIN ANALYZE SELECT sum(rowid) FROM integers WHERE (x > 3000) IS TRUE;
 ----
@@ -37,11 +56,22 @@ false	false	false
 true	true	true
 NULL	NULL	false
 
-# Rewriting a nested IS TRUE would incorrectly exclude the NULL row
+query III
+SELECT FALSE = (p = true), (p = true) = FALSE, (p = true) IS FALSE FROM booleans ORDER BY p NULLS LAST;
+----
+true	true	true
+false	false	false
+NULL	NULL	false
+
+# Rewriting a nested IS TRUE/FALSE would incorrectly exclude the NULL row
+foreach value TRUE FALSE
+
 query I
-SELECT count(*) FROM booleans WHERE NOT (p IS TRUE);
+SELECT count(*) FROM booleans WHERE NOT ((p = true) IS {value});
 ----
 2
+
+endloop
 
 statement ok
 CREATE SEQUENCE s;


### PR DESCRIPTION
Hi team, I found when comparison with boolean value, only true constants prunes correctly (namely, `IS TRUE`); while we don't prune row groups for false const expression; for example,
```sql
memory D ATTACH 'false_pruning_repro.db' AS repro (ROW_GROUP_SIZE 2048);
memory D CREATE TABLE repro.integers AS SELECT range AS x FROM range(4096);
memory D CHECKPOINT repro;

-- doesn't prune
memory D EXPLAIN ANALYZE
         SELECT sum(rowid) FROM repro.integers WHERE (x < 3000) = FALSE;
╭─ Summary ───────────╮
│ Total Time: 0.0038s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ───────╮
│ Aggregates: sum(#0)         │
│ 1 row                   0µs │
╰──────────────┒┎─────────────╯
╭─ Projection ─┚┖─────────────╮
│ Projections: rowid          │
│ 1,096 rows              0µs │
╰──────────────┒┎─────────────╯
╭─ Table Scan ─┚┖─────────────╮
│ Table: repro.main.integers  │
│ Type: Sequential Scan       │
│ Filters: (x < 3000) = false │
│ Row Groups Scanned: 2 / 2   │
│ 1,096 rows              0µs │
╰─────────────────────────────╯

-- doesn't prune
memory D EXPLAIN ANALYZE
         SELECT sum(rowid) FROM repro.integers WHERE (x < 3000) IS FALSE;
╭─ Summary ───────────╮
│ Total Time: 0.0006s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────────────╮
│ Aggregates: sum(#0)                   │
│ 1 row                             0µs │
╰───────────────────┒┎──────────────────╯
╭─ Projection ──────┚┖──────────────────╮
│ Projections: rowid                    │
│ 1,096 rows                        0µs │
╰───────────────────┒┎──────────────────╯
╭─ Table Scan ──────┚┖──────────────────╮
│ Table: repro.main.integers            │
│ Type: Sequential Scan                 │
│ Filters:                              │
│ (x < 3000) IS NOT DISTINCT FROM false │
│ Row Groups Scanned: 2 / 2             │
│ 1,096 rows                        0µs │
╰───────────────────────────────────────╯

-- prunes correctly
memory D EXPLAIN ANALYZE
         SELECT sum(rowid) FROM repro.integers WHERE x >= 3000;
╭─ Summary ───────────╮
│ Total Time: 0.0019s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ──────╮
│ Aggregates: sum(#0)        │
│ 1 row                  0µs │
╰──────────────┒┎────────────╯
╭─ Projection ─┚┖────────────╮
│ Projections: rowid         │
│ 1,096 rows             0µs │
╰──────────────┒┎────────────╯
╭─ Table Scan ─┚┖────────────╮
│ Table: repro.main.integers │
│ Type: Sequential Scan      │
│ Filters: x >= 3000         │
│ Row Groups Scanned: 1 / 2  │
│ 1,096 rows             0µs │
╰────────────────────────────╯
```
The issue is, we only simplify for [true expression here](https://github.com/duckdb/duckdb/blob/ed385454442e17e56f22449df87d2c3069dbe375/src/optimizer/rule/comparison_simplification.cpp#L178)
