### PR TITLE
List fixes: fix list_slice and comparator to not read uninitialized memory

### DIFF
--- a/src/common/vector_operations/comparison_operators.cpp
+++ b/src/common/vector_operations/comparison_operators.cpp
@@ -695,17 +695,17 @@ static void ListOrArrayComparator(const Vector &left, const Vector &right, int8_
 			DistinctComparatorTypeSwitch(left_child, right_child, child_result.get(), left_child_sel, right_child_sel,
 			                             active_count);
 			// partition active into resolved vs still-remaining
-			remaining_count = NestedScatter(child_result.get(), result_data, remaining_count, remaining_lhs_sel,
+			remaining_count = NestedScatter(child_result.get(), result_data, active_count, remaining_lhs_sel,
 			                                remaining_rhs_sel, remaining_result_sel, child_validity, nullptr,
 			                                [](int8_t c, bool n) { return c != Comparator::VALUES_ARE_EQUAL || n; });
 			break;
 		case ExpressionType::COMPARE_EQUAL:
 		case ExpressionType::COMPARE_NOTEQUAL:
-			child_validity.SetAllValid(remaining_count);
+			child_validity.SetAllValid(active_count);
 			ComparatorTypeSwitch(left_child, right_child, child_result.get(), left_child_sel, right_child_sel,
 			                     active_count, comp, child_validity);
 			//	Only keep values we know are not equal.
-			remaining_count = NestedScatter(child_result.get(), result_data, remaining_count, remaining_lhs_sel,
+			remaining_count = NestedScatter(child_result.get(), result_data, active_count, remaining_lhs_sel,
 			                                remaining_rhs_sel, remaining_result_sel, child_validity, nullptr,
 			                                [](int8_t c, bool n) { return c != Comparator::VALUES_ARE_EQUAL && !n; });
 			break;
@@ -728,12 +728,12 @@ static void ListOrArrayComparator(const Vector &left, const Vector &right, int8_
 				break;
 			}
 
-			child_validity.SetAllValid(remaining_count);
+			child_validity.SetAllValid(active_count);
 			DistinctComparatorTypeSwitch(left_child, right_child, child_result.get(), left_child_sel, right_child_sel,
 			                             active_count);
 
 			// partition active into resolved vs still-remaining
-			remaining_count = NestedScatter(child_result.get(), result_data, remaining_count, remaining_lhs_sel,
+			remaining_count = NestedScatter(child_result.get(), result_data, active_count, remaining_lhs_sel,
 			                                remaining_rhs_sel, remaining_result_sel, child_validity, nullptr,
 			                                [](int8_t c, bool n) { return c != Comparator::VALUES_ARE_EQUAL || n; });
 		}

--- a/src/function/cast/list_casts.cpp
+++ b/src/function/cast/list_casts.cpp
@@ -41,27 +41,83 @@ unique_ptr<FunctionLocalState> ListBoundCastData::InitListLocalState(CastLocalSt
 bool ListCast::ListToListCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	auto &cast_data = parameters.cast_data->Cast<ListBoundCastData>();
 
-	// only handle constant and flat vectors here for now
 	auto source_data = source.Values<list_entry_t>();
+	auto &source_cc = ListVector::GetChildMutable(source);
+	auto source_size = ListVector::GetListSize(source);
+	CastParameters child_parameters(parameters, cast_data.child_cast_info.GetCastData(), parameters.local_state);
+
+	// the entries can reference an arbitrary subset of the child vector (e.g. after list_slice) - casting the whole
+	// child then does needless work and reports errors for elements that are not part of any list
+	// a constant vector repeats the same entry for every row, so only the first entry is inspected
+	const auto is_constant = source.GetVectorType() == VectorType::CONSTANT_VECTOR;
+	const idx_t entry_count = is_constant ? MinValue<idx_t>(count, 1) : count;
+	idx_t child_count = 0;
+	bool covers_child = true;
+	for (idx_t r = 0; r < entry_count; r++) {
+		auto source_list = source_data[r];
+		if (!source_list.IsValid()) {
+			continue;
+		}
+		auto entry = source_list.GetValue();
+		covers_child = covers_child && entry.offset == child_count;
+		child_count += entry.length;
+	}
+	covers_child = covers_child && child_count == source_size;
+
+	if (covers_child) {
+		// the lists cover the child vector exactly and in order - cast it as-is and keep the entries
+		auto result_data = FlatVector::Writer<list_entry_t>(result, count);
+		for (idx_t r = 0; r < count; r++) {
+			auto source_list = source_data[r];
+			if (!source_list.IsValid()) {
+				result_data.WriteNull();
+				continue;
+			}
+			result_data.WriteValue(source_list.GetValue());
+		}
+		ListVector::Reserve(result, source_size);
+		auto &append_vector = ListVector::GetChildMutable(result);
+		bool all_succeeded = cast_data.child_cast_info.Cast(source_cc, append_vector, source_size, child_parameters);
+		ListVector::SetListSize(result, source_size);
+		D_ASSERT(ListVector::GetListSize(result) == source_size);
+		return all_succeeded;
+	}
+
+	// gather the referenced elements in list order, so only those are cast
+	SelectionVector child_sel(child_count);
+	idx_t child_offset = 0;
+	for (idx_t r = 0; r < entry_count; r++) {
+		auto source_list = source_data[r];
+		if (!source_list.IsValid()) {
+			continue;
+		}
+		auto entry = source_list.GetValue();
+		for (idx_t i = 0; i < entry.length; i++) {
+			child_sel.set_index(child_offset + i, entry.offset + i);
+		}
+		child_offset += entry.length;
+	}
+
 	auto result_data = FlatVector::Writer<list_entry_t>(result, count);
+	child_offset = 0;
 	for (idx_t r = 0; r < count; r++) {
 		auto source_list = source_data[r];
 		if (!source_list.IsValid()) {
 			result_data.WriteNull();
 			continue;
 		}
-		result_data.WriteValue(source_list.GetValue());
+		auto entry = source_list.GetValue();
+		result_data.WriteValue(list_entry_t(child_offset, entry.length));
+		if (!is_constant) {
+			child_offset += entry.length;
+		}
 	}
-	auto &source_cc = ListVector::GetChildMutable(source);
-	auto source_size = ListVector::GetListSize(source);
 
-	ListVector::Reserve(result, source_size);
+	Vector source_slice(source_cc, child_sel, child_count);
+	ListVector::Reserve(result, child_count);
 	auto &append_vector = ListVector::GetChildMutable(result);
-
-	CastParameters child_parameters(parameters, cast_data.child_cast_info.GetCastData(), parameters.local_state);
-	bool all_succeeded = cast_data.child_cast_info.Cast(source_cc, append_vector, source_size, child_parameters);
-	ListVector::SetListSize(result, source_size);
-	D_ASSERT(ListVector::GetListSize(result) == source_size);
+	bool all_succeeded = cast_data.child_cast_info.Cast(source_slice, append_vector, child_count, child_parameters);
+	ListVector::SetListSize(result, child_count);
 	return all_succeeded;
 }
 

--- a/test/sql/join/test_huge_nested_payloads.test_slow
+++ b/test/sql/join/test_huge_nested_payloads.test_slow
@@ -16,7 +16,7 @@ SELECT count(DISTINCT [[p.v2ProductName for p in h.product] for h in hits]) FROM
 query I
 SELECT count(DISTINCT [[p.customDimensions for p in h.product] for h in hits]) FROM tbl2;
 ----
-910
+794
 
 query III
 SELECT

--- a/test/sql/types/nested/list/list_cast_child_offset.test
+++ b/test/sql/types/nested/list/list_cast_child_offset.test
@@ -1,0 +1,94 @@
+# name: test/sql/types/nested/list/list_cast_child_offset.test
+# description: LIST casts must only look at the child entries the lists point at
+# group: [list]
+
+# Issue #23715: list_slice leaves the removed elements in the child vector, casting the whole child
+# then raises a conversion error for elements that are no longer part of any list
+query I
+WITH t(l) AS (VALUES ([['bad'], ['1', '2'], ['3', '4']]), ([['bad'], ['5', '6'], ['7', '8']]))
+SELECT CAST(list_slice(l, 2, 3) AS INTEGER[][2]) FROM t
+----
+[[1, 2], [3, 4]]
+[[5, 6], [7, 8]]
+
+query I
+WITH t(l) AS (VALUES (['bad', '1', '2']), (['bad', '5', '6']))
+SELECT CAST(list_slice(l, 2, 3) AS INTEGER[]) FROM t
+----
+[1, 2]
+[5, 6]
+
+query I
+WITH t(l) AS (VALUES ([['bad'], ['1', '2'], ['3', '4']]), ([['bad'], ['5', '6'], ['7', '8']]))
+SELECT CAST(list_slice(l, 2, 3) AS INTEGER[][]) FROM t
+----
+[[1, 2], [3, 4]]
+[[5, 6], [7, 8]]
+
+# nested one level deeper
+query I
+WITH t(l) AS (VALUES ([[['bad']], [['1']], [['2']]]), ([[['z']], [['7']], [['8']]]))
+SELECT CAST(list_slice(l, 2, 3) AS INTEGER[][][]) FROM t
+----
+[[[1]], [[2]]]
+[[[7]], [[8]]]
+
+# struct children
+query I
+WITH t(l) AS (VALUES ([{'a': 'bad'}, {'a': '1'}, {'a': '2'}]), ([{'a': 'z'}, {'a': '7'}, {'a': '8'}]))
+SELECT CAST(list_slice(l, 2, 3) AS STRUCT(a INTEGER)[]) FROM t
+----
+[{'a': 1}, {'a': 2}]
+[{'a': 7}, {'a': 8}]
+
+# NULL and empty lists mixed in
+query I
+WITH t(l) AS (VALUES (['bad', '1', '2']), (NULL), ([]), (['bad', '5', '6']))
+SELECT CAST(list_slice(l, 2, 3) AS INTEGER[]) FROM t
+----
+[1, 2]
+NULL
+[]
+[5, 6]
+
+# a constant list is repeated for every row, the elements only need to be cast once
+query II
+SELECT count(*), any_value(x) FROM (SELECT CAST(list_slice(['bad', '3', '4'], 2, 3) AS INTEGER[]) x FROM range(5000))
+----
+5000	[3, 4]
+
+# a filter leaves the child intact, so a surviving row can point past the entries the row count covers
+statement ok
+CREATE TABLE list_child_offset AS
+    SELECT i, [(i * 3 + 1)::VARCHAR, (i * 3 + 2)::VARCHAR, (i * 3 + 3)::VARCHAR] AS l
+    FROM range(100) t(i);
+
+query II
+SELECT i, l::INT[] FROM list_child_offset WHERE i = 99
+----
+99	[298, 299, 300]
+
+# ... and elements that no surviving row points at must not raise a cast error
+statement ok
+CREATE TABLE unreferenced_bad_child AS
+    SELECT i, CASE WHEN i = 0 THEN ['1', '2', '3'] ELSE ['x', 'y', 'z'] END AS l
+    FROM range(100) t(i);
+
+query I
+SELECT l::INT[] FROM unreferenced_bad_child WHERE i = 0
+----
+[1, 2, 3]
+
+# the error is still raised for elements a row does point at
+statement error
+WITH t(l) AS (VALUES (['bad', '1', '2']), (['bad', '5', '6']))
+SELECT CAST(list_slice(l, 1, 3) AS INTEGER[]) FROM t
+----
+<REGEX>:Conversion Error.*Could not convert string 'bad' to INT32.*
+
+query I
+WITH t(l) AS (VALUES (['bad', '1', '2']), (['bad', '5', '6']))
+SELECT TRY_CAST(list_slice(l, 1, 3) AS INTEGER[]) FROM t
+----
+[NULL, 1, 2]
+[NULL, 5, 6]

--- a/test/sql/types/nested/list/list_comparison_stale_positions.test
+++ b/test/sql/types/nested/list/list_comparison_stale_positions.test
@@ -1,0 +1,105 @@
+# name: test/sql/types/nested/list/list_comparison_stale_positions.test
+# description: Nested comparisons must only scatter back the rows that were actually compared
+# group: [list]
+
+# The position-by-position list comparator resolves rows whose list ran out of elements and
+# compacts the remaining rows. Scattering back more rows than were compared re-read stale
+# selection indices from the previous position and clobbered already-resolved rows.
+
+statement ok
+CREATE TABLE t(l INTEGER[]);
+
+statement ok
+INSERT INTO t VALUES ([1, NULL]), ([1, 2]), ([1, NULL, 3]);
+
+query II
+SELECT l, l IS NOT DISTINCT FROM [1, NULL, 3] FROM t
+----
+[1, NULL]	false
+[1, 2]	false
+[1, NULL, 3]	true
+
+query II
+SELECT l, l IS DISTINCT FROM [1, NULL, 3] FROM t
+----
+[1, NULL]	true
+[1, 2]	true
+[1, NULL, 3]	false
+
+statement ok
+DELETE FROM t
+
+statement ok
+INSERT INTO t VALUES ([1, NULL, 3]), ([1, NULL]), ([1, 2]), ([1, NULL, 3])
+
+query II
+SELECT l, l IS NOT DISTINCT FROM [1, NULL, 3] FROM t
+----
+[1, NULL, 3]	true
+[1, NULL]	false
+[1, 2]	false
+[1, NULL, 3]	true
+
+# the ordering comparisons walk the same path
+query IIII
+SELECT l, l < [1, NULL, 3], l > [1, NULL, 3], l <= [1, NULL, 3] FROM t
+----
+[1, NULL, 3]	false	false	true
+[1, NULL]	true	false	true
+[1, 2]	true	false	true
+[1, NULL, 3]	false	false	true
+
+# same shape one level deeper
+statement ok
+CREATE TABLE n(l INTEGER[][]);
+
+statement ok
+INSERT INTO n VALUES ([[1], [NULL]]), ([[1], [2]]), ([[1], [NULL], [3]])
+
+query II
+SELECT l, l IS NOT DISTINCT FROM [[1], [NULL], [3]] FROM n
+----
+[[1], [NULL]]	false
+[[1], [2]]	false
+[[1], [NULL], [3]]	true
+
+# and for fixed-size arrays, which share the comparator
+statement ok
+CREATE TABLE a(l INTEGER[3]);
+
+statement ok
+INSERT INTO a VALUES ([1, NULL, 9]), ([1, 2, 3]), ([1, NULL, 3])
+
+query II
+SELECT l, l IS NOT DISTINCT FROM [1, NULL, 3]::INTEGER[3] FROM a
+----
+[1, NULL, 9]	false
+[1, 2, 3]	false
+[1, NULL, 3]	true
+
+# the distinct ordering must stay total: exactly one of <, >, "not distinct" holds
+statement ok
+CREATE TABLE r AS
+SELECT CASE WHEN random() < 0.1 THEN NULL
+            ELSE [CASE WHEN random() < 0.3 THEN NULL ELSE (random() * 3)::INT END
+                  FOR x IN range((random() * 4)::INT + 1)] END AS a,
+       CASE WHEN random() < 0.1 THEN NULL
+            ELSE [CASE WHEN random() < 0.3 THEN NULL ELSE (random() * 3)::INT END
+                  FOR x IN range((random() * 4)::INT + 1)] END AS b
+FROM range(20000);
+
+query I
+SELECT count(*) FROM r WHERE (a < b)::INT + (a > b)::INT + (a IS NOT DISTINCT FROM b)::INT <> 1
+----
+0
+
+# ... and must agree with an element-wise definition of IS NOT DISTINCT FROM
+query I
+SELECT count(*) FROM r
+WHERE (a IS NOT DISTINCT FROM b) <> (
+    CASE WHEN a IS NULL AND b IS NULL THEN true
+         WHEN a IS NULL OR b IS NULL THEN false
+         WHEN len(a) <> len(b) THEN false
+         ELSE len(list_filter(range(1, len(a) + 1), lambda i: a[i] IS DISTINCT FROM b[i])) = 0 END)
+----
+0


### PR DESCRIPTION
The fix at src/common/vector_operations/comparison_operators.cpp could be worth backporting to v1.5-variegata, I have not done it (yet) due to the API changes.

Fixes https://github.com/duckdb/duckdb/issues/23715 and an issue found while looking into that issue.