### PR TITLE
Prune row group for shared prefix for case functions

### DIFF
--- a/src/function/scalar/string/caseconvert.cpp
+++ b/src/function/scalar/string/caseconvert.cpp
@@ -144,16 +144,13 @@ static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &conte
 	if (!StringStats::HasMinMax(child_stats[0])) {
 		return result.ToUnique();
 	}
-	// When min == max, all values share the stored string (exact) or the stored prefix (truncated).
-	// Case conversion is codepoint-local, so the converted string/prefix bounds the result.
+	// All values share the common prefix of min and max; case conversion preserves this property.
 	auto min = StringStats::Min(child_stats[0]);
 	auto max = StringStats::Max(child_stats[0]);
-	if (min != max) {
-		return result.ToUnique();
-	}
-	const bool is_exact = StringStats::GetMinType(child_stats[0]) == StringStatsType::EXACT_STATS &&
+	const bool is_exact = min == max && StringStats::GetMinType(child_stats[0]) == StringStatsType::EXACT_STATS &&
 	                      StringStats::GetMaxType(child_stats[0]) == StringStatsType::EXACT_STATS;
 	if (!is_exact) {
+		min.resize(StringUtil::GetCommonPrefixSize(min, max));
 		// truncated stats can end in the middle of a character - only complete ones can be converted
 		size_t invalid_pos = 0;
 		if (Utf8Proc::Analyze(min.c_str(), min.size(), nullptr, &invalid_pos) == UnicodeType::INVALID) {

--- a/test/sql/optimizer/upper_lower_zonemap_pruning.test
+++ b/test/sql/optimizer/upper_lower_zonemap_pruning.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/upper_lower_zonemap_pruning.test
-# description: Prune row groups for upper()/lower() when a row group's min == max
+# description: Prune row groups for upper()/lower() using string statistics
 # group: [optimizer]
 
 statement ok
@@ -37,7 +37,7 @@ SELECT count(*) FROM case_pruning WHERE lower(s) = 'gamma';
 ----
 2048
 
-# upper()/lower() are not order-preserving, so a row group with min != max cannot be pruned.
+# All three row groups share v00, so the common prefix cannot exclude any of them.
 statement ok
 CREATE TABLE case_mixed AS
 SELECT i::INTEGER AS i, 'v' || lpad(i::VARCHAR, 6, '0') AS s
@@ -136,3 +136,36 @@ query I
 SELECT count(*) FROM case_split_char WHERE upper(s) = 'KLMNOPQRST🦆002500';
 ----
 1
+
+# Different strings in each row group share the prefix alpha, Beta, or GAMMA.
+statement ok
+CREATE TABLE case_prefix AS
+SELECT CASE WHEN i < 2048 THEN 'alpha'
+            WHEN i < 4096 THEN 'Beta'
+            ELSE 'GAMMA' END || i::VARCHAR AS s
+FROM range(6144) t(i);
+
+foreach func lower upper
+
+query II
+EXPLAIN ANALYZE SELECT s FROM case_prefix WHERE {func}(s) LIKE {func}('beta%');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query I
+SELECT count(*) FROM case_prefix WHERE {func}(s) LIKE {func}('beta%');
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT s FROM case_prefix WHERE {func}(s) > {func}('beta');
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 3.*
+
+# The common prefix is not an exact value: Beta plus a suffix is greater than Beta.
+query I
+SELECT count(*) FROM case_prefix WHERE {func}(s) > {func}('beta');
+----
+4096
+
+endloop


### PR DESCRIPTION
Hi team, I found for case functions (`lower`/`upper`), currently row groups are only pruned when min/max are exactly the same, but actually row groups could be also pruned when min/max shared a common prefix. For example
```sql
memory D ATTACH '/tmp/upper_lower_zonemap_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE case_pruning AS
     SELECT i::INTEGER AS i, CASE WHEN i < 2048 THEN 'alpha' WHEN i < 4096 THEN 'Beta' ELSE 'GAMMA' END AS s
     FROM range(6144) r(i);
db D CREATE TABLE case_prefix AS SELECT s || i::VARCHAR AS s FROM case_pruning;

-- should access only one row group, but access all
db D EXPLAIN ANALYZE SELECT count(*) FROM case_prefix WHERE lower(s) LIKE lower('beta%');
╭─ Summary ───────────╮
│ Total Time: 0.0011s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────────╮
│ Aggregates: count_star()          │
│ 1 row                         0µs │
╰─────────────────┒┎────────────────╯
╭─ Table Scan ────┚┖────────────────╮
│ Table: db.main.case_prefix        │
│ Type: Sequential Scan             │
│ Filters: prefix(lower(s), 'beta') │
│ Row Groups Scanned: 3 / 3         │
│ 2,048 rows                    0µs │
╰───────────────────────────────────╯
```
The root cause is, when min != max, stats are [returned directly](https://github.com/duckdb/duckdb/blob/a0315f712c64627fde0f77879730f28a4e9c8c46/src/function/scalar/string/caseconvert.cpp#L151) without assigning an inexact stats.