### PR TITLE
patch debug and deprecated settings

### DIFF
--- a/src/catalog/default/default_table_functions.cpp
+++ b/src/catalog/default/default_table_functions.cpp
@@ -76,7 +76,7 @@ WHERE type ILIKE log_type
 )"},
 	{DEFAULT_SCHEMA, "duckdb_profiling_settings", {}, {}, R"(
 SELECT * EXCLUDE(input_type, scope, aliases, typed_value)
-  FROM duckdb_settings(deprecated := true)
+  FROM duckdb_settings(deprecated := false)
   WHERE name IN (
       'enable_profiling',
       'profiling_coverage',

--- a/src/function/table/system/duckdb_settings.cpp
+++ b/src/function/table/system/duckdb_settings.cpp
@@ -81,10 +81,10 @@ unique_ptr<GlobalTableFunctionState> DuckDBSettingsInit(ClientContext &context, 
 	for (idx_t i = 0; i < options_count; i++) {
 		auto option = DBConfig::GetOptionByIndex(i);
 		D_ASSERT(option);
-		if (!bind_data.debug && option->is_debug) {
+		if (bind_data.debug != option->is_debug) {
 			continue;
 		}
-		if (!bind_data.deprecated && option->is_deprecated) {
+		if (bind_data.deprecated != option->is_deprecated) {
 			continue;
 		}
 		DuckDBSettingValue value;
@@ -116,6 +116,12 @@ unique_ptr<GlobalTableFunctionState> DuckDBSettingsInit(ClientContext &context, 
 		result->settings.push_back(std::move(value));
 	}
 	for (auto &ext_param : config.GetExtensionSettings()) {
+		if (bind_data.debug != ext_param.second.is_debug) {
+			continue;
+		}
+		if (bind_data.deprecated != ext_param.second.is_deprecated) {
+			continue;
+		}
 		Value setting_val;
 		auto scope = SettingScope::GLOBAL;
 		auto lookup_result = context.TryGetCurrentSetting(ext_param.first, setting_val);

--- a/src/include/duckdb/main/config.hpp
+++ b/src/include/duckdb/main/config.hpp
@@ -224,7 +224,8 @@ public:
 
 	DUCKDB_API void AddExtensionOption(const Identifier &name, string description, LogicalType parameter,
 	                                   const Value &default_value = Value(), set_option_callback_t function = nullptr,
-	                                   SetScope default_scope = SetScope::SESSION);
+	                                   SetScope default_scope = SetScope::SESSION, bool is_debug = false,
+	                                   bool is_deprecated = false);
 	DUCKDB_API bool HasExtensionOption(const Identifier &name) const;
 	DUCKDB_API identifier_map_t<ExtensionOption> GetExtensionSettings() const;
 	DUCKDB_API bool TryGetExtensionOption(const Identifier &name, ExtensionOption &result) const;

--- a/src/include/duckdb/main/setting_info.hpp
+++ b/src/include/duckdb/main/setting_info.hpp
@@ -112,9 +112,10 @@ struct ExtensionOption {
 	}
 	// NOLINTNEXTLINE: work around bug in clang-tidy
 	ExtensionOption(string description_p, LogicalType type_p, set_option_callback_t set_function_p,
-	                Value default_value_p, SetScope default_scope_p)
+	                Value default_value_p, SetScope default_scope_p, bool is_debug_p, bool is_deprecated_p)
 	    : description(std::move(description_p)), type(std::move(type_p)), set_function(set_function_p),
-	      default_value(std::move(default_value_p)), default_scope(default_scope_p) {
+	      default_value(std::move(default_value_p)), default_scope(default_scope_p), is_debug(is_debug_p),
+	      is_deprecated(is_deprecated_p) {
 	}
 
 	string description;
@@ -123,6 +124,8 @@ struct ExtensionOption {
 	Value default_value;
 	SetScope default_scope;
 	optional_idx setting_index;
+	bool is_debug = false;
+	bool is_deprecated = false;
 };
 
 } // namespace duckdb

--- a/src/main/config.cpp
+++ b/src/main/config.cpp
@@ -548,9 +548,10 @@ bool DBConfig::TryGetExtensionOption(const Identifier &name, ExtensionOption &re
 }
 
 void DBConfig::AddExtensionOption(const Identifier &name, string description, LogicalType parameter,
-                                  const Value &default_value, set_option_callback_t function, SetScope default_scope) {
+                                  const Value &default_value, set_option_callback_t function, SetScope default_scope,
+                                  bool is_debug, bool is_deprecated) {
 	ExtensionOption extension_option(std::move(description), std::move(parameter), function, default_value,
-	                                 default_scope);
+	                                 default_scope, is_debug, is_deprecated);
 	auto setting_index = user_settings.AddExtensionOption(name, std::move(extension_option));
 	// copy over unrecognized options, if they match the new extension option
 	auto iter = options.unrecognized_options.find(name);

--- a/test/sql/pragma/profiling/test_duckdb_profiling_settings_function.test
+++ b/test/sql/pragma/profiling/test_duckdb_profiling_settings_function.test
@@ -7,7 +7,6 @@ SELECT * EXCLUDE(value, description) FROM duckdb_profiling_settings();
 ----
 enable_profiling
 profiling_coverage
-profiling_mode
 profiling_output
 tracked_metrics
 
@@ -31,6 +30,5 @@ SELECT * EXCLUDE(description) FROM duckdb_profiling_settings();
 ----
 enable_profiling	json
 profiling_coverage	ALL
-profiling_mode	standard
 profiling_output	{TEST_DIR}/test_profiling_output.json
 tracked_metrics	[query.cpu_time]

--- a/test/sql/settings/debug_deprecated_settings.test
+++ b/test/sql/settings/debug_deprecated_settings.test
@@ -22,7 +22,17 @@ SELECT list_count(
 ----
 0
 
-query I
-SELECT count(*) FROM duckdb_settings(debug := true, deprecated := true);
+query T
+SELECT name FROM duckdb_settings(debug := true) WHERE name = 'debug_enable_caching_operators';
 ----
-0
+debug_enable_caching_operators
+
+query T
+SELECT count(*) != 0 FROM duckdb_settings(debug := true);
+----
+true
+
+query T
+SELECT count(*) != 0 FROM duckdb_settings(deprecated := true);
+----
+true

--- a/test/sql/settings/debug_deprecated_settings.test
+++ b/test/sql/settings/debug_deprecated_settings.test
@@ -1,0 +1,28 @@
+# name: test/sql/settings/debug_deprecated_settings.test
+# description: Check that debug and deprecated settings are mutually exclusive
+# group: [settings]
+
+query I
+SELECT list_count(
+    list_intersect(
+        (SELECT list(name) FROM duckdb_settings(debug := true)),
+        (SELECT list(name) FROM duckdb_settings(debug := false))
+    )
+);
+----
+0
+
+query I
+SELECT list_count(
+    list_intersect(
+        (SELECT list(name) FROM duckdb_settings(deprecated := true)),
+        (SELECT list(name) FROM duckdb_settings(deprecated := false))
+    )
+);
+----
+0
+
+query I
+SELECT count(*) FROM duckdb_settings(debug := true, deprecated := true);
+----
+0


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/10714

Follow-up fix for `duckdb_settings()` debug/deprecated filtering.

* Add `is_debug` and `is_deprecated` flags to `ExtensionOption` and pass them through `DBConfig::AddExtensionOption`.
* Apply the debug/deprecated filtering to extension settings in `duckdb_settings()`.
* Fix the block in `src/catalog/default/default_table_functions.cpp`.
* Add regression tests verifying debug and deprecated settings are mutually exclusive.

All Extension settings currently default to False.