### PR TITLE
Avoid computing unrequested metadata in duckdb_tables()

### DIFF
--- a/src/function/table/system/duckdb_tables.cpp
+++ b/src/function/table/system/duckdb_tables.cpp
@@ -14,11 +14,13 @@
 namespace duckdb {
 
 struct DuckDBTablesData : public GlobalTableFunctionState {
-	DuckDBTablesData() : offset(0) {
+	DuckDBTablesData() : offset(0), needs_storage_info(false) {
 	}
 
 	vector<reference<CatalogEntry>> entries;
+	vector<ColumnIndex> column_ids;
 	idx_t offset;
+	bool needs_storage_info;
 };
 
 static unique_ptr<FunctionData> DuckDBTablesBind(ClientContext &context, TableFunctionBindInput &input,
@@ -77,12 +79,19 @@ static unique_ptr<FunctionData> DuckDBTablesBind(ClientContext &context, TableFu
 unique_ptr<GlobalTableFunctionState> DuckDBTablesInit(ClientContext &context, TableFunctionInitInput &input) {
 	auto result = make_uniq<DuckDBTablesData>();
 
-	// scan all the schemas for tables and collect themand collect them
+	// Scan all the schemas for tables and collect them.
 	auto schemas = Catalog::GetAllSchemas(context);
 	for (auto &schema : schemas) {
 		schema.get().Scan(context, CatalogType::TABLE_ENTRY,
 		                  [&](CatalogEntry &entry) { result->entries.push_back(entry); });
 	};
+	result->column_ids = input.column_indexes;
+	for (auto &column_id : result->column_ids) {
+		// estimated_size and index_count require storage information.
+		if (column_id.GetPrimaryIndex() == 11 || column_id.GetPrimaryIndex() == 13) {
+			result->needs_storage_info = true;
+		}
+	}
 	return std::move(result);
 }
 
@@ -106,39 +115,6 @@ void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, Da
 	// either fill up the chunk or return all the remaining columns
 	idx_t count = 0;
 
-	// database_name, VARCHAR
-	auto &database_name = output.data[0];
-	// database_oid, BIGINT
-	auto &database_oid = output.data[1];
-	// schema_name, VARCHAR
-	auto &schema_name = output.data[2];
-	// schema_oid, BIGINT
-	auto &schema_oid = output.data[3];
-	// table_name, VARCHAR
-	auto &table_name = output.data[4];
-	// table_oid, BIGINT
-	auto &table_oid = output.data[5];
-	// comment, VARCHAR
-	auto &comment = output.data[6];
-	// tags, MAP(VARCHAR, VARCHAR)
-	auto &tags = output.data[7];
-	// internal, BOOLEAN
-	auto &internal = output.data[8];
-	// temporary, BOOLEAN
-	auto &temporary = output.data[9];
-	// has_primary_key, BOOLEAN
-	auto &has_primary_key = output.data[10];
-	// estimated_size, BIGINT
-	auto &estimated_size = output.data[11];
-	// column_count, BIGINT
-	auto &column_count = output.data[12];
-	// index_count, BIGINT
-	auto &index_count = output.data[13];
-	// check_constraint_count, BIGINT
-	auto &check_constraint_count = output.data[14];
-	// sql, VARCHAR
-	auto &sql = output.data[15];
-
 	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
 		auto &entry = data.entries[data.offset++].get();
 
@@ -146,36 +122,97 @@ void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, Da
 			continue;
 		}
 		auto &table = entry.Cast<TableCatalogEntry>();
-		auto storage_info = table.GetStorageInfo(context);
-
-		database_name.Append(Value(table.catalog.GetName()));
-		database_oid.Append(Value::BIGINT(NumericCast<int64_t>(table.catalog.GetOid())));
-		schema_name.Append(Value(table.schema.name));
-		schema_oid.Append(Value::BIGINT(NumericCast<int64_t>(table.schema.oid)));
-		table_name.Append(Value(table.name));
-		table_oid.Append(Value::BIGINT(NumericCast<int64_t>(table.oid)));
-		comment.Append(Value(table.comment));
-		tags.Append(Value::MAP(table.tags));
-		internal.Append(Value::BOOLEAN(table.internal));
-		temporary.Append(Value::BOOLEAN(table.temporary));
-		has_primary_key.Append(Value::BOOLEAN(table.HasPrimaryKey()));
-
-		Value card_val = !storage_info.cardinality.IsValid()
-		                     ? Value()
-		                     : Value::BIGINT(NumericCast<int64_t>(storage_info.cardinality.GetIndex()));
-		estimated_size.Append(card_val);
-		column_count.Append(Value::BIGINT(NumericCast<int64_t>(table.GetColumns().LogicalColumnCount())));
-		index_count.Append(Value::BIGINT(NumericCast<int64_t>(storage_info.index_info.size())));
-		check_constraint_count.Append(Value::BIGINT(NumericCast<int64_t>(CheckConstraintCount(table))));
-		auto table_info = table.GetInfo();
-		table_info->StripCatalogQualification();
-		sql.Append(Value(table_info->ToString()));
+		TableStorageInfo storage_info;
+		if (data.needs_storage_info) {
+			storage_info = table.GetStorageInfo(context);
+		}
+		for (idx_t c = 0; c < data.column_ids.size(); c++) {
+			auto column_id = data.column_ids[c].GetPrimaryIndex();
+			auto &col_vector = output.data[c];
+			switch (column_id) {
+			case 0:
+				// database_name, VARCHAR
+				col_vector.Append(Value(table.catalog.GetName()));
+				break;
+			case 1:
+				// database_oid, BIGINT
+				col_vector.Append(Value::BIGINT(NumericCast<int64_t>(table.catalog.GetOid())));
+				break;
+			case 2:
+				// schema_name, VARCHAR
+				col_vector.Append(Value(table.schema.name));
+				break;
+			case 3:
+				// schema_oid, BIGINT
+				col_vector.Append(Value::BIGINT(NumericCast<int64_t>(table.schema.oid)));
+				break;
+			case 4:
+				// table_name, VARCHAR
+				col_vector.Append(Value(table.name));
+				break;
+			case 5:
+				// table_oid, BIGINT
+				col_vector.Append(Value::BIGINT(NumericCast<int64_t>(table.oid)));
+				break;
+			case 6:
+				// comment, VARCHAR
+				col_vector.Append(Value(table.comment));
+				break;
+			case 7:
+				// tags, MAP(VARCHAR, VARCHAR)
+				col_vector.Append(Value::MAP(table.tags));
+				break;
+			case 8:
+				// internal, BOOLEAN
+				col_vector.Append(Value::BOOLEAN(table.internal));
+				break;
+			case 9:
+				// temporary, BOOLEAN
+				col_vector.Append(Value::BOOLEAN(table.temporary));
+				break;
+			case 10:
+				// has_primary_key, BOOLEAN
+				col_vector.Append(Value::BOOLEAN(table.HasPrimaryKey()));
+				break;
+			case 11: {
+				// estimated_size, BIGINT
+				Value cardinality = !storage_info.cardinality.IsValid()
+				                        ? Value()
+				                        : Value::BIGINT(NumericCast<int64_t>(storage_info.cardinality.GetIndex()));
+				col_vector.Append(cardinality);
+				break;
+			}
+			case 12:
+				// column_count, BIGINT
+				col_vector.Append(Value::BIGINT(NumericCast<int64_t>(table.GetColumns().LogicalColumnCount())));
+				break;
+			case 13:
+				// index_count, BIGINT
+				col_vector.Append(Value::BIGINT(NumericCast<int64_t>(storage_info.index_info.size())));
+				break;
+			case 14:
+				// check_constraint_count, BIGINT
+				col_vector.Append(Value::BIGINT(NumericCast<int64_t>(CheckConstraintCount(table))));
+				break;
+			case 15: {
+				// sql, VARCHAR
+				auto table_info = table.GetInfo();
+				table_info->StripCatalogQualification();
+				col_vector.Append(Value(table_info->ToString()));
+				break;
+			}
+			default:
+				throw InternalException("Unsupported column index for duckdb_tables");
+			}
+		}
 		count++;
 	}
 }
 
 void DuckDBTablesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_tables", {}, DuckDBTablesFunction, DuckDBTablesBind, DuckDBTablesInit));
+	TableFunction duckdb_tables("duckdb_tables", {}, DuckDBTablesFunction, DuckDBTablesBind, DuckDBTablesInit);
+	duckdb_tables.projection_pushdown = true;
+	set.AddFunction(duckdb_tables);
 }
 
 } // namespace duckdb

