### PR TITLE
Escape single quotes in the sniff_csv Prompt

### DIFF
--- a/src/function/table/sniff_csv.cpp
+++ b/src/function/table/sniff_csv.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/execution/operator/csv_scanner/csv_file_handle.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp"
 #include "duckdb/function/table/read_csv.hpp"
+#include "duckdb/common/sql_identifier.hpp"
 
 namespace duckdb {
 
@@ -195,7 +196,8 @@ static void CSVSniffFunction(ClientContext &context, TableFunctionInput &data_p,
 		child_list_t<Value> struct_children {{"name", sniffer_result.names[i]},
 		                                     {"type", {sniffer_result.return_types[i].ToString()}}};
 		values.emplace_back(Value::STRUCT(struct_children));
-		columns << "'" << sniffer_result.names[i].GetIdentifierName() << "': '"
+		// A ' inside a name closes the columns literal unless it arrives doubled.
+		columns << SQLString(sniffer_result.names[i].GetIdentifierName()) << ": '"
 		        << sniffer_result.return_types[i].ToString() << "'";
 		if (i != sniffer_result.return_types.size() - 1) {
 			columns << separator;
@@ -238,7 +240,7 @@ static void CSVSniffFunction(ClientContext &context, TableFunctionInput &data_p,
 	std::ostringstream csv_read;
 
 	// Base, Path and auto_detect=false
-	csv_read << "FROM read_csv('" << files[0].path << "'" << separator << "auto_detect=false" << separator;
+	csv_read << "FROM read_csv(" << SQLString(files[0].path) << separator << "auto_detect=false" << separator;
 	// 10.1. Delimiter
 	if (!sniffer_options.dialect_options.state_machine_options.delimiter.IsSetByUser()) {
 		csv_read << "delim="

--- a/test/sql/copy/csv/test_sniff_csv.test
+++ b/test/sql/copy/csv/test_sniff_csv.test
@@ -136,3 +136,17 @@ FROM read_csv('{DATA_DIR}/csv/comments/simple.csv', auto_detect=false, delim=';'
 ----
 1	3
 6	7
+
+# A column name carrying ' has to come back escaped, or the Prompt does not parse
+statement ok
+COPY (SELECT 1 AS "id", 2 AS "it's") TO '{TEST_DIR}/quote_in_name.csv' (HEADER);
+
+query I
+SELECT Prompt FROM sniff_csv('{TEST_DIR}/quote_in_name.csv');
+----
+FROM read_csv('{TEST_DIR}/quote_in_name.csv', auto_detect=false, delim=',', quote='', escape='', new_line='\n', skip=0, comment='', header=true, columns={'id': 'BIGINT', 'it''s': 'BIGINT'});
+
+query II
+FROM read_csv('{TEST_DIR}/quote_in_name.csv', auto_detect=false, delim=',', quote='', escape='', new_line='\n', skip=0, comment='', header=true, columns={'id': 'BIGINT', 'it''s': 'BIGINT'})
+----
+1	2


### PR DESCRIPTION

`sniff_csv` interpolates each column name into the `Prompt`'s `columns={...}`
unescaped, so a name holding `'` closes the literal and the statement it returns
does not parse. On a file with header `id,it's`:

    columns={'id': 'BIGINT', 'it's': 'BIGINT'}
    Parser Error: unterminated string literal

The name and the path go through `SQLString`, which is how `Value::ToSQLString`
renders the same shape at `value.cpp:1790`. The new sqllogictest asserts the
Prompt and then executes it.
