### PR TITLE
add optional machine friendly json-formatted output to `unittest`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,62 @@ build/reldebug/test/unittest "*"
 
 It is recommended to use `make reldebug` and `build/reldebug/test/unittest` unless a good reason exists to use the debug build - the debug build is much slower than the reldebug build.
 
+Multiple filters go in **one** invocation, comma-separated. Space-separated filters are concatenated
+into a single (usually unmatchable) pattern rather than OR-ed:
+
+```bash
+# correct - runs both
+build/reldebug/test/unittest "test/sql/order/test_limit.test,test/sql/order/limit_union.test"
+
+# wrong - looks for one test named "...test_limit.testtest/sql/order/limit_union.test"
+build/reldebug/test/unittest "test/sql/order/test_limit.test" "test/sql/order/limit_union.test"
+```
+
+Progress lines go to stdout and failure output to stderr, so `2>/dev/null` keeps only progress and
+`1>/dev/null` keeps only failures.
+
+### Machine-Readable Output (`--output=json`)
+
+`--output=json` replaces the human-readable output with JSON Lines on stdout: a `test` object for
+every test case that did not pass, then one `summary` object. Nothing else is written to stdout, so
+the stream can be piped straight into a parser. The process exit code is unchanged.
+
+Passing tests are counted in the summary but not emitted individually - they are ~99% of the lines on
+a full run and carry nothing to act on. A whole green run is 73 lines instead of 6274. Pass Catch's
+`-s`/`--success` to get them back. Skipped tests are always emitted: they are few, and a test that
+silently did not run is usually worth knowing about.
+
+```bash
+build/reldebug/test/unittest "test/sql/order/*" --output=json
+```
+
+```json
+{"event":"test","name":"test/sql/x.test","status":"skip","duration":0.015,"assertions":{"passed":0,"failed":0},"skip_reason":"require notarealextension"}
+{"event":"summary","total":35,"passed":34,"failed":0,"skipped":1,"assertions":{"passed":9355,"failed":0},"failed_tests":[],"skip_reasons":{"require notarealextension":1}}
+```
+
+`status` is `pass`, `fail` or `skip`. A failing test carries a `failure` object with the structured
+detail - `kind` (e.g. `wrong_row_count`, `value_mismatch`, `unexpected_statement`), `file`, `line`,
+`query`, and the `expected` / `actual` values as flat row-major arrays over `columns` columns.
+`mismatch_rows` lists the zero-based rows that differ, computed over the **full** result even when
+the value arrays themselves are capped (`expected_truncated` / `actual_truncated`).
+
+The `summary` object closes every run and names every failure, so a single invocation answers "what
+failed" without a second pass - do not run one invocation per test group and stitch the results
+together with `grep`. A filter that matches nothing emits `{"event":"no_matching_tests",...}`, which
+distinguishes a typo'd filter from a genuinely empty run.
+
+```bash
+# just the verdict - the summary is always the last line
+build/reldebug/test/unittest "*" --output=json | tail -1
+
+# include passing tests too
+build/reldebug/test/unittest "*" --output=json -s
+```
+
+The default output is unaffected by this flag. `--emit-test-events` (`[TEST_EVENT] ` lines on stderr)
+is a separate, narrower mechanism and still behaves as before.
+
 ### Time-Limiting Queries
 
 Use the `max_execution_time` setting (milliseconds, `0` = no limit) to abort a query that runs too long:

--- a/test/helpers/CMakeLists.txt
+++ b/test/helpers/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_definitions(-DDUCKDB_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}"
                 -DDUCKDB_BUILD_DIRECTORY="${PROJECT_BINARY_DIR}")
 
-set(DUCKDB_TEST_HELPERS_UNITS test_helpers.cpp capi_tester.cpp pid.cpp
-                              test_config.cpp test_reporter.cpp)
+set(DUCKDB_TEST_HELPERS_UNITS
+    test_helpers.cpp capi_tester.cpp pid.cpp test_config.cpp test_reporter.cpp
+    test_failure_record.cpp)
 
 add_library(test_helpers STATIC ${DUCKDB_TEST_HELPERS_UNITS})

--- a/test/helpers/test_failure_record.cpp
+++ b/test/helpers/test_failure_record.cpp
@@ -1,0 +1,81 @@
+#include "test_failure_record.hpp"
+
+namespace duckdb {
+
+const char *TestFailureKindToString(TestFailureKind kind) {
+	switch (kind) {
+	case TestFailureKind::UNEXPECTED_FAILURE:
+		return "unexpected_failure";
+	case TestFailureKind::UNEXPECTED_STATEMENT:
+		return "unexpected_statement";
+	case TestFailureKind::WRONG_ROW_COUNT:
+		return "wrong_row_count";
+	case TestFailureKind::WRONG_COLUMN_COUNT:
+		return "wrong_column_count";
+	case TestFailureKind::WRONG_COLUMN_COUNT_CORRECT_RESULT:
+		return "wrong_column_count_correct_result";
+	case TestFailureKind::WRONG_RESULT_HASH:
+		return "wrong_result_hash";
+	case TestFailureKind::VALUE_MISMATCH:
+		return "value_mismatch";
+	case TestFailureKind::EXPECTED_ERROR_MISMATCH:
+		return "expected_error_mismatch";
+	case TestFailureKind::INTERNAL_EXCEPTION:
+		return "internal_exception";
+	case TestFailureKind::NOT_CLEANLY_DIVISIBLE:
+		return "not_cleanly_divisible";
+	case TestFailureKind::SPLIT_MISMATCH:
+		return "split_mismatch";
+	case TestFailureKind::LOAD_DATABASE_FAIL:
+		return "load_database_fail";
+	case TestFailureKind::OTHER:
+		return "other";
+	case TestFailureKind::NONE:
+	default:
+		return "none";
+	}
+}
+
+TestFailureRecorder &TestFailureRecorder::Instance() {
+	static TestFailureRecorder instance;
+	return instance;
+}
+
+void TestFailureRecorder::Record(TestFailureRecord new_record) {
+	auto &recorder = Instance();
+	if (!recorder.enabled) {
+		return;
+	}
+	lock_guard<mutex> guard(recorder.record_lock);
+	recorder.record = std::move(new_record);
+}
+
+TestFailureRecord TestFailureRecorder::Take() {
+	auto &recorder = Instance();
+	lock_guard<mutex> guard(recorder.record_lock);
+	TestFailureRecord result = std::move(recorder.record);
+	recorder.record = TestFailureRecord();
+	return result;
+}
+
+bool TestFailureRecorder::HasRecord() {
+	auto &recorder = Instance();
+	lock_guard<mutex> guard(recorder.record_lock);
+	return recorder.record.IsSet();
+}
+
+void TestFailureRecorder::Clear() {
+	auto &recorder = Instance();
+	lock_guard<mutex> guard(recorder.record_lock);
+	recorder.record = TestFailureRecord();
+}
+
+void TestFailureRecorder::SetEnabled(bool enabled) {
+	Instance().enabled = enabled;
+}
+
+bool TestFailureRecorder::Enabled() {
+	return Instance().enabled;
+}
+
+} // namespace duckdb

