### PR TITLE
[Dev] Add `annotated_mutex` and friends to more places in the storage

### DIFF
--- a/src/function/table/table_scan.cpp
+++ b/src/function/table/table_scan.cpp
@@ -484,6 +484,7 @@ unique_ptr<GlobalTableFunctionState> DuckTableScanInitGlobal(ClientContext &cont
 	// Check if row_number column is requested and initialize row_number_base
 	for (idx_t i = 0; i < input.column_ids.size(); i++) {
 		if (input.column_ids[i] == COLUMN_IDENTIFIER_ROW_NUMBER) {
+			annotated_lock_guard lock(g_state->state.scan_state.lock);
 			g_state->state.scan_state.row_number_base = 0;
 			break;
 		}

--- a/src/include/duckdb/storage/block_manager.hpp
+++ b/src/include/duckdb/storage/block_manager.hpp
@@ -102,7 +102,7 @@ public:
 	virtual void Truncate();
 
 	//! Register a block with the given block id in the base file
-	shared_ptr<BlockHandle> RegisterBlock(block_id_t block_id);
+	shared_ptr<BlockHandle> RegisterBlock(block_id_t block_id) DUCKDB_EXCLUDES(blocks_lock);
 	//! Convert an existing in-memory buffer into a persistent disk-backed block
 	//! If mode is set to destructive (default) - the old_block will be destroyed as part of this method
 	//! This can only be safely used when there is no other (lingering) usage of old_block
@@ -116,7 +116,7 @@ public:
 
 	void UnregisterPersistentBlock(BlockHandle &block);
 	//! UnregisterBlock, only accepts non-temporary block ids
-	virtual void UnregisterBlock(block_id_t id);
+	virtual void UnregisterBlock(block_id_t id) DUCKDB_EXCLUDES(blocks_lock);
 
 	//! Returns a reference to the metadata manager of this block manager.
 	MetadataManager &GetMetadataManager();
@@ -167,8 +167,8 @@ public:
 	}
 
 protected:
-	bool BlockIsRegistered(block_id_t block_id);
-	shared_ptr<BlockHandle> TryGetBlock(block_id_t block_id);
+	bool BlockIsRegistered(block_id_t block_id) DUCKDB_EXCLUDES(blocks_lock);
+	shared_ptr<BlockHandle> TryGetBlock(block_id_t block_id) DUCKDB_EXCLUDES(blocks_lock);
 
 public:
 	template <class TARGET>
@@ -187,11 +187,13 @@ protected:
 	//! Relevant for some Windows edge cases.
 	bool in_destruction = false;
 
-private:
+	//! Acquired after SingleFileBlockManager::single_file_block_lock when both are needed.
 	//! The lock for the set of blocks
-	mutex blocks_lock;
+	annotated_mutex blocks_lock;
+
+private:
 	//! A mapping of block id -> BlockHandle
-	unordered_map<block_id_t, weak_ptr<BlockHandle>> blocks;
+	unordered_map<block_id_t, weak_ptr<BlockHandle>> blocks DUCKDB_GUARDED_BY(blocks_lock);
 	//! The metadata manager
 	unique_ptr<MetadataManager> metadata_manager;
 	//! The allocation size of blocks managed by this block manager. Defaults to DEFAULT_BLOCK_ALLOC_SIZE

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/enums/column_segment_info_scan_type.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "duckdb/storage/table/data_table_info.hpp"
 #include "duckdb/storage/table/persistent_table_data.hpp"
 #include "duckdb/transaction/local_storage.hpp"
@@ -174,28 +175,31 @@ public:
 	                  const vector<column_t> &column_path, DataChunk &updates);
 
 	//! Fetches an append lock
-	void AppendLock(DuckTransaction &transaction, TableAppendState &state);
+	void AppendLock(DuckTransaction &transaction, TableAppendState &state) DUCKDB_EXCLUDES(append_lock);
+	//! Verify the state owns this table's append lock, including across helper calls.
+	void VerifyAppendLock(const TableAppendState &state) const DUCKDB_ASSERT_CAPABILITY(append_lock);
 	//! Begin appending structs to this table, obtaining necessary locks, etc
-	void InitializeAppend(DuckTransaction &transaction, TableAppendState &state);
+	void InitializeAppend(DuckTransaction &transaction, TableAppendState &state) DUCKDB_REQUIRES(append_lock);
 	//! Append a chunk to the table using the AppendState obtained from InitializeAppend
-	void Append(DataChunk &chunk, TableAppendState &state);
+	void Append(DataChunk &chunk, TableAppendState &state) DUCKDB_REQUIRES(append_lock);
 	//! Finalize an append
-	void FinalizeAppend(DuckTransaction &transaction, TableAppendState &state);
+	void FinalizeAppend(DuckTransaction &transaction, TableAppendState &state) DUCKDB_REQUIRES(append_lock);
 	//! Commit the append
-	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count);
+	void CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count) DUCKDB_EXCLUDES(append_lock);
 	//! Write a segment of the table to the WAL
 	void WriteToLog(DuckTransaction &transaction, WriteAheadLog &log, idx_t row_start, idx_t count,
 	                optional_ptr<StorageCommitState> commit_state);
 	//! Revert a set of appends made by the given AppendState, used to revert appends in the event of an error during
 	//! commit (e.g. because of an I/O exception)
-	void RevertAppend(DuckTransaction &transaction, idx_t start_row, idx_t count);
-	void RevertAppendInternal(idx_t start_row);
+	void RevertAppend(DuckTransaction &transaction, idx_t start_row, idx_t count) DUCKDB_EXCLUDES(append_lock);
+	void RevertAppendInternal(idx_t start_row) DUCKDB_REQUIRES(append_lock);
 
 	void ScanTableSegment(DuckTransaction &transaction, idx_t start_row, idx_t count,
 	                      const std::function<void(DataChunk &chunk)> &function);
 
 	//! Merge a row group collection directly into this table - appending it to the end of the table without copying
-	void MergeStorage(RowGroupCollection &data, optional_ptr<StorageCommitState> commit_state);
+	void MergeStorage(RowGroupCollection &data, optional_ptr<StorageCommitState> commit_state)
+	    DUCKDB_REQUIRES(append_lock);
 
 	//! Remove the row identifiers from all the indexes of the table
 	void RemoveFromIndexes(const QueryContext &context, Vector &row_identifiers, idx_t count,
@@ -327,8 +331,8 @@ private:
 	shared_ptr<DataTableInfo> info;
 	//! The set of physical columns stored by this DataTable
 	vector<ColumnDefinition> column_definitions;
-	//! Lock for appending entries to the table
-	mutex append_lock;
+	//! Serializes base-table appends, rollback, and ALTER; held by TableAppendState during commit.
+	annotated_mutex append_lock DUCKDB_ACQUIRED_BEFORE(info->name_lock);
 	//! The row groups of the table
 	shared_ptr<RowGroupCollection> row_groups;
 	//! The version of the data table

--- a/src/include/duckdb/storage/metadata/metadata_manager.hpp
+++ b/src/include/duckdb/storage/metadata/metadata_manager.hpp
@@ -98,19 +98,26 @@ public:
 protected:
 	BlockManager &block_manager;
 	BufferManager &buffer_manager;
-	mutable mutex block_lock;
+	//! Release before allocating, pinning, or registering blocks in the block manager.
+	mutable annotated_mutex block_lock;
+	//! Checkpointing keeps the map structure stable for lock-free Flush/Write/BlockCount access.
 	unordered_map<block_id_t, MetadataBlock> blocks;
-	unordered_map<block_id_t, idx_t> modified_blocks;
+	unordered_map<block_id_t, idx_t> modified_blocks DUCKDB_GUARDED_BY(block_lock);
 
 protected:
-	block_id_t AllocateNewBlock(unique_lock<mutex> &block_lock);
-	block_id_t PeekNextBlockId() const;
-	block_id_t GetNextBlockId() const;
+	//! Acquires the caller's deferred lock after allocating the block.
+	block_id_t AllocateNewBlock(annotated_unique_lock<annotated_mutex> &guard) DUCKDB_ACQUIRE(block_lock);
+	block_id_t PeekNextBlockId() const DUCKDB_EXCLUDES(block_lock);
+	block_id_t GetNextBlockId() const DUCKDB_EXCLUDES(block_lock);
 
-	void AddBlock(unique_lock<mutex> &block_lock, MetadataBlock new_block, bool if_exists = false);
-	void AddAndRegisterBlock(unique_lock<mutex> &block_lock, MetadataBlock block);
-	void ConvertToTransient(unique_lock<mutex> &block_lock, MetadataBlock &block);
-	MetadataPointer FromDiskPointerInternal(unique_lock<mutex> &block_lock, MetaBlockPointer pointer);
+	void AddBlock(annotated_unique_lock<annotated_mutex> &guard, MetadataBlock new_block, bool if_exists = false)
+	    DUCKDB_REQUIRES(block_lock);
+	void AddAndRegisterBlock(annotated_unique_lock<annotated_mutex> &guard, MetadataBlock block)
+	    DUCKDB_REQUIRES(block_lock);
+	void ConvertToTransient(annotated_unique_lock<annotated_mutex> &guard, MetadataBlock &block)
+	    DUCKDB_REQUIRES(block_lock);
+	MetadataPointer FromDiskPointerInternal(annotated_unique_lock<annotated_mutex> &guard, MetaBlockPointer pointer)
+	    DUCKDB_REQUIRES(block_lock);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/object_cache.hpp
+++ b/src/include/duckdb/storage/object_cache.hpp
@@ -67,7 +67,7 @@ public:
 	}
 
 	shared_ptr<ObjectCacheEntry> GetObject(const string &key) {
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 		auto non_evictable_it = non_evictable_entries.find(key);
 		if (non_evictable_it != non_evictable_entries.end()) {
 			return non_evictable_it->second;
@@ -86,7 +86,7 @@ public:
 
 	template <class T, class... ARGS>
 	shared_ptr<T> GetOrCreate(const string &key, ARGS &&... args) {
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 
 		// Check non-evictable entries first
 		auto non_evictable_it = non_evictable_entries.find(key);
@@ -127,7 +127,7 @@ public:
 			return;
 		}
 
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 		const auto estimated_memory = value->GetEstimatedCacheMemory();
 		const bool is_evictable = estimated_memory.IsValid();
 		if (!is_evictable) {
@@ -141,7 +141,7 @@ public:
 	}
 
 	void Delete(const string &key) {
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 		auto iter = non_evictable_entries.find(key);
 		if (iter != non_evictable_entries.end()) {
 			non_evictable_entries.erase(iter);
@@ -177,24 +177,24 @@ public:
 	DUCKDB_API static ObjectCache &GetObjectCache(ClientContext &context);
 
 	idx_t GetMaxMemory() const {
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 		return lru_cache.Capacity();
 	}
 	idx_t GetCurrentMemory() const {
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 		return lru_cache.CurrentTotalWeight();
 	}
 	size_t GetEntryCount() const {
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 		return lru_cache.Size() + non_evictable_entries.size();
 	}
 	bool IsEmpty() const {
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 		return lru_cache.IsEmpty() && non_evictable_entries.empty();
 	}
 
 	idx_t EvictToReduceMemory(idx_t target_bytes) {
-		const lock_guard<mutex> lock(lock_mutex);
+		const annotated_lock_guard lock(lock_mutex);
 		return lru_cache.EvictToReduceAtLeast(target_bytes);
 	}
 
@@ -207,12 +207,12 @@ private:
 	}
 
 private:
-	mutable mutex lock_mutex;
+	mutable annotated_mutex lock_mutex;
 	//! LRU cache for evictable entries
 
-	SharedLruCache<string, ObjectCacheEntry, duckdb::BufferPoolPayload> lru_cache;
+	SharedLruCache<string, ObjectCacheEntry, duckdb::BufferPoolPayload> lru_cache DUCKDB_GUARDED_BY(lock_mutex);
 	//! Separate storage for non-evictable entries (i.e., encryption keys)
-	unordered_map<string, shared_ptr<ObjectCacheEntry>> non_evictable_entries;
+	unordered_map<string, shared_ptr<ObjectCacheEntry>> non_evictable_entries DUCKDB_GUARDED_BY(lock_mutex);
 	//! Used to create buffer pool reservation on entries creation.
 	BufferPool &buffer_pool;
 };

--- a/src/include/duckdb/storage/single_file_block_manager.hpp
+++ b/src/include/duckdb/storage/single_file_block_manager.hpp
@@ -83,27 +83,27 @@ public:
 	unique_ptr<Block> ConvertBlock(block_id_t block_id, FileBuffer &source_buffer) override;
 	unique_ptr<Block> CreateBlock(block_id_t block_id, FileBuffer *source_buffer) override;
 	//! Return the next free block id
-	block_id_t GetFreeBlockId() override;
+	block_id_t GetFreeBlockId() DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Return the next free block id
-	block_id_t GetFreeBlockIdForCheckpoint() override;
+	block_id_t GetFreeBlockIdForCheckpoint() DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Check the next free block id - but do not assign or allocate it
-	block_id_t PeekFreeBlockId() override;
+	block_id_t PeekFreeBlockId() DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Returns whether or not a specified block is the root block
 	bool IsRootBlock(MetaBlockPointer root) override;
 	//! Mark a block as included in a checkpoint
-	void MarkBlockAsCheckpointed(block_id_t block_id) override;
+	void MarkBlockAsCheckpointed(block_id_t block_id) DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Mark a block as used (no longer re-writeable)
-	void MarkBlockAsUsed(block_id_t block_id) override;
+	void MarkBlockAsUsed(block_id_t block_id) DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Mark a block as modified (re-writeable after a checkpoint)
-	void MarkBlockAsModified(block_id_t block_id) override;
+	void MarkBlockAsModified(block_id_t block_id) DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Increase the reference count of a block. The block should hold at least one reference
-	void IncreaseBlockReferenceCount(block_id_t block_id) override;
+	void IncreaseBlockReferenceCount(block_id_t block_id) DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! UnregisterBlock, only accepts non-temporary block ids
-	void UnregisterBlock(block_id_t id) override;
+	void UnregisterBlock(block_id_t id) DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Return the meta block id
 	idx_t GetMetaBlock() override;
 	//! Read the content of the block from disk
-	void Read(QueryContext context, Block &block) override;
+	void Read(QueryContext context, Block &block) DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 
 	//! Read individual blocks
 	void ReadBlock(Block &block, bool skip_block_header = false) const;
@@ -115,19 +115,20 @@ public:
 	//! Write the block to disk.
 	void Write(QueryContext context, FileBuffer &buffer, block_id_t block_id) override;
 	//! Write the header to disk, this is the final step of the checkpointing process
-	void WriteHeader(QueryContext context, DatabaseHeader header) override;
+	void WriteHeader(QueryContext context, DatabaseHeader header)
+	    DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Sync changes to the underlying file
 	void FileSync() override;
 	//! Truncate the underlying database file after a checkpoint
-	void Truncate() override;
+	void Truncate() DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 
 	bool InMemory() override {
 		return false;
 	}
 	//! Returns the number of total blocks
-	idx_t TotalBlocks() override;
+	idx_t TotalBlocks() DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Returns the number of free blocks
-	idx_t FreeBlocks() override;
+	idx_t FreeBlocks() DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 	//! Whether or not the attached database is a remote file
 	bool IsRemote() override;
 	//! Whether or not to prefetch
@@ -179,20 +180,22 @@ private:
 	void CheckAndAddEncryptionKey(MainHeader &main_header);
 
 	//! Return the blocks to which we will write the free list and modified blocks
-	vector<MetadataHandle> GetFreeListBlocks();
-	void TrimFreeBlocks(const set<block_id_t> &blocks);
+	vector<MetadataHandle> GetFreeListBlocks() DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock);
+	void TrimFreeBlocks(const set<block_id_t> &blocks) DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock);
 	void TrimFreeBlockRange(block_id_t start, block_id_t end);
 
-	void IncreaseBlockReferenceCountInternal(block_id_t block_id);
+	void IncreaseBlockReferenceCountInternal(block_id_t block_id) DUCKDB_REQUIRES(single_file_block_lock);
 
 	//! Verify the block usage count
-	void VerifyBlocks(const unordered_map<block_id_t, idx_t> &block_usage_count) override;
+	void VerifyBlocks(const unordered_map<block_id_t, idx_t> &block_usage_count)
+	    DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock) override;
 
 	void AddStorageVersionTag();
 