--- a/test/catalog/CMakeLists.txt
+++ b/test/catalog/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library_unity(test_catalog OBJECT test_catalog_version.cpp)
+add_library_unity(test_catalog OBJECT test_catalog_version.cpp
+                  test_duckdb_tables_projection.cpp)
 
 set(UNITTEST_OBJECT_FILES
     ${UNITTEST_OBJECT_FILES} $<TARGET_OBJECTS:test_catalog>

--- a/test/catalog/test_duckdb_tables_projection.cpp
+++ b/test/catalog/test_duckdb_tables_projection.cpp
@@ -1,0 +1,143 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_schema_entry.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/storage/table_storage_info.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+struct CatalogMetadataCalls {
+	idx_t storage = 0;
+	idx_t sql = 0;
+	optional_idx cardinality = 42;
+};
+
+class CountingTableEntry : public TableCatalogEntry {
+public:
+	CountingTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info, CatalogMetadataCalls &calls)
+	    : TableCatalogEntry(catalog, schema, info), columns(info.columns.Copy()), calls(calls) {
+	}
+
+	const ColumnList &GetColumns() const override {
+		return columns;
+	}
+
+	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override {
+		return nullptr;
+	}
+
+	TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) override {
+		throw NotImplementedException("CountingTableEntry only supports catalog queries");
+	}
+
+	TableStorageInfo GetStorageInfo(ClientContext &context) override {
+		calls.storage++;
+		TableStorageInfo result;
+		result.cardinality = calls.cardinality;
+		result.index_info.emplace_back();
+		return result;
+	}
+
+	unique_ptr<CreateInfo> GetInfo() const override {
+		calls.sql++;
+		return TableCatalogEntry::GetInfo();
+	}
+
+private:
+	ColumnList columns;
+	CatalogMetadataCalls &calls;
+};
+
+} // namespace
+
+TEST_CASE("duckdb_tables only fetches requested metadata", "[catalog]") {
+	CatalogMetadataCalls calls;
+	DuckDB db(nullptr);
+	Connection con(db);
+	con.context->RunFunctionInTransaction([&]() {
+		auto &schema = Catalog::GetSchema(*con.context, "temp", "main").Cast<DuckSchemaEntry>();
+		CreateTableInfo info(schema, "counting_table");
+		info.temporary = true;
+		info.tags["owner"] = "fixture";
+		info.columns.AddColumn(ColumnDefinition("i", LogicalType::INTEGER));
+		info.columns.Finalize();
+		auto entry = make_uniq<CountingTableEntry>(schema.catalog, schema, info, calls);
+		REQUIRE(schema.AddEntry(schema.GetCatalogTransaction(*con.context), std::move(entry),
+		                        OnCreateConflict::ERROR_ON_CONFLICT));
+	});
+	// Ignore any metadata requests made while installing the test entry.
+	calls.storage = 0;
+	calls.sql = 0;
+
+	SECTION("Names, predicates, ordering and counts need neither storage information nor SQL") {
+		auto result = con.Query("SELECT table_name FROM duckdb_tables() "
+		                        "WHERE database_name = 'temp' ORDER BY table_name LIMIT 5");
+		REQUIRE(CHECK_COLUMN(result, 0, {"counting_table"}));
+		result = con.Query("SELECT count(*) FROM duckdb_tables()");
+		REQUIRE(CHECK_COLUMN(result, 0, {1}));
+		result = con.Query("SELECT 1 FROM duckdb_tables()");
+		REQUIRE(CHECK_COLUMN(result, 0, {1}));
+		REQUIRE(calls.storage == 0);
+		REQUIRE(calls.sql == 0);
+	}
+
+	SECTION("Both storage columns share one request, including repeated projections") {
+		auto result = con.Query("SELECT index_count, estimated_size, index_count FROM duckdb_tables()");
+		REQUIRE(CHECK_COLUMN(result, 0, {1}));
+		REQUIRE(CHECK_COLUMN(result, 1, {42}));
+		REQUIRE(CHECK_COLUMN(result, 2, {1}));
+		REQUIRE(calls.storage == 1);
+		REQUIRE(calls.sql == 0);
+	}
+
+	SECTION("Index count alone requires storage information") {
+		auto result = con.Query("SELECT index_count FROM duckdb_tables()");
+		REQUIRE(CHECK_COLUMN(result, 0, {1}));
+		REQUIRE(calls.storage == 1);
+		REQUIRE(calls.sql == 0);
+	}
+
+	SECTION("Projected map values need neither storage information nor SQL") {
+		auto result = con.Query("SELECT tags['owner'] FROM duckdb_tables()");
+		REQUIRE(CHECK_COLUMN(result, 0, {"fixture"}));
+		REQUIRE(calls.storage == 0);
+		REQUIRE(calls.sql == 0);
+	}
+
+	SECTION("Unknown cardinality remains NULL") {
+		calls.cardinality = optional_idx();
+		auto result = con.Query("SELECT estimated_size FROM duckdb_tables()");
+		REQUIRE(CHECK_COLUMN(result, 0, {Value()}));
+		REQUIRE(calls.storage == 1);
+		REQUIRE(calls.sql == 0);
+	}
+
+	SECTION("Storage information is fetched for a predicate without a projected statistic") {
+		auto result = con.Query("SELECT table_name FROM duckdb_tables() WHERE estimated_size > 0");
+		REQUIRE(CHECK_COLUMN(result, 0, {"counting_table"}));
+		REQUIRE(calls.storage == 1);
+		REQUIRE(calls.sql == 0);
+	}
+
+	SECTION("SQL generation does not require storage information") {
+		auto result = con.Query("SELECT sql FROM duckdb_tables()");
+		REQUIRE(CHECK_COLUMN(result, 0, {"CREATE TEMP TABLE counting_table(i INTEGER);"}));
+		REQUIRE(calls.storage == 0);
+		REQUIRE(calls.sql == 1);
+	}
+
+	SECTION("Selecting every column still fetches both kinds of metadata") {
+		auto result = con.Query("SELECT * FROM duckdb_tables()");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->ColumnCount() == 16);
+		REQUIRE(CHECK_COLUMN(result, 11, {42}));
+		REQUIRE(CHECK_COLUMN(result, 13, {1}));
+		REQUIRE(calls.storage == 1);
+		REQUIRE(calls.sql == 1);
+	}
+}