--- a/test/helpers/test_helpers.cpp
+++ b/test/helpers/test_helpers.cpp
@@ -577,6 +577,20 @@ bool EmitTestEventsEnabled() {
 	return emit_test_events;
 }
 
+static TestOutputFormat test_output_format = TestOutputFormat::DEFAULT;
+
+void SetTestOutputFormat(TestOutputFormat format) {
+	test_output_format = format;
+}
+
+TestOutputFormat GetTestOutputFormat() {
+	return test_output_format;
+}
+
+bool SuppressTextFailureOutput() {
+	return test_output_format == TestOutputFormat::JSON;
+}
+
 void ClearTestDirectory() {
 	if (!DeleteTestPath()) {
 		return;

--- a/test/include/test_failure_record.hpp
+++ b/test/include/test_failure_record.hpp
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// test_failure_record.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+//! The semantic kind of a sqllogictest failure. Mirrors the SQLLogicTestLogger method that reports it,
+//! so a consumer can branch on the kind instead of pattern-matching the human-readable message.
+enum class TestFailureKind : uint8_t {
+	NONE,
+	UNEXPECTED_FAILURE,
+	UNEXPECTED_STATEMENT,
+	WRONG_ROW_COUNT,
+	WRONG_COLUMN_COUNT,
+	WRONG_COLUMN_COUNT_CORRECT_RESULT,
+	WRONG_RESULT_HASH,
+	VALUE_MISMATCH,
+	EXPECTED_ERROR_MISMATCH,
+	INTERNAL_EXCEPTION,
+	NOT_CLEANLY_DIVISIBLE,
+	SPLIT_MISMATCH,
+	LOAD_DATABASE_FAIL,
+	OTHER
+};
+
+const char *TestFailureKindToString(TestFailureKind kind);
+
+//! A structured description of the failure that ended a test. Populated by SQLLogicTestLogger alongside
+//! the human-readable output, and rendered by the JSON reporter; fields not meaningful for a given kind
+//! stay empty.
+struct TestFailureRecord {
+	TestFailureKind kind = TestFailureKind::NONE;
+	//! The human-readable headline (the same text the default output prints)
+	string message;
+	string file;
+	idx_t line = 0;
+	string query;
+
+	//! Row-oriented values, one string per cell, laid out row-major over `columns` columns
+	vector<string> expected;
+	vector<string> actual;
+	bool has_expected = false;
+	bool has_actual = false;
+	//! True when the corresponding vector was capped, so a consumer does not read it as the full result
+	bool expected_truncated = false;
+	bool actual_truncated = false;
+	idx_t expected_rows = 0;
+	idx_t actual_rows = 0;
+	idx_t columns = 0;
+
+	//! Row indices (into the untruncated result) whose expected and actual values differ. Only populated
+	//! when both sides have the same shape, which is what makes a row-wise comparison meaningful.
+	vector<idx_t> mismatch_rows;
+
+	string expected_hash;
+	string actual_hash;
+	//! A concrete remedy when the logger can derive one (e.g. the corrected `query III` header)
+	string suggested_fix;
+	string error_message;
+
+	bool IsSet() const {
+		return kind != TestFailureKind::NONE;
+	}
+};
+
+//! Process-wide slot holding the failure that ended the test currently running. A sqllogictest aborts at
+//! its first failure, so one slot per run is enough; Clear() runs at test start and Take() at test end.
+class TestFailureRecorder {
+public:
+	//! Overwrites any record already held: the first failure aborts the test, so a later record can only
+	//! come from a subsequent test whose start cleared this anyway.
+	static void Record(TestFailureRecord record);
+	//! Move the current record out, leaving the slot empty
+	static TestFailureRecord Take();
+	static bool HasRecord();
+	static void Clear();
+	//! Records are only built when a consumer will read them - the default output path skips the work.
+	static void SetEnabled(bool enabled);
+	static bool Enabled();
+
+private:
+	static TestFailureRecorder &Instance();
+
+private:
+	mutex record_lock;
+	TestFailureRecord record;
+	bool enabled = false;
+};
+
+//! Cap on how many cells of each result are copied into a record. Bounds a runaway result to a
+//! predictable payload size while still showing enough to identify the failure.
+static constexpr idx_t TEST_FAILURE_MAX_VALUES = 100;
+
+} // namespace duckdb

--- a/test/include/test_helpers.hpp
+++ b/test/include/test_helpers.hpp
@@ -68,6 +68,16 @@ string GetTempDirHome();
 void SetEmitTestEvents(bool emit);
 bool EmitTestEventsEnabled();
 
+//! How the runner renders its results. DEFAULT is the human-readable Catch console output; JSON
+//! replaces it with one JSON object per line on stdout (--output=json).
+enum class TestOutputFormat : uint8_t { DEFAULT, JSON };
+
+void SetTestOutputFormat(TestOutputFormat format);
+TestOutputFormat GetTestOutputFormat();
+//! True when the human-readable failure dumps must stay off the stream, because a machine-readable
+//! renderer owns the output and carries the same information structurally.
+bool SuppressTextFailureOutput();
+
 unique_ptr<DBConfig> GetTestConfig();
 bool TestIsInternalError(unordered_set<string> &internal_error_messages, const string &error);
 

--- a/test/sqlite/CMakeLists.txt
+++ b/test/sqlite/CMakeLists.txt
@@ -3,6 +3,12 @@ add_extension_definitions()
 add_definitions(-DDUCKDB_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}"
                 -DDUCKDB_BUILD_DIRECTORY="${PROJECT_BINARY_DIR}")
 
