### PR TITLE
Generate stable transform result type names without RTTI

### DIFF
--- a/scripts/parser/generate_transformer.py
+++ b/scripts/parser/generate_transformer.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import re
 import sys
 from dataclasses import dataclass, field
@@ -9,6 +10,7 @@ from typing import List
 sys.path.insert(0, str(Path(__file__).parent))
 from inline_grammar import parse_peg_grammar, PEGTokenType
 from grammar_types import (
+    load_additional_transform_result_types,
     load_grammar_types,
     load_grammar_types_yaml,
     load_matcher_rule_overrides,
@@ -1197,6 +1199,11 @@ _MATCHER_START_BLOCK = _SEPARATOR + "\t// START GENERATED RULE OVERRIDES\n" + _S
 _MATCHER_END_BLOCK = _SEPARATOR + "\t// END GENERATED RULE OVERRIDES\n" + _SEPARATOR
 _PACKRAT_START_BLOCK = _SEPARATOR + "\t// START GENERATED PACKRAT MEMOIZED RULES\n" + _SEPARATOR
 _PACKRAT_END_BLOCK = _SEPARATOR + "\t// END GENERATED PACKRAT MEMOIZED RULES\n" + _SEPARATOR
+_RESULT_TYPE_SEPARATOR = "//===--------------------------------------------------------------------===//\n"
+_RESULT_TYPE_START_BLOCK = (
+    _RESULT_TYPE_SEPARATOR + "// START GENERATED TRANSFORM RESULT TYPES\n" + _RESULT_TYPE_SEPARATOR
+)
+_RESULT_TYPE_END_BLOCK = _RESULT_TYPE_SEPARATOR + "// END GENERATED TRANSFORM RESULT TYPES\n" + _RESULT_TYPE_SEPARATOR
 
 
 def _matcher_override_expr(rule_name, override):
@@ -1267,9 +1274,29 @@ def write_packrat_memoized_rules(packrat_memoized_rules):
     print(f"Updated {matcher_cpp_path}")
 
 
-def write_hpp(all_declarations):
+def generate_transform_result_types(rule_types, additional_result_types):
+    result_types = sorted({info.cpp_type for info in rule_types.values()}.union(additional_result_types))
+    lines = []
+    for cpp_type in result_types:
+        stable_name = json.dumps(f"duckdb.transform_result.{cpp_type}")
+        lines.append(f"DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE({stable_name}, {cpp_type});\n")
+    return "".join(lines)
+
+
+def write_hpp(all_declarations, result_types):
     hpp_path = include_peg_dir / "peg_transformer.hpp"
     content = hpp_path.read_text()
+
+    result_type_start_idx = content.find(_RESULT_TYPE_START_BLOCK)
+    if result_type_start_idx == -1:
+        raise RuntimeError(f"Could not find START GENERATED TRANSFORM RESULT TYPES marker in {hpp_path}")
+    result_type_end_idx = content.find(_RESULT_TYPE_END_BLOCK, result_type_start_idx + len(_RESULT_TYPE_START_BLOCK))
+    if result_type_end_idx == -1:
+        raise RuntimeError(f"Could not find END GENERATED TRANSFORM RESULT TYPES marker in {hpp_path}")
+
+    result_type_block_end = result_type_end_idx + len(_RESULT_TYPE_END_BLOCK)
+    generated_result_type_block = _RESULT_TYPE_START_BLOCK + result_types + _RESULT_TYPE_END_BLOCK
+    content = content[:result_type_start_idx] + generated_result_type_block + content[result_type_block_end:]
 
     start_idx = content.find(_START_BLOCK)
     if start_idx == -1:
@@ -1519,7 +1546,8 @@ def main():
 
     if args.write:
         all_declarations = [d for r in results for d in r.declarations]
-        write_hpp(all_declarations)
+        additional_result_types = load_additional_transform_result_types(grammar_types_file)
+        write_hpp(all_declarations, generate_transform_result_types(rule_types, additional_result_types))
         all_implementations = [impl for r in results for impl in r.implementations]
         all_registrations = [reg for r in results for reg in r.registrations]
         write_cpp(all_implementations, all_registrations)

--- a/scripts/parser/grammar_types.py
+++ b/scripts/parser/grammar_types.py
@@ -113,7 +113,13 @@ def load_grammar_types(types_file):
 
     # Category entries: CategoryName -> {type: "...", by_value: bool, default_initializer: "...", rules: [...]}
     for key, value in data.items():
-        if key in ("overrides", "excluded_rules", "matcher_rule_overrides", "packrat_memoized_rules"):
+        if key in (
+            "overrides",
+            "excluded_rules",
+            "matcher_rule_overrides",
+            "packrat_memoized_rules",
+            "additional_transform_result_types",
+        ):
             continue
         if not isinstance(value, dict):
             continue
@@ -136,6 +142,16 @@ def load_grammar_types(types_file):
     excluded_rules = set(data.get("excluded_rules", []))
     validate_grammar_types(types_file, data, rule_types, excluded_rules)
     return rule_types, excluded_rules
+
+
+def load_additional_transform_result_types(types_file):
+    """Load result types used by transformer infrastructure rather than grammar rules."""
+    data = load_grammar_types_yaml(types_file)
+    result_types = data.get("additional_transform_result_types", [])
+    if not isinstance(result_types, list) or not all(isinstance(result_type, str) for result_type in result_types):
+        print(f"Error: additional_transform_result_types in {types_file} must be a list of strings.", file=sys.stderr)
+        sys.exit(1)
+    return result_types
 
 
 def load_matcher_rule_overrides(types_file):

--- a/scripts/parser/grammar_types.yml
+++ b/scripts/parser/grammar_types.yml
@@ -34,6 +34,9 @@
 # transformer generator should treat only `identifier` and `reserved_identifier`
 # entries as direct IdentifierParseResult-producing rules.
 #
+# additional_transform_result_types: result types used by transformer infrastructure
+# rather than as the declared return type of a grammar rule.
+#
 # packrat_memoized_rules: named grammar rules that should use packrat
 # memoization in MatchParseResult. Keep this selective because cache lookup and
 # parse-result sharing are only worthwhile for rules with repeated backtracking.
@@ -41,6 +44,10 @@
 # ---------------------------------------------------------------------------
 # unique_ptr<T> categories
 # ---------------------------------------------------------------------------
+
+additional_transform_result_types:
+  - "unique_ptr<TransformResultValue>"
+  - "vector<Identifier>"
 
 SQLStatementList:
   type: "vector<unique_ptr<SQLStatement>>"

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -79,6 +79,169 @@ struct GroupByExpressionInfo {
 	vector<GroupByExpressionInfo> children;
 };
 
+//===--------------------------------------------------------------------===//
+// START GENERATED TRANSFORM RESULT TYPES
+//===--------------------------------------------------------------------===//
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.AddColumnEntry", AddColumnEntry);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.AnalyzeTarget", AnalyzeTarget);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.BetweenInLikeOperator", BetweenInLikeOperator);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.BinaryExpressionTail", BinaryExpressionTail);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.CaseCheck", CaseCheck);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.CastArguments", CastArguments);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.CatalogType", CatalogType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ColumnConstraintEntry", ColumnConstraintEntry);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ColumnElements", ColumnElements);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ColumnList", ColumnList);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.CommonTableExpressionMap", CommonTableExpressionMap);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ComparisonExpressionTail", ComparisonExpressionTail);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ConstraintColumnDefinition", ConstraintColumnDefinition);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.CopyDatabaseType", CopyDatabaseType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.CreateTableColumnElement", CreateTableColumnElement);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.CreateTableDefinition", CreateTableDefinition);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.DatePartSpecifier", DatePartSpecifier);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.DescribeTarget", DescribeTarget);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.DistinctClause", DistinctClause);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ExpressionType", ExpressionType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ExtensionRepositoryInfo", ExtensionRepositoryInfo);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.FunctionArgument", FunctionArgument);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.GeneratedColumnDefinition", GeneratedColumnDefinition);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.GenericCopyOption", GenericCopyOption);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.GenericCopyOptionValue", GenericCopyOptionValue);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.GroupByExpressionInfo", GroupByExpressionInfo);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.GroupByNode", GroupByNode);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.Identifier", Identifier);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.InsertColumnOrder", InsertColumnOrder);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.InsertValues", InsertValues);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.IsDistinctFromTail", IsDistinctFromTail);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.JoinPrefix", JoinPrefix);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.JoinQualifier", JoinQualifier);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.JoinType", JoinType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.KeyActions", KeyActions);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.LimitPercentResult", LimitPercentResult);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.LogicalType", LogicalType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.LogicalTypeId", LogicalTypeId);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.MacroParameter", MacroParameter);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.MergeActionCondition", MergeActionCondition);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.MethodArguments", MethodArguments);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.OnConflictAction", OnConflictAction);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.OnConflictExpressionTarget", OnConflictExpressionTarget);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.OrderByNode", OrderByNode);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.OrderByNullType", OrderByNullType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.OrderType", OrderType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.OtherOperatorTail", OtherOperatorTail);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ParsedOperator", ParsedOperator);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.PartitionSortedOptions", PartitionSortedOptions);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.PivotColumn", PivotColumn);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.QualifiedColumnName", QualifiedColumnName);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.QualifiedName", QualifiedName);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.SampleMethod", SampleMethod);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.SecretPersistType", SecretPersistType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.SetOperationType", SetOperationType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.SetScope", SetScope);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.SettingInfo", SettingInfo);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.ShowType", ShowType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.TableAlias", TableAlias);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.TransactionModifierType", TransactionModifierType);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.TriggerEventInfo", TriggerEventInfo);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.TriggerForEach", TriggerForEach);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.TriggerTableReferencingInfo",
+                                      TriggerTableReferencingInfo);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.TriggerTiming", TriggerTiming);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.TrimArguments", TrimArguments);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.UnpivotNameValues", UnpivotNameValues);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.VacuumOptions", VacuumOptions);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.Value", Value);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.WindowBoundaryExpression", WindowBoundaryExpression);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.WindowExcludeMode", WindowExcludeMode);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.WindowFrame", WindowFrame);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.bool", bool);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.case_insensitive_map_t<unique_ptr<ParsedExpression>>",
+                                      case_insensitive_map_t<unique_ptr<ParsedExpression>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.child_list_t<LogicalType>", child_list_t<LogicalType>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.int64_t", int64_t);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.optional_idx", optional_idx);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<Identifier, LogicalType>",
+                                      pair<Identifier, LogicalType>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<Identifier, unique_ptr<CommonTableExpressionInfo>>",
+                                      pair<Identifier, unique_ptr<CommonTableExpressionInfo>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<Identifier, unique_ptr<ParsedExpression>>",
+                                      pair<Identifier, unique_ptr<ParsedExpression>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<MergeActionCondition, unique_ptr<MergeIntoAction>>",
+                                      pair<MergeActionCondition, unique_ptr<MergeIntoAction>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<QualifiedColumnName, string>",
+                                      pair<QualifiedColumnName, string>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<SampleMethod, optional_idx>",
+                                      pair<SampleMethod, optional_idx>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<string, bool>", pair<string, bool>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<string, unique_ptr<ParsedExpression>>",
+                                      pair<string, unique_ptr<ParsedExpression>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.pair<string, unique_ptr<SequenceOption>>",
+                                      pair<string, unique_ptr<SequenceOption>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE(
+    "duckdb.transform_result.pair<unique_ptr<SetOperationNode>, unique_ptr<SelectStatement>>",
+    pair<unique_ptr<SetOperationNode>, unique_ptr<SelectStatement>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.qualified_column_map_t<string>",
+                                      qualified_column_map_t<string>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.qualified_column_set_t", qualified_column_set_t);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.string", string);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<AlterInfo>", unique_ptr<AlterInfo>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<AlterTableInfo>", unique_ptr<AlterTableInfo>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<AtClause>", unique_ptr<AtClause>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<BaseTableRef>", unique_ptr<BaseTableRef>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<ColumnRefExpression>",
+                                      unique_ptr<ColumnRefExpression>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<ConnectInfo>", unique_ptr<ConnectInfo>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<Constraint>", unique_ptr<Constraint>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<CreateStatement>",
+                                      unique_ptr<CreateStatement>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<CreateTypeInfo>", unique_ptr<CreateTypeInfo>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<DropStatement>", unique_ptr<DropStatement>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<MacroFunction>", unique_ptr<MacroFunction>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<MergeIntoAction>",
+                                      unique_ptr<MergeIntoAction>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<OnConflictInfo>", unique_ptr<OnConflictInfo>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<ParsedExpression>",
+                                      unique_ptr<ParsedExpression>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<QueryNode>", unique_ptr<QueryNode>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<ResultModifier>", unique_ptr<ResultModifier>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<SQLStatement>", unique_ptr<SQLStatement>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<SampleOptions>", unique_ptr<SampleOptions>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<SelectNode>", unique_ptr<SelectNode>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<SelectStatement>",
+                                      unique_ptr<SelectStatement>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<SetOperationNode>",
+                                      unique_ptr<SetOperationNode>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<SetStatement>", unique_ptr<SetStatement>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<TableRef>", unique_ptr<TableRef>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<TransformResultValue>",
+                                      unique_ptr<TransformResultValue>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<UpdateSetInfo>", unique_ptr<UpdateSetInfo>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.unique_ptr<WindowExpression>",
+                                      unique_ptr<WindowExpression>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<FunctionArgument>", vector<FunctionArgument>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<GenericCopyOption>", vector<GenericCopyOption>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<Identifier>", vector<Identifier>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<LogicalType>", vector<LogicalType>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<MacroParameter>", vector<MacroParameter>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<OrderByNode>", vector<OrderByNode>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<PivotColumn>", vector<PivotColumn>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<PivotColumnEntry>", vector<PivotColumnEntry>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<WindowBoundaryExpression>",
+                                      vector<WindowBoundaryExpression>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<bool>", vector<bool>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<string>", vector<string>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<unique_ptr<ParsedExpression>>",
+                                      vector<unique_ptr<ParsedExpression>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<unique_ptr<ResultModifier>>",
+                                      vector<unique_ptr<ResultModifier>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<unique_ptr<SQLStatement>>",
+                                      vector<unique_ptr<SQLStatement>>);
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.transform_result.vector<unique_ptr<TableRef>>",
+                                      vector<unique_ptr<TableRef>>);
+//===--------------------------------------------------------------------===//
+// END GENERATED TRANSFORM RESULT TYPES
+//===--------------------------------------------------------------------===//
+
 class PEGTransformer;
 class TransformStack;
 class TransformProcess;

