### PR TITLE
[Dev] annotate the `ClientContextLock` and its uses

### DIFF
--- a/src/include/duckdb/main/buffered_data/buffered_data.hpp
+++ b/src/include/duckdb/main/buffered_data/buffered_data.hpp
@@ -22,11 +22,11 @@
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/thread_annotation.hpp"
+#include "duckdb/main/client_context_lock.hpp"
 
 namespace duckdb {
 
 class StreamQueryResult;
-class ClientContextLock;
 
 //! A blocked sink. Holds the InterruptState and owns the finished copy of the chunk it could not append.
 struct BlockedSink {
@@ -68,9 +68,11 @@ public:
 	bool HasParkedProducer();
 	//! Blocking call that executes tasks on the calling thread until a chunk is buffered or execution reaches a
 	//! terminal state.
-	StreamExecutionResult ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock);
+	StreamExecutionResult ReplenishBuffer(StreamQueryResult &result, ClientContextLock &context_lock)
+	    DUCKDB_REQUIRES(context_lock);
 	//! One blocking replenish step: run executor tasks until a chunk is poppable
-	StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock);
+	StreamExecutionResult ExecuteTaskInternal(StreamQueryResult &result, ClientContextLock &context_lock)
+	    DUCKDB_REQUIRES(context_lock);
 	virtual unique_ptr<DataChunk> Scan() = 0;
 	virtual void UnblockSinks() = 0;
 	shared_ptr<ClientContext> GetContext() {

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -29,6 +29,7 @@
 #include "duckdb/transaction/transaction_context.hpp"
 #include "duckdb/common/query_context.hpp"
 #include "duckdb/common/query_parameters.hpp"
+#include "duckdb/main/client_context_lock.hpp"
 
 namespace duckdb {
 class Logger;
@@ -48,7 +49,6 @@ class StatementIterator;
 class Relation;
 class BufferedFileWriter;
 class QueryProfiler;
-class ClientContextLock;
 struct CreateScalarFunctionInfo;
 class ScalarFunctionCatalogEntry;
 struct ActiveQueryContext;
@@ -88,11 +88,11 @@ enum class ClientInterruptState : uint8_t { NOT_INTERRUPTED, INTERRUPTED, INTERR
 //! The ClientContext holds information relevant to the current client session
 //! during execution
 class ClientContext : public enable_shared_from_this<ClientContext> {
-	friend class PendingQueryResult;  // LockContext
+	friend class PendingQueryResult;  // context_lock
 	friend class BufferedData;        // ExecuteTaskInternal
 	friend class SimpleBufferedData;  // ExecuteTaskInternal
 	friend class BatchedBufferedData; // ExecuteTaskInternal
-	friend class StreamQueryResult;   // LockContext
+	friend class StreamQueryResult;   // context_lock
 	friend class ConnectionManager;
 
 public:
@@ -141,47 +141,56 @@ public:
 	DUCKDB_API void ClearInterrupt();
 	//! Suppress all further interrupts for the current query (called after irreversible operations like COMMIT)
 	DUCKDB_API void SuppressInterrupts();
-	DUCKDB_API void CancelTransaction();
+	DUCKDB_API void CancelTransaction() DUCKDB_EXCLUDES(context_lock);
 
 	//! Check for interrupt or timeout, throws InterruptException if triggered
 	DUCKDB_API void InterruptCheck() const;
 
 	//! Enable query profiling
-	DUCKDB_API void EnableProfiling();
+	DUCKDB_API void EnableProfiling() DUCKDB_EXCLUDES(context_lock);
 	//! Disable query profiling
-	DUCKDB_API void DisableProfiling();
+	DUCKDB_API void DisableProfiling() DUCKDB_EXCLUDES(context_lock);
 
 	//! Issue a query, returning a QueryResult. The QueryResult can be either a StreamQueryResult or a
 	//! MaterializedQueryResult. The StreamQueryResult will only be returned in the case of a successful SELECT
 	//! statement.
-	DUCKDB_API unique_ptr<QueryResult> Query(const string &query, QueryParameters query_parameters);
-	DUCKDB_API unique_ptr<QueryResult> Query(unique_ptr<SQLStatement> statement, QueryParameters query_parameters);
+	DUCKDB_API unique_ptr<QueryResult> Query(const string &query, QueryParameters query_parameters)
+	    DUCKDB_EXCLUDES(context_lock);
+	DUCKDB_API unique_ptr<QueryResult> Query(unique_ptr<SQLStatement> statement, QueryParameters query_parameters)
+	    DUCKDB_EXCLUDES(context_lock);
 
 	//! Issues a query to the database and returns a Pending Query Result. Note that "query" may only contain
 	//! a single statement.
-	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(const string &query, QueryParameters query_parameters);
+	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(const string &query, QueryParameters query_parameters)
+	    DUCKDB_EXCLUDES(context_lock);
 	//! Issues a query to the database and returns a Pending Query Result
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(unique_ptr<SQLStatement> statement,
-	                                                       QueryParameters query_parameters);
+	                                                       QueryParameters query_parameters)
+	    DUCKDB_EXCLUDES(context_lock);
 
 	//! Create a pending query with a list of parameters
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(unique_ptr<SQLStatement> statement,
 	                                                       identifier_map_t<BoundParameterData> &values,
-	                                                       QueryParameters query_parameters);
+	                                                       QueryParameters query_parameters)
+	    DUCKDB_EXCLUDES(context_lock);
 	DUCKDB_API unique_ptr<PendingQueryResult>
-	PendingQuery(const string &query, identifier_map_t<BoundParameterData> &values, QueryParameters query_parameters);
-	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(const string &query, PendingQueryParameters parameters);
+	PendingQuery(const string &query, identifier_map_t<BoundParameterData> &values, QueryParameters query_parameters)
+	    DUCKDB_EXCLUDES(context_lock);
+	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(const string &query, PendingQueryParameters parameters)
+	    DUCKDB_EXCLUDES(context_lock);
 
 	//! Run a statement that was generated internally rather than parsed from user SQL. Statement verification
 	//! is skipped, and the client context lock is held for the entire duration of the query.
 	DUCKDB_API unique_ptr<QueryResult> RunInternalStatement(unique_ptr<SQLStatement> statement,
-	                                                        const PendingQueryParameters &parameters);
+	                                                        const PendingQueryParameters &parameters)
+	    DUCKDB_EXCLUDES(context_lock);
 	//! Same as RunInternalStatement, but returns a pending query result that the caller drives
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingInternalStatement(unique_ptr<SQLStatement> statement,
-	                                                                   const PendingQueryParameters &parameters);
+	                                                                   const PendingQueryParameters &parameters)
+	    DUCKDB_EXCLUDES(context_lock);
 
 	//! Destroy the client context
-	DUCKDB_API void Destroy();
+	DUCKDB_API void Destroy() DUCKDB_EXCLUDES(context_lock);
 
 	//! Get the table info of a specific table, or nullptr if it cannot be found.
 	DUCKDB_API unique_ptr<TableDescription> TableInfo(const Identifier &database_name, const Identifier &schema_name,
@@ -202,18 +211,19 @@ public:
 
 	//! Execute a relation
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(const shared_ptr<Relation> &relation,
-	                                                       QueryParameters query_parameters);
-	DUCKDB_API unique_ptr<QueryResult> Execute(const shared_ptr<Relation> &relation);
+	                                                       QueryParameters query_parameters)
+	    DUCKDB_EXCLUDES(context_lock);
+	DUCKDB_API unique_ptr<QueryResult> Execute(const shared_ptr<Relation> &relation) DUCKDB_EXCLUDES(context_lock);
 
 	//! Prepare a query
-	DUCKDB_API unique_ptr<PreparedStatement> Prepare(const string &query);
+	DUCKDB_API unique_ptr<PreparedStatement> Prepare(const string &query) DUCKDB_EXCLUDES(context_lock);
 	//! Directly prepare a SQL statement
-	DUCKDB_API unique_ptr<PreparedStatement> Prepare(unique_ptr<SQLStatement> statement);
+	DUCKDB_API unique_ptr<PreparedStatement> Prepare(unique_ptr<SQLStatement> statement) DUCKDB_EXCLUDES(context_lock);
 	//! Deallocate the prepared statement with the given name - does nothing if it does not exist
-	DUCKDB_API void RemovePreparedStatement(const string &name);
+	DUCKDB_API void RemovePreparedStatement(const string &name) DUCKDB_EXCLUDES(context_lock);
 	//! Bind a statement and return its signature, without building a PreparedStatement, optimizing, or
 	//! executing. Read-only: binding touches no in-flight query state, so a live result survives. Throws on error.
-	DUCKDB_API StatementSignature BindStatement(unique_ptr<SQLStatement> statement);
+	DUCKDB_API StatementSignature BindStatement(unique_ptr<SQLStatement> statement) DUCKDB_EXCLUDES(context_lock);
 
 	//! Gets current percentage of the query's progress, returns 0 in case the progress bar is disabled.
 	DUCKDB_API QueryProgress GetQueryProgress();
@@ -233,15 +243,15 @@ public:
 	                                     optional_ptr<ClientContextLock> lock = nullptr);
 
 	//! Extract the logical plan of a query
-	DUCKDB_API unique_ptr<LogicalOperator> ExtractPlan(const string &query);
+	DUCKDB_API unique_ptr<LogicalOperator> ExtractPlan(const string &query) DUCKDB_EXCLUDES(context_lock);
 
 	//! Runs a function with a valid transaction context, potentially starting a transaction if the context is in auto
 	//! commit mode.
 	DUCKDB_API void RunFunctionInTransaction(const std::function<void(void)> &fun,
-	                                         bool requires_valid_transaction = true);
+	                                         bool requires_valid_transaction = true) DUCKDB_EXCLUDES(context_lock);
 	//! Same as RunFunctionInTransaction, but does not obtain a lock on the client context or check for validation
 	DUCKDB_API void RunFunctionInTransactionInternal(ClientContextLock &lock, const std::function<void(void)> &fun,
-	                                                 bool requires_valid_transaction = true);
+	                                                 bool requires_valid_transaction = true) DUCKDB_REQUIRES(lock);
 
 	//! Equivalent to CURRENT_SETTING(key) SQL function.
 	DUCKDB_API SettingLookupResult TryGetCurrentSetting(const Identifier &key, Value &result) const;
@@ -252,7 +262,7 @@ public:
 	DUCKDB_API ParserOptions GetParserOptions();
 
 	//! Whether or not the given result object (streaming query result or pending query result) is active
-	DUCKDB_API bool IsActiveResult(ClientContextLock &lock, BaseQueryResult &result);
+	DUCKDB_API bool IsActiveResult(ClientContextLock &lock, BaseQueryResult &result) DUCKDB_REQUIRES(lock);
 
 	//! Returns the current executor
 	Executor &GetExecutor();
