### PR TITLE
Fix hang for database rename

### DIFF
--- a/src/include/duckdb/main/database_file_path_manager.hpp
+++ b/src/include/duckdb/main/database_file_path_manager.hpp
@@ -41,6 +41,9 @@ public:
 	void EraseDatabasePath(const string &path);
 	//! Called when a database is detached, but before it is fully finished being used
 	void DetachDatabase(DatabaseManager &manager, const string &path);
+	//! Rewrite `path`'s tracked name from `old_name` to `new_name`.
+	//! Silent no-op if `path` is not tracked or the tracked name is not `old_name`.
+	void RenameDatabasePath(const string &path, const Identifier &old_name, const Identifier &new_name);
 
 private:
 	//! The lock to add entries to the db_paths map

--- a/src/main/database_file_path_manager.cpp
+++ b/src/main/database_file_path_manager.cpp
@@ -87,4 +87,19 @@ void DatabaseFilePathManager::DetachDatabase(DatabaseManager &manager, const str
 	}
 }
 
+void DatabaseFilePathManager::RenameDatabasePath(const string &path, const Identifier &old_name,
+                                                 const Identifier &new_name) {
+	if (path.empty() || path == IN_MEMORY_PATH) {
+		return;
+	}
+	const lock_guard<mutex> path_lock(db_paths_lock);
+	auto entry = db_paths.find(path);
+	if (entry == db_paths.end()) {
+		return;
+	}
+	if (entry->second.name == old_name.GetIdentifierName()) {
+		entry->second.name = new_name.GetIdentifierName();
+	}
+}
+
 } // namespace duckdb

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -300,6 +300,7 @@ void DatabaseManager::RenameDatabase(ClientContext &context, const Identifier &o
 	}
 
 	shared_ptr<AttachedDatabase> attached_db;
+	string db_path;
 	{
 		lock_guard<mutex> guard(databases_lock);
 		auto old_entry = databases.find(old_name);
@@ -317,10 +318,12 @@ void DatabaseManager::RenameDatabase(ClientContext &context, const Identifier &o
 		}
 
 		attached_db = old_entry->second;
+		db_path = attached_db->GetCatalog().GetDBPath();
 		databases.erase(old_entry);
 		attached_db->SetName(new_name);
 		databases[new_name] = attached_db;
 	}
+	path_manager->RenameDatabasePath(db_path, old_name, new_name);
 }
 
 shared_ptr<AttachedDatabase> DatabaseManager::DetachInternal(const Identifier &name) {

--- a/test/sql/attach/attach_if_not_exists_after_alias.test
+++ b/test/sql/attach/attach_if_not_exists_after_alias.test
@@ -1,0 +1,32 @@
+# name: test/sql/attach/attach_if_not_exists_after_alias.test
+# description: ATTACH IF NOT EXISTS <path> after ALTER DATABASE ... SET ALIAS TO must not hang
+# group: [attach]
+
+statement ok
+ATTACH '{TEST_DIR}/attach_alias_repro.db' AS orig_name
+
+statement ok
+CREATE TABLE orig_name.t AS SELECT range AS i FROM range(3)
+
+statement ok
+ALTER DATABASE orig_name SET ALIAS TO other_name
+
+query I
+SELECT count(*) FROM other_name.t
+----
+3
+
+statement error
+ATTACH IF NOT EXISTS '{TEST_DIR}/attach_alias_repro.db' AS orig_name
+----
+<REGEX>:.*already attached.*
+
+statement error
+ATTACH '{TEST_DIR}/attach_alias_repro.db' AS orig_name
+----
+<REGEX>:.*already attached.*other_name.*
+
+query I
+SELECT count(*) FROM other_name.t
+----
+3


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25502

There're two maps managing database-related information
- [`databases`](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/include/duckdb/main/database_manager.hpp#L125-L126) maps from alias to `AttachedDatabase`
- [`DatabasePathManager`](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/include/duckdb/main/database_manager.hpp#L135-L136) maps from database path to database info [here](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/include/duckdb/main/database_file_path_manager.hpp#L48-L55)
- These two maps should be kept consistent in terms of attached database

When we rename a database, we only update the first map [here](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/main/database_manager.cpp#L303-L323), which breaks the invariant

Why it leads to infinite loop and how it's fixed in the PR
- Before the fix, both [`already_exists`](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/main/database_file_path_manager.cpp#L34) and [`already_in_system`](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/main/database_file_path_manager.cpp#L35) are true, so [`ALREADY_EXISTS`](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/main/database_file_path_manager.cpp#L47) is returned and we're trapped [in the deadloop](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/main/database_manager.cpp#L165)
- After the fix, `already_exists` (decided by matching attached database name, which our fix updates on rename) is false, so [exception is directly thrown](https://github.com/duckdb/duckdb/blob/43f897e5f3446bde2b36cef5dc137eea14211fd9/src/main/database_file_path_manager.cpp#L54-L57)