--- a/test/sql/table_function/duckdb_tables_projection.test
+++ b/test/sql/table_function/duckdb_tables_projection.test
@@ -1,0 +1,168 @@
+# name: test/sql/table_function/duckdb_tables_projection.test
+# description: Projected duckdb_tables columns preserve values and cardinality
+# group: [table_function]
+
+query I
+SELECT count(*) FROM duckdb_tables()
+----
+0
+
+query T
+SELECT sql FROM duckdb_tables()
+----
+
+statement ok
+CREATE TABLE t(i INTEGER PRIMARY KEY, j VARCHAR, CHECK (i > 0))
+
+statement ok
+INSERT INTO t VALUES (1, 'one'), (2, 'two')
+
+statement ok
+COMMENT ON TABLE t IS 'projected comment'
+
+statement ok
+CREATE INDEX j_idx ON t(j)
+
+statement ok
+CREATE TEMP TABLE tmp(i INTEGER)
+
+statement ok
+CREATE VIEW v AS SELECT * FROM t
+
+statement ok
+ATTACH ':memory:' AS attached
+
+statement ok
+CREATE SCHEMA attached.s
+
+statement ok
+CREATE TABLE attached.s.t(i INTEGER)
+
+# Names, aliases and reordered/duplicate projections across catalogs.
+query TTTT rowsort
+SELECT table_name AS n, schema_name, database_name, table_name FROM duckdb_tables()
+----
+t	main	memory	t
+t	s	attached	t
+tmp	main	temp	tmp
+
+query I
+SELECT count(*) FROM duckdb_tables()
+----
+3
+
+query I
+SELECT 1 FROM duckdb_tables()
+----
+1
+1
+1
+
+# Derived fields can be requested independently, including in predicates/order keys.
+query T
+SELECT table_name FROM duckdb_tables() WHERE estimated_size > 0
+----
+t
+
+query TI
+SELECT table_name, estimated_size FROM duckdb_tables() WHERE database_name = 'memory' ORDER BY index_count
+----
+t	2
+
+query II
+SELECT index_count, estimated_size FROM duckdb_tables() WHERE database_name = 'memory'
+----
+2	2
+
+query IIII
+SELECT check_constraint_count, column_count, temporary, has_primary_key FROM duckdb_tables() WHERE database_name = 'memory'
+----
+1	2	False	True
+
+query T
+SELECT comment FROM duckdb_tables() WHERE database_name = 'memory'
+----
+projected comment
+
+query TT rowsort
+SELECT table_name, comment FROM duckdb_tables() WHERE database_name <> 'memory'
+----
+t	NULL
+tmp	NULL
+
+query IIII
+SELECT database_oid IS NOT NULL, schema_oid IS NOT NULL, table_oid IS NOT NULL, internal FROM duckdb_tables() WHERE database_name = 'memory'
+----
+True	True	True	False
+
+query I
+SELECT cardinality(tags) FROM duckdb_tables() WHERE database_name = 'memory'
+----
+0
+
+query T
+SELECT sql FROM duckdb_tables() WHERE database_name = 'attached'
+----
+CREATE TABLE s.t(i INTEGER);
+
+query T
+SELECT table_name FROM duckdb_tables() WHERE sql LIKE 'CREATE TEMP%'
+----
+tmp
+
+# SELECT * preserves all columns; compare to independently projected fields.
+statement ok
+CREATE TEMP TABLE captured AS SELECT * FROM duckdb_tables() WHERE table_name <> 'captured'
+
+query I
+SELECT count(*) FROM captured
+----
+3
+
+query I
+SELECT count(*) FROM (SELECT * FROM captured EXCEPT SELECT * FROM duckdb_tables())
+----
+0
+
+# Prepared statements see later catalog changes with the same projection.
+statement ok
+PREPARE tables_in_attached AS SELECT table_name FROM duckdb_tables() WHERE database_name = 'attached' ORDER BY table_name
+
+query T
+EXECUTE tables_in_attached
+----
+t
+
+statement ok
+CREATE TABLE attached.s.u(i INTEGER)
+
+query T
+EXECUTE tables_in_attached
+----
+t
+u
+
+statement ok
+DROP TABLE attached.s.u
+
+query T
+EXECUTE tables_in_attached
+----
+t
+
+query T
+SELECT table_name FROM duckdb_tables() WHERE database_name = 'missing'
+----
+
+# Exercise output spanning more than one standard vector.
+loop i 0 2050
+
+statement ok
+CREATE TABLE attached.s.chunk_{i}(i INTEGER)
+
+endloop
+
+query III
+SELECT count(*), sum(column_count), sum(index_count) FROM duckdb_tables() WHERE database_name = 'attached'
+----
+2051	2051	0


### PR DESCRIPTION
`duckdb_tables()` currently fetches storage information and generates table SQL even for a query that only requests names. For DuckLake, those unused statistics can require remote metadata queries.

Enable projection pushdown, following `duckdb_views()`. Fetch storage information only for `estimated_size` or `index_count`, including when needed by a predicate, and generate SQL only when requested. Schema enumeration is unchanged; this complements the database-filter pushdown in #25041.

For example:

```sql
SELECT database_name, table_name
FROM duckdb_tables()
WHERE database_name = 'target'
ORDER BY table_name
LIMIT 5;
```

[Fork CI](https://github.com/jdctinuiti/duckdb/actions/runs/34376390831) is running.
