### PR TITLE
Register 'if' as catalog macro (#24633)

### DIFF
--- a/src/catalog/default/default_functions.cpp
+++ b/src/catalog/default/default_functions.cpp
@@ -126,6 +126,7 @@ static const DefaultMacro internal_macros[] = {
     {"pg_catalog", "pg_sleep", "(seconds) AS sleep_ms(CAST(seconds * 1000 AS BIGINT))"},
 
     {DEFAULT_SCHEMA, "nullif", "(a, b) AS CASE WHEN a=b THEN NULL ELSE a END"},
+    {DEFAULT_SCHEMA, "if", "(a, b, c) AS CASE WHEN a THEN b ELSE c END"},
     {DEFAULT_SCHEMA, "assert_true",
      "(condition) AS CASE WHEN condition THEN NULL ELSE error('Assertion failed') END, "
      "(condition, message) AS CASE WHEN condition THEN NULL ELSE "

--- a/src/parser/peg/transformer/transform_expression.cpp
+++ b/src/parser/peg/transformer/transform_expression.cpp
@@ -227,24 +227,6 @@ unique_ptr<ParsedExpression> PEGTransformerFactory::TransformFunctionExpression(
 		lowercase_name = "count_star";
 	}
 
-	if (lowercase_name == "if") {
-		if (function_children.size() != 3) {
-			throw ParserException("Wrong number of arguments to IF.");
-		}
-		for (auto &arg : function_children) {
-			if (arg.HasName()) {
-				throw ParserException("Named arguments are not supported in IF expressions");
-			}
-		}
-
-		auto expr = make_uniq<CaseExpression>();
-		CaseCheck check;
-		check.when_expr = std::move(function_children[0].GetExpressionMutable());
-		check.then_expr = std::move(function_children[1].GetExpressionMutable());
-		expr->CaseChecksMutable().push_back(std::move(check));
-		expr->ElseMutable() = std::move(function_children[2].GetExpressionMutable());
-		return std::move(expr);
-	}
 	if (lowercase_name == "unpack") {
 		if (function_children.size() != 1) {
 			throw ParserException("Wrong number of arguments to the UNPACK operator");


### PR DESCRIPTION
Fixes #24633

### Summary of Changes
* Removed hardcoded parser rewrite rule for `if` from `transform_expression.cpp`.
* Registered `if` as a catalog macro in `default_functions.cpp`: `(a, b, c) AS CASE WHEN a THEN b ELSE c END`.
* Verified that `if` now appears properly inside `duckdb_functions()`.