### PR TITLE
Flush blockallocator when TaskScheduler gets destroyed

### DIFF
--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -40,6 +40,7 @@ TaskScheduler::~TaskScheduler() {
 		for (auto &pool : pools) {
 			pool->RelaunchThreads(*this, true);
 		}
+		BlockAllocator::Get(db).FlushAll();
 	} catch (...) {
 		// nothing we can do in the destructor if this fails
 	}

--- a/src/parallel/task_scheduler_pool.cpp
+++ b/src/parallel/task_scheduler_pool.cpp
@@ -215,7 +215,10 @@ void TaskSchedulerPool::RelaunchThreads(TaskScheduler &scheduler, bool destroy) 
 		}
 	}
 	current_thread_count = threads.size() + (pool_type == TaskSchedulerType::REGULAR ? external_threads : 0);
-	BlockAllocator::Get(db).FlushAll();
+	// on destroy the scheduler flushes once after every pool is joined
+	if (!destroy) {
+		BlockAllocator::Get(db).FlushAll();
+	}
 #endif
 }
 


### PR DESCRIPTION
Reported by @carlopi:

```
==============REPRODUCE==========
/home/runner/work/duckdb/duckdb/build/release/test/unittest --test-config /tmp/storage_compat_r67lslyr/storage_compatibility.json --temp-dir-root /tmp/storage_compat_r67lslyr/test_temp_dir --temp-dir-run-id off --temp-dir-test-id off --temp-dir-destroy never test/sql/optimizer/in_list_row_group_pruning.test
==============RETURNCODE=========
-11
==============STDOUT=============
Filters: test/sql/optimizer/in_list_row_group_pruning.test

[0/1] (0%): test/sql/optimizer/in_list_row_group_pruning.test
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unittest is a Catch v2.13.7 host application.
Run with -? for options

-------------------------------------------------------------------------------
test/sql/optimizer/in_list_row_group_pruning.test
-------------------------------------------------------------------------------
/home/runner/work/duckdb/duckdb/build/release/test/sqlite/../../../../test/sqlite/test_sqllogictest.cpp:47
...............................................................................

/home/runner/work/duckdb/duckdb/build/release/test/sqlite/../../../../test/sqlite/test_sqllogictest.cpp:47: FAILED:
  {Unknown expression after the reported line}
due to a fatal error condition:
  SIGSEGV - Segmentation violation signal
```

Diagnosed by Claude, with the diagnosis and suggested fix confirmed by @lnkuiper :

# What ThreadSanitizer found

A `THREADSAN=1 make reldebug` build, running the full storage compatibility suite with the
repo's suppressions off, reports a data race in test teardown. Two full rounds, 2175 tests
each: one hit in round 1 (`test/sql/join/full_outer/test_full_outer_join_range.test`), two
in round 2 (`test/sql/join/iejoin/test_iejoin_events.test`,
`test/sql/subquery/scalar/test_correlated_grouping_set.test`). Different tests every time,
same frames every time. That is the CI signature: rare, any test, after the last assertion.

Main thread:

```
~SQLLogicTestRunner -> db.reset()
  DatabaseInstance::~DatabaseInstance       src/main/database.cpp:98   scheduler.reset()
  TaskScheduler::~TaskScheduler             src/parallel/task_scheduler.cpp:41
  TaskSchedulerPool::RelaunchThreads(destroy=true)
                                            src/parallel/task_scheduler_pool.cpp:218
  BlockAllocator::FlushAll                  src/storage/block_allocator.cpp:374
  Allocator::FlushAll                       src/common/allocator/allocator_jemalloc.cpp:110
    mallctl "arena.<MALLCTL_ARENAS_ALL>.purge"
  duckdb_je_arena_decay -> malloc_mutex_lock -> pthread_mutex_trylock
```

Worker thread, still running:

```
TaskScheduler::ExecuteForever              src/parallel/task_scheduler.cpp:175
    (idle for 0.5 s, so flush this thread's allocations)
  BlockAllocator::ThreadFlush               src/storage/block_allocator.cpp:365
  Allocator::ThreadFlush                    allocator_jemalloc.cpp:82
  duckdb_je_malloc_mutex_init -> pthread_mutex_init      on the same mutex
```

`pthread_mutex_init` racing `pthread_mutex_trylock` on one object is undefined behaviour. Concretely, a purge of every arena is walking an arena that a live thread is still setting up.

# Why the ordering is wrong

`~TaskScheduler` loops over the two pools, `REGULAR` then `ASYNC`
(`src/include/duckdb/common/enums/task_scheduler_type.hpp`), calling
`RelaunchThreads(*this, true)` on each. Each call joins that pool's own threads and then
calls `BlockAllocator::Get(db).FlushAll()`, which purges all arenas. During the first call
the other pool's threads are alive and can be inside `ThreadFlush`. Default `async_threads`
is `min(4 * cores, 256)` (`src/main/config.cpp:649`), so both pools are populated in every
default process.