-	block_id_t GetFreeBlockIdInternal(FreeBlockType type);
+	block_id_t GetFreeBlockIdInternal(FreeBlockType type) DUCKDB_EXCLUDES(single_file_block_lock, blocks_lock);
 	//! Adds a free block to the free_list, returns true if it was added to the regular free_list
-	bool AddFreeBlock(unique_lock<mutex> &lock, block_id_t block_id);
+	bool AddFreeBlock(annotated_unique_lock<annotated_mutex> &lock, block_id_t block_id)
+	    DUCKDB_REQUIRES(single_file_block_lock);
 
 private:
 	AttachedDatabase &db;
@@ -205,21 +208,21 @@ private:
 	//! The buffer used to read/write to the headers
 	FileBuffer header_buffer;
 	//! The list of free blocks that can be written to currently
-	set<block_id_t> free_list;
+	set<block_id_t> free_list DUCKDB_GUARDED_BY(single_file_block_lock);
 	//! The list of blocks that have been freed, but cannot yet be re-used because they are still in-use
-	set<block_id_t> free_blocks_in_use;
+	set<block_id_t> free_blocks_in_use DUCKDB_GUARDED_BY(single_file_block_lock);
 	//! The list of blocks that are in-use, but haven't been written as part of a checkpoint yet
-	set<block_id_t> newly_used_blocks;
+	set<block_id_t> newly_used_blocks DUCKDB_GUARDED_BY(single_file_block_lock);
 	//! The list of multi-use blocks (i.e. blocks that have >1 reference in the file)
 	//! When a multi-use block is marked as modified, the reference count is decreased by 1 instead of directly
 	//! Appending the block to the modified_blocks list
-	unordered_map<block_id_t, uint32_t> multi_use_blocks;
+	unordered_map<block_id_t, uint32_t> multi_use_blocks DUCKDB_GUARDED_BY(single_file_block_lock);
 	//! The list of blocks that are no longer in-use, but cannot be re-used until the next checkpoint
-	unordered_set<block_id_t> modified_blocks;
+	unordered_set<block_id_t> modified_blocks DUCKDB_GUARDED_BY(single_file_block_lock);
 	//! The current meta block id
 	idx_t meta_block;
 	//! The current maximum block id, this id will be given away first after the free_list runs out
-	block_id_t max_block;
+	block_id_t max_block DUCKDB_GUARDED_BY(single_file_block_lock);
 	//! The block id where the free list can be found
 	idx_t free_list_id;
 	//! The current header iteration count.
@@ -227,6 +230,6 @@ private:
 	//! The storage manager options
 	StorageManagerOptions options;
 	//! Lock for performing various operations in the single file block manager
-	mutex single_file_block_lock;
+	annotated_mutex single_file_block_lock DUCKDB_ACQUIRED_BEFORE(blocks_lock);
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/storage_lock.hpp
+++ b/src/include/duckdb/storage/storage_lock.hpp
@@ -16,6 +16,7 @@ struct StorageLockInternals;
 
 enum class StorageLockType { SHARED = 0, EXCLUSIVE = 1 };
 
+//! Keys can outlive a scope or move between threads; ownership is not a thread-local capability.
 class StorageLockKey {
 public:
 	StorageLockKey(shared_ptr<StorageLockInternals> internals, StorageLockType type);

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -103,7 +103,8 @@ struct TableAppendState {
 	~TableAppendState();
 
 	RowGroupAppendState row_group_append_state;
-	unique_lock<mutex> append_lock;
+	//! Empty for transaction-local appends; owns DataTable::append_lock during commit.
+	annotated_unique_lock<annotated_mutex> append_lock;
 	shared_ptr<CheckpointLock> table_lock;
 	row_t row_start;
 	row_t current_row;

--- a/src/include/duckdb/storage/table/column_data.hpp
+++ b/src/include/duckdb/storage/table/column_data.hpp
@@ -168,8 +168,9 @@ public:
 	//! Finalize appending
 	virtual void FinalizeAppend(ColumnDataFinalizeAppendState &finalize_state, ColumnAppendState &state);
 	void FinalizeAppend(optional_ptr<BaseStatistics> table_stats, ColumnAppendState &state);
-	//! Finalize appending while holding stats_lock (for use by child column calls)
-	void FinalizeAppendLocked(ColumnDataFinalizeAppendState &finalize_state, ColumnAppendState &state);
+	//! Acquires this column's stats_lock before finalizing (for use by child column calls).
+	void FinalizeAppendLocked(ColumnDataFinalizeAppendState &finalize_state, ColumnAppendState &state)
+	    DUCKDB_EXCLUDES(stats_lock);
 	//! Revert a set of appends to the ColumnData
 	virtual void RevertAppend(row_t new_count);
 
@@ -188,7 +189,7 @@ public:
 	virtual void UpdateColumn(TransactionData transaction, DuckTableEntry &table_entry,
 	                          const vector<column_t> &column_path, Vector &update_vector, row_t *row_ids,
 	                          idx_t update_count, idx_t depth, idx_t row_group_start);
-	virtual unique_ptr<BaseStatistics> GetUpdateStatistics();
+	virtual unique_ptr<BaseStatistics> GetUpdateStatistics() DUCKDB_EXCLUDES(update_lock);
 
 	virtual void VisitBlockIds(BlockIdVisitor &visitor) const;
 
@@ -223,16 +224,16 @@ public:
 	                                           ColumnDataType data_type = ColumnDataType::MAIN_TABLE,
 	                                           optional_ptr<ColumnData> parent = nullptr);
 
-	void MergeStatistics(const BaseStatistics &other);
-	void MergeIntoStatistics(BaseStatistics &other);
-	unique_ptr<BaseStatistics> GetStatistics() const;
+	void MergeStatistics(const BaseStatistics &other) DUCKDB_EXCLUDES(stats_lock);
+	void MergeIntoStatistics(BaseStatistics &other) DUCKDB_EXCLUDES(stats_lock);
+	unique_ptr<BaseStatistics> GetStatistics() const DUCKDB_EXCLUDES(stats_lock);
 	const BaseStatistics &GetStatisticsRef() const;
 
 protected:
 	//! Append a transient segment
 	void AppendTransientSegment(SegmentLock &l, optional_ptr<SuballocationBlock> transient,
-	                            optional_ptr<ColumnSegment> prev_segment);
-	void AppendSegment(SegmentLock &l, unique_ptr<ColumnSegment> segment);
+	                            optional_ptr<ColumnSegment> prev_segment) DUCKDB_REQUIRES(l);
+	void AppendSegment(SegmentLock &l, unique_ptr<ColumnSegment> segment) DUCKDB_REQUIRES(l);
 
 	void BeginScanVectorInternal(ColumnScanState &state);
 	//! Scans a base vector from the column
@@ -249,11 +250,12 @@ protected:
 	                  idx_t &sel_count, const TableFilter &filter, TableFilterState &filter_state);
 
 	void FetchUpdates(TransactionData transaction, idx_t vector_index, Vector &result, idx_t scan_count,
-	                  UpdateScanType update_type);
-	void FetchUpdateRow(TransactionData transaction, row_t row_id, Vector &result, idx_t result_idx);
+	                  UpdateScanType update_type) DUCKDB_EXCLUDES(update_lock);
+	void FetchUpdateRow(TransactionData transaction, row_t row_id, Vector &result, idx_t result_idx)
+	    DUCKDB_EXCLUDES(update_lock);
 	void UpdateInternal(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
 	                    Vector &update_vector, row_t *row_ids, idx_t update_count, Vector &base_vector,
-	                    idx_t row_group_start);
+	                    idx_t row_group_start) DUCKDB_EXCLUDES(update_lock);
 	idx_t FetchUpdateData(ColumnScanState &state, row_t *row_ids, Vector &base_vector, idx_t row_group_start);
 
 	idx_t GetVectorCount(idx_t vector_index) const;
@@ -264,17 +266,17 @@ protected:
 	                                           ColumnData &validity_column);
 
 private:
-	void UpdateCompressionFunction(SegmentLock &l, const CompressionFunction &function);
+	void UpdateCompressionFunction(SegmentLock &l, const CompressionFunction &function) DUCKDB_REQUIRES(l);
 
 protected:
 	//! The segments holding the data of this column segment
 	ColumnSegmentTree data;
 	//! The lock for the updates
-	mutable mutex update_lock;
+	mutable annotated_mutex update_lock;
 	//! The updates for this column segment
 	unique_ptr<UpdateSegment> updates;
 	//! The lock for the stats
-	mutable mutex stats_lock;
+	mutable annotated_mutex stats_lock;
 	//! Total transient allocation size
 	atomic<idx_t> allocation_size;
 	//! The stats of the root segment

--- a/src/include/duckdb/storage/table/data_table_info.hpp
+++ b/src/include/duckdb/storage/table/data_table_info.hpp
@@ -55,8 +55,8 @@ public:
 	Identifier GetSchemaName();
 	//! The full (possibly nested) schema path of the table
 	const vector<Identifier> &GetSchemaPath() const;
-	Identifier GetTableName();
-	void SetTableName(Identifier name);
+	Identifier GetTableName() DUCKDB_EXCLUDES(name_lock);
+	void SetTableName(Identifier name) DUCKDB_EXCLUDES(name_lock);
 
 private:
 	//! The database instance of the table
@@ -64,11 +64,11 @@ private:
 	//! The table IO manager
 	shared_ptr<TableIOManager> table_io_manager;
 	//! Lock for modifying the name
-	mutex name_lock;
+	annotated_mutex name_lock;
 	//! The (possibly nested) schema path of the table, outermost schema first
 	vector<Identifier> schema_path;
 	//! The name of the table
-	Identifier table;
+	Identifier table DUCKDB_GUARDED_BY(name_lock);
 	//! The physical list of indexes of this table
 	TableIndexList indexes;
 	//! Index storage information of the indexes created by this table

--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -116,7 +116,7 @@ private:
 	mutable vector<shared_ptr<ColumnData>> columns;
 
 public:
-	void MoveToCollection(RowGroupCollection &collection);
+	void MoveToCollection(RowGroupCollection &collection) DUCKDB_EXCLUDES(row_group_lock);
 	RowGroupCollection &GetCollection() const {
 		return collection.get();
 	}
@@ -267,21 +267,21 @@ private:
 	//! Advances the scan past the current vector, clearing the prepared state
 	void FinishVector(CollectionScanState &state);
 	void InitializeAppendInternal(RowGroupAppendState &append_state);
-	optional_ptr<RowVersionManager> GetVersionInfo();
+	optional_ptr<RowVersionManager> GetVersionInfo() DUCKDB_EXCLUDES(row_group_lock);
 	optional_ptr<RowVersionManager> GetVersionInfoIfLoaded() const;
 	shared_ptr<RowVersionManager> GetOrCreateVersionInfoPtr();
-	shared_ptr<RowVersionManager> GetOrCreateVersionInfoInternal();
-	void SetVersionInfo(shared_ptr<RowVersionManager> version);
+	shared_ptr<RowVersionManager> GetOrCreateVersionInfoInternal() DUCKDB_EXCLUDES(row_group_lock);
+	void SetVersionInfo(shared_ptr<RowVersionManager> version) DUCKDB_REQUIRES(row_group_lock);
 
 	ColumnData &GetColumn(storage_t c) const;
-	void LoadColumn(storage_t c) const;
+	void LoadColumn(storage_t c) const DUCKDB_EXCLUDES(row_group_lock);
 	ColumnData &GetColumn(const StorageIndex &c) const;
 	vector<shared_ptr<ColumnData>> &GetColumns();
-	void LoadRowIdColumnData() const;
-	void LoadRowNumberColumnData() const;
-	void SetCount(idx_t count);
+	void LoadRowIdColumnData() const DUCKDB_EXCLUDES(row_group_lock);
+	void LoadRowNumberColumnData() const DUCKDB_EXCLUDES(row_group_lock);
+	void SetCount(idx_t count) DUCKDB_EXCLUDES(row_group_lock);
 	bool ColumnIsLoaded(storage_t c) const;
-	void UnloadColumn(storage_t c);
+	void UnloadColumn(storage_t c) DUCKDB_EXCLUDES(row_group_lock);
 	bool HasUnchangedColumns() const;
 	static shared_ptr<ColumnData> CheckpointColumn(const RowGroup &row_group, idx_t column_idx, RowGroupWriteInfo &info,
 	                                               RowGroupWriteData &write_data);
@@ -290,7 +290,7 @@ private:
 	unique_ptr<RowGroup> CreateNewRowGroupCopy(RowGroupCollection &new_collection, idx_t new_column_count);
 
 private:
-	mutable mutex row_group_lock;
+	mutable annotated_mutex row_group_lock;
 	vector<MetaBlockPointer> column_pointers;
 	//! Whether or not each column is loaded (mutable because `const` can lazy load)
 	mutable unique_ptr<atomic<bool>[]> is_loaded;

--- a/src/include/duckdb/storage/table/row_group_collection.hpp
+++ b/src/include/duckdb/storage/table/row_group_collection.hpp
@@ -88,7 +88,7 @@ public:
 
 	bool IsEmpty() const;
 
-	void AppendRowGroup(SegmentLock &l, idx_t start_row);
+	void AppendRowGroup(SegmentLock &l, idx_t start_row) DUCKDB_REQUIRES(l);
 	//! Get the nth row-group, negative numbers start from the back (so -1 is the last row group, etc)
 	optional_ptr<RowGroup> GetRowGroup(int64_t index);
 	//! Overrides a row group - should only be used if you know what you're doing (will likely be removed in the future)
@@ -218,13 +218,13 @@ public:
 	idx_t GetSegmentCount();
 
 	//! Get a ptr to the raw segment tree. This can be useful for some extensions to have directly exposed.
-	shared_ptr<RowGroupSegmentTree> GetRowGroups() const;
+	shared_ptr<RowGroupSegmentTree> GetRowGroups() const DUCKDB_EXCLUDES(row_group_pointer_lock);
 
 private:
 	optional_ptr<SegmentNode<RowGroup>> NextUpdateRowGroup(RowGroupSegmentTree &row_groups, row_t *ids, idx_t &pos,
 	                                                       idx_t count) const;
 
-	void SetRowGroups(shared_ptr<RowGroupSegmentTree> row_groups);
+	void SetRowGroups(shared_ptr<RowGroupSegmentTree> row_groups) DUCKDB_EXCLUDES(row_group_pointer_lock);
 
 private:
 	//! BlockManager
@@ -241,9 +241,9 @@ private:
 	//! The column types of the row group collection
 	vector<LogicalType> types;
 	//! Lock held when accessing or modifying the owned_row_groups pointer
-	mutable mutex row_group_pointer_lock;
+	mutable annotated_mutex row_group_pointer_lock;
 	//! The owning pointer of the segment tree
-	shared_ptr<RowGroupSegmentTree> owned_row_groups;
+	shared_ptr<RowGroupSegmentTree> owned_row_groups DUCKDB_GUARDED_BY(row_group_pointer_lock);
 	//! Table statistics
 	TableStatistics stats;
 	//! Allocation size, only tracked for appends

--- a/src/include/duckdb/storage/table/row_group_segment_tree.hpp
+++ b/src/include/duckdb/storage/table/row_group_segment_tree.hpp
@@ -21,19 +21,20 @@ public:
 	RowGroupSegmentTree(RowGroupCollection &collection, idx_t base_row_id);
 	~RowGroupSegmentTree() override;
 
-	void Initialize(PersistentTableData &data, optional_ptr<vector<MetaBlockPointer>> read_pointers = nullptr);
+	void Initialize(PersistentTableData &data, optional_ptr<vector<MetaBlockPointer>> read_pointers = nullptr)
+	    DUCKDB_REQUIRES(node_lock);
 
 	MetaBlockPointer GetRootPointer() const {
 		return root_pointer;
 	}
 
 protected:
-	optional<LoadedSegment<RowGroup>> LoadSegment() const override;
+	optional<LoadedSegment<RowGroup>> LoadSegment() const DUCKDB_REQUIRES(node_lock) override;
 
 	RowGroupCollection &collection;
