### PR TITLE
fix(parser): Preserve CTE metadata when copying

### DIFF
--- a/src/include/duckdb/parser/common_table_expression_info.hpp
+++ b/src/include/duckdb/parser/common_table_expression_info.hpp
@@ -40,7 +40,7 @@ struct CommonTableExpressionInfo {
 
 	void Serialize(Serializer &serializer) const;
 	static unique_ptr<CommonTableExpressionInfo> Deserialize(Deserializer &deserializer);
-	unique_ptr<CommonTableExpressionInfo> Copy();
+	unique_ptr<CommonTableExpressionInfo> Copy() const;
 };
 
 } // namespace duckdb

--- a/src/parser/common_table_expression_info.cpp
+++ b/src/parser/common_table_expression_info.cpp
@@ -17,7 +17,7 @@ CommonTableExpressionInfo::CommonTableExpressionInfo(unique_ptr<SelectStatement>
 	}
 }
 
-unique_ptr<CommonTableExpressionInfo> CommonTableExpressionInfo::Copy() {
+unique_ptr<CommonTableExpressionInfo> CommonTableExpressionInfo::Copy() const {
 	auto result = make_uniq<CommonTableExpressionInfo>();
 	result->aliases = aliases;
 	if (query_node) {

--- a/src/parser/query_node.cpp
+++ b/src/parser/query_node.cpp
@@ -13,21 +13,7 @@ CommonTableExpressionMap::CommonTableExpressionMap() {
 CommonTableExpressionMap CommonTableExpressionMap::Copy() const {
 	CommonTableExpressionMap res;
 	for (auto &kv : this->map) {
-		auto kv_info = make_uniq<CommonTableExpressionInfo>();
-		for (auto &al : kv.second->aliases) {
-			kv_info->aliases.push_back(al);
-		}
-		for (auto &al : kv.second->key_targets) {
-			kv_info->key_targets.push_back(al->Copy());
-		}
-		for (auto &al : kv.second->payload_aggregates) {
-			kv_info->payload_aggregates.push_back(al->Copy());
-		}
-		if (kv.second->query_node) {
-			kv_info->query_node = kv.second->query_node->Copy();
-		}
-		kv_info->materialized = kv.second->materialized;
-		res.map[kv.first] = std::move(kv_info);
+		res.map[kv.first] = kv.second->Copy();
 	}
 
 	return res;
@@ -177,21 +163,7 @@ void QueryNode::CopyProperties(QueryNode &other) const {
 		other.modifiers.push_back(modifier->Copy());
 	}
 	for (auto &kv : cte_map.map) {
-		auto kv_info = make_uniq<CommonTableExpressionInfo>();
-		for (auto &al : kv.second->aliases) {
-			kv_info->aliases.push_back(al);
-		}
-		for (auto &key : kv.second->key_targets) {
-			kv_info->key_targets.push_back(key->Copy());
-		}
-		for (auto &agg : kv.second->payload_aggregates) {
-			kv_info->payload_aggregates.push_back(agg->Copy());
-		}
-		if (kv.second->query_node) {
-			kv_info->query_node = kv.second->query_node->Copy();
-		}
-		kv_info->materialized = kv.second->materialized;
-		other.cte_map.map[kv.first] = std::move(kv_info);
+		other.cte_map.map[kv.first] = kv.second->Copy();
 	}
 }
 

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TEST_API_OBJECTS
     test_dbdir.cpp
     test_pending_with_parameters.cpp
     test_parse_statement_iterator.cpp
+    test_query_node_copy.cpp
     test_grammar_extension.cpp
     test_progress_bar.cpp
     test_uuid.cpp

--- a/test/api/test_query_node_copy.cpp
+++ b/test/api/test_query_node_copy.cpp
@@ -1,0 +1,79 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+
+#include "duckdb/parser/common_table_expression_info.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/query_node/select_node.hpp"
+
+using namespace duckdb;
+
+static unique_ptr<CommonTableExpressionInfo> TestCTE() {
+	auto cte = make_uniq<CommonTableExpressionInfo>();
+	cte->aliases.emplace_back("cte_alias");
+	cte->key_targets.push_back(make_uniq<ColumnRefExpression>(Identifier("key_column")));
+	cte->payload_aggregates.push_back(make_uniq<ConstantExpression>(Value::INTEGER(42)));
+	auto query_node = make_uniq<SelectNode>();
+	query_node->select_list.push_back(make_uniq<ColumnRefExpression>(Identifier("result_column")));
+	cte->query_node = std::move(query_node);
+	cte->materialized = CTEMaterialize::CTE_MATERIALIZE_ALWAYS;
+	cte->is_trigger_generated = true;
+	return cte;
+}
+
+static void RequireEquivalentCTE(const CommonTableExpressionInfo &original, const CommonTableExpressionInfo &copy) {
+	REQUIRE(copy.aliases == original.aliases);
+	REQUIRE(ParsedExpression::ListEquals(copy.key_targets, original.key_targets));
+	REQUIRE(ParsedExpression::ListEquals(copy.payload_aggregates, original.payload_aggregates));
+	REQUIRE(copy.query_node->Equals(original.query_node.get()));
+	REQUIRE(copy.materialized == original.materialized);
+	REQUIRE(copy.is_trigger_generated == original.is_trigger_generated);
+}
+
+TEST_CASE("CTE copy preserves all properties", "[api][parser]") {
+	auto original = TestCTE();
+	auto copy = original->Copy();
+
+	RequireEquivalentCTE(*original, *copy);
+}
+
+TEST_CASE("CTE copy owns its nested state", "[api][parser]") {
+	auto original = TestCTE();
+	auto copy = original->Copy();
+
+	REQUIRE(copy->key_targets[0].get() != original->key_targets[0].get());
+	REQUIRE(copy->payload_aggregates[0].get() != original->payload_aggregates[0].get());
+	REQUIRE(copy->query_node.get() != original->query_node.get());
+	auto &original_query = original->query_node->Cast<SelectNode>();
+	auto &copied_query = copy->query_node->Cast<SelectNode>();
+	REQUIRE(copied_query.select_list[0].get() != original_query.select_list[0].get());
+
+	copy->aliases[0] = "copied_alias";
+	copy->key_targets[0]->SetAlias("copied_key");
+	copy->payload_aggregates[0]->SetAlias("copied_payload");
+	copied_query.select_list[0]->SetAlias("copied_result");
+	REQUIRE(original->aliases[0] == "cte_alias");
+	REQUIRE_FALSE(original->key_targets[0]->HasAlias());
+	REQUIRE_FALSE(original->payload_aggregates[0]->HasAlias());
+	REQUIRE_FALSE(original_query.select_list[0]->HasAlias());
+}
+
+TEST_CASE("CTE containers preserve complete entries when copied", "[api][parser]") {
+	CommonTableExpressionMap cte_map;
+	cte_map.map["generated_cte"] = TestCTE();
+
+	auto copied_map = cte_map.Copy();
+	REQUIRE(copied_map.map.size() == 1);
+	auto copied_map_entry = copied_map.map.find("generated_cte");
+	REQUIRE(copied_map_entry != copied_map.map.end());
+	RequireEquivalentCTE(*cte_map.map["generated_cte"], *copied_map_entry->second);
+
+	SelectNode select;
+	select.cte_map.map["generated_cte"] = TestCTE();
+	auto copied_select = select.Copy();
+	auto &copied_cte_map = copied_select->Cast<SelectNode>().cte_map.map;
+	REQUIRE(copied_cte_map.size() == 1);
+	auto copied_select_entry = copied_cte_map.find("generated_cte");
+	REQUIRE(copied_select_entry != copied_cte_map.end());
+	RequireEquivalentCTE(*select.cte_map.map["generated_cte"], *copied_select_entry->second);
+}


### PR DESCRIPTION
## Summary

  - Reuse `CommonTableExpressionInfo::Copy()` in both CTE container copy paths instead of maintaining duplicate field-copy logic.
  - Preserve `is_trigger_generated` when copying CTEs and mark `Copy()` as `const`.
  - Add focused tests covering property preservation, deep-copy isolation, and both CTE copy entry points.

  ## Testing

  - `cmake --build build/reldebug --target unittest -j 9`
  - `build/reldebug/test/unittest "[api][parser]"` — 3 test cases and 30 assertions passed
  - `build/reldebug/test/unittest "test/sql/cte/*"` — 85 test cases passed, 3 skipped
  - `build/reldebug/test/unittest "test/sql/trigger/*"` — 28 test cases passed, 1 skipped
  - `build/reldebug/test/unittest test/sql/parser/statement_tostring_roundtrip.test` — 174 assertions passed
  - `clang-format --dry-run --Werror` and `git diff --check`

  ## Risk and Rollback

  Risk is low because the change routes existing copy paths through the canonical deep-copy implementation. The intended behavior change is preserving trigger-generated
  CTE metadata. Reverting commit `6b99ca6526` restores the previous behavior.
