### PR TITLE
Fix wal replay

### DIFF
--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/duck_catalog.hpp"
 #include "duckdb/common/assert.hpp"
@@ -64,14 +65,18 @@ public:
 	WALReplayState replay_state;
 
 	struct ReplayIndexInfo {
-		ReplayIndexInfo(TableIndexList &index_list, unique_ptr<Index> index, QualifiedName table_name)
-		    : index_list(index_list), index(std::move(index)), table_name(std::move(table_name)) {
+		ReplayIndexInfo(TableIndexList &index_list, unique_ptr<Index> index, idx_t table_oid, optional_idx index_oid)
+		    : index_list(index_list), index(std::move(index)), table_oid(table_oid), index_oid(index_oid) {
 		}
 
 		reference<TableIndexList> index_list;
 		unique_ptr<Index> index;
-		//! The fully-qualified name of the table the index belongs to ([catalog, schema path..., table])
-		QualifiedName table_name;
+		//! The oid of the table, used to uniquely identify the table (even after a rename).
+		idx_t table_oid;
+		//! The oid of the index catalog entry, used to match a DROP INDEX in the same replayed transaction.
+		//! Invalid for constraint-backed indexes (i.e., UNIQUE): they have no separate catalog entry and cannot be
+		//! targeted by DROP INDEX.
+		optional_idx index_oid;
 	};
 	vector<ReplayIndexInfo> replay_index_infos;
 };
@@ -860,9 +865,10 @@ void WriteAheadLogDeserializer::ReplayDropTable() {
 	}
 
 	// Remove any replay indexes of this table.
+	auto &table_entry = catalog.GetEntry<TableCatalogEntry>(context, info.GetQualifiedName());
 	state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
-	                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
-		                                              return replay_info.table_name == info.GetQualifiedName();
+	                                              [&table_entry](const ReplayState::ReplayIndexInfo &replay_info) {
+		                                              return replay_info.table_oid == table_entry.oid;
 	                                              }),
 	                               state.replay_index_infos.end());
 
@@ -981,7 +987,8 @@ void WriteAheadLogDeserializer::ReplayAlter() {
 	auto index_instance = index_type->create_instance(input);
 
 	auto &table_index_list = storage.GetDataTableInfo()->GetIndexes();
-	state.replay_index_infos.emplace_back(table_index_list, std::move(index_instance), std::move(table_name));
+	state.replay_index_infos.emplace_back(table_index_list, std::move(index_instance), table.oid,
+	                                      /*index_oid=*/optional_idx());
 
 	catalog.Alter(context, alter_info);
 }