--- a/src/include/duckdb/parser/peg/transformer/transform_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/transform_result.hpp
@@ -6,17 +6,28 @@
 
 namespace duckdb {
 
-//! A per-type name, used to identify transform results without RTTI.
-//! The address of a static member cannot be used for this: a loadable extension links its own copy of
-//! DuckDB, so the same instantiation exists at a different address in each image. Comparing the name
-//! keeps a transform result created in one image castable in the other.
+template <class T>
+struct TransformResultTypeIdentifier {
+	static const char *GetName() {
+		static_assert(AlwaysFalse<T>::VALUE,
+		              "Transform result types must be registered with DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE");
+		return nullptr;
+	}
+};
+
+//! Registers a stable name for a transform result type. Invoke this macro from namespace duckdb.
+#define DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE(NAME, ...)                                                               \
+	template <>                                                                                                        \
+	struct TransformResultTypeIdentifier<__VA_ARGS__> {                                                                \
+		static constexpr const char *GetName() {                                                                       \
+			return NAME;                                                                                               \
+		}                                                                                                              \
+	};
+
+//! A stable per-type name, used to identify transform results across loadable extension boundaries without RTTI.
 template <class T>
 const char *TransformResultTypeName() {
-#ifdef _MSC_VER
-	return __FUNCSIG__;
-#else
-	return __PRETTY_FUNCTION__;
-#endif
+	return TransformResultTypeIdentifier<T>::GetName();
 }
 
 struct DUCKDB_API TransformResultValue {

--- a/test/api/test_grammar_extension.cpp
+++ b/test/api/test_grammar_extension.cpp
@@ -16,6 +16,23 @@
 
 using namespace duckdb;
 
+struct RegisteredTransformResult {
+	idx_t value;
+};
+
+namespace duckdb {
+DUCKDB_REGISTER_TRANSFORM_RESULT_TYPE("duckdb.test.RegisteredTransformResult", ::RegisteredTransformResult);
+} // namespace duckdb
+
+TEST_CASE("Transform result types use stable registered names", "[api][grammar_extension]") {
+	TypedTransformResult<RegisteredTransformResult> result({42});
+	auto copied_type_name = string(TransformResultTypeName<RegisteredTransformResult>());
+
+	REQUIRE(result.GetValuePointer(copied_type_name.c_str()) == &result.value);
+	REQUIRE(TryGetTransformResult<RegisteredTransformResult>(result) == &result.value);
+	REQUIRE(TryGetTransformResult<bool>(result) == nullptr);
+}
+
 class GrammarExtensionTestValueTransformProcess final : public TransformProcess {
 public:
 	TransformStep Resume(unique_ptr<TransformResultValue> child_result) override {


### PR DESCRIPTION
### Summary

CI [fails](https://github.com/duckdb/duckdb/actions/runs/33619641074/job/100219139766#step:12:22) when DuckDB extensions are built with Clang 20+ but the host `unittest` binary is built with GCC 14.

The JSON extension loads successfully, but initialization fails when a transformed `SQLStatement` crosses the extension/host boundary.

DuckDB’s RTTI-free type checking uses `TransformResultTypeName<T>()`, derived from compiler-specific `__PRETTY_FUNCTION__` output. GCC and Clang produce different strings for the same C++ type, so `TryCastTransformResult` incorrectly reports:

```
Transformer for rule 'Statement' returned an unexpected type.
```

We fix this error by generating stable type identifiers at parser generation time from the parser grammar.

Fixes https://github.com/duckdblabs/duckdb-internal/issues/10656.
See also: https://github.com/duckdblabs/duckdb-internal/issues/10709.