+# json_test_reporter.cpp derives from Catch's reporter bases, which catch.hpp
+# only declares under this flag. Set for the directory rather than the file:
+# these sources are combined into a unity build, so a per-file #define would
+# land after another source had already included catch.hpp.
+add_definitions(-DCATCH_CONFIG_EXTERNAL_INTERFACES)
+
 set(SQLITE_TEST_RUNNER_SOURCES
     result_helper.cpp
     sqllogic_command.cpp
@@ -10,7 +16,8 @@ set(SQLITE_TEST_RUNNER_SOURCES
     sqllogic_parser.cpp
     test_sqllogictest.cpp
     sqllogic_test_logger.cpp
-    catch_test_reporter.cpp)
+    catch_test_reporter.cpp
+    json_test_reporter.cpp)
 
 add_library_unity(test_sqlite OBJECT ${SQLITE_TEST_RUNNER_SOURCES})
 set(UNITTEST_OBJECT_FILES

--- a/test/sqlite/catch_test_reporter.cpp
+++ b/test/sqlite/catch_test_reporter.cpp
@@ -1,10 +1,21 @@
 #include "catch_test_reporter.hpp"
 
 #include "catch.hpp"
+#include "test_failure_record.hpp"
 
 namespace duckdb {
 
 void CatchTestReporter::Fail(const string &message, const string &file, idx_t line) {
+	// Failures routed through the sqllogictest logger already carry a far richer record; this covers the
+	// rest (parse errors, load and cleanup failures), which know the script location but nothing else.
+	if (TestFailureRecorder::Enabled() && !TestFailureRecorder::HasRecord()) {
+		TestFailureRecord record;
+		record.kind = TestFailureKind::OTHER;
+		record.message = message;
+		record.file = file;
+		record.line = line;
+		TestFailureRecorder::Record(std::move(record));
+	}
 	// FAIL/FAIL_LINE throw Catch's own TestFailureException, so this never returns.
 	if (file.empty()) {
 		FAIL(message);

--- a/test/sqlite/json_test_reporter.cpp
+++ b/test/sqlite/json_test_reporter.cpp
@@ -1,0 +1,272 @@
+#include "catch.hpp"
+
+#include "duckdb/common/json_document.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "test_failure_record.hpp"
+#include "test_helpers.hpp"
+#include "test_reporter.hpp"
+
+#include <chrono>
+
+namespace duckdb {
+
+namespace {
+
+//! Renders the run as JSON Lines on the reporter's stream: a "test" object per test case that did not
+//! pass, then a single "summary" object. Selected with --output=json (or -r json). Replacing the
+//! console reporter rather than adding to it is what keeps the stream free of prose a consumer would
+//! have to skip.
+//!
+//! Passing tests are counted in the summary but not emitted individually - on a full run they are
+//! ~99% of the lines and carry nothing a consumer acts on. Catch's own -s/--success asks for them
+//! back, matching what that flag means for the built-in reporters. Skips are always emitted: they are
+//! few, and a test that silently did not run is exactly what a consumer needs to be told about.
+class JSONTestReporter : public Catch::StreamingReporterBase<JSONTestReporter> {
+public:
+	explicit JSONTestReporter(Catch::ReporterConfig const &config)
+	    : Catch::StreamingReporterBase<JSONTestReporter>(config),
+	      include_passing(config.fullConfig()->includeSuccessfulResults()) {
+	}
+
+	~JSONTestReporter() override = default;
+
+	static std::string getDescription() {
+		return "Reports each test case as a JSON object on its own line, followed by a summary object";
+	}
+
+	// The verdict this reporter renders is per test case, so assertions produce no output of their own.
+	void assertionStarting(Catch::AssertionInfo const &) override {
+	}
+
+	bool assertionEnded(Catch::AssertionStats const &stats) override {
+		auto &result = stats.assertionResult;
+		if (result.succeeded() || !TestFailureRecorder::Enabled() || TestFailureRecorder::HasRecord()) {
+			// Both sqllogictest paths (the logger and CatchTestReporter::Fail) have already recorded, and
+			// they know the script location; what is left here is a compiled C++ test, whose failure
+			// location genuinely is the Catch source info below.
+			return true;
+		}
+		TestFailureRecord record;
+		record.kind = TestFailureKind::OTHER;
+		if (result.hasExpression()) {
+			record.message = result.getExpressionInMacro();
+			if (result.hasExpandedExpression()) {
+				record.error_message = result.getExpandedExpression();
+			}
+		} else if (result.hasMessage()) {
+			record.message = result.getMessage();
+		}
+		auto source_info = result.getSourceInfo();
+		record.file = source_info.file;
+		record.line = NumericCast<idx_t>(source_info.line);
+		for (auto &info : stats.infoMessages) {
+			if (!record.error_message.empty()) {
+				record.error_message += "\n";
+			}
+			record.error_message += info.message;
+		}
+		TestFailureRecorder::Record(std::move(record));
+		return true;
+	}
+
+	void testCaseStarting(Catch::TestCaseInfo const &test_info) override {
+		Catch::StreamingReporterBase<JSONTestReporter>::testCaseStarting(test_info);
+		// A record left by the previous test case would otherwise be attributed to this one
+		TestFailureRecorder::Clear();
+		TestReporter::Get().skip_reason.clear();
+		test_start = std::chrono::steady_clock::now();
+	}
+
+	void testCaseEnded(Catch::TestCaseStats const &stats) override {
+		const auto elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - test_start).count();
+		const bool skipped = stats.totals.skippedTests > 0;
+		const bool failed = stats.totals.testCases.failed > 0 || stats.totals.assertions.failed > 0;
+
+		JSONWriter writer;
+		auto obj = writer.CreateObject();
+		obj.AddString("event", "test");
+		obj.AddString("name", stats.testInfo.name);
+		obj.AddString("status", skipped ? "skip" : (failed ? "fail" : "pass"));
+		obj.Add("duration", writer.CreateDouble(elapsed));
+
+		auto assertions = writer.CreateObject();
+		assertions.Add("passed", writer.CreateUnsignedInteger(stats.totals.assertions.passed));
+		assertions.Add("failed", writer.CreateUnsignedInteger(stats.totals.assertions.failed));
+		obj.Add("assertions", std::move(assertions));
+
+		if (skipped) {
+			total_skipped++;
+			auto &reason = TestReporter::Get().skip_reason;
+			if (!reason.empty()) {
+				obj.AddString("skip_reason", reason);
+				skip_reasons[reason]++;
+			}
+		} else if (failed) {
+			total_failed++;
+			auto record = TestFailureRecorder::Take();
+			if (record.IsSet()) {
+				obj.Add("failure", SerializeFailure(writer, record));
+				failed_tests.emplace_back(stats.testInfo.name, record.line, TestFailureKindToString(record.kind));
+			} else {
+				// A compiled C++ test, or a failure raised outside the sqllogictest logger: the verdict is
+				// still exact, only the structured detail is unavailable.
+				failed_tests.emplace_back(stats.testInfo.name, 0, "unknown");
+			}
+		} else {
+			total_passed++;
+		}
+
+		total_assertions_passed += stats.totals.assertions.passed;
+		total_assertions_failed += stats.totals.assertions.failed;
+
+		if (failed || skipped || include_passing) {
+			writer.SetRoot(obj);
+			WriteLine(writer.ToString());
+		}
+		Catch::StreamingReporterBase<JSONTestReporter>::testCaseEnded(stats);
+	}
+
+	void testRunEnded(Catch::TestRunStats const &stats) override {
+		JSONWriter writer;
+		auto obj = writer.CreateObject();
+		obj.AddString("event", "summary");
+		obj.Add("total", writer.CreateUnsignedInteger(total_passed + total_failed + total_skipped));
+		obj.Add("passed", writer.CreateUnsignedInteger(total_passed));
+		obj.Add("failed", writer.CreateUnsignedInteger(total_failed));
+		obj.Add("skipped", writer.CreateUnsignedInteger(total_skipped));
+
+		auto assertions = writer.CreateObject();
+		assertions.Add("passed", writer.CreateUnsignedInteger(total_assertions_passed));
+		assertions.Add("failed", writer.CreateUnsignedInteger(total_assertions_failed));
+		obj.Add("assertions", std::move(assertions));
+
+		auto failed_array = writer.CreateArray();
+		for (auto &entry : failed_tests) {
+			auto failed_obj = writer.CreateObject();
+			failed_obj.AddString("name", entry.name);
+			if (entry.line > 0) {
+				failed_obj.Add("line", writer.CreateUnsignedInteger(entry.line));
+			}
+			failed_obj.AddString("kind", entry.kind);
+			failed_array.Append(std::move(failed_obj));
+		}
+		obj.Add("failed_tests", std::move(failed_array));
+
+		if (!skip_reasons.empty()) {
+			auto reasons = writer.CreateObject();
+			for (auto &entry : skip_reasons) {
+				reasons.Add(entry.first, writer.CreateUnsignedInteger(entry.second));
+			}
+			obj.Add("skip_reasons", std::move(reasons));
+		}
+
+		writer.SetRoot(obj);
+		WriteLine(writer.ToString());
+		Catch::StreamingReporterBase<JSONTestReporter>::testRunEnded(stats);
+	}
+
+	void noMatchingTestCases(std::string const &spec) override {
+		// Emitted as an event rather than swallowed: an empty run is otherwise indistinguishable from a
+		// filter that matched nothing, which is the most common way a run is silently wrong.
+		JSONWriter writer;
+		auto obj = writer.CreateObject();
+		obj.AddString("event", "no_matching_tests");
+		obj.AddString("filter", spec);
+		writer.SetRoot(obj);
+		WriteLine(writer.ToString());
+	}
+
+private:
+	struct FailedTest {
+		FailedTest(string name_p, idx_t line_p, string kind_p)
+		    : name(std::move(name_p)), line(line_p), kind(std::move(kind_p)) {
+		}
+		string name;
+		idx_t line;
+		string kind;
+	};
+
+	void WriteLine(const string &line) {
+		stream << line << "\n";
+		stream.flush();
+	}
+
+	static JSONMutableValue SerializeValues(JSONWriter &writer, const vector<string> &values) {
+		auto array = writer.CreateArray();
+		for (auto &value : values) {
+			array.AppendString(value);
+		}
+		return array;
+	}
+
+	static JSONMutableValue SerializeFailure(JSONWriter &writer, const TestFailureRecord &record) {
+		auto failure = writer.CreateObject();
+		failure.AddString("kind", TestFailureKindToString(record.kind));
+		failure.AddString("message", record.message);
+		if (!record.file.empty()) {
+			failure.AddString("file", record.file);
+		}
+		if (record.line > 0) {
+			failure.Add("line", writer.CreateUnsignedInteger(record.line));
+		}
+		if (!record.query.empty()) {
+			auto query = record.query;
+			StringUtil::RTrim(query);
+			failure.AddString("query", query);
+		}
+		if (record.columns > 0) {
+			failure.Add("columns", writer.CreateUnsignedInteger(record.columns));
+		}
+		if (record.has_expected) {
+			failure.Add("expected", SerializeValues(writer, record.expected));
+			failure.Add("expected_rows", writer.CreateUnsignedInteger(record.expected_rows));
+			if (record.expected_truncated) {
+				failure.Add("expected_truncated", writer.CreateBoolean(true));
+			}
+		}
+		if (record.has_actual) {
+			failure.Add("actual", SerializeValues(writer, record.actual));
+			failure.Add("actual_rows", writer.CreateUnsignedInteger(record.actual_rows));
+			if (record.actual_truncated) {
+				failure.Add("actual_truncated", writer.CreateBoolean(true));
+			}
+		}
+		if (!record.mismatch_rows.empty()) {
+			auto rows = writer.CreateArray();
+			for (auto row : record.mismatch_rows) {
+				rows.Append(writer.CreateUnsignedInteger(row));
+			}
+			failure.Add("mismatch_rows", std::move(rows));
+		}
+		if (!record.expected_hash.empty()) {
+			failure.AddString("expected_hash", record.expected_hash);
+		}
+		if (!record.actual_hash.empty()) {
+			failure.AddString("actual_hash", record.actual_hash);
+		}
+		if (!record.suggested_fix.empty()) {
+			failure.AddString("suggested_fix", record.suggested_fix);
+		}
+		if (!record.error_message.empty()) {
+			failure.AddString("error", record.error_message);
+		}
+		return failure;
+	}
+
+private:
+	const bool include_passing;
+	std::chrono::steady_clock::time_point test_start;
+	idx_t total_passed = 0;
+	idx_t total_failed = 0;
+	idx_t total_skipped = 0;
+	idx_t total_assertions_passed = 0;
+	idx_t total_assertions_failed = 0;
+	vector<FailedTest> failed_tests;
+	std::map<string, idx_t> skip_reasons;
+};
+
+CATCH_REGISTER_REPORTER("json", JSONTestReporter)
+
+} // namespace
+
+} // namespace duckdb

--- a/test/sqlite/result_helper.cpp
+++ b/test/sqlite/result_helper.cpp
@@ -552,18 +552,8 @@ bool TestResultHelper::CompareValues(SQLLogicTestLogger &logger, MaterializedQue
 	}
 	if (error) {
 		if (print_error) {
-			std::ostringstream oss;
-			logger.PrintErrorHeader("Wrong result in query!");
-			logger.PrintLineSep();
-			logger.PrintSQL();
-			logger.PrintLineSep();
-			oss << termcolor::red << termcolor::bold << "Mismatch on row " << current_row + 1 << ", column "
-			    << result.ColumnName(current_column) << "(index " << current_column + 1 << ")" << std::endl
-			    << termcolor::reset;
-			oss << lvalue_str << " <> " << rvalue_str << std::endl;
-			logger.LogFailure(oss.str());
-			logger.PrintLineSep();
-			logger.PrintResultError(result_values, values, expected_column_count, row_wise);
+			logger.ValueMismatch(result, lvalue_str, rvalue_str, current_row, current_column, result_values, values,
+			                     expected_column_count, row_wise);
 		}
 		return false;
 	}
@@ -577,13 +567,7 @@ bool TestResultHelper::MatchesRegex(SQLLogicTestLogger &logger, string lvalue_st
 	options.set_dot_nl(true);
 	RE2 re(regex_str, options);
 	if (!re.ok()) {
-		std::ostringstream oss;
-		logger.PrintErrorHeader("Test error!");
-		logger.PrintLineSep();
-		oss << termcolor::red << termcolor::bold << "Failed to parse regex: " << re.error() << termcolor::reset
-		    << std::endl;
-		logger.LogFailure(oss.str());
-		logger.PrintLineSep();
+		logger.TestError("Test error!", "Failed to parse regex: " + re.error());
 		return false;
 	}
 	bool regex_matches = RE2::FullMatch(lvalue_str, re);

--- a/test/sqlite/sqllogic_test_logger.cpp
+++ b/test/sqlite/sqllogic_test_logger.cpp
@@ -18,8 +18,63 @@ SQLLogicTestLogger::SQLLogicTestLogger(ExecuteContext &context, const Command &c
 SQLLogicTestLogger::~SQLLogicTestLogger() {
 }
 
+TestFailureRecord SQLLogicTestLogger::BaseRecord(TestFailureKind kind, const string &message) const {
+	TestFailureRecord record;
+	record.kind = kind;
+	record.message = message;
+	record.file = file_name;
+	record.line = NumericCast<idx_t>(query_line);
+	record.query = sql_query;
+	return record;
+}
+
+void SQLLogicTestLogger::FillValues(const vector<string> &values, idx_t columns, vector<string> &out, bool &truncated,
+                                    idx_t &rows) {
+	rows = columns == 0 ? 0 : values.size() / columns;
+	const idx_t copy_count = MinValue<idx_t>(values.size(), TEST_FAILURE_MAX_VALUES);
+	truncated = copy_count < values.size();
+	out.assign(values.begin(), values.begin() + NumericCast<int64_t>(copy_count));
+}
+
+void SQLLogicTestLogger::FillValues(MaterializedQueryResult &result, vector<string> &out, bool &truncated, idx_t &rows,
+                                    idx_t &columns) {
+	rows = result.RowCount();
+	columns = result.ColumnCount();
+	const idx_t total = rows * columns;
+	const idx_t copy_count = MinValue<idx_t>(total, TEST_FAILURE_MAX_VALUES);
+	truncated = copy_count < total;
+	out.clear();
+	out.reserve(copy_count);
+	for (idx_t i = 0; i < copy_count; i++) {
+		const idx_t r = columns == 0 ? 0 : i / columns;
+		const idx_t c = columns == 0 ? 0 : i % columns;
+		out.push_back(result.GetValue(c, r).ToString());
+	}
+}
+
+vector<idx_t> SQLLogicTestLogger::ComputeMismatchRows(const vector<string> &expected, const vector<string> &actual,
+                                                      idx_t columns) {
+	vector<idx_t> mismatches;
+	if (columns == 0 || expected.size() != actual.size()) {
+		// different shapes: a row-wise comparison would pair up unrelated cells
+		return mismatches;
+	}
+	const idx_t rows = expected.size() / columns;
+	for (idx_t r = 0; r < rows; r++) {
+		for (idx_t c = 0; c < columns; c++) {
+			if (expected[r * columns + c] != actual[r * columns + c]) {
+				mismatches.push_back(r);
+				break;
+			}
+		}
+	}
+	return mismatches;
+}
+
 void SQLLogicTestLogger::Log(const string &annotation, const string &str) {
-	std::cerr << annotation << str;
+	if (!SuppressTextFailureOutput()) {
+		std::cerr << annotation << str;
+	}
 	AppendFailure(str);
 }
 
@@ -70,13 +125,15 @@ void SQLLogicTestLogger::PrintSummaryHeader(const std::string &file_name, idx_t 
 }
 
 void SQLLogicTestLogger::PrintExpectedResult(const vector<string> &values, idx_t columns, bool row_wise) {
+	// Cap the dump: a runaway result otherwise buries the failure it is supposed to explain.
+	const idx_t print_count = MinValue<idx_t>(values.size(), TEST_FAILURE_MAX_VALUES);
 	if (row_wise) {
-		for (idx_t r = 0; r < values.size(); r++) {
+		for (idx_t r = 0; r < print_count; r++) {
 			LogFailure("\n" + values[r]);
 		}
 	} else {
 		idx_t c = 0;
-		for (idx_t r = 0; r < values.size(); r++) {
+		for (idx_t r = 0; r < print_count; r++) {
 			if (c != 0) {
 				LogFailure("\t");
 			}
@@ -89,6 +146,10 @@ void SQLLogicTestLogger::PrintExpectedResult(const vector<string> &values, idx_t
 		}
 	}
 	LogFailure("\n");
+	if (print_count < values.size()) {
+		LogFailure("[... " + to_string(values.size() - print_count) + " of " + to_string(values.size()) +
+		           " values not shown]\n");
+	}
 }
 
 void SQLLogicTestLogger::PrintLineSep() {
@@ -219,6 +280,11 @@ void SQLLogicTestLogger::UnexpectedFailure(MaterializedQueryResult &result) {
 	PrintHeader("Actual result:");
 	PrintLineSep();
 	PrintResultString(result);
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::UNEXPECTED_FAILURE, "Query unexpectedly failed");
+		record.error_message = result.HasError() ? result.GetError() : string();
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 void SQLLogicTestLogger::OutputResult(MaterializedQueryResult &result, const vector<string> &result_values_string) {
 	// names
@@ -238,14 +304,21 @@ void SQLLogicTestLogger::OutputResult(MaterializedQueryResult &result, const vec
 	}
 	LogFailure("\n");
 	PrintLineSep();
-	for (idx_t r = 0; r < result.RowCount(); r++) {
-		for (idx_t c = 0; c < result.ColumnCount(); c++) {
+	const idx_t column_count = result.ColumnCount();
+	const idx_t max_rows = column_count == 0 ? 0 : TEST_FAILURE_MAX_VALUES / column_count;
+	const idx_t print_rows = MinValue<idx_t>(result.RowCount(), MaxValue<idx_t>(max_rows, 1));
+	for (idx_t r = 0; r < print_rows; r++) {
+		for (idx_t c = 0; c < column_count; c++) {
 			if (c != 0) {
 				LogFailure("\t");
 			}
-			LogFailure(result_values_string[r * result.ColumnCount() + c]);
+			LogFailure(result_values_string[r * column_count + c]);
 		}
 		LogFailure("\n");
+	}
+	if (print_rows < result.RowCount()) {
+		LogFailure("[... " + to_string(result.RowCount() - print_rows) + " of " + to_string(result.RowCount()) +
+		           " rows not shown]\n");
 	}
 }
 
@@ -269,6 +342,17 @@ void SQLLogicTestLogger::ColumnCountMismatch(MaterializedQueryResult &result,
 	PrintSQL();
 	PrintLineSep();
 	PrintResultError(result, result_values_string, expected_column_count, row_wise);
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::WRONG_COLUMN_COUNT, "Wrong column count in query!");
+		record.has_expected = true;
+		FillValues(result_values_string, expected_column_count, record.expected, record.expected_truncated,
+		           record.expected_rows);
+		record.has_actual = true;
+		idx_t actual_columns = 0;
+		FillValues(result, record.actual, record.actual_truncated, record.actual_rows, actual_columns);
+		record.columns = expected_column_count;
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::NotCleanlyDivisible(idx_t expected_column_count, idx_t actual_column_count) {
@@ -277,6 +361,13 @@ void SQLLogicTestLogger::NotCleanlyDivisible(idx_t expected_column_count, idx_t 
 	PrintLineSep();
 	LogFailure("Expected " + to_string(expected_column_count) + " columns, but " + to_string(actual_column_count) +
 	           " values were supplied\nThis is not cleanly divisible (i.e. the last row does not have enough values)");
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::NOT_CLEANLY_DIVISIBLE,
+		                         "Expected " + to_string(expected_column_count) + " columns, but " +
+		                             to_string(actual_column_count) + " values were supplied");
+		record.columns = expected_column_count;
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::WrongRowCount(idx_t expected_rows, MaterializedQueryResult &result,
@@ -291,6 +382,18 @@ void SQLLogicTestLogger::WrongRowCount(idx_t expected_rows, MaterializedQueryRes
 	PrintSQL();
 	PrintLineSep();
 	PrintResultError(result, comparison_values, expected_column_count, row_wise);
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::WRONG_ROW_COUNT, "Wrong row count in query!");
+		record.has_expected = true;
+		FillValues(comparison_values, expected_column_count, record.expected, record.expected_truncated,
+		           record.expected_rows);
+		record.expected_rows = expected_rows;
+		record.has_actual = true;
+		idx_t actual_columns = 0;
+		FillValues(result, record.actual, record.actual_truncated, record.actual_rows, actual_columns);
+		record.columns = expected_column_count;
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::ColumnCountMismatchCorrectResult(idx_t original_expected_columns, idx_t expected_column_count,
@@ -315,6 +418,13 @@ void SQLLogicTestLogger::ColumnCountMismatchCorrectResult(idx_t original_expecte
 	    << std::endl;
 	LogFailure(oss.str());
 	PrintLineSep();
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::WRONG_COLUMN_COUNT_CORRECT_RESULT, "Wrong column count in query!");
+		record.columns = original_expected_columns;
+		record.actual_rows = result.RowCount();
+		record.suggested_fix = "query " + string(result.ColumnCount(), 'I');
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::SplitMismatch(idx_t row_number, idx_t expected_column_count, idx_t split_count) {
@@ -329,6 +439,13 @@ void SQLLogicTestLogger::SplitMismatch(idx_t row_number, idx_t expected_column_c
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::SPLIT_MISMATCH,
+		                         "Column count mismatch after splitting on tab on row " + to_string(row_number));
+		record.columns = expected_column_count;
+		record.actual_rows = split_count;
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::WrongResultHash(const string &expected_result, MaterializedQueryResult &result,
@@ -347,14 +464,35 @@ void SQLLogicTestLogger::WrongResultHash(const string &expected_result, Material
 	PrintHeader("Actual result:");
 	PrintLineSep();
 	PrintResultString(result);
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::WRONG_RESULT_HASH, "Wrong result hash!");
+		record.expected_hash = expected_hash;
+		record.actual_hash = actual_hash;
+		if (!expected_result.empty()) {
+			record.has_expected = true;
+			record.expected.push_back(expected_result);
+		}
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::UnexpectedStatement(bool expect_ok, MaterializedQueryResult &result) {
-	PrintErrorHeader(!expect_ok ? "Query unexpectedly succeeded!" : "Query unexpectedly failed!");
+	const string message = !expect_ok ? "Query unexpectedly succeeded!" : "Query unexpectedly failed!";
+	PrintErrorHeader(message);
 	PrintLineSep();
 	PrintSQL();
 	PrintLineSep();
 	PrintResultString(result);
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::UNEXPECTED_STATEMENT, message);
+		if (result.HasError()) {
+			record.error_message = result.GetError();
+		} else {
+			record.has_actual = true;
+			FillValues(result, record.actual, record.actual_truncated, record.actual_rows, record.columns);
+		}
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::ExpectedErrorMismatch(const string &expected_error, MaterializedQueryResult &result) {
@@ -365,6 +503,14 @@ void SQLLogicTestLogger::ExpectedErrorMismatch(const string &expected_error, Mat
 	PrintHeader("Actual result:");
 	PrintLineSep();
 	PrintResultString(result);
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::EXPECTED_ERROR_MISMATCH,
+		                         "Query failed, but error message did not match expected error message");
+		record.has_expected = true;
+		record.expected.push_back(expected_error);
+		record.error_message = result.HasError() ? result.GetError() : string();
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::InternalException(MaterializedQueryResult &result) {
@@ -374,6 +520,11 @@ void SQLLogicTestLogger::InternalException(MaterializedQueryResult &result) {
 	PrintHeader("Actual result:");
 	PrintLineSep();
 	PrintResultString(result);
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::INTERNAL_EXCEPTION, "Query failed with internal exception!");
+		record.error_message = result.HasError() ? result.GetError() : string();
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 void SQLLogicTestLogger::LoadDatabaseFail(const string &file_name, const string &dbpath, const string &message) {
@@ -381,6 +532,73 @@ void SQLLogicTestLogger::LoadDatabaseFail(const string &file_name, const string 
 	PrintLineSep();
 	LogFailure("Error message: " + message + "\n");
 	PrintLineSep();
+	if (TestFailureRecorder::Enabled()) {
+		TestFailureRecord record;
+		record.kind = TestFailureKind::LOAD_DATABASE_FAIL;
+		record.message = "Failed to load database " + dbpath;
+		record.file = file_name;
+		record.error_message = message;
+		TestFailureRecorder::Record(std::move(record));
+	}
+}
+
+void SQLLogicTestLogger::ValueMismatch(MaterializedQueryResult &result, const string &actual_value,
+                                       const string &expected_value, idx_t row, idx_t column,
+                                       const vector<string> &result_values, const vector<string> &values,
+                                       idx_t expected_column_count, bool row_wise) {
+	std::ostringstream oss;
+	PrintErrorHeader("Wrong result in query!");
+	PrintLineSep();
+	PrintSQL();
+	PrintLineSep();
+	oss << termcolor::red << termcolor::bold << "Mismatch on row " << row + 1 << ", column "
+	    << result.ColumnName(column) << "(index " << column + 1 << ")" << std::endl
+	    << termcolor::reset;
+	oss << actual_value << " <> " << expected_value << std::endl;
+	LogFailure(oss.str());
+	PrintLineSep();
+
+	auto mismatch_rows = ComputeMismatchRows(values, result_values, expected_column_count);
+	if (mismatch_rows.size() > 1) {
+		// The dumps below may be truncated, so name the differing rows up front rather than leaving the
+		// reader to diff two long lists by eye.
+		const idx_t list_count = MinValue<idx_t>(mismatch_rows.size(), 20);
+		string rows_str;
+		for (idx_t i = 0; i < list_count; i++) {
+			rows_str += (i == 0 ? "" : ", ") + to_string(mismatch_rows[i] + 1);
+		}
+		if (list_count < mismatch_rows.size()) {
+			rows_str += ", ...";
+		}
+		LogFailure(to_string(mismatch_rows.size()) + " rows differ (1-based): " + rows_str + "\n");
+		PrintLineSep();
+	}
+	PrintResultError(result_values, values, expected_column_count, row_wise);
+
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::VALUE_MISMATCH, "Wrong result in query!");
+		record.has_expected = true;
+		FillValues(values, expected_column_count, record.expected, record.expected_truncated, record.expected_rows);
+		record.has_actual = true;
+		FillValues(result_values, expected_column_count, record.actual, record.actual_truncated, record.actual_rows);
+		record.columns = expected_column_count;
+		record.mismatch_rows = std::move(mismatch_rows);
+		TestFailureRecorder::Record(std::move(record));
+	}
+}
+
+void SQLLogicTestLogger::TestError(const string &description, const string &detail) {
+	std::ostringstream oss;
+	PrintErrorHeader(description);
+	PrintLineSep();
+	oss << termcolor::red << termcolor::bold << detail << termcolor::reset << std::endl;
+	LogFailure(oss.str());
+	PrintLineSep();
+	if (TestFailureRecorder::Enabled()) {
+		auto record = BaseRecord(TestFailureKind::OTHER, description);
+		record.error_message = detail;
+		TestFailureRecorder::Record(std::move(record));
+	}
 }
 
 } // namespace duckdb

--- a/test/sqlite/sqllogic_test_logger.hpp
+++ b/test/sqlite/sqllogic_test_logger.hpp
@@ -11,6 +11,7 @@
 #include "duckdb.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "sqllogic_command.hpp"
+#include "test_failure_record.hpp"
 
 namespace duckdb {
 
@@ -56,6 +57,11 @@ public:
 	void UnexpectedStatement(bool expect_ok, MaterializedQueryResult &result);
 	void ExpectedErrorMismatch(const string &expected_error, MaterializedQueryResult &result);
 	void InternalException(MaterializedQueryResult &result);
+	//! A single cell differed. `row`/`column` are zero-based indices into the compared result.
+	void ValueMismatch(MaterializedQueryResult &result, const string &actual_value, const string &expected_value,
+	                   idx_t row, idx_t column, const vector<string> &result_values, const vector<string> &values,
+	                   idx_t expected_column_count, bool row_wise);
+	void TestError(const string &description, const string &detail);
 	static void LoadDatabaseFail(const string &file_name, const string &dbpath, const string &message);
 	//! Write a machine-readable event line: "[TEST_EVENT] <json>" (--emit-test-events). Caller gates.
 	static void EmitTestEvent(const string &json_payload);
@@ -64,6 +70,19 @@ public:
 	static void LogFailure(const string &log_message);
 	static void LogFailureAnnotation(const string &log_message);
 	string ResultToString(MaterializedQueryResult &result);
+
+private:
+	//! Seed a record with this failure's location and query. Cheap enough to build unconditionally;
+	//! callers still gate on TestFailureRecorder::Enabled() before doing the result-copying work.
+	TestFailureRecord BaseRecord(TestFailureKind kind, const string &message) const;
+	//! Copy a row-major value list into `out`, capping it at TEST_FAILURE_MAX_VALUES cells.
+	static void FillValues(const vector<string> &values, idx_t columns, vector<string> &out, bool &truncated,
+	                       idx_t &rows);
+	//! Copy a query result into `out` in the same row-major layout, under the same cap.
+	void FillValues(MaterializedQueryResult &result, vector<string> &out, bool &truncated, idx_t &rows, idx_t &columns);
+	//! Row indices where `expected` and `actual` differ. Empty unless both sides share a shape.
+	static vector<idx_t> ComputeMismatchRows(const vector<string> &expected, const vector<string> &actual,
+	                                         idx_t columns);
 
 private:
 	Connection &connection;

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -11,6 +11,7 @@
 #include "sqlite/sqllogic_test_runner.hpp"
 #include "test_helpers.hpp"
 #include "test_config.hpp"
+#include "test_failure_record.hpp"
 
 using namespace duckdb;
 
@@ -81,6 +82,7 @@ int main(int argc_in, char *argv[]) {
 	}
 	bool keep_home = false;
 	bool use_stdin = false;
+	auto output_format = TestOutputFormat::DEFAULT;
 	vector<string> input_files;
 	unordered_set<idx_t> input_file_arg_indices;
 
@@ -89,7 +91,8 @@ int main(int argc_in, char *argv[]) {
 	// remains here is what that table cannot express.
 	idx_t argc = NumericCast<idx_t>(argc_in);
 	int new_argc = 0;
-	auto new_argv = duckdb::unique_ptr<char *[]>(new char *[argc]);
+	// +2: --output=json injects "-r json" below
+	auto new_argv = duckdb::unique_ptr<char *[]>(new char *[argc + 2]);
 	for (idx_t i = 0; i < argc; i++) {
 		string argument(argv[i]);
 		if (argument == "--test-dir") {
@@ -104,6 +107,27 @@ int main(int argc_in, char *argv[]) {
 			use_stdin = true;
 		} else if (argument == "--emit-test-events") {
 			SetEmitTestEvents(true);
+		} else if (argument == "--output" || StringUtil::StartsWith(argument, "--output=")) {
+			string format;
+			if (argument == "--output") {
+				if (i + 1 >= argc) {
+					fprintf(stderr, "Missing value for --output (expected \"default\" or \"json\")\n");
+					return 1;
+				}
+				format = string(argv[++i]);
+			} else {
+				format = argument.substr(strlen("--output="));
+			}
+			format = StringUtil::Lower(format);
+			if (format == "json") {
+				output_format = TestOutputFormat::JSON;
+			} else if (format == "default") {
+				output_format = TestOutputFormat::DEFAULT;
+			} else {
+				fprintf(stderr, "Unsupported --output format \"%s\" (expected \"default\" or \"json\")\n",
+				        format.c_str());
+				return 1;
+			}
 		} else {
 			try {
 				if (!test_config.ParseArgument(argument, argc, argv, i)) {
@@ -201,9 +225,22 @@ int main(int argc_in, char *argv[]) {
 	} else {
 		RegisterSqllogictests();
 	}
+	if (output_format == TestOutputFormat::JSON) {
+		// Swap the console reporter for the JSON one and silence everything that writes to the streams
+		// outside it, so stdout carries nothing but JSON Lines.
+		static char reporter_flag[] = "-r";
+		static char reporter_name[] = "json";
+		new_argv[new_argc++] = reporter_flag;
+		new_argv[new_argc++] = reporter_name;
+		Catch::setProgressReporting(false);
+		TestFailureRecorder::SetEnabled(true);
+		SetTestOutputFormat(TestOutputFormat::JSON);
+	}
+
 	int result = Catch::Session().run(new_argc, new_argv.get());
 
-	std::string failures_summary = FailureSummary::GetFailureSummary();
+	std::string failures_summary =
+	    output_format == TestOutputFormat::JSON ? std::string() : FailureSummary::GetFailureSummary();
 	if (!failures_summary.empty()) {
 		auto description = test_config.GetDescription();
 		if (!description.empty()) {
@@ -217,7 +254,8 @@ int main(int argc_in, char *argv[]) {
 		std::cerr << "====================================================\n" << std::endl;
 		std::cerr << failures_summary;
 	}
-	std::string skip_reason_summary = SQLLogicTestRunner::GetSkipReasonSummary();
+	std::string skip_reason_summary =
+	    output_format == TestOutputFormat::JSON ? std::string() : SQLLogicTestRunner::GetSkipReasonSummary();
 	if (!skip_reason_summary.empty()) {
 		std::cerr << "\n"
 		          << "Skipped tests for the following reasons:" << std::endl;

--- a/third_party/catch/catch.hpp
+++ b/third_party/catch/catch.hpp
@@ -13446,7 +13446,22 @@ namespace Catch {
 
 namespace Catch {
 
+    bool &progressReportingEnabledRef() {
+        // Machine-readable reporters own the stream; the progress line is written straight to
+        // std::cout and would otherwise interleave with their output.
+        static bool enabled = true;
+        return enabled;
+    }
+
+    void setProgressReporting(bool enabled) {
+        progressReportingEnabledRef() = enabled;
+    }
+
     namespace {
+        bool progressReportingEnabled() {
+            return progressReportingEnabledRef();
+        }
+
         const int MaxExitCode = 255;
 
         // Helper function to check if stdout is a terminal
@@ -13479,6 +13494,9 @@ namespace Catch {
         }
 
         void renderTestProgress(int current_test, int total_tests, std::string next_test, double elapsed_seconds = -1) {
+            if (!progressReportingEnabled()) {
+                return;
+            }
             double progress = (double) current_test / (double) total_tests;
             std::string prefix = "[" + std::to_string(current_test) + "/" + std::to_string(total_tests) + "] (" + std::to_string(int(progress * 100)) + "%): ";
             std::string test_label = next_test;
@@ -13513,8 +13531,9 @@ namespace Catch {
 
                 std::cout << "\r" << result;
             } else {
-                // For non-terminals, we just print each line
-                std::cout << "\n" << result;
+                // For non-terminals, we just print each line. The newline terminates this line rather
+                // than opening it, so a consumer never sees another writer's output appended to it.
+                std::cout << result << "\n";
             }
 
             std::cout.flush();
@@ -13599,7 +13618,9 @@ namespace Catch {
                         current_test++;
                         if (!m_config->printFailingTests()) {
                             renderTestProgress(current_test, total_tests_run, testCase->name, elapsed_seconds);
-                            if (current_test == total_tests_run) {
+                            if (current_test == total_tests_run && progressReportingEnabled()) {
+                                // terminates the \r-overwritten progress line; nothing to terminate when
+                                // progress reporting is off
                                 std::cout << std::endl;
                             }
                         }


### PR DESCRIPTION
Pending a future unit testing rework, this should make it much easier for agents/scripts/machines to inspect the output of `unittest`. 

A full green run with `--output=json` now produces 14kb of stdout output, compared to ~507kb.

```
  ┌───────────────────────────────────┬─────────┬───────┐
  │                                   │  bytes  │ lines │
  ├───────────────────────────────────┼─────────┼───────┤
  │ Before this work (default output) │ 506,860 │ 6,377 │
  ├───────────────────────────────────┼─────────┼───────┤
  │ JSON emitting every test          │ 950,910 │ 6,274 │
  ├───────────────────────────────────┼─────────┼───────┤
  │ JSON now (non-passing only)       │ 14,110  │ 73    │
  └───────────────────────────────────┴─────────┴───────┘
  ```
  
  Example:
  ```bash
  ./build/reldebug/test/unittest --output='json' "test/sql/function/list/*"
{"event":"test","name":"test/sql/function/list/aggregates/avg.test","status":"skip","duration":0.0127215,"assertions":{"passed":18,"failed":0},"skip_reason":"require longdouble"}
{"event":"summary","total":117,"passed":116,"failed":0,"skipped":1,"assertions":{"passed":9667,"failed":0},"failed_tests":[],"skip_reasons":{"require longdouble":1}}
```