### PR TITLE
Prune row group for contains on inexact stats

### DIFF
--- a/src/function/scalar/string/contains.cpp
+++ b/src/function/scalar/string/contains.cpp
@@ -147,8 +147,7 @@ static FilterPropagateResult ContainsFilterPrune(const FunctionStatisticsPruneIn
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 
-	if (StringStats::GetMinType(*haystack_stats) != StringStatsType::EXACT_STATS ||
-	    StringStats::GetMaxType(*haystack_stats) != StringStatsType::EXACT_STATS) {
+	if (!StringStats::HasMinMax(*haystack_stats)) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
 
@@ -157,8 +156,13 @@ static FilterPropagateResult ContainsFilterPrune(const FunctionStatisticsPruneIn
 	if (min != max) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	// If all strings are the same, we can evaluate the predicate directly.
+	// All strings share the stored prefix, so a needle within it always matches.
 	if (FindStrInStr(string_t(min), string_t(needle)) == DConstants::INVALID_INDEX) {
+		// A missing needle could still occur beyond the truncated prefix.
+		if (StringStats::GetMinType(*haystack_stats) != StringStatsType::EXACT_STATS ||
+		    StringStats::GetMaxType(*haystack_stats) != StringStatsType::EXACT_STATS) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
 		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
 	}
 	return haystack_stats->CanHaveNull() ? FilterPropagateResult::FILTER_TRUE_OR_NULL

--- a/test/sql/optimizer/contains_row_group_pruning.test
+++ b/test/sql/optimizer/contains_row_group_pruning.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/contains_row_group_pruning.test
-# description: Row-group pruning through contains when all values in a row group are identical
+# description: Row-group pruning through contains using constant values and shared prefixes
 # group: [optimizer]
 
 statement ok
@@ -88,3 +88,19 @@ query I
 SELECT count(*) FROM long_strings WHERE contains(s, 'python');
 ----
 0
+
+# The first two row groups share /api/health/; the first also contains a NULL.
+statement ok
+CREATE TABLE requests AS
+SELECT CASE WHEN i = 0 THEN NULL WHEN i < 4096 THEN '/api/health/' ELSE '/api/orders/' END || i::VARCHAR AS path
+FROM range(6144) t(i);
+
+query I
+SELECT count(*) FROM requests WHERE path NOT LIKE '%health%';
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT path FROM requests WHERE path NOT LIKE '%health%';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*


### PR DESCRIPTION
Hi team, I found for `contains` function, row groups are not pruned as expected for inexact stats, for example
```sql
memory D ATTACH '/tmp/contains_prune.duckdb' AS db (ROW_GROUP_SIZE 2048);
memory D USE db;
db D CREATE TABLE requests AS
     SELECT CASE WHEN i = 0 THEN NULL WHEN i < 4096 THEN '/api/health/' ELSE '/api/orders/' END || i::VARCHAR AS path
     FROM range(6144) t(i);

-- only third row group contains non-"health" strings, so should only access one rg
db D EXPLAIN ANALYZE SELECT path FROM requests WHERE path NOT LIKE '%health%';
╭─ Summary ───────────╮
│ Total Time: 0.0016s │
╰─────────────────────╯
╭─ Table Scan ──────────────────────────╮
│ Table: db.main.requests               │
│ Type: Sequential Scan                 │
│ Projections: path                     │
│ Filters: NOT contains(path, 'health') │
│ Row Groups Scanned: 3 / 3             │
│ 2,048 rows                        0µs │
╰───────────────────────────────────────╯
```
The reason is, in the current implementation, we conclude [unable to prune when not exact stats](https://github.com/duckdb/duckdb/blob/a0315f712c64627fde0f77879730f28a4e9c8c46/src/function/scalar/string/contains.cpp#L150-L153); the missing case is, for inexact stats we're possible to tell the needle exists in the row group.