### PR TITLE
Store latest alpha version of a commit in duckdb-staging

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -1318,6 +1318,8 @@ jobs:
           AWS_ENDPOINT_URL: ${{ secrets.S3_DUCKDB_STAGING_ENDPOINT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
+          DUCKDB_COMMIT: ${{ needs.prepare.outputs.duckdb_commit }}
+          DUCKDB_VERSION: ${{ needs.prepare.outputs.duckdb_version }}
           STAGED_VERSION: ${{ needs.prepare.outputs.staged_version }}
         run: |
           set -euo pipefail
@@ -1342,3 +1344,18 @@ jobs:
             --header-upload "Cache-Control: no-cache" \
             "$pointer_file" \
             ":s3:duckdb-staging/latest_alpha_version.txt"
+
+          target="${DUCKDB_COMMIT:0:10}"
+          printf '%s\n' "$DUCKDB_VERSION" > "$pointer_file"
+
+          rclone copyto \
+            --s3-provider "$s3_provider" \
+            --s3-endpoint "$AWS_ENDPOINT_URL" \
+            --s3-access-key-id "$AWS_ACCESS_KEY_ID" \
+            --s3-secret-access-key "$AWS_SECRET_ACCESS_KEY" \
+            --s3-no-check-bucket \
+            --s3-no-head \
+            --header-upload "Content-Type: text/plain" \
+            --header-upload "Cache-Control: no-cache" \
+            "$pointer_file" \
+            ":s3:duckdb-staging/$target/latest_alpha_version.txt"


### PR DESCRIPTION
Add a commit-scoped `latest_alpha_version.txt` file to the staging bucket.

Consumers can fetch:
```text
https://duckdb-staging.duckdb.org/$commit/latest_alpha_version.txt
```
to determine the latest alpha version built for that specific DuckDB commit.

The overall latest alpha release remains a separate file.