@@ -1240,13 +1247,13 @@ void WriteAheadLogDeserializer::ReplayCreateIndex() {
 	auto &io_manager = TableIOManager::Get(storage);
 
 	// Create the index in the catalog.
-	table.schema.CreateIndex(context, info, table);
+	auto index_entry = table.schema.CreateIndex(context, info, table);
 
 	// add the index to the storage
 	auto unbound_index = make_uniq<UnboundIndex>(std::move(create_info), std::move(index_info), io_manager, db);
 
 	auto &table_index_list = storage.GetDataTableInfo()->GetIndexes();
-	state.replay_index_infos.emplace_back(table_index_list, std::move(unbound_index), std::move(table_name));
+	state.replay_index_infos.emplace_back(table_index_list, std::move(unbound_index), table.oid, index_entry->oid);
 }
 
 void WriteAheadLogDeserializer::ReplayDropIndex() {
@@ -1258,12 +1265,11 @@ void WriteAheadLogDeserializer::ReplayDropIndex() {
 		return;
 	}
 
-	// Remove the replay index, if any - the index lives in the same (possibly nested) schema as its table
+	// Remove the replay index, if any. Match on the index entry's oid.
+	auto &index_entry = catalog.GetEntry<IndexCatalogEntry>(context, info.GetQualifiedName());
 	state.replay_index_infos.erase(std::remove_if(state.replay_index_infos.begin(), state.replay_index_infos.end(),
-	                                              [&info](const ReplayState::ReplayIndexInfo &replay_info) {
-		                                              return replay_info.table_name.WithName(
-		                                                         replay_info.index->GetIndexName()) ==
-		                                                     info.GetQualifiedName();
+	                                              [&index_entry](const ReplayState::ReplayIndexInfo &replay_info) {
+		                                              return replay_info.index_oid == index_entry.oid;
 	                                              }),
 	                               state.replay_index_infos.end());
 

--- a/test/sql/storage/wal/wal_replay_pending_index_dropped_table.test
+++ b/test/sql/storage/wal/wal_replay_pending_index_dropped_table.test
@@ -1,0 +1,48 @@
+# name: test/sql/storage/wal/wal_replay_pending_index_dropped_table.test
+# description: WAL replay of same-transaction ADD PRIMARY KEY + RENAME + DROP TABLE
+# group: [wal]
+
+require skip_reload
+
+load {TEST_DIR}/wal_replay_pending_index_dropped_table.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB'
+
+statement ok
+CREATE TABLE t(a INT)
+
+statement ok
+INSERT INTO t VALUES (1), (2)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t ADD PRIMARY KEY (a)
+
+statement ok
+ALTER TABLE t RENAME TO s
+
+statement ok
+DROP TABLE s
+
+statement ok
+COMMIT
+
+statement ok
+CREATE TABLE other(x INT)
+
+statement ok
+INSERT INTO other VALUES (42)
+
+# Trigger WAL replay.
+restart
+
+query I
+SELECT x FROM other
+----
+42


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25510

Copy the transaction code here for easier review
```sql
failed_lock D BEGIN;
failed_lock D ALTER TABLE t ADD PRIMARY KEY (a);
failed_lock D ALTER TABLE t RENAME TO s;
failed_lock D DROP TABLE s;
failed_lock D COMMIT;
```

Use pseudocode to represent what's happening for the crash on WAL replay (generated by GPT-5.6, I made modification)
```sh
-- Background: how WAL replay installs indexes
--
-- When replay sees "ALTER TABLE ... ADD PRIMARY KEY" (or CREATE INDEX), it builds
-- the index object but does NOT attach it to the table yet. Instead it appends a
-- record to a deferred list, and only attaches everything after the transaction's
-- commit marker (WAL_FLUSH). This way, if the WAL is truncated mid-transaction,
-- the rollback simply discards the list and the table is left untouched.

pending_index_list : list of PendingIndex

struct PendingIndex {
    index_list_ref : raw reference into table.data_table_info.index_list
                     -- where the index must be attached at commit time;
                     -- NOT owning: dies together with the table
    index          : the built index object
    table_name     : string, COPIED from the table's name at registration time
                     -- a snapshot; nothing keeps it in sync with the catalog
}

-- Replaying one WAL transaction:
--   ALTER TABLE t ADD PRIMARY KEY(a);  ALTER TABLE t RENAME TO s;  DROP TABLE s;

on ALTER t ADD PRIMARY KEY:
    idx = build_index(t)
    pending_index_list += PendingIndex {
        index_list_ref = &t.index_list,
        index          = idx,
        table_name     = "t",            -- snapshot taken NOW
    }

on RENAME t -> s:
    catalog.rename("t", "s")             -- only the catalog entry is renamed;
                                         -- nobody walks pending_index_list to
                                         -- update the "t" snapshots, so the
                                         -- record above still says table_name="t"
                                         -- while the live table is now named "s"

on DROP TABLE s:
    -- defensive cleanup: purge pending records that belong to the dropped table,
    -- so no record outlives the table it points into. Matching is done BY NAME:
    pending_index_list.erase_if(p -> p.table_name == "s")
        -- record says "t", drop says "s"  =>  no match  =>  record SURVIVES (BUG)
    catalog.drop("s")

on WAL_FLUSH (commit marker):
    con.Commit()
        -- the dropped table is destroyed here, including the DataTableInfo
        -- that pending record's index_list_ref points into
    for p in pending_index_list:
        p.index_list_ref->AddIndex(p.index)
        -- for the surviving record this locks a mutex inside freed memory:
        -- use-after-free  =>  "mutex lock failed: Invalid argument"

-- The error is not of type SERIALIZATION, so replay rethrows it on EVERY open:
-- the database stays unopenable until the user deletes the WAL (losing data).
```

The root cause is we use name (which is unstable after rename) to identify table and index to remove, instead of oid (which is stable for an DB entity).