-	mutable idx_t current_row_group;
-	mutable idx_t max_row_group;
-	mutable unique_ptr<MetadataReader> reader;
+	mutable idx_t current_row_group DUCKDB_GUARDED_BY(node_lock);
+	mutable idx_t max_row_group DUCKDB_GUARDED_BY(node_lock);
+	mutable unique_ptr<MetadataReader> reader DUCKDB_GUARDED_BY(node_lock);
 	MetaBlockPointer root_pointer;
 };
 

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -25,52 +25,57 @@ public:
 	explicit RowVersionManager(BufferManager &buffer_manager) noexcept;
 
 	//! Returns the number of non-deleted rows in this segment
-	idx_t GetRowCount(ScanOptions options, idx_t count);
+	idx_t GetRowCount(ScanOptions options, idx_t count) DUCKDB_EXCLUDES(version_lock);
 
-	idx_t GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
+	idx_t GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count)
+	    DUCKDB_EXCLUDES(version_lock);
 	//! Bulk visibility check. Returns the number of visible rows.
-	idx_t GetVisibleRows(TransactionData transaction, const idx_t *offsets, idx_t count, SelectionVector &visible_sel);
+	idx_t GetVisibleRows(TransactionData transaction, const idx_t *offsets, idx_t count, SelectionVector &visible_sel)
+	    DUCKDB_EXCLUDES(version_lock);
 
-	void AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start, idx_t row_group_end);
-	void CommitAppend(transaction_t commit_id, idx_t row_group_start, idx_t count);
-	void RevertAppend(idx_t new_count);
-	void CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t row_group_start, idx_t count);
+	void AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start, idx_t row_group_end)
+	    DUCKDB_EXCLUDES(version_lock);
+	void CommitAppend(transaction_t commit_id, idx_t row_group_start, idx_t count) DUCKDB_EXCLUDES(version_lock);
+	void RevertAppend(idx_t new_count) DUCKDB_EXCLUDES(version_lock);
+	void CleanupAppend(VisibilityBound lowest_visibility_bound, idx_t row_group_start, idx_t count)
+	    DUCKDB_EXCLUDES(version_lock);
 
-	idx_t DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count);
-	void CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info);
+	idx_t DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count)
+	    DUCKDB_EXCLUDES(version_lock);
+	void CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info) DUCKDB_EXCLUDES(version_lock);
 
 	//! Attempts to compress the per-row insert/delete ids of each vector into constants. Ids that precede
 	//! lowest_visibility_bound look the same to every active and future transaction, so they can collapse.
 	//! Cheap when nothing can have changed: the pass only runs when version ids were modified since the
 	//! last pass, or when a previous pass left ids that can still compress once older transactions finish
-	void CompressVersionIds(VisibilityBound lowest_visibility_bound);
+	void CompressVersionIds(VisibilityBound lowest_visibility_bound) DUCKDB_EXCLUDES(version_lock);
 
-	vector<MetaBlockPointer> Checkpoint(RowGroupWriter &writer);
+	vector<MetaBlockPointer> Checkpoint(RowGroupWriter &writer) DUCKDB_EXCLUDES(version_lock);
 	static shared_ptr<RowVersionManager> Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager);
 
-	bool HasUnserializedChanges();
-	bool HasDeletes();
-	bool HasUncommittedChanges();
-	vector<MetaBlockPointer> GetStoragePointers();
+	bool HasUnserializedChanges() DUCKDB_EXCLUDES(version_lock);
+	bool HasDeletes() DUCKDB_EXCLUDES(version_lock);
+	bool HasUncommittedChanges() DUCKDB_EXCLUDES(version_lock);
+	vector<MetaBlockPointer> GetStoragePointers() DUCKDB_EXCLUDES(version_lock);
 
 private:
-	mutex version_lock;
-	FixedSizeAllocator allocator;
-	vector<unique_ptr<ChunkVectorInfo>> vector_info;
-	optional_idx uncheckpointed_delete_commit;
-	vector<MetaBlockPointer> storage_pointers;
+	annotated_mutex version_lock;
+	FixedSizeAllocator allocator DUCKDB_GUARDED_BY(version_lock);
+	vector<unique_ptr<ChunkVectorInfo>> vector_info DUCKDB_GUARDED_BY(version_lock);
+	optional_idx uncheckpointed_delete_commit DUCKDB_GUARDED_BY(version_lock);
+	vector<MetaBlockPointer> storage_pointers DUCKDB_GUARDED_BY(version_lock);
 	//! Whether a compression pass may achieve anything: set when version ids are modified, cleared when a
 	//! pass finds no ids that could still compress. For deserialized version info this is derived from the
 	//! deserialized content (with the current storage format checkpointed ids are always settled).
-	bool needs_compression_check = false;
+	bool needs_compression_check DUCKDB_GUARDED_BY(version_lock) = false;
 
 private:
