### PR TITLE
[Dev] annotated `IndexLock`

### DIFF
--- a/src/execution/index/art/art.cpp
+++ b/src/execution/index/art/art.cpp
@@ -25,7 +25,7 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/storage/arena_allocator.hpp"
 #include "duckdb/storage/metadata/metadata_reader.hpp"
-#include "duckdb/storage/table/append_state.hpp"
+#include "duckdb/execution/index/index_lock.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
 #include "duckdb/storage/table_io_manager.hpp"
 #include "duckdb/storage/storage_manager.hpp"
@@ -517,11 +517,13 @@ ARTConflictType ART::Build(unsafe_vector<ARTKey> &keys, unsafe_vector<ARTKey> &r
 //===--------------------------------------------------------------------===//
 
 ErrorData ART::Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids) {
+	l.AssertHeld(*this);
 	IndexAppendInfo info;
 	return Insert(l, chunk, row_ids, info);
 }
 
 ErrorData ART::Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) {
+	l.AssertHeld(*this);
 	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
 	auto row_count = chunk.size();
 
@@ -591,6 +593,7 @@ ErrorData ART::InsertKeys(ArenaAllocator &arena, unsafe_vector<ARTKey> &keys, un
 }
 
 ErrorData ART::Append(IndexLock &l, DataChunk &chunk, Vector &row_ids) {
+	l.AssertHeld(*this);
 	// Execute all column expressions before inserting the data chunk.
 	DataChunk expr_chunk;
 	expr_chunk.Initialize(Allocator::DefaultAllocator(), logical_types);
@@ -602,6 +605,7 @@ ErrorData ART::Append(IndexLock &l, DataChunk &chunk, Vector &row_ids) {
 }
 
 ErrorData ART::Append(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) {
+	l.AssertHeld(*this);
 	// Execute all column expressions before inserting the data chunk.
 	DataChunk expr_chunk;
 	expr_chunk.Initialize(Allocator::DefaultAllocator(), logical_types);
@@ -625,6 +629,7 @@ void ART::VerifyAppend(DataChunk &chunk, IndexAppendInfo &info, optional_ptr<Con
 //===--------------------------------------------------------------------===//
 
 void ART::ResetStorage(IndexLock &index_lock) {
+	index_lock.AssertHeld(*this);
 	for (auto &allocator : *allocators) {
 		allocator->Reset();
 	}
@@ -633,6 +638,7 @@ void ART::ResetStorage(IndexLock &index_lock) {
 
 idx_t ART::TryDelete(IndexLock &state, DataChunk &entries, Vector &row_ids, optional_ptr<SelectionVector> deleted_sel,
                      optional_ptr<SelectionVector> non_deleted_sel) {
+	state.AssertHeld(*this);
 	// FIXME: We could pass a row_count in here, as we sometimes don't have to delete all row IDs in the chunk,
 	// FIXME: but rather all row IDs up to the conflicting row.
 	auto row_count = entries.size();
@@ -782,7 +788,7 @@ bool ART::Scan(IndexScanState &state, const idx_t max_count, set<row_t> &row_ids
 	auto &scan_state = state.Cast<ARTIndexScanState>();
 	if (scan_state.values[0].IsNull()) {
 		// full scan
-		lock_guard<mutex> l(lock);
+		IndexLock l(*this);
 		return FullScan(max_count, row_ids);
 	}
 	D_ASSERT(scan_state.values[0].type().InternalType() == types[0]);
@@ -790,7 +796,7 @@ bool ART::Scan(IndexScanState &state, const idx_t max_count, set<row_t> &row_ids
 
 	auto key = ARTKey::CreateKey(arena_allocator, scan_state.values[0], storage_version);
 
-	lock_guard<mutex> l(lock);
+	IndexLock l(*this);
 	if (scan_state.values[1].IsNull()) {
 		// Single predicate.
 		switch (scan_state.expressions[0]) {
@@ -944,7 +950,7 @@ void ART::VerifyLeaf(const NodePtr &leaf, const ARTKey &key, DeleteIndexInfo del
 
 void ART::VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, ConflictManager &manager) {
 	// Lock the index during constraint checking.
-	lock_guard<mutex> l(lock);
+	IndexLock l(*this);
 
 	DataChunk expr_chunk;
 	expr_chunk.Initialize(Allocator::DefaultAllocator(), logical_types);
@@ -981,7 +987,7 @@ void ART::VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, ConflictMana
 }
 
 string ART::GetConstraintViolationMessage(VerifyExistenceType verify_type, idx_t failed_index, DataChunk &input) const {
-	lock_guard<mutex> l(lock);
+	IndexLock l(*this);
 	auto key_name = GenerateErrorKeyName(input, failed_index);
 	auto exception_msg = GenerateConstraintErrorMessage(verify_type, key_name);
 	return exception_msg;
@@ -1051,7 +1057,7 @@ IndexStorageInfo ART::PrepareSerialize(const case_insensitive_map_t<Value> &opti
 }
 
 IndexStorageInfo ART::SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options) {
-	lock_guard<mutex> guard(lock);
+	IndexLock guard(*this);
 
 	// If the storage format uses deprecated leaf storage,
 	// then we need to transform all nested leaves before serialization.
@@ -1151,6 +1157,7 @@ void ART::SetPrefixCount(const IndexStorageInfo &info) {
 }
 
 idx_t ART::GetInMemorySize(IndexLock &index_lock) const {
+	index_lock.AssertHeld(*this);
 	D_ASSERT(owns_data);
 
 	idx_t in_memory_size = 0;
@@ -1206,6 +1213,7 @@ static void VacuumPointerIfNeeded(ART &art, const unordered_set<uint8_t> &indexe
 }
 
 void ART::Vacuum(IndexLock &state) {
+	state.AssertHeld(*this);
 	D_ASSERT(owns_data);
 
 	if (!tree.HasMetadata()) {
@@ -1309,6 +1317,7 @@ void ART::InitializeMerge(NodePtr &other_tree, unsafe_vector<idx_t> &upper_bound
 }
 
 bool ART::MergeIndexes(IndexLock &state, BoundIndex &source_index) {
+	state.AssertHeld(*this);
 	auto &other_art = source_index.Cast<ART>();
 	if (!other_art.tree.HasMetadata()) {
 		return true;
@@ -1348,6 +1357,7 @@ bool ART::MergeIndexes(IndexLock &state, BoundIndex &source_index) {
 // FIXME : Make this a more efficient structural tree removal merge
 //		   Right now this is only used in MergeCheckpointDeltas to avoid having to do a table scan.
 void ART::RemovalMerge(IndexLock &state, BoundIndex &source_index) {
+	state.AssertHeld(*this);
 	auto &source = source_index.Cast<ART>();
 	if (!source.tree.HasMetadata()) {
 		return;
@@ -1382,8 +1392,7 @@ void ART::RemovalMerge(IndexLock &state, BoundIndex &source_index) {
 }
 
 void ART::RemovalMerge(BoundIndex &source_index) {
-	IndexLock state;
-	InitializeLock(state);
+	IndexLock state(*this);
 	RemovalMerge(state, source_index);
 }
 
@@ -1391,6 +1400,7 @@ void ART::RemovalMerge(BoundIndex &source_index) {
 // handle deprecated leaves. This is being used in merging checkpoint deltas, to avoid a more inefficient table scan.
 // Once the structural merge adds support for deprecated leaves, we can replace the calls of this function with that.
 ErrorData ART::InsertMerge(IndexLock &state, BoundIndex &source_index, IndexAppendMode append_mode) {
+	state.AssertHeld(*this);
 	auto &source = source_index.Cast<ART>();
 	if (!source.tree.HasMetadata()) {
 		return ErrorData();
@@ -1422,8 +1432,7 @@ ErrorData ART::InsertMerge(IndexLock &state, BoundIndex &source_index, IndexAppe
 }
 
 ErrorData ART::InsertMerge(BoundIndex &source_index, IndexAppendMode append_mode) {
-	IndexLock state;
-	InitializeLock(state);
+	IndexLock state(*this);
 	return InsertMerge(state, source_index, append_mode);
 }
 
@@ -1445,6 +1454,7 @@ ErrorData ART::MergeCheckpointDelta(const IndexDeltaType type, BoundIndex &delta
 //===--------------------------------------------------------------------===//
 
 string ART::ToString(IndexLock &l, bool display_ascii) {
+	l.AssertHeld(*this);
 	return ToStringInternal(display_ascii);
 }
 
@@ -1456,6 +1466,7 @@ string ART::ToStringInternal(bool display_ascii) {
 }
 
 void ART::Verify(IndexLock &l) {
+	l.AssertHeld(*this);
 	VerifyInternal();
 }
 
@@ -1466,6 +1477,7 @@ void ART::VerifyInternal() {
 }
 
 void ART::VerifyAllocations(IndexLock &l) {
+	l.AssertHeld(*this);
 	return VerifyAllocationsInternal();
 }
 
@@ -1488,6 +1500,7 @@ void ART::VerifyAllocationsInternal() {
 }
 
 void ART::VerifyBuffers(IndexLock &l) {
+	l.AssertHeld(*this);
 	for (auto &allocator : *allocators) {
 		allocator->VerifyBuffers();
 	}

--- a/src/execution/index/bound_index.cpp
+++ b/src/execution/index/bound_index.cpp
@@ -6,7 +6,7 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
-#include "duckdb/storage/table/append_state.hpp"
+#include "duckdb/execution/index/index_lock.hpp"
 #include "duckdb/common/types/selection_vector.hpp"
 #include "duckdb/common/types/column/column_data_scan_states.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
@@ -32,24 +32,19 @@ BoundIndex::BoundIndex(const Identifier &name, const string &index_type, IndexCo
 	}
 }
 
-void BoundIndex::InitializeLock(IndexLock &state) const {
-	state.index_lock = unique_lock<mutex>(lock);
-}
-
 ErrorData BoundIndex::Append(DataChunk &chunk, Vector &row_ids) {
-	IndexLock l;
-	InitializeLock(l);
+	IndexLock l(*this);
 	return Append(l, chunk, row_ids);
 }
 
 ErrorData BoundIndex::Append(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) {
+	l.AssertHeld(*this);
 	// Fallback to the old Append.
 	return Append(l, chunk, row_ids);
 }
 
 ErrorData BoundIndex::Append(DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) {
-	IndexLock l;
-	InitializeLock(l);
+	IndexLock l(*this);
 	return Append(l, chunk, row_ids, info);
 }
 
@@ -62,30 +57,29 @@ void BoundIndex::VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, Confl
 }
 
 void BoundIndex::ResetStorage() {
-	IndexLock index_lock;
-	InitializeLock(index_lock);
+	IndexLock index_lock(*this);
 	ResetStorage(index_lock);
 }
 
 idx_t BoundIndex::TryDelete(DataChunk &entries, Vector &row_identifiers, optional_ptr<SelectionVector> deleted_sel,
                             optional_ptr<SelectionVector> non_deleted_sel) {
-	IndexLock state;
-	InitializeLock(state);
+	IndexLock state(*this);
 	return TryDelete(state, entries, row_identifiers, deleted_sel, non_deleted_sel);
 }
 
 idx_t BoundIndex::TryDelete(IndexLock &state, DataChunk &entries, Vector &row_identifiers,
                             optional_ptr<SelectionVector> deleted_sel, optional_ptr<SelectionVector> non_deleted_sel) {
+	state.AssertHeld(*this);
 	throw InternalException("TryDelete not implemented");
 }
 
 void BoundIndex::Delete(DataChunk &entries, Vector &row_identifiers) {
-	IndexLock state;
-	InitializeLock(state);
+	IndexLock state(*this);
 	Delete(state, entries, row_identifiers);
 }
 
 void BoundIndex::Delete(IndexLock &state, DataChunk &entries, Vector &row_identifiers) {
+	state.AssertHeld(*this);
 	auto deleted_rows = TryDelete(state, entries, row_identifiers);
 	if (deleted_rows != entries.size()) {
 		throw InvalidInputException("Failed to delete all rows from index. Only deleted %d out of %d rows.\nChunk: %s",
@@ -94,52 +88,47 @@ void BoundIndex::Delete(IndexLock &state, DataChunk &entries, Vector &row_identi
 }
 
 ErrorData BoundIndex::Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) {
+	l.AssertHeld(*this);
 	throw NotImplementedException("this implementation of Insert does not exist.");
 }
 
 bool BoundIndex::MergeIndexes(BoundIndex &other_index) {
-	IndexLock state;
-	InitializeLock(state);
+	IndexLock state(*this);
 	return MergeIndexes(state, other_index);
 }
 
 void BoundIndex::Verify() {
-	IndexLock l;
-	InitializeLock(l);
+	IndexLock l(*this);
 	Verify(l);
 }
 
 string BoundIndex::ToString(bool display_ascii) {
-	IndexLock l;
-	InitializeLock(l);
+	IndexLock l(*this);
 	return ToString(l, display_ascii);
 }
 
 void BoundIndex::VerifyAllocations() {
-	IndexLock l;
-	InitializeLock(l);
+	IndexLock l(*this);
 	return VerifyAllocations(l);
 }
 
 void BoundIndex::VerifyBuffers(IndexLock &l) {
+	l.AssertHeld(*this);
 	throw NotImplementedException("this implementation of VerifyBuffers does not exist");
 }
 
 void BoundIndex::VerifyBuffers() {
-	IndexLock l;
-	InitializeLock(l);
+	IndexLock l(*this);
 	return VerifyBuffers(l);
 }
 
 void BoundIndex::Vacuum() {
-	IndexLock state;
-	InitializeLock(state);
+	IndexLock state(*this);
 	Vacuum(state);
 }
 
 idx_t BoundIndex::GetInMemorySize() const {
-	IndexLock state;
-	InitializeLock(state);
+	IndexLock state(*this);
 	return GetInMemorySize(state);
 }
 

--- a/src/include/duckdb/execution/index/art/art.hpp
+++ b/src/include/duckdb/execution/index/art/art.hpp
@@ -77,68 +77,73 @@ public:
 	unique_ptr<IndexScanState> InitializeFullScan();
 	//! Perform a lookup on the ART, fetching up to max_count row IDs.
 	//! If all row IDs were fetched, it return true, else false.
-	bool Scan(IndexScanState &state, idx_t max_count, set<row_t> &row_ids) const;
+	bool Scan(IndexScanState &state, idx_t max_count, set<row_t> &row_ids) const DUCKDB_EXCLUDES(lock);
 
 	//! Simple merge: scan source ART and delete each (key, rowid) from this ART.
 	// FIXME: replace with structural tree delete merge.
-	void RemovalMerge(IndexLock &state, BoundIndex &source_index);
+	void RemovalMerge(IndexLock &state, BoundIndex &source_index) DUCKDB_REQUIRES(state);
 	//! Obtains a lock and calls RemovalMerge while holding that lock.
-	void RemovalMerge(BoundIndex &source_index);
+	void RemovalMerge(BoundIndex &source_index) DUCKDB_EXCLUDES(lock);
 	//! Simple merge: scan source ART and insert each (key, rowid) into this ART.
 	//! Returns error data if constraint violation.
 	// FIXME: This is only used in MergeCheckpointDeltas, and even then it is used in lieu of the existing
 	// MergeIndexes which don't support deprecated leaf chains. Once support for that is added, this simpler insert
 	// merge may be removed.
-	ErrorData InsertMerge(IndexLock &state, BoundIndex &source_index, IndexAppendMode append_mode);
+	ErrorData InsertMerge(IndexLock &state, BoundIndex &source_index, IndexAppendMode append_mode)
+	    DUCKDB_REQUIRES(state);
 	//! Obtains a lock and calls InsertMerge while holding that lock.
-	ErrorData InsertMerge(BoundIndex &source_index, IndexAppendMode append_mode);
+	ErrorData InsertMerge(BoundIndex &source_index, IndexAppendMode append_mode) DUCKDB_EXCLUDES(lock);
 
 	//! Appends data to the locked index.
-	ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids) override;
+	ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids) override DUCKDB_REQUIRES(l);
 	//! Appends data to the locked index and verifies constraint violations.
-	ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) override;
+	ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) override
+	    DUCKDB_REQUIRES(l);
 
 	//! Insert a chunk.
-	ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids) override;
+	ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids) override DUCKDB_REQUIRES(l);
 	//! Insert a chunk and verify constraint violations (generates keys and calls InsertKeys which does the
 	//! verification).
-	ErrorData Insert(IndexLock &l, DataChunk &data, Vector &row_ids, IndexAppendInfo &info) override;
+	ErrorData Insert(IndexLock &l, DataChunk &data, Vector &row_ids, IndexAppendInfo &info) override DUCKDB_REQUIRES(l);
 	//! Insert keys and row_ids into ART and verify constraint violations.
 	ErrorData InsertKeys(ArenaAllocator &arena, unsafe_vector<ARTKey> &keys, unsafe_vector<ARTKey> &row_id_keys,
 	                     idx_t count, const DeleteIndexInfo &delete_info, IndexAppendMode append_mode,
 	                     optional_ptr<DataChunk> chunk = nullptr);
 
 	//! Verify that data can be appended to the index without a constraint violation.
-	void VerifyAppend(DataChunk &chunk, IndexAppendInfo &info, optional_ptr<ConflictManager> manager) override;
+	void VerifyAppend(DataChunk &chunk, IndexAppendInfo &info, optional_ptr<ConflictManager> manager) override
+	    DUCKDB_EXCLUDES(lock);
 
 	//! Delete a chunk from the ART.
 	idx_t TryDelete(IndexLock &state, DataChunk &entries, Vector &row_identifiers,
-	                optional_ptr<SelectionVector> deleted_sel, optional_ptr<SelectionVector> non_deleted_sel) override;
+	                optional_ptr<SelectionVector> deleted_sel, optional_ptr<SelectionVector> non_deleted_sel) override
+	    DUCKDB_REQUIRES(state);
 	//! Delete keys and row_ids from the ART.
 	idx_t DeleteKeys(unsafe_vector<ARTKey> &keys, unsafe_vector<ARTKey> &row_id_keys, idx_t count,
 	                 optional_ptr<SelectionVector> deleted_sel = nullptr,
 	                 optional_ptr<SelectionVector> non_deleted_sel = nullptr);
 
 	//! Reset all ART storage.
-	void ResetStorage(IndexLock &index_lock) override;
+	void ResetStorage(IndexLock &index_lock) override DUCKDB_REQUIRES(index_lock);
 
 	//! Build an ART from a vector of sorted keys and their row IDs.
 	ARTConflictType Build(unsafe_vector<ARTKey> &keys, unsafe_vector<ARTKey> &row_ids, const idx_t row_count);
 
-	//! Merge another ART into this ART. Both must be locked.
+	//! Merge another ART into this locked ART; the caller must have exclusive access to the source.
 	//! FIXME: Return ARTConflictType instead of a boolean.
-	bool MergeIndexes(IndexLock &state, BoundIndex &other_index) override;
+	bool MergeIndexes(IndexLock &state, BoundIndex &other_index) override DUCKDB_REQUIRES(state);
 
 	//! Vacuums the ART storage.
-	void Vacuum(IndexLock &state) override;
+	void Vacuum(IndexLock &state) override DUCKDB_REQUIRES(state);
 
 	//! Serializes ART memory to disk and returns the ART storage information.
-	IndexStorageInfo SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options) override;
+	IndexStorageInfo SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options) override
+	    DUCKDB_EXCLUDES(lock);
 	//! Serializes ART memory to the WAL and returns the ART storage information.
 	IndexStorageInfo SerializeToWAL(const case_insensitive_map_t<Value> &options) override;
 
 	//! Returns the in-memory usage of the ART.
-	idx_t GetInMemorySize(IndexLock &index_lock) const override;
+	idx_t GetInMemorySize(IndexLock &index_lock) const override DUCKDB_REQUIRES(index_lock);
 
 	bool SupportsDeltaIndexes() const override;
 
@@ -157,14 +162,14 @@ public:
 	bool HasLegacyGeometryKeys() const;
 
 	//! Verifies the nodes.
-	void Verify(IndexLock &l) override;
+	void Verify(IndexLock &l) override DUCKDB_REQUIRES(l);
 	//! Verifies that the node allocations match the node counts.
-	void VerifyAllocations(IndexLock &l) override;
+	void VerifyAllocations(IndexLock &l) override DUCKDB_REQUIRES(l);
 	//! Verifies the index buffers.
-	void VerifyBuffers(IndexLock &l) override;
+	void VerifyBuffers(IndexLock &l) override DUCKDB_REQUIRES(l);
 
 	//! Returns string representation of the ART.
-	string ToString(IndexLock &l, bool display_ascii = false) override;
+	string ToString(IndexLock &l, bool display_ascii = false) override DUCKDB_REQUIRES(l);
 
 	//! Returns the configured prefix byte capacity.
 	uint8_t PrefixCount() const {
@@ -186,9 +191,10 @@ private:
 	string GenerateConstraintErrorMessage(VerifyExistenceType verify_type, const string &key_name) const;
 	void VerifyLeaf(const NodePtr &leaf, const ARTKey &key, DeleteIndexInfo delete_index_info, ConflictManager &manager,
 	                optional_idx &conflict_idx, idx_t i) const;
-	void VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, ConflictManager &manager) override;
+	void VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, ConflictManager &manager) override
+	    DUCKDB_EXCLUDES(lock);
 	string GetConstraintViolationMessage(VerifyExistenceType verify_type, idx_t failed_index,
-	                                     DataChunk &input) const override;
+	                                     DataChunk &input) const override DUCKDB_EXCLUDES(lock);
 
 	void InitializeMergeUpperBounds(unsafe_vector<idx_t> &upper_bounds);
 	void InitializeMerge(NodePtr &other_tree, unsafe_vector<idx_t> &upper_bounds);

--- a/src/include/duckdb/execution/index/bound_index.hpp
+++ b/src/include/duckdb/execution/index/bound_index.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "duckdb/common/mutex.hpp"
+
 #include "duckdb/execution/index/unbound_index.hpp"
 #include "duckdb/common/enums/index_constraint_type.hpp"
 #include "duckdb/common/types/constraint_conflict_info.hpp"
@@ -29,7 +31,7 @@ class ConflictManager;
 class IndexDeltas;
 class IndexEntry;
 
-struct IndexLock;
+struct DUCKDB_CAPABILITY("mutex") DUCKDB_SCOPED_CAPABILITY IndexLock;
 struct IndexScanState;
 
 enum class IndexAppendMode : uint8_t { DEFAULT = 0, IGNORE_DUPLICATES = 1, INSERT_DUPLICATES = 2 };
@@ -59,6 +61,8 @@ enum class IndexDeltaType : uint8_t {
 
 //! The index is an abstract base class that serves as the basis for indexes
 class BoundIndex : public Index {
+	friend struct IndexLock;
+
 public:
 	BoundIndex(const Identifier &name, const string &index_type, IndexConstraintType index_constraint_type,
 	           const vector<column_t> &column_ids, TableIOManager &table_io_manager,
@@ -108,93 +112,95 @@ public:
 	}
 
 public:
-	//! Obtains a lock on the index.
-	void InitializeLock(IndexLock &state) const;
 	//! Appends data to the locked index.
-	virtual ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids) = 0;
+	virtual ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids) DUCKDB_REQUIRES(l) = 0;
 	//! Obtains a lock and calls Append while holding that lock.
-	ErrorData Append(DataChunk &chunk, Vector &row_ids);
+	ErrorData Append(DataChunk &chunk, Vector &row_ids) DUCKDB_EXCLUDES(lock);
 	//! Appends data to the locked index and verifies constraint violations.
-	virtual ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info);
+	virtual ErrorData Append(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) DUCKDB_REQUIRES(l);
 	//! Obtains a lock and calls Append while holding that lock.
-	ErrorData Append(DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info);
+	ErrorData Append(DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) DUCKDB_EXCLUDES(lock);
 
 	//! Verify that data can be appended to the index without a constraint violation.
-	virtual void VerifyAppend(DataChunk &chunk, IndexAppendInfo &info, optional_ptr<ConflictManager> manager);
+	virtual void VerifyAppend(DataChunk &chunk, IndexAppendInfo &info, optional_ptr<ConflictManager> manager)
+	    DUCKDB_EXCLUDES(lock);
 	//! Verifies the constraint for a chunk of data.
-	virtual void VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, ConflictManager &manager);
+	virtual void VerifyConstraint(DataChunk &chunk, IndexAppendInfo &info, ConflictManager &manager)
+	    DUCKDB_EXCLUDES(lock);
 
-	//! Resets all index storage, clearing the index entirely. The lock obtained from InitializeLock must be held.
-	virtual void ResetStorage(IndexLock &index_lock) = 0;
+	//! Resets all index storage, clearing the index entirely. The index lock must be held.
+	virtual void ResetStorage(IndexLock &index_lock) DUCKDB_REQUIRES(index_lock) = 0;
 	//! Obtains a lock and calls ResetStorage while holding that lock.
-	void ResetStorage() override;
+	void ResetStorage() override DUCKDB_EXCLUDES(lock);
 
-	//! Delete a chunk of entries from the index. The lock obtained from InitializeLock must be held.
+	//! Delete a chunk of entries from the index. The index lock must be held.
 	//! Returns the amount of rows successfully deleted from the index.
 	//! If either deleted_sel or non_deleted_sel are provided the exact rows that were (not) deleted are written there
 	virtual idx_t TryDelete(IndexLock &state, DataChunk &entries, Vector &row_identifiers,
 	                        optional_ptr<SelectionVector> deleted_sel = nullptr,
-	                        optional_ptr<SelectionVector> non_deleted_sel = nullptr);
+	                        optional_ptr<SelectionVector> non_deleted_sel = nullptr) DUCKDB_REQUIRES(state);
 	//! Obtains a lock and calls TryDelete while holding that lock
 	idx_t TryDelete(DataChunk &entries, Vector &row_identifiers, optional_ptr<SelectionVector> deleted_sel = nullptr,
-	                optional_ptr<SelectionVector> non_deleted_sel = nullptr);
-	//! Delete a chunk of entries from the index. The lock obtained from InitializeLock must be held.
+	                optional_ptr<SelectionVector> non_deleted_sel = nullptr) DUCKDB_EXCLUDES(lock);
+	//! Delete a chunk of entries from the index. The index lock must be held.
 	//! Throws an error if not all rows are deleted
-	virtual void Delete(IndexLock &state, DataChunk &entries, Vector &row_identifiers);
+	virtual void Delete(IndexLock &state, DataChunk &entries, Vector &row_identifiers) DUCKDB_REQUIRES(state);
 	//! Obtains a lock and calls Delete while holding that lock
-	void Delete(DataChunk &entries, Vector &row_identifiers);
+	void Delete(DataChunk &entries, Vector &row_identifiers) DUCKDB_EXCLUDES(lock);
 
 	//! Insert a chunk.
-	virtual ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids) = 0;
+	virtual ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids) DUCKDB_REQUIRES(l) = 0;
 	//! Insert a chunk and verifies constraint violations.
-	virtual ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info);
+	virtual ErrorData Insert(IndexLock &l, DataChunk &chunk, Vector &row_ids, IndexAppendInfo &info) DUCKDB_REQUIRES(l);
 
-	//! Merge another index into this index. The lock obtained from InitializeLock must be held, and the other
-	//! index must also be locked during the merge
-	virtual bool MergeIndexes(IndexLock &state, BoundIndex &other_index) = 0;
+	//! Merge another index into this index while holding the index lock.
+	//! The caller must have exclusive access to the source index.
+	virtual bool MergeIndexes(IndexLock &state, BoundIndex &other_index) DUCKDB_REQUIRES(state) = 0;
 	//! Obtains a lock and calls MergeIndexes while holding that lock
-	bool MergeIndexes(BoundIndex &other_index);
+	bool MergeIndexes(BoundIndex &other_index) DUCKDB_EXCLUDES(lock);
 
 	//! Performs a full traversal of the ART while vacuuming the qualifying nodes.
-	//! The lock obtained from InitializeLock must be held.
-	virtual void Vacuum(IndexLock &l) = 0;
+	//! The index lock must be held.
+	virtual void Vacuum(IndexLock &l) DUCKDB_REQUIRES(l) = 0;
 	//! Obtains a lock and calls Vacuum while holding that lock.
-	void Vacuum();
+	void Vacuum() DUCKDB_EXCLUDES(lock);
 
 	//! Whether or not the index supports the creation of delta indexes
 	virtual bool SupportsDeltaIndexes() const;
 
-	//! Returns the in-memory usage of the index. The lock obtained from InitializeLock must be held
-	virtual idx_t GetInMemorySize(IndexLock &state) const = 0;
+	//! Returns the in-memory usage of the index. The index lock must be held
+	virtual idx_t GetInMemorySize(IndexLock &state) const DUCKDB_REQUIRES(state) = 0;
 	//! Returns the in-memory usage of the index
-	idx_t GetInMemorySize() const;
+	idx_t GetInMemorySize() const DUCKDB_EXCLUDES(lock);
 
 	//! Returns the string representation of an index, or only traverses and verifies the index.
-	virtual void Verify(IndexLock &l) = 0;
+	virtual void Verify(IndexLock &l) DUCKDB_REQUIRES(l) = 0;
 	//! Obtains a lock and calls VerifyAndToString.
-	void Verify();
+	void Verify() DUCKDB_EXCLUDES(lock);
 
 	//! Returns the string representation of an index.
-	virtual string ToString(IndexLock &l, bool display_ascii = false) = 0;
+	virtual string ToString(IndexLock &l, bool display_ascii = false) DUCKDB_REQUIRES(l) = 0;
 	//! Obtains a lock and calls ToString.
-	string ToString(bool display_ascii = false);
+	string ToString(bool display_ascii = false) DUCKDB_EXCLUDES(lock);
 
 	//! Ensures that the node allocation counts match the node counts.
-	virtual void VerifyAllocations(IndexLock &l) = 0;
+	virtual void VerifyAllocations(IndexLock &l) DUCKDB_REQUIRES(l) = 0;
 	//! Obtains a lock and calls VerifyAllocations.
-	void VerifyAllocations();
+	void VerifyAllocations() DUCKDB_EXCLUDES(lock);
 
 	//! Verify the index buffers.
-	virtual void VerifyBuffers(IndexLock &l);
+	virtual void VerifyBuffers(IndexLock &l) DUCKDB_REQUIRES(l);
 	//! Obtains a lock and calls VerifyBuffers.
-	void VerifyBuffers();
+	void VerifyBuffers() DUCKDB_EXCLUDES(lock);
 
 	//! Returns true if the index is affected by updates on the specified column IDs, and false otherwise
 	bool IndexIsUpdated(const vector<PhysicalIndex> &column_ids) const;
 
 	//! Serializes index memory to disk and returns the index storage information.
-	virtual IndexStorageInfo SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options);
+	virtual IndexStorageInfo SerializeToDisk(QueryContext context, const case_insensitive_map_t<Value> &options)
+	    DUCKDB_EXCLUDES(lock);
 	//! Serializes index memory to the WAL and returns the index storage information.
+	//! The caller must have exclusive access to the index.
 	virtual IndexStorageInfo SerializeToWAL(const case_insensitive_map_t<Value> &options);
 
 	//! Execute the index expressions on an input chunk
@@ -203,7 +209,7 @@ public:
 
 	//! Throw a constraint violation exception
 	virtual string GetConstraintViolationMessage(VerifyExistenceType verify_type, idx_t failed_index,
-	                                             DataChunk &input) const = 0;
+	                                             DataChunk &input) const DUCKDB_EXCLUDES(lock) = 0;
 
 	//! Replay index insert and delete operations buffered during WAL replay.
 	//! table_types has the physical types of the table in the order they appear, not logical (no generated columns).
@@ -221,7 +227,7 @@ protected:
 	virtual ErrorData MergeCheckpointDelta(IndexDeltaType type, BoundIndex &delta_index);
 
 	//! Lock used for any changes to the index
-	mutable mutex lock;
+	mutable annotated_mutex lock;
 
 	//! The vector of bound expressions to generate the Index keys based on a data chunk.
 	//! The leaves of the bound expressions are BoundReferenceExpressions.

--- a/src/include/duckdb/execution/index/index_lock.hpp
+++ b/src/include/duckdb/execution/index/index_lock.hpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/execution/index/index_lock.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/execution/index/bound_index.hpp"
+
+namespace duckdb {
+
+struct DUCKDB_CAPABILITY("mutex") DUCKDB_SCOPED_CAPABILITY IndexLock {
+public:
+	explicit IndexLock(const BoundIndex &index) DUCKDB_ACQUIRE(index.lock)
+	    : index_guard(index.lock), locked_index(index) {
+	}
+	~IndexLock() DUCKDB_RELEASE() = default;
+
+	IndexLock(const IndexLock &) = delete;
+	IndexLock &operator=(const IndexLock &) = delete;
+
+	//! Verify that a borrowed guard holds this index's mutex.
+	void AssertHeld(const BoundIndex &index) const DUCKDB_ASSERT_CAPABILITY(this) DUCKDB_ASSERT_CAPABILITY(index.lock) {
+		D_ASSERT(&locked_index == &index);
+	}
+
+private:
+	lock_guard<mutex> index_guard;
+	const BoundIndex &locked_index;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/table/append_state.hpp
+++ b/src/include/duckdb/storage/table/append_state.hpp
@@ -94,10 +94,6 @@ struct RowGroupAppendState {
 	SuballocationBlock transient;
 };
 
-struct IndexLock {
-	unique_lock<mutex> index_lock;
-};
-
 struct TableAppendState {
 	TableAppendState();
 	~TableAppendState();


### PR DESCRIPTION
Gets rid of the two-stage initialization in the process (`InitializeLock`)

cc @artjomPlaunov @Maxxen @taniabogatsch 
If there's a good reason we shouldn't do this (tie IndexLock to BoundIndex) then we can close this