@@ -268,7 +278,8 @@ public:
 	//! Fetch the set of tables names of the query.
 	//! Returns the fully qualified, escaped table names, if qualified is set to true,
 	//! else returns the not qualified, not escaped table names.
-	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false);
+	DUCKDB_API unordered_set<string> GetTableNames(const string &query, const bool qualified = false)
+	    DUCKDB_EXCLUDES(context_lock);
 
 	DUCKDB_API ClientProperties GetClientProperties();
 
@@ -278,68 +289,76 @@ public:
 	//! Process an error for display to the user
 	DUCKDB_API void ProcessError(ErrorData &error, const string &query) const;
 
-	DUCKDB_API LogicalType ParseLogicalType(const string &type);
+	DUCKDB_API LogicalType ParseLogicalType(const string &type) DUCKDB_EXCLUDES(context_lock);
 
 private:
 	//! Issues a query to the database and returns a Pending Query Result
 	unique_ptr<PendingQueryResult> PendingQueryInternal(ClientContextLock &lock, unique_ptr<SQLStatement> statement,
-	                                                    const PendingQueryParameters &parameters, bool verify = true);
-	unique_ptr<QueryResult> ExecutePendingQueryInternal(ClientContextLock &lock, PendingQueryResult &query);
+	                                                    const PendingQueryParameters &parameters, bool verify = true)
+	    DUCKDB_REQUIRES(lock);
+	unique_ptr<QueryResult> ExecutePendingQueryInternal(ClientContextLock &lock, PendingQueryResult &query)
+	    DUCKDB_REQUIRES(lock);
 
 	//! Parse statements from a query
-	vector<unique_ptr<SQLStatement>> ParseStatementsInternal(ClientContextLock &lock, const string &query);
+	vector<unique_ptr<SQLStatement>> ParseStatementsInternal(ClientContextLock &lock, const string &query)
+	    DUCKDB_REQUIRES(lock);
 	void StatementVerification(ClientContextLock &lock, unique_ptr<SQLStatement> &statement,
-	                           PendingQueryParameters query_parameters);
+	                           PendingQueryParameters query_parameters) DUCKDB_REQUIRES(lock);
 
-	void InitialCleanup(ClientContextLock &lock);
+	void InitialCleanup(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 	//! Internal clean up, does not lock. Caller must hold the context_lock.
 	void CleanupInternal(ClientContextLock &lock, BaseQueryResult *result = nullptr,
-	                     bool invalidate_transaction = false);
+	                     bool invalidate_transaction = false) DUCKDB_REQUIRES(lock);
 	unique_ptr<PendingQueryResult> PendingStatement(ClientContextLock &lock, unique_ptr<SQLStatement> statement,
-	                                                const PendingQueryParameters &parameters);
+	                                                const PendingQueryParameters &parameters) DUCKDB_REQUIRES(lock);
 	unique_ptr<PendingQueryResult> PendingPreparedStatementInternal(ClientContextLock &lock,
 	                                                                shared_ptr<PreparedStatementData> statement_data_p,
-	                                                                const PendingQueryParameters &parameters);
+	                                                                const PendingQueryParameters &parameters)
+	    DUCKDB_REQUIRES(lock);
 	void CheckIfPreparedStatementIsExecutable(PreparedStatementData &statement);
 
 	//! Internally prepare a SQL statement. Caller must hold the context_lock.
 	shared_ptr<PreparedStatementData> CreatePreparedStatement(ClientContextLock &lock,
 	                                                          unique_ptr<SQLStatement> statement,
-	                                                          PendingQueryParameters parameters);
+	                                                          PendingQueryParameters parameters) DUCKDB_REQUIRES(lock);
 	unique_ptr<PendingQueryResult> PendingStatementInternal(ClientContextLock &lock, unique_ptr<SQLStatement> statement,
-	                                                        const PendingQueryParameters &parameters);
+	                                                        const PendingQueryParameters &parameters)
+	    DUCKDB_REQUIRES(lock);
 	unique_ptr<QueryResult> RunStatementInternal(ClientContextLock &lock, unique_ptr<SQLStatement> statement,
-	                                             const PendingQueryParameters &parameters, bool verify = true);
-	unique_ptr<PreparedStatement> PrepareInternal(ClientContextLock &lock, unique_ptr<SQLStatement> statement);
-	void LogQueryInternal(ClientContextLock &lock, const string &query);
+	                                             const PendingQueryParameters &parameters, bool verify = true)
+	    DUCKDB_REQUIRES(lock);
+	unique_ptr<PreparedStatement> PrepareInternal(ClientContextLock &lock, unique_ptr<SQLStatement> statement)
+	    DUCKDB_REQUIRES(lock);
+	void LogQueryInternal(ClientContextLock &lock, const string &query) DUCKDB_REQUIRES(lock);
 
-	unique_ptr<QueryResult> FetchResultInternal(ClientContextLock &lock, PendingQueryResult &pending);
+	unique_ptr<QueryResult> FetchResultInternal(ClientContextLock &lock, PendingQueryResult &pending)
+	    DUCKDB_REQUIRES(lock);
 
-	unique_ptr<ClientContextLock> LockContext();
-
-	void BeginQueryInternal(ClientContextLock &lock, const SQLStatement &statement);
+	void BeginQueryInternal(ClientContextLock &lock, const SQLStatement &statement) DUCKDB_REQUIRES(lock);
 	ErrorData EndQueryInternal(ClientContextLock &lock, bool success, bool invalidate_transaction,
-	                           optional_ptr<ErrorData> previous_error);
+	                           optional_ptr<ErrorData> previous_error) DUCKDB_REQUIRES(lock);
 
 	//! Wait until a task is available to execute
-	void WaitForTask(ClientContextLock &lock, BaseQueryResult &result);
-	PendingExecutionResult ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result, bool dry_run = false);
+	void WaitForTask(ClientContextLock &lock, BaseQueryResult &result) DUCKDB_REQUIRES(lock);
+	PendingExecutionResult ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result, bool dry_run = false)
+	    DUCKDB_REQUIRES(lock);
 
-	unique_ptr<PendingQueryResult> PendingQueryInternal(ClientContextLock &, const shared_ptr<Relation> &relation,
-	                                                    QueryParameters query_parameters);
+	unique_ptr<PendingQueryResult> PendingQueryInternal(ClientContextLock &lock, const shared_ptr<Relation> &relation,
+	                                                    QueryParameters query_parameters) DUCKDB_REQUIRES(lock);
 
 	template <class T>
 	unique_ptr<T> ErrorResult(ErrorData error, const string &query = string());
 
 	shared_ptr<PreparedStatementData> CreatePreparedStatementInternal(ClientContextLock &lock,
 	                                                                  unique_ptr<SQLStatement> statement,
-	                                                                  PendingQueryParameters parameters);
+	                                                                  PendingQueryParameters parameters)
+	    DUCKDB_REQUIRES(lock);
 
 	bool ErrorInvalidatesTransaction(ExceptionType type);
 
 private:
 	//! Lock on using the ClientContext in parallel
-	mutex context_lock;
+	annotated_mutex context_lock;
 	//! The currently active query context
 	unique_ptr<ActiveQueryContext> active_query;
 	//! The current query progress
@@ -351,18 +370,6 @@ private:
 	//! `Catalog::RemoteExecute(string)` and wraps the returned TableRef into a SelectStatement.
 	weak_ptr<AttachedDatabase> connected_to_database;
 	bool is_connected = false;