-	FixedSizeAllocator &GetAllocator() {
+	FixedSizeAllocator &GetAllocator() DUCKDB_REQUIRES(version_lock) {
 		return allocator;
 	}
-	optional_ptr<ChunkVectorInfo> GetChunkInfo(idx_t vector_idx);
-	ChunkVectorInfo &GetVectorInfo(idx_t vector_idx);
-	void FillVectorInfo(idx_t vector_idx);
+	optional_ptr<ChunkVectorInfo> GetChunkInfo(idx_t vector_idx) DUCKDB_REQUIRES(version_lock);
+	ChunkVectorInfo &GetVectorInfo(idx_t vector_idx) DUCKDB_REQUIRES(version_lock);
+	void FillVectorInfo(idx_t vector_idx) DUCKDB_REQUIRES(version_lock);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/table/scan_state.hpp
+++ b/src/include/duckdb/storage/table/scan_state.hpp
@@ -306,7 +306,8 @@ public:
 	ScanSamplingInfo &GetSamplingInfo();
 	TableScanOptions &GetOptions();
 	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(SegmentNode<RowGroup> &row_group) const;
-	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(SegmentLock &l, SegmentNode<RowGroup> &row_group) const;
+	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(SegmentLock &l, SegmentNode<RowGroup> &row_group) const
+	    DUCKDB_REQUIRES(l);
 	optional_ptr<SegmentNode<RowGroup>> GetRootSegment() const;
 	bool Scan(DuckTransaction &transaction, DataChunk &result);
 	bool Scan(ScanOptions options, DataChunk &result, optional_ptr<SegmentLock> l = nullptr);
@@ -383,7 +384,7 @@ private:
 
 struct ParallelCollectionScanState {
 	ParallelCollectionScanState();
-	void AssignRowGroup(optional_ptr<SegmentNode<RowGroup>> row_group);
+	void AssignRowGroup(optional_ptr<SegmentNode<RowGroup>> row_group) DUCKDB_REQUIRES(lock);
 	optional_ptr<SegmentNode<RowGroup>> GetRootSegment(RowGroupSegmentTree &row_groups) const;
 	optional_ptr<SegmentNode<RowGroup>> GetNextRowGroup(RowGroupSegmentTree &row_groups,
 	                                                    SegmentNode<RowGroup> &row_group) const;
@@ -391,13 +392,13 @@ struct ParallelCollectionScanState {
 	//! The row group collection we are scanning
 	RowGroupCollection *collection;
 	shared_ptr<RowGroupSegmentTree> row_groups;
-	optional_ptr<SegmentNode<RowGroup>> current_row_group;
-	idx_t vector_index;
+	optional_ptr<SegmentNode<RowGroup>> current_row_group DUCKDB_GUARDED_BY(lock);
+	idx_t vector_index DUCKDB_GUARDED_BY(lock);
 	idx_t max_row;
-	idx_t batch_index;
+	idx_t batch_index DUCKDB_GUARDED_BY(lock);
 	atomic<idx_t> processed_rows;
-	optional_idx row_number_base;
-	mutex lock;
+	optional_idx row_number_base DUCKDB_GUARDED_BY(lock);
+	annotated_mutex lock;
 
 	//! Optional state for custom row group ordering
 	unique_ptr<RowGroupReorderer> reorderer;

--- a/src/include/duckdb/storage/table/segment_lock.hpp
+++ b/src/include/duckdb/storage/table/segment_lock.hpp
@@ -12,12 +12,13 @@
 
 namespace duckdb {
 
-struct SegmentLock {
+struct DUCKDB_CAPABILITY("mutex") DUCKDB_SCOPED_CAPABILITY SegmentLock {
 public:
 	SegmentLock() {
 	}
-	explicit SegmentLock(mutex &lock) : lock(lock) {
+	explicit SegmentLock(annotated_mutex &lock) DUCKDB_ACQUIRE(lock) : lock(lock) {
 	}
+	~SegmentLock() DUCKDB_RELEASE() = default;
 	// disable copy constructors
 	SegmentLock(const SegmentLock &other) = delete;
 	SegmentLock &operator=(const SegmentLock &) = delete;
@@ -30,8 +31,17 @@ public:
 		return *this;
 	}
 
-	void Release() {
+	void Release() DUCKDB_RELEASE() {
 		lock.unlock();
+	}
+
+	//! Verify ownership when a lock is passed through an iterator or another helper.
+	void AssertHeld() const DUCKDB_ASSERT_CAPABILITY(this) {
+		D_ASSERT(lock.owns_lock());
+	}
+	void AssertHeld(const annotated_mutex &mutex) const DUCKDB_ASSERT_CAPABILITY(mutex) {
+		D_ASSERT(lock.owns_lock());
+		D_ASSERT(lock.mutex() == &mutex);
 	}
 
 private:

--- a/src/include/duckdb/storage/table/segment_tree.hpp
+++ b/src/include/duckdb/storage/table/segment_tree.hpp
@@ -114,11 +114,12 @@ public:
 
 	//! Locks the segment tree. All methods to the segment tree either lock the segment tree, or take an already
 	//! obtained lock.
-	SegmentLock Lock() const {
+	SegmentLock Lock() const DUCKDB_ACQUIRE(node_lock) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 		return SegmentLock(node_lock);
 	}
 
-	bool IsEmpty(SegmentLock &l) const {
+	bool IsEmpty(SegmentLock &l) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		return GetRootSegment(l) == nullptr;
 	}
 
@@ -128,14 +129,16 @@ public:
 		return GetRootSegment(l);
 	}
 
-	optional_ptr<SegmentNode<T>> GetRootSegment(SegmentLock &l) const {
+	optional_ptr<SegmentNode<T>> GetRootSegment(SegmentLock &l) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		if (nodes.empty()) {
 			LoadNextSegment(l);
 		}
 		return GetRootSegmentInternal();
 	}
 	//! Obtains ownership of the data of the segment tree
-	vector<unique_ptr<SegmentNode<T>>> MoveSegments(SegmentLock &l) {
+	vector<unique_ptr<SegmentNode<T>>> MoveSegments(SegmentLock &l) DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		LoadAllSegments(l);
 		return std::move(nodes);
 	}
@@ -144,7 +147,8 @@ public:
 		return MoveSegments(l);
 	}
 
-	vector<unique_ptr<SegmentNode<T>>> &ReferenceLoadedSegmentsMutable(SegmentLock &l) {
+	vector<unique_ptr<SegmentNode<T>>> &ReferenceLoadedSegmentsMutable(SegmentLock &l) DUCKDB_REQUIRES(l, node_lock) {
+		l.AssertHeld(node_lock);
 		return nodes;
 	}
 
@@ -152,7 +156,8 @@ public:
 		auto l = Lock();
 		return GetSegmentCount(l);
 	}
-	idx_t GetSegmentCount(SegmentLock &l) const {
+	idx_t GetSegmentCount(SegmentLock &l) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		LoadAllSegments(l);
 		return nodes.size();
 	}
@@ -161,7 +166,8 @@ public:
 		auto l = Lock();
 		return GetSegmentByIndex(l, index);
 	}
-	optional_ptr<SegmentNode<T>> GetSegmentByIndex(SegmentLock &l, int64_t index) const {
+	optional_ptr<SegmentNode<T>> GetSegmentByIndex(SegmentLock &l, int64_t index) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		if (index < 0) {
 			// load all segments
 			LoadAllSegments(l);
@@ -191,7 +197,8 @@ public:
 		auto l = Lock();
 		return GetNextSegment(l, node);
 	}
-	optional_ptr<SegmentNode<T>> GetNextSegment(SegmentLock &l, SegmentNode<T> &node) const {
+	optional_ptr<SegmentNode<T>> GetNextSegment(SegmentLock &l, SegmentNode<T> &node) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 #ifdef DEBUG
 		D_ASSERT(RefersToSameObject(*nodes[node.GetIndex()], node));
 #endif
@@ -199,7 +206,8 @@ public:
 	}
 
 	//! Gets a pointer to the last segment. Useful for appends.
-	optional_ptr<SegmentNode<T>> GetLastSegment(SegmentLock &l) const {
+	optional_ptr<SegmentNode<T>> GetLastSegment(SegmentLock &l) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		LoadAllSegments(l);
 		if (nodes.empty()) {
 			return nullptr;
@@ -211,7 +219,8 @@ public:
 		auto l = Lock();
 		return GetSegment(l, row_number);
 	}
-	optional_ptr<SegmentNode<T>> GetSegment(SegmentLock &l, idx_t row_number) const {
+	optional_ptr<SegmentNode<T>> GetSegment(SegmentLock &l, idx_t row_number) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		return nodes[GetSegmentIndex(l, row_number)].get();
 	}
 
@@ -223,11 +232,13 @@ public:
 		auto l = Lock();
 		AppendSegment(l, std::move(segment), row_start);
 	}
-	void AppendSegment(SegmentLock &l, shared_ptr<T> segment) {
+	void AppendSegment(SegmentLock &l, shared_ptr<T> segment) DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		LoadAllSegments(l);
 		AppendSegmentInternal(l, std::move(segment));
 	}
-	void AppendSegment(SegmentLock &l, shared_ptr<T> segment, idx_t row_start) {
+	void AppendSegment(SegmentLock &l, shared_ptr<T> segment, idx_t row_start) DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		LoadAllSegments(l);
 		AppendSegmentInternal(l, std::move(segment), row_start);
 	}
@@ -236,13 +247,15 @@ public:
 		auto l = Lock();
 		return HasSegment(l, segment);
 	}
-	bool HasSegment(SegmentLock &, SegmentNode<T> &segment) const {
+	bool HasSegment(SegmentLock &l, SegmentNode<T> &segment) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		auto segment_idx = segment.GetIndex();
 		return segment_idx < nodes.size() && RefersToSameObject(*nodes[segment_idx], segment);
 	}
 
 	//! Erase all segments after a specific segment
-	void EraseSegments(SegmentLock &l, idx_t segment_start) {
+	void EraseSegments(SegmentLock &l, idx_t segment_start) DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		LoadAllSegments(l);
 		if (segment_start >= nodes.size()) {
 			return;
@@ -251,7 +264,8 @@ public:
 	}
 
 	//! Get the segment index of the column segment for the given row
-	idx_t GetSegmentIndex(SegmentLock &l, idx_t row_number) const {
+	idx_t GetSegmentIndex(SegmentLock &l, idx_t row_number) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		idx_t segment_index;
 		if (TryGetSegmentIndex(l, row_number, segment_index)) {
 			return segment_index;
@@ -265,7 +279,8 @@ public:
 		throw InternalException("Could not find node in column segment tree!\n%s", error);
 	}
 
-	bool TryGetSegmentIndex(SegmentLock &l, idx_t row_number, idx_t &result) const {
+	bool TryGetSegmentIndex(SegmentLock &l, idx_t row_number, idx_t &result) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		// load segments until the row number is within bounds
 		while (nodes.empty() || (row_number >= nodes.back()->GetRowEnd())) {
 			if (!LoadNextSegment(l)) {
@@ -299,7 +314,9 @@ public:
 		return false;
 	}
 
-	void Verify(SegmentLock &, SegmentTreeVerifyMode mode = SegmentTreeVerifyMode::CONTIGUOUS) const {
+	void Verify(SegmentLock &l, SegmentTreeVerifyMode mode = SegmentTreeVerifyMode::CONTIGUOUS) const
+	    DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 #ifdef DEBUG
 		idx_t current_rowid_end = nodes.empty() ? 0 : nodes[0]->GetRowStart();
 		for (idx_t i = 0; i < nodes.size(); i++) {
@@ -327,7 +344,8 @@ public:
 		return SegmentIterationHelper(*this);
 	}
 
-	SegmentIterationHelper Segments(SegmentLock &l) const {
+	SegmentIterationHelper Segments(SegmentLock &l) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		return SegmentIterationHelper(*this, l);
 	}
 
@@ -335,27 +353,28 @@ public:
 		return SegmentNodeIterationHelper(*this);
 	}
 
-	SegmentNodeIterationHelper SegmentNodes(SegmentLock &l) const {
+	SegmentNodeIterationHelper SegmentNodes(SegmentLock &l) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		return SegmentNodeIterationHelper(*this, l);
 	}
 
 protected:
+	//! Lock to access or modify nodes and lazy-loading state.
+	mutable annotated_mutex node_lock;
 	mutable atomic<bool> finished_loading;
 
 	//! Load the next segment - only used when lazily loading
-	virtual optional<LoadedSegment<T>> LoadSegment() const {
+	virtual optional<LoadedSegment<T>> LoadSegment() const DUCKDB_REQUIRES(node_lock) {
 		return nullopt;
 	}
 
-	optional_ptr<SegmentNode<T>> GetRootSegmentInternal() const {
+	optional_ptr<SegmentNode<T>> GetRootSegmentInternal() const DUCKDB_REQUIRES(node_lock) {
 		return nodes.empty() ? nullptr : nodes[0].get();
 	}
 
 private:
 	//! The nodes in the tree, can be binary searched
-	mutable vector<unique_ptr<SegmentNode<T>>> nodes;
-	//! Lock to access or modify the nodes
-	mutable mutex node_lock;
+	mutable vector<unique_ptr<SegmentNode<T>>> nodes DUCKDB_GUARDED_BY(node_lock);
 	//! Base row id (row id of the first segment)
 	idx_t base_row_id;
 
@@ -373,7 +392,13 @@ private:
 
 	public:
 		void Next() {
-			current = lock ? tree.GetNextSegment(*lock, *current) : tree.GetNextSegment(*current);
+			if (lock) {
+				auto &held_lock = *lock;
+				held_lock.AssertHeld();
+				current = tree.GetNextSegment(held_lock, *current);
+			} else {
+				current = tree.GetNextSegment(*current);
+			}
 		}
 
 		BaseSegmentIterator &operator++() {
@@ -410,8 +435,12 @@ private:
 
 	public:
 		SegmentIterator begin() { // NOLINT: match stl API
-			auto root = lock ? tree.GetRootSegment(*lock) : tree.GetRootSegment();
-			return SegmentIterator(tree, root, lock);
+			if (lock) {
+				auto &held_lock = *lock;
+				held_lock.AssertHeld();
+				return SegmentIterator(tree, tree.GetRootSegment(held_lock), lock);
+			}
+			return SegmentIterator(tree, tree.GetRootSegment(), nullptr);
 		}
 		SegmentIterator end() { // NOLINT: match stl API
 			return SegmentIterator(tree, nullptr, lock);
@@ -443,8 +472,12 @@ private:
 
 	public:
 		SegmentIterator begin() { // NOLINT: match stl API
-			auto root = lock ? tree.GetRootSegment(*lock) : tree.GetRootSegment();
-			return SegmentIterator(tree, root, lock);
+			if (lock) {
+				auto &held_lock = *lock;
+				held_lock.AssertHeld();
+				return SegmentIterator(tree, tree.GetRootSegment(held_lock), lock);
+			}
+			return SegmentIterator(tree, tree.GetRootSegment(), nullptr);
 		}
 		SegmentIterator end() { // NOLINT: match stl API
 			return SegmentIterator(tree, nullptr, lock);
@@ -452,7 +485,8 @@ private:
 	};
 
 	//! Load the next segment, if there are any left to load
-	bool LoadNextSegment(SegmentLock &l) const {
+	bool LoadNextSegment(SegmentLock &l) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		if (!SUPPORTS_LAZY_LOADING) {
 			return false;
 		}
@@ -468,7 +502,8 @@ private:
 	}
 
 	//! Load all segments, if there are any left to load
-	void LoadAllSegments(SegmentLock &l) const {
+	void LoadAllSegments(SegmentLock &l) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		if (!SUPPORTS_LAZY_LOADING) {
 			return;
 		}
@@ -477,7 +512,8 @@ private:
 	}
 
 	//! Append a column segment to the tree
-	void AppendSegmentInternal(SegmentLock &l, shared_ptr<T> segment, idx_t row_start) const {
+	void AppendSegmentInternal(SegmentLock &l, shared_ptr<T> segment, idx_t row_start) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		D_ASSERT(segment);
 		// add the node to the list of nodes
 		auto node = make_uniq<SegmentNode<T>>(row_start, std::move(segment), nodes.size());
@@ -486,7 +522,8 @@ private:
 		}
 		nodes.push_back(std::move(node));
 	}
-	void AppendSegmentInternal(SegmentLock &l, shared_ptr<T> segment) const {
+	void AppendSegmentInternal(SegmentLock &l, shared_ptr<T> segment) const DUCKDB_REQUIRES(l) {
+		l.AssertHeld(node_lock);
 		idx_t row_start;
 		if (nodes.empty()) {
 			row_start = base_row_id;

--- a/src/include/duckdb/storage/table/table_statistics.hpp
+++ b/src/include/duckdb/storage/table/table_statistics.hpp
@@ -19,12 +19,21 @@ class PersistentTableData;
 class Serializer;
 class Deserializer;
 
-class TableStatisticsLock {
+class DUCKDB_SCOPED_CAPABILITY TableStatisticsLock {
 public:
-	explicit TableStatisticsLock(mutex &l) : guard(l) {
+	explicit TableStatisticsLock(annotated_mutex &l) DUCKDB_ACQUIRE(l) : guard(l), locked_mutex(l) {
+	}
+
+	~TableStatisticsLock() DUCKDB_RELEASE() = default;
+
+	void AssertHeld(const annotated_mutex &expected) const DUCKDB_ASSERT_CAPABILITY(expected) {
+		D_ASSERT(&locked_mutex == &expected);
 	}
 
 	lock_guard<mutex> guard;
+
+private:
+	annotated_mutex &locked_mutex;
 };
 
 class TableStatistics {
@@ -67,8 +76,8 @@ public:
 	void Deserialize(Deserializer &deserializer, ColumnList &columns);
 
 private:
-	//! The statistics lock
-	shared_ptr<mutex> stats_lock;
+	//! Shared by table versions created by ALTER; held until the statistics lock token is destroyed.
+	shared_ptr<annotated_mutex> stats_lock;
 	//! Column statistics
 	vector<shared_ptr<ColumnStatistics>> column_stats;
 	//! The table sample

--- a/src/include/duckdb/storage/table/update_segment.hpp
+++ b/src/include/duckdb/storage/table/update_segment.hpp
@@ -49,7 +49,7 @@ public:
 	void CleanupUpdateInternal(const StorageLockKey &lock, UpdateInfo &info);
 	void CleanupUpdate(UpdateInfo &info);
 
-	unique_ptr<BaseStatistics> GetStatistics();
+	unique_ptr<BaseStatistics> GetStatistics() DUCKDB_EXCLUDES(stats_lock);
 	StringHeap &GetStringHeap() {
 		return heap;
 	}
@@ -60,9 +60,9 @@ private:
 	//! The root node (if any)
 	unique_ptr<UpdateNode> root;
 	//! Update statistics
-	SegmentStatistics stats;
+	SegmentStatistics stats DUCKDB_GUARDED_BY(stats_lock);
 	//! Stats lock
-	mutex stats_lock;
+	annotated_mutex stats_lock;
 	//! Internal type size
 	idx_t type_size;
 	//! String heap, only used for strings

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -150,9 +150,10 @@ public:
 	~TemporaryFileHandle();
 
 public:
-	struct TemporaryFileLock {
+	struct DUCKDB_SCOPED_CAPABILITY TemporaryFileLock {
 	public:
-		explicit TemporaryFileLock(mutex &mutex);
+		explicit TemporaryFileLock(annotated_mutex &mutex) DUCKDB_ACQUIRE(mutex);
+		~TemporaryFileLock() DUCKDB_RELEASE() = default;
 
 	public:
 		lock_guard<mutex> lock;
@@ -160,9 +161,9 @@ public:
 
 public:
 	//! Try to get an index of where to write in this file. Returns an invalid index if full
-	TemporaryFileIndex TryGetBlockIndex(idx_t block_header_size);
+	TemporaryFileIndex TryGetBlockIndex(idx_t block_header_size) DUCKDB_EXCLUDES(file_lock);
 	//! Remove block index from this TemporaryFileHandle
-	void EraseBlockIndex(block_id_t block_index);
+	void EraseBlockIndex(block_id_t block_index) DUCKDB_EXCLUDES(file_lock);
 
 	//! Read/Write temporary buffers at given positions in this file (potentially compressed)
 	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, const TemporaryFileIndex &index_in_file,
@@ -171,16 +172,16 @@ public:
 	                          AllocatedData &compressed_buffer) const;
 
 	//! Deletes the file if there are no more blocks
-	bool DeleteIfEmpty();
+	bool DeleteIfEmpty() DUCKDB_EXCLUDES(file_lock);
 	bool IsEncrypted() const;
 	//! Get information about this temporary file
-	TemporaryFileInformation GetTemporaryFile();
+	TemporaryFileInformation GetTemporaryFile() DUCKDB_EXCLUDES(file_lock);
 
 private:
 	//! Create temporary file if it did not exist yet
-	void CreateFileIfNotExists(TemporaryFileLock &);
+	void CreateFileIfNotExists(TemporaryFileLock &) DUCKDB_REQUIRES(file_lock);
 	//! Remove block index from this file
-	void RemoveTempBlockIndex(TemporaryFileLock &, idx_t index);
+	void RemoveTempBlockIndex(TemporaryFileLock &, idx_t index) DUCKDB_REQUIRES(file_lock);
 	//! Get the position of a block in the file
 	idx_t GetPositionInFile(idx_t index) const;
 
@@ -191,12 +192,12 @@ private:
 	const TemporaryFileIdentifier identifier;
 	//! The maximum allowed index
 	const idx_t max_allowed_index;
-	//! File path/handle
 	const string path;
+	//! File I/O uses an allocated block index to keep the handle alive without file_lock.
 	unique_ptr<FileHandle> handle;
 	//! Lock for concurrent access and block index manager
-	mutex file_lock;
-	BlockIndexManager index_manager;
+	annotated_mutex file_lock;
+	BlockIndexManager index_manager DUCKDB_GUARDED_BY(file_lock);
 };
 
 //===--------------------------------------------------------------------===//
@@ -296,24 +297,27 @@ private:
 	};
 
 public:
-	struct TemporaryFileManagerLock {
+	struct DUCKDB_SCOPED_CAPABILITY TemporaryFileManagerLock {
 	public:
-		explicit TemporaryFileManagerLock(mutex &mutex);
+		explicit TemporaryFileManagerLock(annotated_mutex &mutex) DUCKDB_ACQUIRE(mutex);
+		~TemporaryFileManagerLock() DUCKDB_RELEASE() = default;
 
 	public:
 		lock_guard<mutex> lock;
 	};
 
 	//! Create/Read/Update/Delete operations for temporary buffers
-	idx_t WriteTemporaryBuffer(QueryContext context, block_id_t block_id, FileBuffer &buffer);
-	bool HasTemporaryBuffer(block_id_t block_id);
+	idx_t WriteTemporaryBuffer(QueryContext context, block_id_t block_id, FileBuffer &buffer)
+	    DUCKDB_EXCLUDES(manager_lock);
+	bool HasTemporaryBuffer(block_id_t block_id) DUCKDB_EXCLUDES(manager_lock);
 	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, block_id_t id,
-	                                           unique_ptr<FileBuffer> reusable_buffer, idx_t *eviction_size = nullptr);
-	idx_t DeleteTemporaryBuffer(block_id_t id);
+	                                           unique_ptr<FileBuffer> reusable_buffer, idx_t *eviction_size = nullptr)
+	    DUCKDB_EXCLUDES(manager_lock);
+	idx_t DeleteTemporaryBuffer(block_id_t id) DUCKDB_EXCLUDES(manager_lock);
 	bool IsEncrypted() const;
 
 	//! Get the list of temporary files and their sizes
-	vector<TemporaryFileInformation> GetTemporaryFiles();
+	vector<TemporaryFileInformation> GetTemporaryFiles() DUCKDB_EXCLUDES(manager_lock);
 
 	//! Get/set maximum swap space
 	optional_idx GetMaxSwapSpace() const;
@@ -335,14 +339,16 @@ private:
 	string CreateTemporaryFileName(const TemporaryFileIdentifier &identifier) const;
 
 	//! Get/erase a temporary block
-	TemporaryFileIndex GetTempBlockIndex(TemporaryFileManagerLock &, block_id_t id);
+	TemporaryFileIndex GetTempBlockIndex(TemporaryFileManagerLock &, block_id_t id) DUCKDB_REQUIRES(manager_lock);
 	void EraseUsedBlock(TemporaryFileManagerLock &lock, block_id_t id, TemporaryFileHandle &handle,
-	                    TemporaryFileIndex index);
+	                    TemporaryFileIndex index) DUCKDB_REQUIRES(manager_lock);
 
 	//! Get/erase a temporary file handle
 	optional_ptr<TemporaryFileHandle> GetFileHandle(TemporaryFileManagerLock &,
-	                                                const TemporaryFileIdentifier &identifier);
-	void EraseFileHandle(TemporaryFileManagerLock &, const TemporaryFileIdentifier &identifier);
+	                                                const TemporaryFileIdentifier &identifier)
+	    DUCKDB_REQUIRES(manager_lock);
+	void EraseFileHandle(TemporaryFileManagerLock &, const TemporaryFileIdentifier &identifier)
+	    DUCKDB_REQUIRES(manager_lock);
 
 private:
 	//! Reference to the DB instance
@@ -351,14 +357,14 @@ private:
 	DatabaseInstance &db;
 	//! The temporary directory
 	string temp_directory;
-	//! Lock for parallel access
-	mutex manager_lock;
+	//! Acquire before a TemporaryFileHandle::file_lock; release before buffer I/O.
+	annotated_mutex manager_lock;
 	//! The set of active temporary file handles
-	TemporaryFileMap files;
+	TemporaryFileMap files DUCKDB_GUARDED_BY(manager_lock);
 	//! Map of block_id -> temporary file position
-	unordered_map<block_id_t, TemporaryFileIndex> used_blocks;
+	unordered_map<block_id_t, TemporaryFileIndex> used_blocks DUCKDB_GUARDED_BY(manager_lock);
 	//! Map of TemporaryBufferSize -> manager of in-use temporary file indexes
-	unordered_map<TemporaryBufferSize, BlockIndexManager, EnumClassHash> index_managers;
+	unordered_map<TemporaryBufferSize, BlockIndexManager, EnumClassHash> index_managers DUCKDB_GUARDED_BY(manager_lock);
 	//! The size in bytes of the temporary files that are currently alive
 	atomic<idx_t> &size_on_disk;
 	//! The max amount of disk space that can be used

--- a/src/storage/buffer/block_manager.cpp
+++ b/src/storage/buffer/block_manager.cpp
@@ -15,7 +15,7 @@ BlockManager::BlockManager(BufferManager &buffer_manager, const optional_idx blo
 }
 
 bool BlockManager::BlockIsRegistered(block_id_t block_id) {
-	lock_guard<mutex> lock(blocks_lock);
+	annotated_lock_guard lock(blocks_lock);
 	// check if the block already exists
 	auto entry = blocks.find(block_id);
 	if (entry == blocks.end()) {
@@ -26,7 +26,7 @@ bool BlockManager::BlockIsRegistered(block_id_t block_id) {
 }
 
 shared_ptr<BlockHandle> BlockManager::TryGetBlock(block_id_t block_id) {
-	lock_guard<mutex> lock(blocks_lock);
+	annotated_lock_guard lock(blocks_lock);
 	// check if the block already exists
 	auto entry = blocks.find(block_id);
 	if (entry == blocks.end()) {
@@ -38,7 +38,7 @@ shared_ptr<BlockHandle> BlockManager::TryGetBlock(block_id_t block_id) {
 }
 
 shared_ptr<BlockHandle> BlockManager::RegisterBlock(block_id_t block_id) {
-	lock_guard<mutex> lock(blocks_lock);
+	annotated_lock_guard lock(blocks_lock);
 	// check if the block already exists
 	auto entry = blocks.find(block_id);
 	if (entry != blocks.end()) {
@@ -127,7 +127,7 @@ shared_ptr<BlockHandle> BlockManager::ConvertToPersistent(QueryContext context, 
 
 void BlockManager::UnregisterBlock(block_id_t id) {
 	D_ASSERT(id < MAXIMUM_BLOCK);
-	lock_guard<mutex> lock(blocks_lock);
+	annotated_lock_guard lock(blocks_lock);
 	// on-disk block: erase from list of blocks in manager
 	blocks.erase(id);
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -101,7 +101,7 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, ColumnDefinition
 	default_executor.AddExpression(default_value);
 
 	// prevent any new tuples from being added to the parent
-	lock_guard<mutex> parent_lock(parent.append_lock);
+	annotated_lock_guard parent_lock(parent.append_lock);
 
 	this->row_groups = parent.row_groups->AddColumn(context, new_column, default_executor);
 
@@ -116,7 +116,7 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t removed_co
     : db(parent.db), info(parent.info), version(DataTableVersion::MAIN_TABLE) {
 	// prevent any new tuples from being added to the parent
 	auto &local_storage = LocalStorage::Get(context, db);
-	lock_guard<mutex> parent_lock(parent.append_lock);
+	annotated_lock_guard parent_lock(parent.append_lock);
 
 	for (auto &column_def : parent.column_definitions) {
 		column_definitions.emplace_back(column_def.Copy());
@@ -166,7 +166,7 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, BoundConstraint 
 	info->BindIndexes(context);
 
 	auto &local_storage = LocalStorage::Get(context, db);
-	lock_guard<mutex> parent_lock(parent.append_lock);
+	annotated_lock_guard parent_lock(parent.append_lock);
 	for (auto &column_def : parent.column_definitions) {
 		column_definitions.emplace_back(column_def.Copy());
 	}
@@ -184,7 +184,7 @@ DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_id
 	auto &transaction = DuckTransaction::Get(context, db);
 	auto &local_storage = LocalStorage::Get(transaction);
 	// prevent any tuples from being added to the parent
-	lock_guard<mutex> parent_lock(parent.append_lock);
+	annotated_lock_guard parent_lock(parent.append_lock);
 	for (auto &column_def : parent.column_definitions) {
 		column_definitions.emplace_back(column_def.Copy());
 	}
@@ -306,9 +306,12 @@ idx_t DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState
 	if (row_groups->NextParallelScan(context, state.scan_state, scan_state.table_state)) {
 		return scan_state.table_state.row_group->GetCount();
 	}
-	if (state.scan_state.row_number_base.IsValid()) {
-		// start the row number for transaction-local rows from the final row count in the base table
-		scan_state.local_state.row_number_base = state.scan_state.row_number_base.GetIndex();
+	{
+		annotated_lock_guard guard(state.scan_state.lock);
+		if (state.scan_state.row_number_base.IsValid()) {
+			// Start transaction-local row numbers after the final row count in the base table.
+			scan_state.local_state.row_number_base = state.scan_state.row_number_base.GetIndex();
+		}
 	}
 	auto &local_storage = LocalStorage::Get(context, db);
 	if (local_storage.NextParallelScan(context, *this, state.local_state, scan_state.local_state)) {
@@ -436,12 +439,12 @@ const vector<Identifier> &DataTableInfo::GetSchemaPath() const {
 }
 
 Identifier DataTableInfo::GetTableName() {
-	lock_guard<mutex> l(name_lock);
+	annotated_lock_guard l(name_lock);
 	return table;
 }
 
 void DataTableInfo::SetTableName(Identifier name) {
-	lock_guard<mutex> l(name_lock);
+	annotated_lock_guard l(name_lock);
 	table = std::move(name);
 }
 
@@ -1044,8 +1047,9 @@ void DataTable::LocalAppend(DuckTableEntry &table, ClientContext &context, Colum
 	storage.FinalizeLocalAppend(append_state);
 }
 
-void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state) {
-	state.append_lock = unique_lock<mutex>(append_lock);
+// The lock is transferred to state, which releases it when the commit append state is destroyed.
+void DataTable::AppendLock(DuckTransaction &transaction, TableAppendState &state) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+	state.append_lock = annotated_unique_lock<annotated_mutex>(append_lock);
 	if (!IsMainTable()) {
 		throw TransactionException("Transaction conflict: attempting to insert into table \"%s\" but it has been %s by "
 		                           "a different transaction",
@@ -1090,11 +1094,14 @@ optional_idx DataTableInfo::CheckpointRowGroupCount(const CheckpointOptions &opt
 	return checkpoint_row_group_count;
 }
 
-void DataTable::InitializeAppend(DuckTransaction &transaction, TableAppendState &state) {
-	// obtain the append lock for this table
-	if (!state.append_lock) {
-		throw InternalException("DataTable::AppendLock should be called before DataTable::InitializeAppend");
+void DataTable::VerifyAppendLock(const TableAppendState &state) const {
+	if (!state.append_lock.owns_lock() || state.append_lock.mutex() != &append_lock) {
+		throw InternalException("TableAppendState must hold this table's append lock");
 	}
+}
+
+void DataTable::InitializeAppend(DuckTransaction &transaction, TableAppendState &state) {
+	VerifyAppendLock(state);
 	row_groups->InitializeAppend(transaction, state);
 }
 
@@ -1203,7 +1210,7 @@ void DataTable::WriteToLog(DuckTransaction &transaction, WriteAheadLog &log, idx
 }
 
 void DataTable::CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count) {
-	lock_guard<mutex> lock(append_lock);
+	annotated_lock_guard lock(append_lock);
 	row_groups->CommitAppend(commit_id, row_start, count);
 }
 
@@ -1214,7 +1221,7 @@ void DataTable::RevertAppendInternal(idx_t start_row) {
 }
 
 void DataTable::RevertAppend(DuckTransaction &transaction, idx_t start_row, idx_t count) {
-	lock_guard<mutex> lock(append_lock);
+	annotated_lock_guard lock(append_lock);
 	auto table_lock = transaction.SharedLockTable(*info);
 
 	// revert any appends to indexes

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -191,6 +191,7 @@ ErrorData LocalTableStorage::AppendToIndexes(DuckTransaction &transaction, RowGr
 
 void LocalTableStorage::AppendToTable(DuckTransaction &transaction, TableAppendState &append_state) {
 	auto &table = table_ref.get();
+	table.VerifyAppendLock(append_state);
 	table.InitializeAppend(transaction, append_state);
 	auto &collection = *row_groups->collection;
 	for (auto &table_chunk : collection.Chunks(transaction)) {
@@ -382,7 +383,9 @@ void LocalStorage::Scan(CollectionScanState &state, const vector<StorageIndex> &
 	state.Scan(transaction, result);
 }
 
-void LocalStorage::InitializeParallelScan(DataTable &table, ParallelCollectionScanState &state) {
+// The scan state is initialized before it is shared with worker threads.
+void LocalStorage::InitializeParallelScan(DataTable &table,
+                                          ParallelCollectionScanState &state) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	auto storage = table_manager.GetStorage(table);
 	if (!storage) {
 		state.max_row = 0;
@@ -571,6 +574,7 @@ void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage, optional_
 
 	TableAppendState append_state;
 	table.AppendLock(transaction, append_state);
+	table.VerifyAppendLock(append_state);
 	if (storage.IsBulkAppend() ||
 	    (append_state.row_start == 0 && storage.deleted_rows == 0 && !storage.WritesToDisk())) {
 		// bulk append (at least one full row group, no deletes): move over the storage directly.

--- a/src/storage/metadata/metadata_manager.cpp
+++ b/src/storage/metadata/metadata_manager.cpp
@@ -55,7 +55,7 @@ MetadataHandle MetadataManager::AllocateHandle() {
 	// check if there is any free space left in an existing block
 	// if not allocate a new block
 	MetadataPointer pointer;
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 	block_id_t free_block = INVALID_BLOCK;
 	for (auto &kv : blocks) {
 		auto &block = kv.second;
@@ -103,7 +103,7 @@ MetadataHandle MetadataManager::Pin(const QueryContext &context, const MetadataP
 	D_ASSERT(pointer.index < METADATA_BLOCK_COUNT);
 	shared_ptr<BlockHandle> block_handle;
 	{
-		lock_guard<mutex> guard(block_lock);
+		annotated_lock_guard guard(block_lock);
 		auto entry = blocks.find(UnsafeNumericCast<int64_t>(pointer.block_index));
 		if (entry == blocks.end()) {
 			throw InternalException("Trying to pin block %llu - but the block did not exist", pointer.block_index);
@@ -127,10 +127,12 @@ MetadataHandle MetadataManager::Pin(const QueryContext &context, const MetadataP
 	return handle;
 }
 
-void MetadataManager::ConvertToTransient(unique_lock<mutex> &block_lock, MetadataBlock &metadata_block) {
-	D_ASSERT(block_lock.owns_lock());
+// Clang cannot track the caller-owned scoped lock across unlock/relock through a reference.
+void MetadataManager::ConvertToTransient(annotated_unique_lock<annotated_mutex> &guard,
+                                         MetadataBlock &metadata_block) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+	D_ASSERT(guard.owns_lock());
 	auto old_block = metadata_block.block;
-	block_lock.unlock();
+	guard.unlock();
 	// pin the old block
 	auto old_buffer = buffer_manager.Pin(old_block);
 
@@ -144,13 +146,15 @@ void MetadataManager::ConvertToTransient(unique_lock<mutex> &block_lock, Metadat
 	// unregister the old block
 	block_manager.UnregisterBlock(metadata_block.block_id);
 
-	block_lock.lock();
+	guard.lock();
 	metadata_block.block = std::move(new_block);
 	metadata_block.dirty = true;
 }
 
-block_id_t MetadataManager::AllocateNewBlock(unique_lock<mutex> &block_lock) {
-	D_ASSERT(!block_lock.owns_lock());
+// Clang cannot track the caller-owned scoped lock across unlock/relock through a reference.
+block_id_t
+MetadataManager::AllocateNewBlock(annotated_unique_lock<annotated_mutex> &guard) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+	D_ASSERT(!guard.owns_lock());
 	auto new_block_id = GetNextBlockId();
 
 	MetadataBlock new_block;
@@ -164,13 +168,13 @@ block_id_t MetadataManager::AllocateNewBlock(unique_lock<mutex> &block_lock) {
 	// zero-initialize the handle
 	memset(handle.GetDataMutable(), 0, block_manager.GetBlockSize());
 
-	block_lock.lock();
-	AddBlock(block_lock, std::move(new_block));
+	guard.lock();
+	AddBlock(guard, std::move(new_block));
 	return new_block_id;
 }
 
-void MetadataManager::AddBlock(unique_lock<mutex> &block_lock, MetadataBlock new_block, bool if_exists) {
-	D_ASSERT(block_lock.owns_lock());
+void MetadataManager::AddBlock(annotated_unique_lock<annotated_mutex> &guard, MetadataBlock new_block, bool if_exists) {
+	D_ASSERT(guard.owns_lock());
 	if (blocks.find(new_block.block_id) != blocks.end()) {
 		if (if_exists) {
 			return;
@@ -180,17 +184,19 @@ void MetadataManager::AddBlock(unique_lock<mutex> &block_lock, MetadataBlock new
 	blocks[new_block.block_id] = std::move(new_block);
 }
 
-void MetadataManager::AddAndRegisterBlock(unique_lock<mutex> &block_lock, MetadataBlock block) {
+// Clang cannot track the caller-owned scoped lock across unlock/relock through a reference.
+void MetadataManager::AddAndRegisterBlock(annotated_unique_lock<annotated_mutex> &guard,
+                                          MetadataBlock block) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	if (block.block) {
 		throw InternalException("Calling AddAndRegisterBlock on block that already exists");
 	}
 	if (block.block_id >= MAXIMUM_BLOCK) {
 		throw InternalException("AddAndRegisterBlock called with a transient block id");
 	}
-	block_lock.unlock();
+	guard.unlock();
 	block.block = block_manager.RegisterBlock(block.block_id);
-	block_lock.lock();
-	AddBlock(block_lock, std::move(block), true);
+	guard.lock();
+	AddBlock(guard, std::move(block), true);
 }
 
 MetaBlockPointer MetadataManager::GetDiskPointer(const MetadataPointer &pointer, uint32_t offset) {
@@ -208,11 +214,12 @@ uint32_t MetaBlockPointer::GetBlockIndex() const {
 }
 
 MetadataPointer MetadataManager::FromDiskPointer(MetaBlockPointer pointer) {
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 	return FromDiskPointerInternal(guard, pointer);
 }
 
-MetadataPointer MetadataManager::FromDiskPointerInternal(unique_lock<mutex> &block_lock, MetaBlockPointer pointer) {
+MetadataPointer MetadataManager::FromDiskPointerInternal(annotated_unique_lock<annotated_mutex> &guard,
+                                                         MetaBlockPointer pointer) {
 	auto block_id = pointer.GetBlockId();
 	auto index = pointer.GetBlockIndex();
 	if (index >= METADATA_BLOCK_COUNT) {
@@ -231,7 +238,7 @@ MetadataPointer MetadataManager::FromDiskPointerInternal(unique_lock<mutex> &blo
 }
 
 MetadataPointer MetadataManager::RegisterDiskPointer(MetaBlockPointer pointer) {
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 
 	auto block_id = pointer.GetBlockId();
 	MetadataBlock block;
@@ -278,7 +285,7 @@ void MetadataManager::Flush(QueryContext context) {
 	// Write the blocks of the metadata manager to disk.
 	const idx_t total_metadata_size = GetMetadataBlockSize() * METADATA_BLOCK_COUNT;
 
-	unique_lock<mutex> guard(block_lock, std::defer_lock);
+	annotated_unique_lock guard(block_lock, std::defer_lock);
 	for (auto &kv : blocks) {
 		auto &block = kv.second;
 		if (!block.dirty) {
@@ -324,7 +331,7 @@ void MetadataManager::Read(ReadStream &source) {
 	for (idx_t i = 0; i < block_count; i++) {
 		auto block = MetadataBlock::Read(source);
 
-		unique_lock<mutex> guard(block_lock);
+		annotated_unique_lock guard(block_lock);
 		auto entry = blocks.find(block.block_id);
 		if (entry == blocks.end()) {
 			// block does not exist yet
@@ -384,7 +391,7 @@ void MetadataBlock::FreeBlocksFromInteger(idx_t free_list) {
 }
 
 void MetadataManager::MarkBlocksAsModified() {
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 	// for any blocks that were modified in the last checkpoint - set them to free blocks currently
 	for (auto &kv : modified_blocks) {
 		auto block_id = kv.first;
@@ -422,7 +429,7 @@ void MetadataManager::ClearModifiedBlocks(const vector<MetaBlockPointer> &pointe
 	if (pointers.empty()) {
 		return;
 	}
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 	for (auto &pointer : pointers) {
 		auto block_id = pointer.GetBlockId();
 		auto block_index = pointer.GetBlockIndex();
@@ -437,7 +444,7 @@ void MetadataManager::ClearModifiedBlocks(const vector<MetaBlockPointer> &pointe
 }
 
 bool MetadataManager::BlockIsModified(const MetaBlockPointer &pointer) {
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 	auto block_id = pointer.GetBlockId();
 	auto entry = blocks.find(block_id);
 	if (entry == blocks.end()) {
@@ -448,7 +455,7 @@ bool MetadataManager::BlockIsModified(const MetaBlockPointer &pointer) {
 }
 
 bool MetadataManager::BlockHasBeenCleared(const MetaBlockPointer &pointer) {
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 	auto block_id = pointer.GetBlockId();
 	auto block_index = pointer.GetBlockIndex();
 	auto entry = modified_blocks.find(block_id);
@@ -461,7 +468,7 @@ bool MetadataManager::BlockHasBeenCleared(const MetaBlockPointer &pointer) {
 
 vector<MetadataBlockInfo> MetadataManager::GetMetadataInfo() const {
 	vector<MetadataBlockInfo> result;
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 	for (auto &block : blocks) {
 		MetadataBlockInfo block_info;
 		block_info.block_id = block.second.block_id;
@@ -479,7 +486,7 @@ vector<MetadataBlockInfo> MetadataManager::GetMetadataInfo() const {
 
 vector<shared_ptr<BlockHandle>> MetadataManager::GetBlocks() const {
 	vector<shared_ptr<BlockHandle>> result;
-	unique_lock<mutex> guard(block_lock);
+	annotated_unique_lock guard(block_lock);
 	for (auto &entry : blocks) {
 		result.push_back(entry.second.block);
 	}

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -513,7 +513,8 @@ void SingleFileBlockManager::CheckAndAddEncryptionKey(MainHeader &main_header) {
 	return CheckAndAddEncryptionKey(main_header, *options.encryption_options.user_key);
 }
 
-void SingleFileBlockManager::CreateNewDatabase(QueryContext context) {
+// Initialization runs before this block manager is shared with other threads.
+void SingleFileBlockManager::CreateNewDatabase(QueryContext context) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	auto encryption_enabled = options.encryption_options.encryption_enabled;
 	if (encryption_enabled) {
 		// Check if we can read/write the encrypted database
@@ -813,7 +814,9 @@ void SingleFileBlockManager::ChecksumAndWrite(QueryContext context, FileBuffer &
 	}
 }
 
-void SingleFileBlockManager::Initialize(const DatabaseHeader &header, const optional_idx block_alloc_size) {
+// Initialization runs before this block manager is shared with other threads.
+void SingleFileBlockManager::Initialize(const DatabaseHeader &header,
+                                        const optional_idx block_alloc_size) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	try {
 		Storage::VerifyBlockAllocSize(header.block_alloc_size);
 	} catch (const InvalidInputException &) {
@@ -867,7 +870,8 @@ void SingleFileBlockManager::RewriteMainHeader(QueryContext &context, StorageVer
 	handle->Sync();
 }
 
-void SingleFileBlockManager::LoadFreeList(QueryContext context) {
+// Initialization runs before this block manager is shared with other threads.
+void SingleFileBlockManager::LoadFreeList(QueryContext context) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	MetaBlockPointer free_pointer(free_list_id, 0);
 	if (!free_pointer.IsValid()) {
 		// no free list
@@ -896,7 +900,7 @@ bool SingleFileBlockManager::IsRootBlock(MetaBlockPointer root) {
 }
 
 block_id_t SingleFileBlockManager::GetFreeBlockIdInternal(FreeBlockType type) {
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	block_id_t block_id;
 	if (!free_list.empty()) {
 		// The free list is not empty, so we take its first element.
@@ -925,7 +929,7 @@ block_id_t SingleFileBlockManager::GetFreeBlockIdForCheckpoint() {
 }
 
 block_id_t SingleFileBlockManager::PeekFreeBlockId() {
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	if (!free_list.empty()) {
 		return *free_list.begin();
 	} else {
@@ -934,13 +938,13 @@ block_id_t SingleFileBlockManager::PeekFreeBlockId() {
 }
 
 void SingleFileBlockManager::MarkBlockAsCheckpointed(block_id_t block_id) {
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	D_ASSERT(block_id >= 0);
 	newly_used_blocks.erase(block_id);
 }
 
 void SingleFileBlockManager::MarkBlockAsUsed(block_id_t block_id) {
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	D_ASSERT(block_id >= 0);
 	if (max_block <= block_id) {
 		// the block is past the current max_block
@@ -962,7 +966,7 @@ void SingleFileBlockManager::MarkBlockAsUsed(block_id_t block_id) {
 }
 
 void SingleFileBlockManager::MarkBlockAsModified(block_id_t block_id) {
-	unique_lock<mutex> lock(single_file_block_lock);
+	annotated_unique_lock lock(single_file_block_lock);
 	D_ASSERT(block_id >= 0);
 	D_ASSERT(block_id < max_block);
 
@@ -1012,7 +1016,7 @@ void SingleFileBlockManager::IncreaseBlockReferenceCountInternal(block_id_t bloc
 
 void SingleFileBlockManager::VerifyBlocks(const unordered_map<block_id_t, idx_t> &block_usage_count) {
 	// probably don't need this?
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	// all blocks should be accounted for - either in the block_usage_count, or in the free list
 	set<block_id_t> referenced_blocks;
 	for (auto &block : block_usage_count) {
@@ -1101,7 +1105,7 @@ void SingleFileBlockManager::VerifyBlocks(const unordered_map<block_id_t, idx_t>
 }
 
 void SingleFileBlockManager::IncreaseBlockReferenceCount(block_id_t block_id) {
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	IncreaseBlockReferenceCountInternal(block_id);
 }
 
@@ -1110,12 +1114,12 @@ idx_t SingleFileBlockManager::GetMetaBlock() {
 }
 
 idx_t SingleFileBlockManager::TotalBlocks() {
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	return NumericCast<idx_t>(max_block);
 }
 
 idx_t SingleFileBlockManager::FreeBlocks() {
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	return free_list.size();
 }
 
@@ -1189,7 +1193,12 @@ void SingleFileBlockManager::ReadBlock(Block &block, bool skip_block_header) con
 
 void SingleFileBlockManager::Read(QueryContext context, Block &block) {
 	D_ASSERT(block.id >= 0);
-	D_ASSERT(std::find(free_list.begin(), free_list.end(), block.id) == free_list.end());
+#ifdef D_ASSERT_IS_ENABLED
+	{
+		annotated_lock_guard lock(single_file_block_lock);
+		D_ASSERT(free_list.find(block.id) == free_list.end());
+	}
+#endif
 	ReadAndChecksum(context, block, GetBlockLocation(block.id));
 }
 
@@ -1222,7 +1231,7 @@ void SingleFileBlockManager::Write(QueryContext context, FileBuffer &buffer, blo
 void SingleFileBlockManager::Truncate() {
 	BlockManager::Truncate();
 
-	lock_guard<mutex> guard(single_file_block_lock);
+	annotated_lock_guard guard(single_file_block_lock);
 	idx_t blocks_to_truncate = 0;
 	// reverse iterate over the free-list
 	for (auto entry = free_list.rbegin(); entry != free_list.rend(); entry++) {
@@ -1255,7 +1264,7 @@ vector<MetadataHandle> SingleFileBlockManager::GetFreeListBlocks() {
 		idx_t free_list_count;
 		idx_t multi_use_blocks_count;
 		{
-			lock_guard<mutex> guard(single_file_block_lock);
+			annotated_lock_guard guard(single_file_block_lock);
 			free_list_count =
 			    free_list.size() + modified_blocks.size() + free_blocks_in_use.size() + newly_used_blocks.size();
 			multi_use_blocks_count = multi_use_blocks.size();
@@ -1297,7 +1306,9 @@ protected:
 	}
 };
 
-bool SingleFileBlockManager::AddFreeBlock(unique_lock<mutex> &lock, block_id_t block_id) {
+// Clang cannot track the caller-owned scoped lock across unlock/relock through a reference.
+bool SingleFileBlockManager::AddFreeBlock(annotated_unique_lock<annotated_mutex> &lock,
+                                          block_id_t block_id) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	if (!lock.owns_lock()) {
 		throw InternalException("AddFreeBlock must be called while holding the lock");
 	}
@@ -1325,7 +1336,7 @@ void SingleFileBlockManager::WriteHeader(QueryContext context, DatabaseHeader he
 	// add all modified blocks to the free list: they can now be written to again
 	metadata_manager.MarkBlocksAsModified();
 
-	unique_lock<mutex> lock(single_file_block_lock);
+	annotated_unique_lock lock(single_file_block_lock);
 	// set the iteration count
 	header.iteration = ++iteration_count;
 
@@ -1410,7 +1421,7 @@ void SingleFileBlockManager::WriteHeader(QueryContext context, DatabaseHeader he
 	handle->Sync();
 	set<block_id_t> fully_freed_blocks;
 	{
-		unique_lock<mutex> release_lock(single_file_block_lock);
+		annotated_unique_lock release_lock(single_file_block_lock);
 		for (auto &block : checkpoint_freed_blocks) {
 			modified_blocks.erase(block);
 			if (AddFreeBlock(release_lock, block)) {
@@ -1430,7 +1441,7 @@ void SingleFileBlockManager::UnregisterBlock(block_id_t id) {
 	// perform the actual unregistration
 	BlockManager::UnregisterBlock(id);
 	// check if it is part of the newly free list
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	auto entry = free_blocks_in_use.find(id);
 	if (entry != free_blocks_in_use.end()) {
 		// it is! move it to the regular free list so the block can be re-used
@@ -1450,7 +1461,7 @@ void SingleFileBlockManager::TrimFreeBlocks(const set<block_id_t> &blocks) {
 	if (!DBConfig::Get(db).options.trim_free_blocks) {
 		return;
 	}
-	lock_guard<mutex> lock(single_file_block_lock);
+	annotated_lock_guard lock(single_file_block_lock);
 	for (auto itr = blocks.begin(); itr != blocks.end(); ++itr) {
 		if (!free_list.count(*itr)) {
 			continue;

--- a/src/storage/storage_lock.cpp
+++ b/src/storage/storage_lock.cpp
@@ -17,35 +17,35 @@ public:
 	StorageLockInternals() : read_count(0), writer_active(false), writer_tickets(0), writers_done(0) {
 	}
 
-	mutex state_lock;
+	annotated_mutex state_lock;
 	std::condition_variable state_cv;
-	idx_t read_count;
-	bool writer_active;
+	idx_t read_count DUCKDB_GUARDED_BY(state_lock);
+	bool writer_active DUCKDB_GUARDED_BY(state_lock);
 	//! Incremented when a writer registers (blocking acquisition) or acquires (try/upgrade)
-	idx_t writer_tickets;
+	idx_t writer_tickets DUCKDB_GUARDED_BY(state_lock);
 	//! Incremented when a writer releases
-	idx_t writers_done;
+	idx_t writers_done DUCKDB_GUARDED_BY(state_lock);
 
 public:
-	unique_ptr<StorageLockKey> GetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		unique_lock<mutex> guard(state_lock);
+	unique_ptr<StorageLockKey> GetExclusiveLock() {
+		annotated_unique_lock guard(state_lock);
 		writer_tickets++;
-		state_cv.wait(guard, [&]() { return !writer_active && read_count == 0; });
+		state_cv.wait(guard, [&]() DUCKDB_REQUIRES(state_lock) { return !writer_active && read_count == 0; });
 		writer_active = true;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
-	unique_ptr<StorageLockKey> GetSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		unique_lock<mutex> guard(state_lock);
+	unique_ptr<StorageLockKey> GetSharedLock() {
+		annotated_unique_lock guard(state_lock);
 		// wait for the writers registered before us (they drain and run first), but not for later ones
 		auto target = writer_tickets;
-		state_cv.wait(guard, [&]() { return !writer_active && writers_done >= target; });
+		state_cv.wait(guard, [&]() DUCKDB_REQUIRES(state_lock) { return !writer_active && writers_done >= target; });
 		read_count++;
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::SHARED);
 	}
 
-	unique_ptr<StorageLockKey> TryGetExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
-		lock_guard<mutex> guard(state_lock);
+	unique_ptr<StorageLockKey> TryGetExclusiveLock() {
+		annotated_lock_guard guard(state_lock);
 		if (writer_active || read_count != 0) {
 			return nullptr;
 		}
@@ -54,11 +54,11 @@ public:
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
-	unique_ptr<StorageLockKey> TryUpgradeCheckpointLock(StorageLockKey &lock) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+	unique_ptr<StorageLockKey> TryUpgradeCheckpointLock(StorageLockKey &lock) {
 		if (lock.GetType() != StorageLockType::SHARED) {
 			throw InternalException("StorageLock::TryUpgradeLock called on an exclusive lock");
 		}
-		lock_guard<mutex> guard(state_lock);
+		annotated_lock_guard guard(state_lock);
 		if (writer_active || read_count != 1) {
 			// other shared locks (or a writer) are active: failed to upgrade
 			D_ASSERT(read_count != 0);
@@ -70,18 +70,18 @@ public:
 		return make_uniq<StorageLockKey>(shared_from_this(), StorageLockType::EXCLUSIVE);
 	}
 
-	void ReleaseExclusiveLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+	void ReleaseExclusiveLock() {
 		{
-			lock_guard<mutex> guard(state_lock);
+			annotated_lock_guard guard(state_lock);
 			writer_active = false;
 			writers_done++;
 		}
 		state_cv.notify_all();
 	}
-	void ReleaseSharedLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
+	void ReleaseSharedLock() {
 		bool notify;
 		{
-			lock_guard<mutex> guard(state_lock);
+			annotated_lock_guard guard(state_lock);
 			read_count--;
 			notify = read_count == 0;
 		}

--- a/src/storage/table/column_data.cpp
+++ b/src/storage/table/column_data.cpp
@@ -88,7 +88,7 @@ StorageManager &ColumnData::GetStorageManager() const {
 }
 
 bool ColumnData::HasUpdates() const {
-	lock_guard<mutex> update_guard(update_lock);
+	annotated_lock_guard update_guard(update_lock);
 	return updates.get();
 }
 
@@ -293,13 +293,13 @@ void ColumnData::FilterVector(ColumnScanState &state, Vector &result, idx_t targ
 }
 
 unique_ptr<BaseStatistics> ColumnData::GetUpdateStatistics() {
-	lock_guard<mutex> update_guard(update_lock);
+	annotated_lock_guard update_guard(update_lock);
 	return updates ? updates->GetStatistics() : nullptr;
 }
 
 void ColumnData::FetchUpdates(TransactionData transaction, idx_t vector_index, Vector &result, idx_t scan_count,
                               UpdateScanType update_type) {
-	lock_guard<mutex> update_guard(update_lock);
+	annotated_lock_guard update_guard(update_lock);
 	if (!updates) {
 		return;
 	}
@@ -311,7 +311,7 @@ void ColumnData::FetchUpdates(TransactionData transaction, idx_t vector_index, V
 }
 
 void ColumnData::FetchUpdateRow(TransactionData transaction, row_t row_id, Vector &result, idx_t result_idx) {
-	lock_guard<mutex> update_guard(update_lock);
+	annotated_lock_guard update_guard(update_lock);
 	if (!updates) {
 		return;
 	}
@@ -322,7 +322,7 @@ void ColumnData::FetchUpdateRow(TransactionData transaction, row_t row_id, Vecto
 void ColumnData::UpdateInternal(TransactionData transaction, DuckTableEntry &table_entry, idx_t column_index,
                                 Vector &update_vector, row_t *row_ids, idx_t update_count, Vector &base_vector,
                                 idx_t row_group_start) {
-	lock_guard<mutex> update_guard(update_lock);
+	annotated_lock_guard update_guard(update_lock);
 	if (!updates) {
 		updates = make_uniq<UpdateSegment>(*this);
 	}
@@ -417,7 +417,7 @@ void ColumnData::FinalizeAppend(optional_ptr<BaseStatistics> table_stats, Column
 	if (!stats) {
 		throw InternalException("ColumnData::FinalizeAppend called on a column with a parent or without stats");
 	}
-	lock_guard<mutex> l(stats_lock);
+	annotated_lock_guard l(stats_lock);
 	ColumnDataFinalizeAppendState finalize_state(stats->statistics);
 	if (table_stats) {
 		finalize_state.global_stats.emplace_back(*table_stats);
@@ -426,7 +426,7 @@ void ColumnData::FinalizeAppend(optional_ptr<BaseStatistics> table_stats, Column
 }
 
 void ColumnData::FinalizeAppendLocked(ColumnDataFinalizeAppendState &finalize_state, ColumnAppendState &state) {
-	lock_guard<mutex> l(stats_lock);
+	annotated_lock_guard l(stats_lock);
 	FinalizeAppend(finalize_state, state);
 }
 
@@ -448,7 +448,7 @@ FilterPropagateResult ColumnData::CheckZonemap(ColumnScanState &state, TableFilt
 	                      : state.current;
 	FilterPropagateResult prune_result;
 	{
-		lock_guard<mutex> l(stats_lock);
+		annotated_lock_guard l(stats_lock);
 		auto &segment_stats = checked_segment->GetNode().GetStatsMutable();
 		auto context = state.context.GetClientContext();
 		prune_result =
@@ -477,7 +477,7 @@ FilterPropagateResult ColumnData::CheckZonemap(optional_ptr<ClientContext> conte
 	if (!stats) {
 		throw InternalException("ColumnData::CheckZonemap called on a column without stats");
 	}
-	lock_guard<mutex> l(stats_lock);
+	annotated_lock_guard l(stats_lock);
 	if (index.IsPushdownExtract()) {
 		auto child_stats = stats->statistics.PushdownExtract(index.GetChildIndex(0));
 		if (!child_stats) {
@@ -508,7 +508,7 @@ unique_ptr<BaseStatistics> ColumnData::GetStatistics() const {
 	if (!stats) {
 		throw InternalException("ColumnData::GetStatistics called on a column without stats");
 	}
-	lock_guard<mutex> l(stats_lock);
+	annotated_lock_guard l(stats_lock);
 	return stats->statistics.ToUnique();
 }
 
@@ -516,7 +516,7 @@ void ColumnData::MergeStatistics(const BaseStatistics &other) {
 	if (!stats) {
 		throw InternalException("ColumnData::MergeStatistics called on a column without stats");
 	}
-	lock_guard<mutex> l(stats_lock);
+	annotated_lock_guard l(stats_lock);
 	return stats->statistics.Merge(other);
 }
 
@@ -524,7 +524,7 @@ void ColumnData::MergeIntoStatistics(BaseStatistics &other) {
 	if (!stats) {
 		throw InternalException("ColumnData::MergeIntoStatistics called on a column without stats");
 	}
-	lock_guard<mutex> l(stats_lock);
+	annotated_lock_guard l(stats_lock);
 	return other.Merge(stats->statistics);
 }
 
@@ -622,7 +622,7 @@ void ColumnData::AppendData(ColumnAppendState &state, UnifiedVectorFormat &vdata
 		// segment is full and we have more to copy
 		// first flush the stats into the segment and the column data
 		{
-			lock_guard<mutex> guard(stats_lock);
+			annotated_lock_guard guard(stats_lock);
 			state.FlushSegmentStats();
 		}
 		// re-initialize the stats
@@ -722,7 +722,7 @@ void ColumnData::FetchRowsAtSegmentLevel(TransactionData transaction, ColumnFetc
 		current_segment->GetNode().FetchRow(state, NumericCast<row_t>(index_in_segment), result, result_offset + idx);
 	}
 	{
-		const lock_guard<mutex> update_guard(update_lock);
+		const annotated_lock_guard update_guard(update_lock);
 		if (updates) {
 			updates->FetchRows(transaction, offsets, sel, fetch_count, result, result_offset);
 		}
@@ -1301,7 +1301,7 @@ void ColumnData::GetColumnSegmentInfo(const QueryContext &context, idx_t row_gro
 		column_info.segment_count = segment.count;
 		column_info.compression_type = CompressionTypeToString(segment.GetCompressionFunction().type);
 		{
-			lock_guard<mutex> l(stats_lock);
+			annotated_lock_guard l(stats_lock);
 			column_info.segment_stats = segment.GetStats().ToStruct();
 		}
 		column_info.has_updates = ColumnData::HasUpdates();

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -84,7 +84,7 @@ RowGroup::RowGroup(RowGroupCollection &collection_p, PersistentRowGroupData &dat
 }
 
 void RowGroup::MoveToCollection(RowGroupCollection &collection_p) {
-	lock_guard<mutex> l(row_group_lock);
+	annotated_lock_guard l(row_group_lock);
 	// FIXME
 	// MoveToCollection causes any_changes to be set to true because we are changing the start position of the row group
 	// the start position is ONLY written when targeting old serialization versions - as such, we don't actually
@@ -133,7 +133,7 @@ void RowGroup::LoadRowIdColumnData() const {
 	if (row_id_is_loaded) {
 		return;
 	}
-	lock_guard<mutex> l(row_group_lock);
+	annotated_lock_guard l(row_group_lock);
 	if (row_id_column_data) {
 		return;
 	}
@@ -146,7 +146,7 @@ void RowGroup::LoadRowNumberColumnData() const {
 	if (row_number_is_loaded) {
 		return;
 	}
-	lock_guard<mutex> l(row_group_lock);
+	annotated_lock_guard l(row_group_lock);
 	if (row_number_column_data) {
 		return;
 	}
@@ -198,7 +198,7 @@ void RowGroup::LoadColumn(storage_t c) const {
 		D_ASSERT(columns[c]);
 		return;
 	}
-	lock_guard<mutex> l(row_group_lock);
+	annotated_lock_guard l(row_group_lock);
 	if (columns[c]) {
 		// another thread loaded the column while we were waiting for the lock
 		D_ASSERT(is_loaded[c]);
@@ -228,7 +228,7 @@ void RowGroup::UnloadColumn(storage_t c) {
 	if (!ColumnIsLoaded(c)) {
 		throw InternalException("Trying to unload a column that is not loaded");
 	}
-	lock_guard<mutex> l(row_group_lock);
+	annotated_lock_guard l(row_group_lock);
 	if (!is_loaded) {
 		// is_loaded is not set - all columns must be loaded
 		this->is_loaded = unique_ptr<atomic<bool>[]>(new atomic<bool>[columns.size()]);
@@ -495,7 +495,7 @@ unique_ptr<RowGroup> RowGroup::AlterType(RowGroupCollection &new_collection, con
 		// in case these don't fit in memory here
 		GetColumns();
 	}
-	unique_lock<mutex> lock(row_group_lock);
+	annotated_unique_lock lock(row_group_lock);
 	auto row_group = CreateNewRowGroupCopy(new_collection, columns.size());
 	// copy existing columns, but swap out the one at changed_idx
 	for (idx_t i = 0; i < columns.size(); i++) {
@@ -559,7 +559,7 @@ unique_ptr<RowGroup> RowGroup::AddColumn(RowGroupCollection &new_collection, Col
 		GetColumns();
 	}
 
-	unique_lock<mutex> lock(row_group_lock);
+	annotated_unique_lock lock(row_group_lock);
 	auto row_group = CreateNewRowGroupCopy(new_collection, columns.size() + 1);
 	// copy existing columns
 	for (idx_t i = 0; i < columns.size(); i++) {
@@ -594,7 +594,7 @@ unique_ptr<RowGroup> RowGroup::RemoveColumn(RowGroupCollection &new_collection, 
 		// in case these don't fit in memory here
 		GetColumns();
 	}
-	unique_lock<mutex> lock(row_group_lock);
+	annotated_unique_lock lock(row_group_lock);
 	auto row_group = CreateNewRowGroupCopy(new_collection, columns.size() - 1);
 	// copy over all columns except for the removed one
 	idx_t target_idx = 0;
@@ -1102,7 +1102,7 @@ optional_ptr<RowVersionManager> RowGroup::GetVersionInfo() {
 		// deletes are loaded - return the version info
 		return version_info;
 	}
-	lock_guard<mutex> lock(row_group_lock);
+	annotated_lock_guard lock(row_group_lock);
 	// double-check after obtaining the lock whether or not deletes are still not loaded to avoid double load
 	if (!HasUnloadedDeletes()) {
 		return version_info;
@@ -1122,7 +1122,7 @@ void RowGroup::SetVersionInfo(shared_ptr<RowVersionManager> version) {
 
 shared_ptr<RowVersionManager> RowGroup::GetOrCreateVersionInfoInternal() {
 	// version info does not exist - need to create it
-	lock_guard<mutex> lock(row_group_lock);
+	annotated_lock_guard lock(row_group_lock);
 	if (!owned_version_info) {
 		auto &buffer_manager = GetBlockManager().GetBufferManager();
 		auto new_info = make_shared_ptr<RowVersionManager>(buffer_manager);
@@ -1201,7 +1201,7 @@ void RowGroup::FetchRows(TransactionData transaction, ColumnFetchState &state, c
 
 void RowGroup::SetCount(idx_t count) {
 	this->count = count;
-	lock_guard<mutex> guard(row_group_lock);
+	annotated_lock_guard guard(row_group_lock);
 	if (row_id_is_loaded) {
 		row_id_column_data->count = count;
 	}
@@ -2103,7 +2103,7 @@ void RowGroup::Verify() {
 			columns[c]->Verify(*this);
 		}
 	}
-	lock_guard<mutex> guard(row_group_lock);
+	annotated_lock_guard guard(row_group_lock);
 	if (row_id_is_loaded) {
 		D_ASSERT(row_id_column_data->count == count);
 	}

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -187,12 +187,12 @@ MetadataManager &RowGroupCollection::GetMetadataManager() {
 }
 
 shared_ptr<RowGroupSegmentTree> RowGroupCollection::GetRowGroups() const {
-	lock_guard<mutex> guard(row_group_pointer_lock);
+	annotated_lock_guard guard(row_group_pointer_lock);
 	return owned_row_groups;
 }
 
 void RowGroupCollection::SetRowGroups(shared_ptr<RowGroupSegmentTree> new_row_groups) {
-	lock_guard<mutex> guard(row_group_pointer_lock);
+	annotated_lock_guard guard(row_group_pointer_lock);
 	owned_row_groups = std::move(new_row_groups);
 }
 
@@ -200,14 +200,15 @@ void RowGroupCollection::SetRowGroups(shared_ptr<RowGroupSegmentTree> new_row_gr
 // Initialize
 //===--------------------------------------------------------------------===//
 void RowGroupCollection::Initialize(PersistentTableData &data) {
-	D_ASSERT(owned_row_groups->GetBaseRowId() == 0);
-	auto l = owned_row_groups->Lock();
+	auto row_groups = GetRowGroups();
+	D_ASSERT(row_groups->GetBaseRowId() == 0);
+	auto l = row_groups->Lock();
 	this->total_rows = data.total_rows;
 	this->next_row_id = data.next_row_id;
 	D_ASSERT(this->next_row_id >= this->total_rows);
 	metadata_pointer = data.base_table_pointer;
 	metadata_pointers = data.read_metadata_pointers;
-	owned_row_groups->Initialize(data, metadata_pointers);
+	row_groups->Initialize(data, metadata_pointers);
 	stats.Initialize(types, data);
 }
 
@@ -218,14 +219,15 @@ void RowGroupCollection::FinalizeCheckpoint(MetaBlockPointer pointer,
 }
 
 void RowGroupCollection::Initialize(PersistentCollectionData &data) {
+	auto row_groups = GetRowGroups();
 	stats.InitializeEmpty(types);
-	auto l = owned_row_groups->Lock();
+	auto l = row_groups->Lock();
 	for (auto &row_group_data : data.row_group_data) {
-		D_ASSERT(row_group_data.start == owned_row_groups->GetBaseRowId() + total_rows.load());
+		D_ASSERT(row_group_data.start == row_groups->GetBaseRowId() + total_rows.load());
 		auto row_group = make_uniq<RowGroup>(*this, row_group_data);
 		row_group->MergeIntoStatistics(stats);
 		total_rows += row_group->count;
-		owned_row_groups->AppendSegment(l, std::move(row_group), row_group_data.start);
+		row_groups->AppendSegment(l, std::move(row_group), row_group_data.start);
 	}
 	next_row_id = total_rows.load();
 }
@@ -256,14 +258,16 @@ ColumnDataType GetColumnDataType(idx_t row_start) {
 }
 
 void RowGroupCollection::AppendRowGroup(SegmentLock &l, idx_t start_row) {
+	auto row_groups = GetRowGroups();
 	auto new_row_group = make_uniq<RowGroup>(*this, 0U);
 	new_row_group->InitializeEmpty(types, GetColumnDataType(start_row));
-	owned_row_groups->AppendSegment(l, std::move(new_row_group), start_row);
+	row_groups->AppendSegment(l, std::move(new_row_group), start_row);
 	row_group_append_mode = RowGroupAppendMode::APPEND_TO_EXISTING;
 }
 
 optional_ptr<RowGroup> RowGroupCollection::GetRowGroup(int64_t index) {
-	auto result = owned_row_groups->GetSegmentByIndex(index);
+	auto row_groups = GetRowGroups();
+	auto result = row_groups->GetSegmentByIndex(index);
 	if (!result) {
 		return nullptr;
 	}
@@ -276,7 +280,8 @@ idx_t RowGroupCollection::GetSegmentCount() {
 }
 
 void RowGroupCollection::SetRowGroup(int64_t index, shared_ptr<RowGroup> new_row_group) {
-	auto result = owned_row_groups->GetSegmentByIndex(index);
+	auto row_groups = GetRowGroups();
+	auto result = row_groups->GetSegmentByIndex(index);
 	if (!result) {
 		throw InternalException("RowGroupCollection::SetRowGroup - Segment is out of range");
 	}
@@ -349,7 +354,8 @@ bool RowGroupCollection::InitializeScanInRowGroup(ClientContext &context, Collec
 	return row_group.GetNode().InitializeScanWithOffset(state, row_group, vector_index);
 }
 
-void RowGroupCollection::InitializeParallelScan(ParallelCollectionScanState &state) {
+// The scan state is initialized before it is shared with worker threads.
+void RowGroupCollection::InitializeParallelScan(ParallelCollectionScanState &state) DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	state.collection = this;
 	state.row_groups = GetRowGroups();
 	state.AssignRowGroup(state.GetRootSegment(*state.row_groups));
@@ -369,7 +375,7 @@ bool RowGroupCollection::NextParallelScan(ClientContext &context, ParallelCollec
 		optional_ptr<SegmentNode<RowGroup>> row_group;
 		{
 			// select the next row group to scan from the parallel state
-			lock_guard<mutex> l(state.lock);
+			annotated_lock_guard l(state.lock);
 			if (!state.current_row_group) {
 				// no more data left to scan
 				break;
@@ -422,7 +428,7 @@ bool RowGroupCollection::NextParallelScan(ClientContext &context, ParallelCollec
 		}
 		return true;
 	}
-	lock_guard<mutex> l(state.lock);
+	annotated_lock_guard l(state.lock);
 	scan_state.batch_index = state.batch_index;
 	return false;
 }
@@ -2083,8 +2089,9 @@ private:
 };
 
 void RowGroupCollection::Destroy() {
-	auto l = owned_row_groups->Lock();
-	auto &segments = owned_row_groups->ReferenceLoadedSegmentsMutable(l);
+	auto row_groups = GetRowGroups();
+	auto l = row_groups->Lock();
+	auto &segments = row_groups->ReferenceLoadedSegmentsMutable(l);
 
 	TaskExecutor executor(TaskScheduler::GetScheduler(GetAttached().GetDatabase()));
 	for (auto &segment : segments) {

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -13,7 +13,7 @@ RowVersionManager::RowVersionManager(BufferManager &buffer_manager_p) noexcept
 }
 
 idx_t RowVersionManager::GetRowCount(ScanOptions options, idx_t count) {
-	lock_guard<mutex> l(version_lock);
+	annotated_lock_guard l(version_lock);
 	idx_t total_count = 0;
 	for (idx_t r = 0, i = 0; r < count; r += STANDARD_VECTOR_SIZE, i++) {
 		idx_t segment_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, count - r);
@@ -40,7 +40,7 @@ optional_ptr<ChunkVectorInfo> RowVersionManager::GetChunkInfo(idx_t vector_idx) 
 
 idx_t RowVersionManager::GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector,
                                       idx_t max_count) {
-	lock_guard<mutex> l(version_lock);
+	annotated_lock_guard l(version_lock);
 	auto chunk_info = GetChunkInfo(vector_idx);
 	if (!chunk_info) {
 		return max_count;
@@ -53,7 +53,7 @@ idx_t RowVersionManager::GetVisibleRows(TransactionData transaction, const idx_t
 	if (count == 0) {
 		return 0;
 	}
-	const lock_guard<mutex> lock(version_lock);
+	const annotated_lock_guard lock(version_lock);
 	idx_t visible_count = 0;
 	idx_t idx = 0;
 	while (idx < count) {
@@ -96,7 +96,7 @@ void RowVersionManager::FillVectorInfo(idx_t vector_idx) {
 
 void RowVersionManager::AppendVersionInfo(TransactionData transaction, idx_t count, idx_t row_group_start,
                                           idx_t row_group_end) {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	needs_compression_check = true;
 	idx_t start_vector_idx = row_group_start / STANDARD_VECTOR_SIZE;
 	idx_t end_vector_idx = (row_group_end - 1) / STANDARD_VECTOR_SIZE;
@@ -131,7 +131,7 @@ void RowVersionManager::CommitAppend(transaction_t commit_id, idx_t row_group_st
 	}
 	idx_t row_group_end = row_group_start + count;
 
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	idx_t start_vector_idx = row_group_start / STANDARD_VECTOR_SIZE;
 	idx_t end_vector_idx = (row_group_end - 1) / STANDARD_VECTOR_SIZE;
 	for (idx_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
@@ -149,7 +149,7 @@ void RowVersionManager::CleanupAppend(VisibilityBound lowest_visibility_bound, i
 	}
 	idx_t row_group_end = row_group_start + count;
 
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	idx_t start_vector_idx = row_group_start / STANDARD_VECTOR_SIZE;
 	idx_t end_vector_idx = (row_group_end - 1) / STANDARD_VECTOR_SIZE;
 	for (idx_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
@@ -173,7 +173,7 @@ void RowVersionManager::CleanupAppend(VisibilityBound lowest_visibility_bound, i
 }
 
 void RowVersionManager::RevertAppend(idx_t new_count) {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	idx_t start_vector_idx = (new_count + (STANDARD_VECTOR_SIZE - 1)) / STANDARD_VECTOR_SIZE;
 	for (idx_t vector_idx = start_vector_idx; vector_idx < vector_info.size(); vector_idx++) {
 		vector_info[vector_idx].reset();
@@ -191,13 +191,13 @@ ChunkVectorInfo &RowVersionManager::GetVectorInfo(idx_t vector_idx) {
 }
 
 idx_t RowVersionManager::DeleteRows(idx_t vector_idx, transaction_t transaction_id, row_t rows[], idx_t count) {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	needs_compression_check = true;
 	return GetVectorInfo(vector_idx).Delete(transaction_id, rows, count);
 }
 
 void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info) {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	needs_compression_check = true;
 	if (!uncheckpointed_delete_commit.IsValid() || commit_id > uncheckpointed_delete_commit.GetIndex()) {
 		uncheckpointed_delete_commit = commit_id;
@@ -206,7 +206,7 @@ void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, 
 }
 
 void RowVersionManager::CompressVersionIds(VisibilityBound lowest_visibility_bound) {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	if (!needs_compression_check) {
 		// no version ids were modified since the last pass, and the last pass left nothing
 		// that could still become compressible - nothing to do
@@ -236,7 +236,7 @@ void RowVersionManager::CompressVersionIds(VisibilityBound lowest_visibility_bou
 }
 
 vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	auto &manager = *writer.GetMetadataManager();
 	auto options = writer.GetCheckpointOptions();
 	if (!uncheckpointed_delete_commit.IsValid()) {
@@ -282,11 +282,12 @@ vector<MetaBlockPointer> RowVersionManager::Checkpoint(RowGroupWriter &writer) {
 	return storage_pointers;
 }
 
-shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer delete_pointer,
-                                                             MetadataManager &manager) {
+shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer delete_pointer, MetadataManager &manager)
+    DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	if (!delete_pointer.IsValid()) {
 		return nullptr;
 	}
+	// The new manager is not published until deserialization completes.
 	auto version_info = make_shared_ptr<RowVersionManager>(manager.GetBufferManager());
 	MetadataReader source(manager, delete_pointer, &version_info->storage_pointers);
 	auto chunk_count = source.Read<idx_t>();
@@ -313,12 +314,12 @@ shared_ptr<RowVersionManager> RowVersionManager::Deserialize(MetaBlockPointer de
 }
 
 bool RowVersionManager::HasUnserializedChanges() {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	return uncheckpointed_delete_commit.IsValid();
 }
 
 bool RowVersionManager::HasDeletes() {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	for (auto &info : vector_info) {
 		if (info && info->AnyDeleted()) {
 			return true;
@@ -328,7 +329,7 @@ bool RowVersionManager::HasDeletes() {
 }
 
 bool RowVersionManager::HasUncommittedChanges() {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	for (auto &info : vector_info) {
 		if (info && info->HasUncommittedChanges()) {
 			return true;
@@ -338,7 +339,7 @@ bool RowVersionManager::HasUncommittedChanges() {
 }
 
 vector<MetaBlockPointer> RowVersionManager::GetStoragePointers() {
-	lock_guard<mutex> lock(version_lock);
+	annotated_lock_guard lock(version_lock);
 	D_ASSERT(!uncheckpointed_delete_commit.IsValid());
 	return storage_pointers;
 }

--- a/src/storage/table/scan_state.cpp
+++ b/src/storage/table/scan_state.cpp
@@ -271,7 +271,9 @@ bool CollectionScanState::Scan(ScanOptions options, DataChunk &result, optional_
 		}
 		do {
 			if (l) {
-				row_group = GetNextRowGroup(*l, *row_group).get();
+				auto &held_lock = *l;
+				held_lock.AssertHeld();
+				row_group = GetNextRowGroup(held_lock, *row_group).get();
 			} else {
 				row_group = GetNextRowGroup(*row_group).get();
 			}
@@ -299,7 +301,9 @@ bool CollectionScanState::Scan(DataChunk &result, TableScanType type, optional_p
 		}
 		// move to the next row group
 		if (l) {
-			row_group = GetNextRowGroup(*l, *row_group).get();
+			auto &held_lock = *l;
+			held_lock.AssertHeld();
+			row_group = GetNextRowGroup(held_lock, *row_group).get();
 		} else {
 			row_group = GetNextRowGroup(*row_group).get();
 		}

--- a/src/storage/table/standard_column_data.cpp
+++ b/src/storage/table/standard_column_data.cpp
@@ -191,7 +191,7 @@ void StandardColumnData::UpdateColumn(TransactionData transaction, DuckTableEntr
 unique_ptr<BaseStatistics> StandardColumnData::GetUpdateStatistics() {
 	unique_ptr<BaseStatistics> stats;
 	{
-		lock_guard<mutex> update_guard(update_lock);
+		annotated_lock_guard update_guard(update_lock);
 		stats = updates ? updates->GetStatistics() : nullptr;
 	}
 	auto validity_stats = validity->GetUpdateStatistics();

--- a/src/storage/table/table_statistics.cpp
+++ b/src/storage/table/table_statistics.cpp
@@ -12,7 +12,7 @@ void TableStatistics::Initialize(const vector<LogicalType> &types, PersistentTab
 	D_ASSERT(Empty());
 	D_ASSERT(!table_sample);
 
-	stats_lock = make_shared_ptr<mutex>();
+	stats_lock = make_shared_ptr<annotated_mutex>();
 	column_stats = std::move(data.table_stats.column_stats);
 	if (data.table_stats.table_sample) {
 		table_sample = std::move(data.table_stats.table_sample);
@@ -29,7 +29,7 @@ void TableStatistics::InitializeEmpty(const TableStatistics &other) {
 	D_ASSERT(Empty());
 	D_ASSERT(!table_sample);
 
-	stats_lock = make_shared_ptr<mutex>();
+	stats_lock = make_shared_ptr<annotated_mutex>();
 	if (other.table_sample) {
 		D_ASSERT(other.table_sample->type == SampleType::RESERVOIR_SAMPLE);
 		auto &res = other.table_sample->Cast<ReservoirSample>();
@@ -56,7 +56,7 @@ void TableStatistics::InitializeEmpty(const vector<LogicalType> &types) {
 	D_ASSERT(Empty());
 	D_ASSERT(!table_sample);
 
-	stats_lock = make_shared_ptr<mutex>();
+	stats_lock = make_shared_ptr<annotated_mutex>();
 	table_sample = make_uniq<ReservoirSample>(static_cast<idx_t>(FIXED_SAMPLE_SIZE));
 	for (auto &type : types) {
 		column_stats.push_back(ColumnStatistics::CreateEmptyStats(type));
@@ -68,7 +68,7 @@ void TableStatistics::InitializeAddColumn(TableStatistics &parent, const Logical
 	D_ASSERT(parent.stats_lock);
 
 	stats_lock = parent.stats_lock;
-	lock_guard<mutex> lock(*stats_lock);
+	annotated_lock_guard lock(*stats_lock);
 	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
 		column_stats.push_back(parent.column_stats[i]);
 	}
@@ -86,7 +86,7 @@ void TableStatistics::InitializeRemoveColumn(TableStatistics &parent, idx_t remo
 	D_ASSERT(parent.stats_lock);
 
 	stats_lock = parent.stats_lock;
-	lock_guard<mutex> lock(*stats_lock);
+	annotated_lock_guard lock(*stats_lock);
 	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
 		if (i != removed_column) {
 			column_stats.push_back(parent.column_stats[i]);
@@ -105,7 +105,7 @@ void TableStatistics::InitializeAlterType(TableStatistics &parent, idx_t changed
 	D_ASSERT(parent.stats_lock);
 
 	stats_lock = parent.stats_lock;
-	lock_guard<mutex> lock(*stats_lock);
+	annotated_lock_guard lock(*stats_lock);
 	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
 		if (i == changed_idx) {
 			column_stats.push_back(ColumnStatistics::CreateEmptyStats(new_type));
@@ -126,7 +126,7 @@ void TableStatistics::InitializeAddConstraint(TableStatistics &parent) {
 	D_ASSERT(parent.stats_lock);
 
 	stats_lock = parent.stats_lock;
-	lock_guard<mutex> lock(*stats_lock);
+	annotated_lock_guard lock(*stats_lock);
 	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
 		column_stats.push_back(parent.column_stats[i]);
 	}
@@ -167,10 +167,12 @@ void TableStatistics::MergeStats(idx_t i, BaseStatistics &stats) {
 }
 
 void TableStatistics::MergeStats(TableStatisticsLock &lock, idx_t i, BaseStatistics &stats, StatsMergeType merge_type) {
+	lock.AssertHeld(*stats_lock);
 	column_stats[i]->Statistics().Merge(stats, merge_type);
 }
 
 ColumnStatistics &TableStatistics::GetStats(TableStatisticsLock &lock, idx_t i) {
+	lock.AssertHeld(*stats_lock);
 	return *column_stats[i];
 }
 
@@ -180,14 +182,17 @@ ColumnStatistics &TableStatistics::GetStats(TableStatisticsLock &lock, idx_t i) 
 //}
 
 unique_ptr<BlockingSample> TableStatistics::GetTableSample(TableStatisticsLock &lock) {
+	lock.AssertHeld(*stats_lock);
 	return std::move(table_sample);
 }
 
 void TableStatistics::SetTableSample(TableStatisticsLock &lock, unique_ptr<BlockingSample> sample) {
+	lock.AssertHeld(*stats_lock);
 	table_sample = std::move(sample);
 }
 
 void TableStatistics::DestroyTableSample(TableStatisticsLock &lock) const {
+	lock.AssertHeld(*stats_lock);
 	if (table_sample) {
 		table_sample->Destroy();
 	}
@@ -200,7 +205,7 @@ void TableStatistics::SetStats(TableStatistics &other) {
 }
 
 unique_ptr<BaseStatistics> TableStatistics::CopyStats(const StorageIndex &index) {
-	lock_guard<mutex> l(*stats_lock);
+	annotated_lock_guard l(*stats_lock);
 
 	auto column_index = index.GetPrimaryIndex();
 	auto &stats = *column_stats[column_index];
@@ -220,8 +225,9 @@ void TableStatistics::CopyStats(TableStatistics &other) {
 }
 
 void TableStatistics::CopyStats(TableStatisticsLock &lock, TableStatistics &other) {
+	lock.AssertHeld(*stats_lock);
 	D_ASSERT(other.Empty());
-	other.stats_lock = make_shared_ptr<mutex>();
+	other.stats_lock = make_shared_ptr<annotated_mutex>();
 	for (auto &stats : column_stats) {
 		other.column_stats.push_back(stats->Copy());
 	}
@@ -276,9 +282,10 @@ void TableStatistics::Deserialize(Deserializer &deserializer, ColumnList &column
 	}
 }
 
-unique_ptr<TableStatisticsLock> TableStatistics::GetLock() {
+// Ownership escapes in the heap-allocated token, whose destructor releases the mutex.
+unique_ptr<TableStatisticsLock> TableStatistics::GetLock() DUCKDB_NO_THREAD_SAFETY_ANALYSIS {
 	D_ASSERT(stats_lock);
-	return make_uniq<TableStatisticsLock>(*stats_lock);
+	return unique_ptr<TableStatisticsLock>(new TableStatisticsLock(*stats_lock));
 }
 
 bool TableStatistics::Empty() const {

--- a/src/storage/table/update_segment.cpp
+++ b/src/storage/table/update_segment.cpp
@@ -1060,7 +1060,7 @@ static UpdateSegment::merge_update_function_t GetMergeUpdateFunction(PhysicalTyp
 // Update statistics
 //===--------------------------------------------------------------------===//
 unique_ptr<BaseStatistics> UpdateSegment::GetStatistics() {
-	lock_guard<mutex> stats_guard(stats_lock);
+	annotated_lock_guard stats_guard(stats_lock);
 	return stats.statistics.ToUnique();
 }
 
@@ -1394,7 +1394,7 @@ void UpdateSegment::Update(TransactionData transaction, DuckTableEntry &table_en
 	// update statistics
 	SelectionVector sel;
 	{
-		lock_guard<mutex> stats_guard(stats_lock);
+		annotated_lock_guard stats_guard(stats_lock);
 		count = statistics_update_function(this, stats, update_format, count, sel);
 	}
 	if (count == 0) {

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -200,7 +200,7 @@ TemporaryFileHandle::TemporaryFileHandle(TemporaryFileManager &manager, Temporar
 TemporaryFileHandle::~TemporaryFileHandle() {
 }
 
-TemporaryFileHandle::TemporaryFileLock::TemporaryFileLock(mutex &mutex) : lock(mutex) {
+TemporaryFileHandle::TemporaryFileLock::TemporaryFileLock(annotated_mutex &mutex) : lock(mutex) {
 }
 
 TemporaryFileIndex TemporaryFileHandle::TryGetBlockIndex(idx_t block_header_size) {
@@ -503,7 +503,7 @@ TemporaryFileManager::~TemporaryFileManager() {
 	files.Clear();
 }
 
-TemporaryFileManager::TemporaryFileManagerLock::TemporaryFileManagerLock(mutex &mutex) : lock(mutex) {
+TemporaryFileManager::TemporaryFileManagerLock::TemporaryFileManagerLock(annotated_mutex &mutex) : lock(mutex) {
 }
 
 idx_t TemporaryFileManager::WriteTemporaryBuffer(QueryContext context, block_id_t block_id, FileBuffer &buffer) {
@@ -583,7 +583,7 @@ TemporaryFileManager::CompressBuffer(TemporaryFileCompressionAdaptivity &compres
 }
 
 bool TemporaryFileManager::HasTemporaryBuffer(block_id_t block_id) {
-	lock_guard<mutex> lock(manager_lock);
+	annotated_lock_guard lock(manager_lock);
 	return used_blocks.find(block_id) != used_blocks.end();
 }
 
@@ -689,7 +689,7 @@ idx_t TemporaryFileManager::DeleteTemporaryBuffer(block_id_t id) {
 }
 
 vector<TemporaryFileInformation> TemporaryFileManager::GetTemporaryFiles() {
-	lock_guard<mutex> lock(manager_lock);
+	annotated_lock_guard lock(manager_lock);
 	vector<TemporaryFileInformation> result;
 	for (auto &size : TemporaryBufferSizes()) {
 		for (const auto &file : files.GetMapForSize(size)) {

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -38,6 +38,7 @@
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/transaction/duck_transaction.hpp"
 #include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/table/append_state.hpp"
 #include "duckdb/storage/table/row_group_collection.hpp"
 #include "duckdb/main/profiler/metrics.hpp"
 #include "duckdb/main/query_profiler.hpp"
@@ -1325,6 +1326,10 @@ void WriteAheadLogDeserializer::ReplayRowGroupData() {
 		throw InternalException("Corrupt WAL: insert without table");
 	}
 	auto &storage = state.current_table->GetStorage();
+	auto &transaction = DuckTransaction::Get(context, db);
+	TableAppendState append_state;
+	storage.AppendLock(transaction, append_state);
+	storage.VerifyAppendLock(append_state);
 	auto &table_info = storage.GetDataTableInfo();
 	auto base_row = storage.GetNextRowId();
 	RowGroupCollection new_row_groups(table_info, table_info->GetIOManager(), storage.GetTypes(), base_row);
@@ -1333,7 +1338,6 @@ void WriteAheadLogDeserializer::ReplayRowGroupData() {
 	// if we have any indexes - scan the row groups and add data to the indexes
 	auto &indexes = table_info->GetIndexes();
 	if (!indexes.Empty()) {
-		auto &transaction = DuckTransaction::Get(context, db);
 		// we have indexes - append
 		vector<StorageIndex> column_ids;
 		for (auto &col : state.current_table->GetColumns().Physical()) {


### PR DESCRIPTION
By annotating the mutexes, through clang's analysis a couple (small) problems were found in our use of lock guards. Besides those fixes, annotating these contracts helps everyone that deals with this code.