### PR TITLE
 Fix validity mask bounds during append rollback

### DIFF
--- a/src/storage/compression/validity_uncompressed.cpp
+++ b/src/storage/compression/validity_uncompressed.cpp
@@ -622,7 +622,7 @@ void ValidityRevertAppend(ColumnSegment &segment, idx_t new_count) {
 		idx_t byte_pos = start_bit / 8;
 		idx_t bit_end = (byte_pos + 1) * 8;
 		ValidityMask mask(reinterpret_cast<validity_t *>(buffer_ptr), segment.count);
-		for (idx_t i = start_bit; i < bit_end; i++) {
+		for (idx_t i = start_bit; i < bit_end && i < segment.count; i++) {
 			mask.SetValid(i);
 		}
 		revert_start = bit_end / 8;

--- a/test/sql/transactions/test_validity_append_rollback.test
+++ b/test/sql/transactions/test_validity_append_rollback.test
@@ -1,0 +1,69 @@
+# name: test/sql/transactions/test_validity_append_rollback.test
+# description: Rollback of a conflicting append must not exceed validity segment count
+# group: [transactions]
+
+statement ok con1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+
+statement ok con1
+CREATE TABLE pos(fname VARCHAR, off BIGINT);
+
+statement ok con1
+BEGIN;
+
+statement ok con2
+BEGIN;
+
+statement ok con1
+INSERT INTO t VALUES (1,101),(2,102);
+
+statement ok con2
+INSERT INTO t VALUES (1,201),(3,203);
+
+statement ok con1
+INSERT INTO pos VALUES ('a',1);
+
+statement ok con1
+COMMIT;
+
+statement ok con2
+INSERT INTO pos VALUES ('b',2);
+
+statement error con2
+COMMIT;
+----
+<REGEX>:.*TransactionContext Error.*duplicate key.*
+
+query II con1
+SELECT * FROM t ORDER BY id;
+----
+1	101
+2	102
+
+query TI con1
+SELECT * FROM pos ORDER BY fname;
+----
+a	1
+
+statement ok con1
+BEGIN;
+
+statement ok con1
+INSERT INTO t VALUES (4,104);
+
+statement ok con1
+COMMIT;
+
+statement ok con2
+BEGIN;
+
+statement ok con2
+INSERT INTO t VALUES (5,105);
+
+statement ok con2
+COMMIT;
+
+query I con2
+SELECT count(*) FROM t;
+----
+4


### PR DESCRIPTION
 ### Problem 

  A primary-key conflict during commit can trigger a fatal rollback error in Debug builds: ValidityRevertAppend clears bits up to the next byte boundary, exceeding the mask’s logical capacity.

```
void ValidityRevertAppend(ColumnSegment &segment, idx_t new_count) {
...
	for (idx_t i = start_bit; i < bit_end; i++) {
			mask.SetValid(i);  // Here i would possibly exceed segment.count
		}
...
```

```
	inline void SetValid(idx_t row_idx) {
#ifdef DEBUG
		if (row_idx >= capacity) {
			throw InternalException("ValidityMask::SetValid - row_idx %d is out-of-range for mask with capacity %llu",
			                        row_idx, capacity);
		}
#endif
```
  Validation: the native Debug reproducer now returns a normal constraint error. Running the new regression test is blocked by a compilation error in test_http_transport_manager.cpp.