-};
-
-class ClientContextLock {
-public:
-	explicit ClientContextLock(mutex &context_lock) : client_guard(context_lock) {
-	}
-
-	~ClientContextLock() {
-	}
-
-private:
-	lock_guard<mutex> client_guard;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -23,17 +23,20 @@
 #include "duckdb/main/client_context_state.hpp"
 #include "duckdb/main/client_properties.hpp"
 #include "duckdb/main/external_dependencies.hpp"
-#include "duckdb/main/pending_query_result.hpp"
 #include "duckdb/main/table_description.hpp"
 #include "duckdb/planner/expression/bound_parameter_data.hpp"
 #include "duckdb/transaction/transaction_context.hpp"
 #include "duckdb/common/query_context.hpp"
 #include "duckdb/common/query_parameters.hpp"
-#include "duckdb/main/client_context_lock.hpp"
+#include "duckdb/common/mutex.hpp"
 
 namespace duckdb {
 class Logger;
 
+class DUCKDB_CAPABILITY("mutex") DUCKDB_SCOPED_CAPABILITY ClientContextLock;
+class BaseQueryResult;
+class QueryResult;
+class PendingQueryResult;
 class Appender;
 class AttachedDatabase;
 class Catalog;
@@ -88,6 +91,7 @@ enum class ClientInterruptState : uint8_t { NOT_INTERRUPTED, INTERRUPTED, INTERR
 //! The ClientContext holds information relevant to the current client session
 //! during execution
 class ClientContext : public enable_shared_from_this<ClientContext> {
+	friend class ClientContextLock;   // context_lock
 	friend class PendingQueryResult;  // context_lock
 	friend class BufferedData;        // ExecuteTaskInternal
 	friend class SimpleBufferedData;  // ExecuteTaskInternal

--- a/src/include/duckdb/main/client_context_lock.hpp
+++ b/src/include/duckdb/main/client_context_lock.hpp
@@ -10,13 +10,14 @@
 
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
 
 class DUCKDB_CAPABILITY("mutex") DUCKDB_SCOPED_CAPABILITY ClientContextLock {
 public:
-	explicit ClientContextLock(annotated_mutex &context_lock) DUCKDB_ACQUIRE(context_lock)
-	    : client_guard(context_lock), locked_mutex(context_lock) {
+	explicit ClientContextLock(ClientContext &context) DUCKDB_ACQUIRE(context.context_lock)
+	    : client_guard(context.context_lock), locked_context(context) {
 	}
 	~ClientContextLock() DUCKDB_RELEASE() = default;
 
@@ -24,14 +25,14 @@ public:
 	ClientContextLock &operator=(const ClientContextLock &) = delete;
 
 	//! Verify that a borrowed guard holds this context's mutex.
-	void AssertHeld(const annotated_mutex &context_lock) const DUCKDB_ASSERT_CAPABILITY(this)
-	    DUCKDB_ASSERT_CAPABILITY(context_lock) {
-		D_ASSERT(&locked_mutex == &context_lock);
+	void AssertHeld(const ClientContext &context) const DUCKDB_ASSERT_CAPABILITY(this)
+	    DUCKDB_ASSERT_CAPABILITY(context.context_lock) {
+		D_ASSERT(&locked_context == &context);
 	}
 
 private:
 	lock_guard<mutex> client_guard;
-	annotated_mutex &locked_mutex;
+	ClientContext &locked_context;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/client_context_lock.hpp
+++ b/src/include/duckdb/main/client_context_lock.hpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/main/client_context_lock.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/mutex.hpp"
+
+namespace duckdb {
+
+class DUCKDB_CAPABILITY("mutex") DUCKDB_SCOPED_CAPABILITY ClientContextLock {
+public:
+	explicit ClientContextLock(annotated_mutex &context_lock) DUCKDB_ACQUIRE(context_lock)
+	    : client_guard(context_lock), locked_mutex(context_lock) {
+	}
+	~ClientContextLock() DUCKDB_RELEASE() = default;
+
+	ClientContextLock(const ClientContextLock &) = delete;
+	ClientContextLock &operator=(const ClientContextLock &) = delete;
+
+	//! Verify that a borrowed guard holds this context's mutex.
+	void AssertHeld(const annotated_mutex &context_lock) const DUCKDB_ASSERT_CAPABILITY(this)
+	    DUCKDB_ASSERT_CAPABILITY(context_lock) {
+		D_ASSERT(&locked_mutex == &context_lock);
+	}
+
+private:
+	lock_guard<mutex> client_guard;
+	annotated_mutex &locked_mutex;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/main/pending_query_result.hpp
+++ b/src/include/duckdb/main/pending_query_result.hpp
@@ -11,10 +11,10 @@
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/common/enums/pending_execution_result.hpp"
 #include "duckdb/execution/executor.hpp"
+#include "duckdb/main/client_context_lock.hpp"
 
 namespace duckdb {
 class ClientContext;
-class ClientContextLock;
 class PreparedStatementData;
 
 class PendingQueryResult : public BaseQueryResult {
@@ -40,16 +40,16 @@ public:
 	//! If this returns NO_TASKS_AVAILABLE, this means currently no meaningful work can be done by the current executor,
 	//!	    but tasks may become available in the future.
 	//! The error message can be obtained by calling GetError() on the PendingQueryResult.
-	DUCKDB_API PendingExecutionResult ExecuteTask();
-	DUCKDB_API PendingExecutionResult CheckPulse();
+	DUCKDB_API PendingExecutionResult ExecuteTask() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API PendingExecutionResult CheckPulse() DUCKDB_EXCLUDES(GetContextMutex());
 	//! Halt execution of the thread until a Task is ready to be executed (use with caution)
-	void WaitForTask();
+	void WaitForTask() DUCKDB_EXCLUDES(GetContextMutex());
 
 	//! Returns the result of the query as an actual query result.
 	//! This returns (mostly) instantly if ExecuteTask has been called until RESULT_READY was returned.
-	DUCKDB_API unique_ptr<QueryResult> Execute();
+	DUCKDB_API unique_ptr<QueryResult> Execute() DUCKDB_EXCLUDES(GetContextMutex());
 
-	DUCKDB_API void Close();
+	DUCKDB_API void Close() DUCKDB_EXCLUDES(GetContextMutex());
 
 	//! Function to determine whether execution is considered finished
 	DUCKDB_API static bool IsResultReady(PendingExecutionResult result);
@@ -60,11 +60,11 @@ private:
 	bool allow_stream_result;
 
 private:
-	void CheckExecutableInternal(ClientContextLock &lock);
+	void CheckExecutableInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 
-	PendingExecutionResult ExecuteTaskInternal(ClientContextLock &lock);
-	unique_ptr<QueryResult> ExecuteInternal(ClientContextLock &lock);
-	unique_ptr<ClientContextLock> LockContext();
+	PendingExecutionResult ExecuteTaskInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
+	unique_ptr<QueryResult> ExecuteInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
+	annotated_mutex &GetContextMutex() const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/pending_query_result.hpp
+++ b/src/include/duckdb/main/pending_query_result.hpp
@@ -40,16 +40,16 @@ public:
 	//! If this returns NO_TASKS_AVAILABLE, this means currently no meaningful work can be done by the current executor,
 	//!	    but tasks may become available in the future.
 	//! The error message can be obtained by calling GetError() on the PendingQueryResult.
-	DUCKDB_API PendingExecutionResult ExecuteTask() DUCKDB_EXCLUDES(GetContextMutex());
-	DUCKDB_API PendingExecutionResult CheckPulse() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API PendingExecutionResult ExecuteTask() DUCKDB_EXCLUDES(GetClientContext().context_lock);
+	DUCKDB_API PendingExecutionResult CheckPulse() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 	//! Halt execution of the thread until a Task is ready to be executed (use with caution)
-	void WaitForTask() DUCKDB_EXCLUDES(GetContextMutex());
+	void WaitForTask() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 
 	//! Returns the result of the query as an actual query result.
 	//! This returns (mostly) instantly if ExecuteTask has been called until RESULT_READY was returned.
-	DUCKDB_API unique_ptr<QueryResult> Execute() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API unique_ptr<QueryResult> Execute() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 
-	DUCKDB_API void Close() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API void Close() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 
 	//! Function to determine whether execution is considered finished
 	DUCKDB_API static bool IsResultReady(PendingExecutionResult result);
@@ -64,7 +64,7 @@ private:
 
 	PendingExecutionResult ExecuteTaskInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 	unique_ptr<QueryResult> ExecuteInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
-	annotated_mutex &GetContextMutex() const;
+	ClientContext &GetClientContext() const;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/main/statement_iterator.hpp
+++ b/src/include/duckdb/main/statement_iterator.hpp
@@ -13,10 +13,10 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/parse_iterator.hpp"
+#include "duckdb/main/client_context_lock.hpp"
 
 namespace duckdb {
 class ClientContext;
-class ClientContextLock;
 class SQLStatement;
 
 //! Iterator over the engine-facing statements of a query.
@@ -58,11 +58,11 @@ public:
 	//! Self-locking variant for callers that do not hold the context lock.
 	DUCKDB_API unique_ptr<SQLStatement> GetStatement();
 	//! Same, for callers that already hold the context lock.
-	DUCKDB_API unique_ptr<SQLStatement> GetStatementWithLock(ClientContextLock &lock);
+	DUCKDB_API unique_ptr<SQLStatement> GetStatementWithLock(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 	//! Pull the next statement and attach its parser timing to the per-statement query profiler.
 	DUCKDB_API unique_ptr<SQLStatement> GetStatementForExecution();
 	//! Same, for callers that already hold the context lock.
-	DUCKDB_API unique_ptr<SQLStatement> GetStatementForExecutionWithLock(ClientContextLock &lock);
+	DUCKDB_API unique_ptr<SQLStatement> GetStatementForExecutionWithLock(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 
 private:
 	//! Shared body for both Get variants. `lock` is null for the self-locking path (preprocessing

--- a/src/include/duckdb/main/stream_query_result.hpp
+++ b/src/include/duckdb/main/stream_query_result.hpp
@@ -41,15 +41,15 @@ public:
 public:
 	static bool IsChunkReady(StreamExecutionResult result);
 	//! Reschedules the tasks that work on producing a result chunk, returning when at least one task can be executed
-	DUCKDB_API void WaitForTask() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API void WaitForTask() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 	//! Executes a single task within the final pipeline, returning whether or not a chunk is ready to be fetched
-	DUCKDB_API StreamExecutionResult ExecuteTask() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API StreamExecutionResult ExecuteTask() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 	//! Converts the QueryResult to a string
 	DUCKDB_API string ToString() override;
 	//! Materializes the query result and turns it into a materialized query result
-	DUCKDB_API unique_ptr<MaterializedQueryResult> Materialize() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API unique_ptr<MaterializedQueryResult> Materialize() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 
-	DUCKDB_API bool IsOpen() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API bool IsOpen() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 
 	//! The buffer backing this stream result
 	BufferedData &GetBufferedData() {
@@ -62,20 +62,20 @@ public:
 	}
 
 	//! Closes the StreamQueryResult
-	DUCKDB_API void Close() DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API void Close() DUCKDB_EXCLUDES(GetClientContext().context_lock);
 
 	//! The client context this StreamQueryResult belongs to
 	shared_ptr<ClientContext> context;
 
 protected:
-	DUCKDB_API unique_ptr<DataChunk> FetchInternal() override DUCKDB_EXCLUDES(GetContextMutex());
+	DUCKDB_API unique_ptr<DataChunk> FetchInternal() override DUCKDB_EXCLUDES(GetClientContext().context_lock);
 
 private:
 	StreamExecutionResult ExecuteTaskInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 	unique_ptr<DataChunk> FetchNextInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 	//! The materialize of a stream a fetch already chose: the remainder is copied out under the cap
 	unique_ptr<MaterializedQueryResult> MaterializeByDraining();
-	annotated_mutex &GetContextMutex() const;
+	ClientContext &GetClientContext() const;
 	void CheckExecutableInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 	bool IsOpenInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 

--- a/src/include/duckdb/main/stream_query_result.hpp
+++ b/src/include/duckdb/main/stream_query_result.hpp
@@ -14,11 +14,11 @@
 #include "duckdb/common/queue.hpp"
 #include "duckdb/common/enums/stream_execution_result.hpp"
 #include "duckdb/main/buffered_data/simple_buffered_data.hpp"
+#include "duckdb/main/client_context_lock.hpp"
 
 namespace duckdb {
 
 class ClientContext;
-class ClientContextLock;
 class Executor;
 class MaterializedQueryResult;
 class PreparedStatementData;
@@ -41,15 +41,15 @@ public:
 public:
 	static bool IsChunkReady(StreamExecutionResult result);
 	//! Reschedules the tasks that work on producing a result chunk, returning when at least one task can be executed
-	DUCKDB_API void WaitForTask();
+	DUCKDB_API void WaitForTask() DUCKDB_EXCLUDES(GetContextMutex());
 	//! Executes a single task within the final pipeline, returning whether or not a chunk is ready to be fetched
-	DUCKDB_API StreamExecutionResult ExecuteTask();
+	DUCKDB_API StreamExecutionResult ExecuteTask() DUCKDB_EXCLUDES(GetContextMutex());
 	//! Converts the QueryResult to a string
 	DUCKDB_API string ToString() override;
 	//! Materializes the query result and turns it into a materialized query result
-	DUCKDB_API unique_ptr<MaterializedQueryResult> Materialize();
+	DUCKDB_API unique_ptr<MaterializedQueryResult> Materialize() DUCKDB_EXCLUDES(GetContextMutex());
 
-	DUCKDB_API bool IsOpen();
+	DUCKDB_API bool IsOpen() DUCKDB_EXCLUDES(GetContextMutex());
 
 	//! The buffer backing this stream result
 	BufferedData &GetBufferedData() {
@@ -62,22 +62,22 @@ public:
 	}
 
 	//! Closes the StreamQueryResult
-	DUCKDB_API void Close();
+	DUCKDB_API void Close() DUCKDB_EXCLUDES(GetContextMutex());
 
 	//! The client context this StreamQueryResult belongs to
 	shared_ptr<ClientContext> context;
 
 protected:
-	DUCKDB_API unique_ptr<DataChunk> FetchInternal() override;
+	DUCKDB_API unique_ptr<DataChunk> FetchInternal() override DUCKDB_EXCLUDES(GetContextMutex());
 
 private:
-	StreamExecutionResult ExecuteTaskInternal(ClientContextLock &lock);
-	unique_ptr<DataChunk> FetchNextInternal(ClientContextLock &lock);
+	StreamExecutionResult ExecuteTaskInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
+	unique_ptr<DataChunk> FetchNextInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 	//! The materialize of a stream a fetch already chose: the remainder is copied out under the cap
 	unique_ptr<MaterializedQueryResult> MaterializeByDraining();
-	unique_ptr<ClientContextLock> LockContext();
-	void CheckExecutableInternal(ClientContextLock &lock);
-	bool IsOpenInternal(ClientContextLock &lock);
+	annotated_mutex &GetContextMutex() const;
+	void CheckExecutableInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
+	bool IsOpenInternal(ClientContextLock &lock) DUCKDB_REQUIRES(lock);
 
 private:
 	shared_ptr<BufferedData> buffered_data;

--- a/src/include/duckdb/planner/statement_preprocessor.hpp
+++ b/src/include/duckdb/planner/statement_preprocessor.hpp
@@ -13,10 +13,10 @@
 #include "duckdb/parser/statement/pragma_statement.hpp"
 #include "duckdb/transaction/transaction_context.hpp"
 #include "duckdb/common/enums/current_transaction_state.hpp"
+#include "duckdb/main/client_context_lock.hpp"
 
 namespace duckdb {
 class ClientContext;
-class ClientContextLock;
 class SQLStatement;
 struct PragmaInfo;
 //! Preprocesses parsed statements: expands pragmas, unpacks multi-statements, and wraps in transactions
@@ -24,9 +24,9 @@ class StatementPreprocessor {
 public:
 	explicit StatementPreprocessor(ClientContext &context);
 	void Preprocess(ClientContextLock &lock, vector<unique_ptr<SQLStatement>> &statements,
-	                CurrentTransactionState transaction_context_state);
+	                CurrentTransactionState transaction_context_state) DUCKDB_REQUIRES(lock);
 	void PreprocessInternal(ClientContextLock &lock, vector<unique_ptr<SQLStatement>> &statements,
-	                        CurrentTransactionState transaction_context_state);
+	                        CurrentTransactionState transaction_context_state) DUCKDB_REQUIRES(lock);
 
 private:
 	ClientContext &context;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_context_lock.hpp"
 
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
@@ -267,7 +268,7 @@ static unique_ptr<SQLStatement> WrapAsSelect(unique_ptr<TableRef> from_ref) {
 }
 
 void ClientContext::Destroy() {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	if (transaction.HasActiveTransaction()) {
 		transaction.ResetActiveQuery();
 		if (!transaction.IsAutoCommit()) {
@@ -293,7 +294,7 @@ unique_ptr<T> ClientContext::ErrorResult(ErrorData error, const string &query) {
 }
 
 void ClientContext::BeginQueryInternal(ClientContextLock &lock, const SQLStatement &statement) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	// check if we are on AutoCommit. In this case we should start a transaction
 	D_ASSERT(!active_query);
 	auto &db_inst = DatabaseInstance::GetDatabase(*this);
@@ -339,7 +340,7 @@ void ClientContext::BeginQueryInternal(ClientContextLock &lock, const SQLStateme
 
 ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success, bool invalidate_transaction,
                                           optional_ptr<ErrorData> previous_error) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	if (active_query->executor) {
 		active_query->executor->CancelTasks();
 	}
@@ -393,7 +394,7 @@ ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success,
 }
 
 void ClientContext::CleanupInternal(ClientContextLock &lock, BaseQueryResult *result, bool invalidate_transaction) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	if (!active_query) {
 		// no query currently active
 		return;
@@ -447,7 +448,7 @@ connection_t ClientContext::GetConnectionId() const {
 }
 
 unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lock, PendingQueryResult &pending) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	D_ASSERT(active_query);
 	D_ASSERT(active_query->IsOpenResult(pending));
 	D_ASSERT(active_query->prepared);
@@ -480,7 +481,7 @@ static bool IsExplainAnalyze(SQLStatement *statement) {
 shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal(ClientContextLock &lock,
                                                                                  unique_ptr<SQLStatement> statement,
                                                                                  PendingQueryParameters parameters) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	StatementType statement_type = statement->type;
 	auto result = make_shared_ptr<PreparedStatementData>(statement_type);
 
@@ -549,7 +550,7 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(ClientContextLock &lock,
                                                                          unique_ptr<SQLStatement> statement,
                                                                          PendingQueryParameters parameters) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	// check if any client context state could request a rebind
 	bool can_request_rebind = false;
 	for (auto &state : registered_state->States()) {
@@ -637,7 +638,7 @@ unique_ptr<PendingQueryResult>
 ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
                                                 shared_ptr<PreparedStatementData> statement_data_p,
                                                 const PendingQueryParameters &parameters) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	D_ASSERT(active_query);
 	auto &statement_data = *statement_data_p;
 	BindPreparedStatementParameters(*this, statement_data, parameters);
@@ -689,7 +690,7 @@ ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
 }
 
 void ClientContext::WaitForTask(ClientContextLock &lock, BaseQueryResult &result) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	auto &executor = *active_query->executor;
 	if (executor.HasTaskInProgress()) {
 		// This thread is holding a partially processed task, the next step resumes it without waiting.
@@ -710,7 +711,7 @@ bool ClientContext::ErrorInvalidatesTransaction(ExceptionType type) {
 
 PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result,
                                                           bool dry_run) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	D_ASSERT(active_query);
 	D_ASSERT(active_query->IsOpenResult(result));
 	bool invalidate_transaction = true;
@@ -758,7 +759,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 }
 
 void ClientContext::InitialCleanup(ClientContextLock &lock) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	//! Cleanup any open results and reset the interrupted flag
 	CleanupInternal(lock);
 	interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
@@ -775,12 +776,12 @@ StatementIterator ClientContext::IterateStatements(const string &query) {
 void ClientContext::PreprocessStatements(vector<unique_ptr<SQLStatement>> &buffer,
                                          optional_ptr<ClientContextLock> lock) {
 	if (!lock) {
-		ClientContextLock own_lock(context_lock);
+		ClientContextLock own_lock(*this);
 		PreprocessStatements(buffer, own_lock);
 		return;
 	}
 	auto &held_lock = *lock;
-	held_lock.AssertHeld(context_lock);
+	held_lock.AssertHeld(*this);
 	StatementPreprocessor preprocessor(*this);
 	const CurrentTransactionState transaction_state =
 	    transaction.HasActiveTransaction() ? IN_ACTIVE_TRANSACTION : NOT_IN_ACTIVE_TRANSACTION;
@@ -788,7 +789,7 @@ void ClientContext::PreprocessStatements(vector<unique_ptr<SQLStatement>> &buffe
 }
 
 vector<unique_ptr<SQLStatement>> ClientContext::ParseStatementsInternal(ClientContextLock &lock, const string &query) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	try {
 		QueryProfiler::Get(*this).StartQuery(query);
 
@@ -811,7 +812,7 @@ vector<unique_ptr<SQLStatement>> ClientContext::ParseStatementsInternal(ClientCo
 }
 
 unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 
 	auto statements = ParseStatementsInternal(lock, query);
 	if (statements.size() != 1) {
@@ -859,7 +860,7 @@ static PreparedStatementInfo GetPreparedStatementInfo(PreparedStatementData &dat
 
 unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &lock,
                                                              unique_ptr<SQLStatement> statement) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	auto statement_query = statement->query;
 	// prepare the statement under a generated name - the returned PreparedStatement only refers to that name
 	auto name = "duckdb_prepare_internal_" + UUID::ToString(UUID::GenerateRandomUUID());
@@ -884,12 +885,12 @@ unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &
 }
 
 void ClientContext::RemovePreparedStatement(const string &name) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	client_data->prepared_statements.erase(Identifier(name));
 }
 
 unique_ptr<PreparedStatement> ClientContext::Prepare(unique_ptr<SQLStatement> statement) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	// Store the query in case of an error.
 	auto query = statement->query;
 
@@ -903,7 +904,7 @@ unique_ptr<PreparedStatement> ClientContext::Prepare(unique_ptr<SQLStatement> st
 }
 
 StatementSignature ClientContext::BindStatement(unique_ptr<SQLStatement> statement) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	auto named_param_map = statement->named_param_map;
 	StatementSignature signature;
 	ErrorData bind_error;
@@ -947,7 +948,7 @@ StatementSignature ClientContext::BindStatement(unique_ptr<SQLStatement> stateme
 }
 
 unique_ptr<PreparedStatement> ClientContext::Prepare(const string &query) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	// prepare the query
 	try {
 		InitialCleanup(lock);
@@ -969,7 +970,7 @@ unique_ptr<PreparedStatement> ClientContext::Prepare(const string &query) {
 unique_ptr<PendingQueryResult> ClientContext::PendingStatementInternal(ClientContextLock &lock,
                                                                        unique_ptr<SQLStatement> statement,
                                                                        const PendingQueryParameters &parameters) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	// prepare the query for execution
 	if (!statement->named_param_map.empty() && parameters.parameters) {
 		PreparedStatement::VerifyParameters(*parameters.parameters, statement->named_param_map, this);
@@ -990,7 +991,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementInternal(ClientCon
 
 unique_ptr<QueryResult> ClientContext::RunStatementInternal(ClientContextLock &lock, unique_ptr<SQLStatement> statement,
                                                             const PendingQueryParameters &parameters, bool verify) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	auto pending = PendingQueryInternal(lock, std::move(statement), parameters, verify);
 	if (pending->HasError()) {
 		return ErrorResult<MaterializedQueryResult>(pending->GetErrorObject());
@@ -999,7 +1000,7 @@ unique_ptr<QueryResult> ClientContext::RunStatementInternal(ClientContextLock &l
 }
 
 bool ClientContext::IsActiveResult(ClientContextLock &lock, BaseQueryResult &result) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	if (!active_query) {
 		return false;
 	}
@@ -1017,7 +1018,7 @@ static bool HasBoundParameterValues(const SQLStatement &statement) {
 unique_ptr<PendingQueryResult> ClientContext::PendingStatement(ClientContextLock &lock,
                                                                unique_ptr<SQLStatement> statement,
                                                                const PendingQueryParameters &parameters) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	// CONNECT chokepoint: when connected, non-control SQL is rewritten in place and falls through to
 	// the normal pipeline. No recursion — the rewrite goes through PendingStatementInternal, not back here.
 	if (is_connected) {
@@ -1092,7 +1093,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatement(ClientContextLock
 }
 
 void ClientContext::LogQueryInternal(ClientContextLock &lock, const string &query) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	if (!client_data->log_query_writer) {
 #ifdef DUCKDB_FORCE_QUERY_LOG
 		try {
@@ -1125,7 +1126,7 @@ unique_ptr<QueryResult> ClientContext::Query(unique_ptr<SQLStatement> statement,
 }
 
 unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameters query_parameters) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	// The lazy path bypasses ParseStatementsInternal → InitialCleanup, so clear leftover query state
 	// (interrupt flag, etc.) ourselves.
 	InitialCleanup(lock);
@@ -1250,7 +1251,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query,
 }
 
 unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query, PendingQueryParameters parameters) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	try {
 		InitialCleanup(lock);
 
@@ -1273,7 +1274,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query, 
 unique_ptr<PendingQueryResult> ClientContext::PendingQuery(unique_ptr<SQLStatement> statement,
                                                            identifier_map_t<BoundParameterData> &values,
                                                            QueryParameters parameters) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	try {
 		InitialCleanup(lock);
 
@@ -1289,7 +1290,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(unique_ptr<SQLStateme
 
 unique_ptr<QueryResult> ClientContext::RunInternalStatement(unique_ptr<SQLStatement> statement,
                                                             const PendingQueryParameters &parameters) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	try {
 		InitialCleanup(lock);
 	} catch (std::exception &ex) {
@@ -1304,7 +1305,7 @@ unique_ptr<QueryResult> ClientContext::RunInternalStatement(unique_ptr<SQLStatem
 
 unique_ptr<PendingQueryResult> ClientContext::PendingInternalStatement(unique_ptr<SQLStatement> statement,
                                                                        const PendingQueryParameters &parameters) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	try {
 		InitialCleanup(lock);
 	} catch (std::exception &ex) {
@@ -1317,7 +1318,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
                                                                    unique_ptr<SQLStatement> statement,
                                                                    const PendingQueryParameters &parameters,
                                                                    bool verify) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	if (verify) {
 		try {
 			StatementVerification(lock, statement, parameters);
@@ -1330,7 +1331,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 }
 
 unique_ptr<QueryResult> ClientContext::ExecutePendingQueryInternal(ClientContextLock &lock, PendingQueryResult &query) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	return query.ExecuteInternal(lock);
 }
 
@@ -1369,18 +1370,18 @@ void ClientContext::InterruptCheck() const {
 }
 
 void ClientContext::CancelTransaction() {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	InitialCleanup(lock);
 }
 
 void ClientContext::EnableProfiling() {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	auto &client_config = ClientConfig::GetConfig(*this);
 	client_config.enable_profiler = true;
 }
 
 void ClientContext::DisableProfiling() {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	auto &client_config = ClientConfig::GetConfig(*this);
 	client_config.enable_profiler = false;
 }
@@ -1406,7 +1407,7 @@ void ClientContext::RegisterFunction(CreateFunctionInfo &info) {
 
 void ClientContext::RunFunctionInTransactionInternal(ClientContextLock &lock, const std::function<void(void)> &fun,
                                                      bool requires_valid_transaction) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	if (requires_valid_transaction && transaction.HasActiveTransaction() &&
 	    ValidChecker::IsInvalidated(ActiveTransaction())) {
 		throw TransactionException(ErrorManager::FormatException(*this, ErrorType::INVALIDATED_TRANSACTION));
@@ -1444,7 +1445,7 @@ void ClientContext::RunFunctionInTransactionInternal(ClientContextLock &lock, co
 }
 
 void ClientContext::RunFunctionInTransaction(const std::function<void(void)> &fun, bool requires_valid_transaction) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	RunFunctionInTransactionInternal(lock, fun, requires_valid_transaction);
 }
 
@@ -1510,7 +1511,7 @@ void ClientContext::TryBindRelation(Relation &relation, vector<ColumnDefinition>
 }
 
 unordered_set<string> ClientContext::GetTableNames(const string &query, const bool qualified) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 
 	// Preprocess before binding so PRAGMA reparse / macro expansion happens up front — GetTableNames
 	// extracts names from the *underlying* query (e.g. `PRAGMA tpch(1)` -> the TPC-H SELECT, whose
@@ -1535,7 +1536,7 @@ unordered_set<string> ClientContext::GetTableNames(const string &query, const bo
 unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContextLock &lock,
                                                                    const shared_ptr<Relation> &relation,
                                                                    QueryParameters query_parameters) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	InitialCleanup(lock);
 
 #ifdef DEBUG
@@ -1552,12 +1553,12 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 
 unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const shared_ptr<Relation> &relation,
                                                            QueryParameters query_parameters) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	return PendingQueryInternal(lock, relation, query_parameters);
 }
 
 unique_ptr<QueryResult> ClientContext::Execute(const shared_ptr<Relation> &relation) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	auto &expected_columns = relation->Columns();
 	auto pending = PendingQueryInternal(lock, relation, false);
 	if (pending->HasError()) {
@@ -1673,7 +1674,7 @@ bool ClientContext::ExecutionIsFinished() {
 }
 
 LogicalType ClientContext::ParseLogicalType(const string &type) {
-	ClientContextLock lock(context_lock);
+	ClientContextLock lock(*this);
 	LogicalType logical_type;
 	RunFunctionInTransactionInternal(lock,
 	                                 [&]() { logical_type = TypeManager::Get(*db).ParseLogicalType(type, *this); });

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -225,10 +225,6 @@ ClientContext::~ClientContext() {
 	Destroy();
 }
 
-unique_ptr<ClientContextLock> ClientContext::LockContext() {
-	return make_uniq<ClientContextLock>(context_lock);
-}
-
 void ClientContext::ConnectToCatalog(const shared_ptr<AttachedDatabase> &target) {
 	D_ASSERT(target);
 	// Pre-flight: Supports(RemoteCapability::CONNECT) is the capability declaration; catalogs that
@@ -271,14 +267,14 @@ static unique_ptr<SQLStatement> WrapAsSelect(unique_ptr<TableRef> from_ref) {
 }
 
 void ClientContext::Destroy() {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	if (transaction.HasActiveTransaction()) {
 		transaction.ResetActiveQuery();
 		if (!transaction.IsAutoCommit()) {
 			transaction.Rollback(nullptr);
 		}
 	}
-	CleanupInternal(*lock);
+	CleanupInternal(lock);
 }
 
 void ClientContext::ProcessError(ErrorData &error, const string &query) const {
@@ -297,6 +293,7 @@ unique_ptr<T> ClientContext::ErrorResult(ErrorData error, const string &query) {
 }
 
 void ClientContext::BeginQueryInternal(ClientContextLock &lock, const SQLStatement &statement) {
+	lock.AssertHeld(context_lock);
 	// check if we are on AutoCommit. In this case we should start a transaction
 	D_ASSERT(!active_query);
 	auto &db_inst = DatabaseInstance::GetDatabase(*this);
@@ -342,6 +339,7 @@ void ClientContext::BeginQueryInternal(ClientContextLock &lock, const SQLStateme
 
 ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success, bool invalidate_transaction,
                                           optional_ptr<ErrorData> previous_error) {
+	lock.AssertHeld(context_lock);
 	if (active_query->executor) {
 		active_query->executor->CancelTasks();
 	}
@@ -395,6 +393,7 @@ ErrorData ClientContext::EndQueryInternal(ClientContextLock &lock, bool success,
 }
 
 void ClientContext::CleanupInternal(ClientContextLock &lock, BaseQueryResult *result, bool invalidate_transaction) {
+	lock.AssertHeld(context_lock);
 	if (!active_query) {
 		// no query currently active
 		return;
@@ -448,6 +447,7 @@ connection_t ClientContext::GetConnectionId() const {
 }
 
 unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lock, PendingQueryResult &pending) {
+	lock.AssertHeld(context_lock);
 	D_ASSERT(active_query);
 	D_ASSERT(active_query->IsOpenResult(pending));
 	D_ASSERT(active_query->prepared);
@@ -480,6 +480,7 @@ static bool IsExplainAnalyze(SQLStatement *statement) {
 shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal(ClientContextLock &lock,
                                                                                  unique_ptr<SQLStatement> statement,
                                                                                  PendingQueryParameters parameters) {
+	lock.AssertHeld(context_lock);
 	StatementType statement_type = statement->type;
 	auto result = make_shared_ptr<PreparedStatementData>(statement_type);
 
@@ -548,6 +549,7 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(ClientContextLock &lock,
                                                                          unique_ptr<SQLStatement> statement,
                                                                          PendingQueryParameters parameters) {
+	lock.AssertHeld(context_lock);
 	// check if any client context state could request a rebind
 	bool can_request_rebind = false;
 	for (auto &state : registered_state->States()) {
@@ -635,6 +637,7 @@ unique_ptr<PendingQueryResult>
 ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
                                                 shared_ptr<PreparedStatementData> statement_data_p,
                                                 const PendingQueryParameters &parameters) {
+	lock.AssertHeld(context_lock);
 	D_ASSERT(active_query);
 	auto &statement_data = *statement_data_p;
 	BindPreparedStatementParameters(*this, statement_data, parameters);
@@ -686,6 +689,7 @@ ClientContext::PendingPreparedStatementInternal(ClientContextLock &lock,
 }
 
 void ClientContext::WaitForTask(ClientContextLock &lock, BaseQueryResult &result) {
+	lock.AssertHeld(context_lock);
 	auto &executor = *active_query->executor;
 	if (executor.HasTaskInProgress()) {
 		// This thread is holding a partially processed task, the next step resumes it without waiting.
@@ -706,6 +710,7 @@ bool ClientContext::ErrorInvalidatesTransaction(ExceptionType type) {
 
 PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &lock, BaseQueryResult &result,
                                                           bool dry_run) {
+	lock.AssertHeld(context_lock);
 	D_ASSERT(active_query);
 	D_ASSERT(active_query->IsOpenResult(result));
 	bool invalidate_transaction = true;
@@ -753,6 +758,7 @@ PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &loc
 }
 
 void ClientContext::InitialCleanup(ClientContextLock &lock) {
+	lock.AssertHeld(context_lock);
 	//! Cleanup any open results and reset the interrupted flag
 	CleanupInternal(lock);
 	interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
@@ -768,20 +774,21 @@ StatementIterator ClientContext::IterateStatements(const string &query) {
 
 void ClientContext::PreprocessStatements(vector<unique_ptr<SQLStatement>> &buffer,
                                          optional_ptr<ClientContextLock> lock) {
-	// Acquire our own lock if the caller doesn't hold one (e.g. the shell); own_lock keeps it alive
-	// for the duration of the preprocess pass.
-	unique_ptr<ClientContextLock> own_lock;
 	if (!lock) {
-		own_lock = LockContext();
-		lock = own_lock.get();
+		ClientContextLock own_lock(context_lock);
+		PreprocessStatements(buffer, own_lock);
+		return;
 	}
+	auto &held_lock = *lock;
+	held_lock.AssertHeld(context_lock);
 	StatementPreprocessor preprocessor(*this);
 	const CurrentTransactionState transaction_state =
 	    transaction.HasActiveTransaction() ? IN_ACTIVE_TRANSACTION : NOT_IN_ACTIVE_TRANSACTION;
-	preprocessor.Preprocess(*lock, buffer, transaction_state);
+	preprocessor.Preprocess(held_lock, buffer, transaction_state);
 }
 
 vector<unique_ptr<SQLStatement>> ClientContext::ParseStatementsInternal(ClientContextLock &lock, const string &query) {
+	lock.AssertHeld(context_lock);
 	try {
 		QueryProfiler::Get(*this).StartQuery(query);
 
@@ -804,15 +811,15 @@ vector<unique_ptr<SQLStatement>> ClientContext::ParseStatementsInternal(ClientCo
 }
 
 unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 
-	auto statements = ParseStatementsInternal(*lock, query);
+	auto statements = ParseStatementsInternal(lock, query);
 	if (statements.size() != 1) {
 		throw InvalidInputException("ExtractPlan can only prepare a single statement");
 	}
 
 	unique_ptr<LogicalOperator> plan;
-	RunFunctionInTransactionInternal(*lock, [&]() {
+	RunFunctionInTransactionInternal(lock, [&]() {
 		Planner planner(*this);
 		planner.CreatePlan(std::move(statements[0]));
 		D_ASSERT(planner.plan);
@@ -852,6 +859,7 @@ static PreparedStatementInfo GetPreparedStatementInfo(PreparedStatementData &dat
 
 unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &lock,
                                                              unique_ptr<SQLStatement> statement) {
+	lock.AssertHeld(context_lock);
 	auto statement_query = statement->query;
 	// prepare the statement under a generated name - the returned PreparedStatement only refers to that name
 	auto name = "duckdb_prepare_internal_" + UUID::ToString(UUID::GenerateRandomUUID());
@@ -876,31 +884,31 @@ unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &
 }
 
 void ClientContext::RemovePreparedStatement(const string &name) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	client_data->prepared_statements.erase(Identifier(name));
 }
 
 unique_ptr<PreparedStatement> ClientContext::Prepare(unique_ptr<SQLStatement> statement) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	// Store the query in case of an error.
 	auto query = statement->query;
 
 	// Try to prepare.
 	try {
-		InitialCleanup(*lock);
-		return PrepareInternal(*lock, std::move(statement));
+		InitialCleanup(lock);
+		return PrepareInternal(lock, std::move(statement));
 	} catch (std::exception &ex) {
 		return ErrorResult<PreparedStatement>(ErrorData(ex), query);
 	}
 }
 
 StatementSignature ClientContext::BindStatement(unique_ptr<SQLStatement> statement) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	auto named_param_map = statement->named_param_map;
 	StatementSignature signature;
 	ErrorData bind_error;
 	RunFunctionInTransactionInternal(
-	    *lock,
+	    lock,
 	    [&]() {
 		    try {
 			    Planner planner(*this);
@@ -939,20 +947,20 @@ StatementSignature ClientContext::BindStatement(unique_ptr<SQLStatement> stateme
 }
 
 unique_ptr<PreparedStatement> ClientContext::Prepare(const string &query) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	// prepare the query
 	try {
-		InitialCleanup(*lock);
+		InitialCleanup(lock);
 
 		// first parse the query
-		auto statements = ParseStatementsInternal(*lock, query);
+		auto statements = ParseStatementsInternal(lock, query);
 		if (statements.empty()) {
 			throw InvalidInputException("No statement to prepare!");
 		}
 		if (statements.size() > 1) {
 			throw InvalidInputException("Cannot prepare multiple statements at once!");
 		}
-		return PrepareInternal(*lock, std::move(statements[0]));
+		return PrepareInternal(lock, std::move(statements[0]));
 	} catch (std::exception &ex) {
 		return ErrorResult<PreparedStatement>(ErrorData(ex), query);
 	}
@@ -961,6 +969,7 @@ unique_ptr<PreparedStatement> ClientContext::Prepare(const string &query) {
 unique_ptr<PendingQueryResult> ClientContext::PendingStatementInternal(ClientContextLock &lock,
                                                                        unique_ptr<SQLStatement> statement,
                                                                        const PendingQueryParameters &parameters) {
+	lock.AssertHeld(context_lock);
 	// prepare the query for execution
 	if (!statement->named_param_map.empty() && parameters.parameters) {
 		PreparedStatement::VerifyParameters(*parameters.parameters, statement->named_param_map, this);
@@ -981,6 +990,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementInternal(ClientCon
 
 unique_ptr<QueryResult> ClientContext::RunStatementInternal(ClientContextLock &lock, unique_ptr<SQLStatement> statement,
                                                             const PendingQueryParameters &parameters, bool verify) {
+	lock.AssertHeld(context_lock);
 	auto pending = PendingQueryInternal(lock, std::move(statement), parameters, verify);
 	if (pending->HasError()) {
 		return ErrorResult<MaterializedQueryResult>(pending->GetErrorObject());
@@ -989,6 +999,7 @@ unique_ptr<QueryResult> ClientContext::RunStatementInternal(ClientContextLock &l
 }
 
 bool ClientContext::IsActiveResult(ClientContextLock &lock, BaseQueryResult &result) {
+	lock.AssertHeld(context_lock);
 	if (!active_query) {
 		return false;
 	}
@@ -1006,6 +1017,7 @@ static bool HasBoundParameterValues(const SQLStatement &statement) {
 unique_ptr<PendingQueryResult> ClientContext::PendingStatement(ClientContextLock &lock,
                                                                unique_ptr<SQLStatement> statement,
                                                                const PendingQueryParameters &parameters) {
+	lock.AssertHeld(context_lock);
 	// CONNECT chokepoint: when connected, non-control SQL is rewritten in place and falls through to
 	// the normal pipeline. No recursion — the rewrite goes through PendingStatementInternal, not back here.
 	if (is_connected) {
@@ -1079,7 +1091,8 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatement(ClientContextLock
 	return pending;
 }
 
-void ClientContext::LogQueryInternal(ClientContextLock &, const string &query) {
+void ClientContext::LogQueryInternal(ClientContextLock &lock, const string &query) {
+	lock.AssertHeld(context_lock);
 	if (!client_data->log_query_writer) {
 #ifdef DUCKDB_FORCE_QUERY_LOG
 		try {
@@ -1112,10 +1125,10 @@ unique_ptr<QueryResult> ClientContext::Query(unique_ptr<SQLStatement> statement,
 }
 
 unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameters query_parameters) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	// The lazy path bypasses ParseStatementsInternal → InitialCleanup, so clear leftover query state
 	// (interrupt flag, etc.) ourselves.
-	InitialCleanup(*lock);
+	InitialCleanup(lock);
 	auto &profiler = QueryProfiler::Get(*this);
 	profiler.StartQuery(query);
 	// ParseIterator's constructor runs UTF-8 validation / Unicode-space strip and can throw — route
@@ -1162,7 +1175,7 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameter
 		// nothing, in which case statement is null and there is nothing to execute.
 		unique_ptr<SQLStatement> statement;
 		try {
-			statement = iterator.GetStatementForExecutionWithLock(*lock);
+			statement = iterator.GetStatementForExecutionWithLock(lock);
 		} catch (const std::exception &ex) {
 			return ErrorResult<MaterializedQueryResult>(ErrorData(ex), query);
 		}
@@ -1180,13 +1193,13 @@ unique_ptr<QueryResult> ClientContext::Query(const string &query, QueryParameter
 			if (!is_last_overall) {
 				parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
 			}
-			auto pending_query = PendingQueryInternal(*lock, std::move(statement), parameters);
+			auto pending_query = PendingQueryInternal(lock, std::move(statement), parameters);
 			auto has_result = pending_query->GetStatementProperties().return_type == StatementReturnType::QUERY_RESULT;
 			unique_ptr<QueryResult> current_result;
 			if (pending_query->HasError()) {
 				current_result = ErrorResult<MaterializedQueryResult>(pending_query->GetErrorObject());
 			} else {
-				current_result = ExecutePendingQueryInternal(*lock, *pending_query);
+				current_result = ExecutePendingQueryInternal(lock, *pending_query);
 			}
 			if (current_result->HasError()) {
 				if (transaction.HasActiveTransaction() && transaction.GetAutoRollback()) {
@@ -1237,11 +1250,11 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query,
 }
 
 unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query, PendingQueryParameters parameters) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	try {
-		InitialCleanup(*lock);
+		InitialCleanup(lock);
 
-		auto statements = ParseStatementsInternal(*lock, query);
+		auto statements = ParseStatementsInternal(lock, query);
 		if (statements.empty()) {
 			throw InvalidInputException("No statement to prepare!");
 		}
@@ -1249,7 +1262,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query, 
 			throw InvalidInputException("Cannot prepare multiple statements at once!");
 		}
 
-		return PendingQueryInternal(*lock, std::move(statements[0]), parameters, true);
+		return PendingQueryInternal(lock, std::move(statements[0]), parameters, true);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);
 		ProcessError(error, query);
@@ -1260,15 +1273,15 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query, 
 unique_ptr<PendingQueryResult> ClientContext::PendingQuery(unique_ptr<SQLStatement> statement,
                                                            identifier_map_t<BoundParameterData> &values,
                                                            QueryParameters parameters) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	try {
-		InitialCleanup(*lock);
+		InitialCleanup(lock);
 
 		PendingQueryParameters params;
 		params.query_parameters = parameters;
 		params.parameters = values;
 
-		return PendingQueryInternal(*lock, std::move(statement), params, true);
+		return PendingQueryInternal(lock, std::move(statement), params, true);
 	} catch (std::exception &ex) {
 		return make_uniq<PendingQueryResult>(ErrorData(ex));
 	}
@@ -1276,34 +1289,35 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(unique_ptr<SQLStateme
 
 unique_ptr<QueryResult> ClientContext::RunInternalStatement(unique_ptr<SQLStatement> statement,
                                                             const PendingQueryParameters &parameters) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	try {
-		InitialCleanup(*lock);
+		InitialCleanup(lock);
 	} catch (std::exception &ex) {
 		return ErrorResult<MaterializedQueryResult>(ErrorData(ex), statement->query);
 	}
-	auto pending = PendingQueryInternal(*lock, std::move(statement), parameters, false);
+	auto pending = PendingQueryInternal(lock, std::move(statement), parameters, false);
 	if (pending->HasError()) {
 		return ErrorResult<MaterializedQueryResult>(pending->GetErrorObject());
 	}
-	return pending->ExecuteInternal(*lock);
+	return pending->ExecuteInternal(lock);
 }
 
 unique_ptr<PendingQueryResult> ClientContext::PendingInternalStatement(unique_ptr<SQLStatement> statement,
                                                                        const PendingQueryParameters &parameters) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	try {
-		InitialCleanup(*lock);
+		InitialCleanup(lock);
 	} catch (std::exception &ex) {
 		return ErrorResult<PendingQueryResult>(ErrorData(ex), statement->query);
 	}
-	return PendingQueryInternal(*lock, std::move(statement), parameters, false);
+	return PendingQueryInternal(lock, std::move(statement), parameters, false);
 }
 
 unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContextLock &lock,
                                                                    unique_ptr<SQLStatement> statement,
                                                                    const PendingQueryParameters &parameters,
                                                                    bool verify) {
+	lock.AssertHeld(context_lock);
 	if (verify) {
 		try {
 			StatementVerification(lock, statement, parameters);
@@ -1316,6 +1330,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 }
 
 unique_ptr<QueryResult> ClientContext::ExecutePendingQueryInternal(ClientContextLock &lock, PendingQueryResult &query) {
+	lock.AssertHeld(context_lock);
 	return query.ExecuteInternal(lock);
 }
 
@@ -1354,18 +1369,18 @@ void ClientContext::InterruptCheck() const {
 }
 
 void ClientContext::CancelTransaction() {
-	auto lock = LockContext();
-	InitialCleanup(*lock);
+	ClientContextLock lock(context_lock);
+	InitialCleanup(lock);
 }
 
 void ClientContext::EnableProfiling() {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	auto &client_config = ClientConfig::GetConfig(*this);
 	client_config.enable_profiler = true;
 }
 
 void ClientContext::DisableProfiling() {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	auto &client_config = ClientConfig::GetConfig(*this);
 	client_config.enable_profiler = false;
 }
@@ -1391,6 +1406,7 @@ void ClientContext::RegisterFunction(CreateFunctionInfo &info) {
 
 void ClientContext::RunFunctionInTransactionInternal(ClientContextLock &lock, const std::function<void(void)> &fun,
                                                      bool requires_valid_transaction) {
+	lock.AssertHeld(context_lock);
 	if (requires_valid_transaction && transaction.HasActiveTransaction() &&
 	    ValidChecker::IsInvalidated(ActiveTransaction())) {
 		throw TransactionException(ErrorManager::FormatException(*this, ErrorType::INVALIDATED_TRANSACTION));
@@ -1428,8 +1444,8 @@ void ClientContext::RunFunctionInTransactionInternal(ClientContextLock &lock, co
 }
 
 void ClientContext::RunFunctionInTransaction(const std::function<void(void)> &fun, bool requires_valid_transaction) {
-	auto lock = LockContext();
-	RunFunctionInTransactionInternal(*lock, fun, requires_valid_transaction);
+	ClientContextLock lock(context_lock);
+	RunFunctionInTransactionInternal(lock, fun, requires_valid_transaction);
 }
 
 unique_ptr<TableDescription> ClientContext::TableInfo(const Identifier &database_name, const Identifier &schema_name,
@@ -1494,18 +1510,18 @@ void ClientContext::TryBindRelation(Relation &relation, vector<ColumnDefinition>
 }
 
 unordered_set<string> ClientContext::GetTableNames(const string &query, const bool qualified) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 
 	// Preprocess before binding so PRAGMA reparse / macro expansion happens up front — GetTableNames
 	// extracts names from the *underlying* query (e.g. `PRAGMA tpch(1)` -> the TPC-H SELECT, whose
 	// tables are what the caller wants). A raw, un-preprocessed PRAGMA would never surface them.
-	auto statements = ParseStatementsInternal(*lock, query);
+	auto statements = ParseStatementsInternal(lock, query);
 	if (statements.size() != 1) {
 		throw InvalidInputException("Expected a single statement");
 	}
 
 	unordered_set<string> result;
-	RunFunctionInTransactionInternal(*lock, [&]() {
+	RunFunctionInTransactionInternal(lock, [&]() {
 		// bind the expressions
 		auto binder = Binder::CreateBinder(*this);
 		auto mode = qualified ? BindingMode::EXTRACT_QUALIFIED_NAMES : BindingMode::EXTRACT_NAMES;
@@ -1519,6 +1535,7 @@ unordered_set<string> ClientContext::GetTableNames(const string &query, const bo
 unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContextLock &lock,
                                                                    const shared_ptr<Relation> &relation,
                                                                    QueryParameters query_parameters) {
+	lock.AssertHeld(context_lock);
 	InitialCleanup(lock);
 
 #ifdef DEBUG
@@ -1535,20 +1552,20 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 
 unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const shared_ptr<Relation> &relation,
                                                            QueryParameters query_parameters) {
-	auto lock = LockContext();
-	return PendingQueryInternal(*lock, relation, query_parameters);
+	ClientContextLock lock(context_lock);
+	return PendingQueryInternal(lock, relation, query_parameters);
 }
 
 unique_ptr<QueryResult> ClientContext::Execute(const shared_ptr<Relation> &relation) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	auto &expected_columns = relation->Columns();
-	auto pending = PendingQueryInternal(*lock, relation, false);
+	auto pending = PendingQueryInternal(lock, relation, false);
 	if (pending->HasError()) {
 		return ErrorResult<MaterializedQueryResult>(pending->GetErrorObject());
 	}
 
 	unique_ptr<QueryResult> result;
-	result = ExecutePendingQueryInternal(*lock, *pending);
+	result = ExecutePendingQueryInternal(lock, *pending);
 	if (result->HasError()) {
 		return result;
 	}
@@ -1656,9 +1673,9 @@ bool ClientContext::ExecutionIsFinished() {
 }
 
 LogicalType ClientContext::ParseLogicalType(const string &type) {
-	auto lock = LockContext();
+	ClientContextLock lock(context_lock);
 	LogicalType logical_type;
-	RunFunctionInTransactionInternal(*lock,
+	RunFunctionInTransactionInternal(lock,
 	                                 [&]() { logical_type = TypeManager::Get(*db).ParseLogicalType(type, *this); });
 	return logical_type;
 }

--- a/src/main/client_verify.cpp
+++ b/src/main/client_verify.cpp
@@ -75,6 +75,7 @@ static void ReplaceStatement(unique_ptr<SQLStatement> &statement, unique_ptr<SQL
 
 void ClientContext::StatementVerification(ClientContextLock &lock, unique_ptr<SQLStatement> &statement,
                                           PendingQueryParameters query_parameters) {
+	lock.AssertHeld(context_lock);
 	auto verification = Settings::Get<DebugVerifyStatementSetting>(*this);
 	if (verification == DebugStatementVerification::COPY_STATEMENT) {
 		if (statement->type == StatementType::LOGICAL_PLAN_STATEMENT) {

--- a/src/main/client_verify.cpp
+++ b/src/main/client_verify.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/error_data.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_context_lock.hpp"
 #include "duckdb/parser/statement/explain_statement.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/common/enums/debug_statement_verification.hpp"
@@ -75,7 +76,7 @@ static void ReplaceStatement(unique_ptr<SQLStatement> &statement, unique_ptr<SQL
 
 void ClientContext::StatementVerification(ClientContextLock &lock, unique_ptr<SQLStatement> &statement,
                                           PendingQueryParameters query_parameters) {
-	lock.AssertHeld(context_lock);
+	lock.AssertHeld(*this);
 	auto verification = Settings::Get<DebugVerifyStatementSetting>(*this);
 	if (verification == DebugStatementVerification::COPY_STATEMENT) {
 		if (statement->type == StatementType::LOGICAL_PLAN_STATEMENT) {

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -20,7 +20,7 @@ PendingQueryResult::PendingQueryResult(ErrorData error)
 PendingQueryResult::~PendingQueryResult() {
 }
 
-annotated_mutex &PendingQueryResult::GetContextMutex() const {
+ClientContext &PendingQueryResult::GetClientContext() const {
 	if (!context) {
 		if (HasError()) {
 			throw InvalidInputException(
@@ -28,7 +28,7 @@ annotated_mutex &PendingQueryResult::GetContextMutex() const {
 		}
 		throw InvalidInputException("Attempting to execute an unsuccessful or closed pending query result");
 	}
-	return context->context_lock;
+	return *context;
 }
 
 void PendingQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
@@ -46,17 +46,17 @@ void PendingQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
 }
 
 void PendingQueryResult::WaitForTask() {
-	ClientContextLock lock(GetContextMutex());
+	ClientContextLock lock(GetClientContext());
 	context->WaitForTask(lock, *this);
 }
 
 PendingExecutionResult PendingQueryResult::ExecuteTask() {
-	ClientContextLock lock(GetContextMutex());
+	ClientContextLock lock(GetClientContext());
 	return ExecuteTaskInternal(lock);
 }
 
 PendingExecutionResult PendingQueryResult::CheckPulse() {
-	ClientContextLock lock(GetContextMutex());
+	ClientContextLock lock(GetClientContext());
 	CheckExecutableInternal(lock);
 	return context->ExecuteTaskInternal(lock, *this, true);
 }
@@ -94,13 +94,13 @@ unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &l
 }
 
 unique_ptr<QueryResult> PendingQueryResult::Execute() {
-	ClientContextLock lock(GetContextMutex());
+	ClientContextLock lock(GetClientContext());
 	return ExecuteInternal(lock);
 }
 
 void PendingQueryResult::Close() {
 	if (context) {
-		ClientContextLock lock(GetContextMutex());
+		ClientContextLock lock(GetClientContext());
 		if (context->IsActiveResult(lock, *this)) {
 			// Abandoned before execution finished: release the active-query state now (matching
 			// InitialCleanup) instead of leaking it until the next query or context teardown.

--- a/src/main/pending_query_result.cpp
+++ b/src/main/pending_query_result.cpp
@@ -20,7 +20,7 @@ PendingQueryResult::PendingQueryResult(ErrorData error)
 PendingQueryResult::~PendingQueryResult() {
 }
 
-unique_ptr<ClientContextLock> PendingQueryResult::LockContext() {
+annotated_mutex &PendingQueryResult::GetContextMutex() const {
 	if (!context) {
 		if (HasError()) {
 			throw InvalidInputException(
@@ -28,7 +28,7 @@ unique_ptr<ClientContextLock> PendingQueryResult::LockContext() {
 		}
 		throw InvalidInputException("Attempting to execute an unsuccessful or closed pending query result");
 	}
-	return context->LockContext();
+	return context->context_lock;
 }
 
 void PendingQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
@@ -46,19 +46,19 @@ void PendingQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
 }
 
 void PendingQueryResult::WaitForTask() {
-	auto lock = LockContext();
-	context->WaitForTask(*lock, *this);
+	ClientContextLock lock(GetContextMutex());
+	context->WaitForTask(lock, *this);
 }
 
 PendingExecutionResult PendingQueryResult::ExecuteTask() {
-	auto lock = LockContext();
-	return ExecuteTaskInternal(*lock);
+	ClientContextLock lock(GetContextMutex());
+	return ExecuteTaskInternal(lock);
 }
 
 PendingExecutionResult PendingQueryResult::CheckPulse() {
-	auto lock = LockContext();
-	CheckExecutableInternal(*lock);
-	return context->ExecuteTaskInternal(*lock, *this, true);
+	ClientContextLock lock(GetContextMutex());
+	CheckExecutableInternal(lock);
+	return context->ExecuteTaskInternal(lock, *this, true);
 }
 
 bool PendingQueryResult::AllowStreamResult() const {
@@ -94,17 +94,17 @@ unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &l
 }
 
 unique_ptr<QueryResult> PendingQueryResult::Execute() {
-	auto lock = LockContext();
-	return ExecuteInternal(*lock);
+	ClientContextLock lock(GetContextMutex());
+	return ExecuteInternal(lock);
 }
 
 void PendingQueryResult::Close() {
 	if (context) {
-		auto lock = LockContext();
-		if (context->IsActiveResult(*lock, *this)) {
+		ClientContextLock lock(GetContextMutex());
+		if (context->IsActiveResult(lock, *this)) {
 			// Abandoned before execution finished: release the active-query state now (matching
 			// InitialCleanup) instead of leaking it until the next query or context teardown.
-			context->CleanupInternal(*lock, this, false);
+			context->CleanupInternal(lock, this, false);
 		}
 	}
 	context.reset();

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -35,7 +35,7 @@ string StreamQueryResult::ToString() {
 	return result;
 }
 
-annotated_mutex &StreamQueryResult::GetContextMutex() const {
+ClientContext &StreamQueryResult::GetClientContext() const {
 	if (!context) {
 		string error_str = "Attempting to execute an unsuccessful or closed pending query result";
 		if (HasError()) {
@@ -43,7 +43,7 @@ annotated_mutex &StreamQueryResult::GetContextMutex() const {
 		}
 		throw InvalidInputException(error_str);
 	}
-	return context->context_lock;
+	return *context;
 }
 
 StreamExecutionResult StreamQueryResult::ExecuteTaskInternal(ClientContextLock &lock) {
@@ -51,12 +51,12 @@ StreamExecutionResult StreamQueryResult::ExecuteTaskInternal(ClientContextLock &
 }
 
 StreamExecutionResult StreamQueryResult::ExecuteTask() {
-	ClientContextLock lock(GetContextMutex());
+	ClientContextLock lock(GetClientContext());
 	return ExecuteTaskInternal(lock);
 }
 
 void StreamQueryResult::WaitForTask() {
-	ClientContextLock lock(GetContextMutex());
+	ClientContextLock lock(GetClientContext());
 	// Nothing to wait for on a result being materialized; ExecuteTask reports it
 	if (buffered_data->Decide(ResultLifetime::DRAINING) != ResultLifetime::DRAINING) {
 		return;
@@ -112,7 +112,7 @@ unique_ptr<DataChunk> StreamQueryResult::FetchNextInternal(ClientContextLock &lo
 unique_ptr<DataChunk> StreamQueryResult::FetchInternal() {
 	unique_ptr<DataChunk> chunk;
 	{
-		ClientContextLock lock(GetContextMutex());
+		ClientContextLock lock(GetClientContext());
 		CheckExecutableInternal(lock);
 		chunk = FetchNextInternal(lock);
 	}
@@ -179,7 +179,7 @@ unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
 	bool retained;
 	unique_ptr<QueryResult> result;
 	{
-		ClientContextLock lock(GetContextMutex());
+		ClientContextLock lock(GetClientContext());
 		CheckExecutableInternal(lock);
 		retained = buffered_data->Decide(ResultLifetime::RETAINED) == ResultLifetime::RETAINED;
 		if (retained) {
@@ -232,14 +232,14 @@ bool StreamQueryResult::IsOpen() {
 	if (HasError() || !context) {
 		return false;
 	}
-	ClientContextLock lock(GetContextMutex());
+	ClientContextLock lock(GetClientContext());
 	return IsOpenInternal(lock);
 }
 
 void StreamQueryResult::Close() {
 	buffered_data->Close();
 	if (context) {
-		ClientContextLock lock(GetContextMutex());
+		ClientContextLock lock(GetClientContext());
 		if (context->IsActiveResult(lock, *this)) {
 			// Abandoned before the stream was fully drained: release the active-query state now
 			// (matching InitialCleanup) instead of leaking it until the next query or context teardown.

--- a/src/main/stream_query_result.cpp
+++ b/src/main/stream_query_result.cpp
@@ -35,7 +35,7 @@ string StreamQueryResult::ToString() {
 	return result;
 }
 
-unique_ptr<ClientContextLock> StreamQueryResult::LockContext() {
+annotated_mutex &StreamQueryResult::GetContextMutex() const {
 	if (!context) {
 		string error_str = "Attempting to execute an unsuccessful or closed pending query result";
 		if (HasError()) {
@@ -43,7 +43,7 @@ unique_ptr<ClientContextLock> StreamQueryResult::LockContext() {
 		}
 		throw InvalidInputException(error_str);
 	}
-	return context->LockContext();
+	return context->context_lock;
 }
 
 StreamExecutionResult StreamQueryResult::ExecuteTaskInternal(ClientContextLock &lock) {
@@ -51,18 +51,18 @@ StreamExecutionResult StreamQueryResult::ExecuteTaskInternal(ClientContextLock &
 }
 
 StreamExecutionResult StreamQueryResult::ExecuteTask() {
-	auto lock = LockContext();
-	return ExecuteTaskInternal(*lock);
+	ClientContextLock lock(GetContextMutex());
+	return ExecuteTaskInternal(lock);
 }
 
 void StreamQueryResult::WaitForTask() {
-	auto lock = LockContext();
+	ClientContextLock lock(GetContextMutex());
 	// Nothing to wait for on a result being materialized; ExecuteTask reports it
 	if (buffered_data->Decide(ResultLifetime::DRAINING) != ResultLifetime::DRAINING) {
 		return;
 	}
 	buffered_data->UnblockSinks();
-	context->WaitForTask(*lock, *this);
+	context->WaitForTask(lock, *this);
 }
 
 static bool ExecutionErrorOccurred(StreamExecutionResult result) {
@@ -112,9 +112,9 @@ unique_ptr<DataChunk> StreamQueryResult::FetchNextInternal(ClientContextLock &lo
 unique_ptr<DataChunk> StreamQueryResult::FetchInternal() {
 	unique_ptr<DataChunk> chunk;
 	{
-		auto lock = LockContext();
-		CheckExecutableInternal(*lock);
-		chunk = FetchNextInternal(*lock);
+		ClientContextLock lock(GetContextMutex());
+		CheckExecutableInternal(lock);
+		chunk = FetchNextInternal(lock);
 	}
 	if (!chunk || chunk->ColumnCount() == 0 || chunk->size() == 0) {
 		if (!HasError()) {
@@ -179,23 +179,23 @@ unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
 	bool retained;
 	unique_ptr<QueryResult> result;
 	{
-		auto lock = LockContext();
-		CheckExecutableInternal(*lock);
+		ClientContextLock lock(GetContextMutex());
+		CheckExecutableInternal(lock);
 		retained = buffered_data->Decide(ResultLifetime::RETAINED) == ResultLifetime::RETAINED;
 		if (retained) {
 			// Producers append into the sink's collection from here on, so the query runs to
 			// completion and the collection is taken from the sink instead of copied out of the buffer
 			PendingExecutionResult execution_result;
 			while (!PendingQueryResult::IsExecutionFinished(execution_result =
-			                                                    context->ExecuteTaskInternal(*lock, *this))) {
+			                                                    context->ExecuteTaskInternal(lock, *this))) {
 				if (execution_result == PendingExecutionResult::BLOCKED ||
 				    execution_result == PendingExecutionResult::RESULT_READY) {
-					context->WaitForTask(*lock, *this);
+					context->WaitForTask(lock, *this);
 				}
 			}
 			if (execution_result == PendingExecutionResult::EXECUTION_FINISHED) {
 				result = context->GetExecutor().GetResult();
-				context->CleanupInternal(*lock, result.get(), false);
+				context->CleanupInternal(lock, result.get(), false);
 			}
 		}
 	}
@@ -232,18 +232,18 @@ bool StreamQueryResult::IsOpen() {
 	if (HasError() || !context) {
 		return false;
 	}
-	auto lock = LockContext();
-	return IsOpenInternal(*lock);
+	ClientContextLock lock(GetContextMutex());
+	return IsOpenInternal(lock);
 }
 
 void StreamQueryResult::Close() {
 	buffered_data->Close();
 	if (context) {
-		auto lock = LockContext();
-		if (context->IsActiveResult(*lock, *this)) {
+		ClientContextLock lock(GetContextMutex());
+		if (context->IsActiveResult(lock, *this)) {
 			// Abandoned before the stream was fully drained: release the active-query state now
 			// (matching InitialCleanup) instead of leaking it until the next query or context teardown.
-			context->CleanupInternal(*lock, this, false);
+			context->CleanupInternal(lock, this, false);
 		}
 	}
 	context.reset();

--- a/src/planner/statement_preprocessor.cpp
+++ b/src/planner/statement_preprocessor.cpp
@@ -137,8 +137,8 @@ void StatementPreprocessor::Preprocess(ClientContextLock &lock, vector<unique_pt
 		return;
 	}
 
-	context.RunFunctionInTransactionInternal(lock,
-	                                         [&] { PreprocessInternal(lock, statements, transaction_context_state); });
+	context.RunFunctionInTransactionInternal(
+	    lock, [&]() DUCKDB_REQUIRES(lock) { PreprocessInternal(lock, statements, transaction_context_state); });
 }
 
 void StatementPreprocessor::PreprocessInternal(ClientContextLock &lock, vector<unique_ptr<SQLStatement>> &statements,


### PR DESCRIPTION
This one is more trivial than #25515 , no missing locks found

`ClientContextLock` moves to its own header, and now contains a reference to the `ClientContext` that it's related to, instead of only a lock_guard.

We also remove `LockContext` because there's no reason for this to use `unique_ptr`.
The one placed that made an `own_lock` if not give one now creates one on the stack and recurses on itself for simplicity