### PR TITLE
Fix integer overflow in suffix() for 2GB+ suffixes

### DIFF
--- a/src/function/scalar/string/suffix.cpp
+++ b/src/function/scalar/string/suffix.cpp
@@ -18,16 +18,7 @@ static bool SuffixFunction(const string_t &str, const string_t &suffix) {
 		return false;
 	}
 
-	auto suffix_data = suffix.GetData();
-	auto str_data = str.GetData();
-	auto suf_idx = UnsafeNumericCast<int32_t>(suffix_size) - 1;
-	idx_t str_idx = str_size - 1;
-	for (; suf_idx >= 0; --suf_idx, --str_idx) {
-		if (suffix_data[suf_idx] != str_data[str_idx]) {
-			return false;
-		}
-	}
-	return true;
+	return memcmp(str.GetData() + str_size - suffix_size, suffix.GetData(), suffix_size) == 0;
 }
 
 struct SuffixOperator {

--- a/test/sql/function/string/suffix_large_string.test_slow
+++ b/test/sql/function/string/suffix_large_string.test_slow
@@ -1,0 +1,17 @@
+# name: test/sql/function/string/suffix_large_string.test_slow
+# group: [string]
+
+mode skip Test allocates 9GB and takes ~40 seconds on a release build
+
+# suffixes of 2^31 bytes or more used to overflow the comparison index
+query I
+SELECT suffix(repeat('a', 2147483648), repeat('b', 2147483648))
+----
+false
+
+query I
+SELECT suffix(repeat('a', 2147483648), repeat('a', 2147483648))
+----
+true
+
+mode unskip


### PR DESCRIPTION
Fixes #25270

`suffix()` cast the suffix length to `int32_t` to drive its comparison loop. Strings can be up to 4 GiB, so anything >= 2 GiB overflowed .

Swapped the loop for a single `memcmp` over the tail so everything stays in `idx_t`. Nicer and faster for normal strings too.

### Testing
Added `suffix_large_string.test_slow`, but with `mode skip`' because it needs ~9 GB and ~40 s per query, similar to `arg_max_overflow.test_slow`
