### PR TITLE
Support triggers on custom table catalog entries

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -393,6 +393,10 @@ optional_ptr<CatalogEntry> TableCatalogEntry::GetTrigger(CatalogTransaction tran
 	return nullptr;
 }
 
+bool TableCatalogEntry::DropTrigger(CatalogTransaction transaction, const Identifier &name, bool cascade) {
+	throw NotImplementedException("Triggers are not supported for this table type");
+}
+
 vector<const_reference<TriggerCatalogEntry>> TableCatalogEntry::GetTriggersForEvent(CatalogTransaction transaction,
                                                                                     TriggerEventType event_type,
                                                                                     TriggerForEach for_each) const {

--- a/src/execution/operator/schema/physical_drop.cpp
+++ b/src/execution/operator/schema/physical_drop.cpp
@@ -5,8 +5,8 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/catalog/catalog_search_path.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/main/settings.hpp"
-#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/parser/parsed_data/extra_drop_info.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
 
@@ -69,9 +69,8 @@ SourceResultType PhysicalDrop::GetDataInternal(ExecutionContext &context, DataCh
 		}
 		auto &base_table_ref = trigger_extra.base_table->Cast<BaseTableRef>();
 		auto &table_entry = Catalog::GetEntry<TableCatalogEntry>(context.client, base_table_ref.GetQualifiedName());
-		auto &duck_table = table_entry.Cast<DuckTableEntry>();
-		auto transaction = duck_table.catalog.GetCatalogTransaction(context.client);
-		if (!duck_table.DropTrigger(transaction, info->GetQualifiedName().Name(), info->cascade)) {
+		auto transaction = table_entry.ParentCatalog().GetCatalogTransaction(context.client);
+		if (!table_entry.DropTrigger(transaction, info->GetQualifiedName().Name(), info->cascade)) {
 			if (info->if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
 				throw CatalogException("Trigger with name %s does not exist on table %s",
 				                       info->GetQualifiedName().Name(), base_table_ref.Table());

--- a/src/function/table/system/duckdb_triggers.cpp
+++ b/src/function/table/system/duckdb_triggers.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/function/table/system_functions.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/trigger_catalog_entry.hpp"
@@ -72,24 +71,19 @@ unique_ptr<GlobalTableFunctionState> DuckDBTriggersInit(ClientContext &context, 
 	auto result = make_uniq<DuckDBTriggersData>();
 
 	auto schemas = Catalog::GetAllSchemas(context);
-	vector<reference<DuckTableEntry>> tables;
+	vector<reference<TableCatalogEntry>> tables;
 	for (auto &schema : schemas) {
 		schema.get().Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
 			if (entry.type != CatalogType::TABLE_ENTRY) {
 				return;
 			}
-			auto &table = entry.Cast<TableCatalogEntry>();
-			if (!table.IsDuckTable()) {
-				return;
-			}
-			auto &duck_table = entry.Cast<DuckTableEntry>();
-			tables.push_back(duck_table);
+			tables.push_back(entry.Cast<TableCatalogEntry>());
 		});
 	}
 	for (auto &table : tables) {
-		auto &duck_table = table.get();
-		auto transaction = CatalogTransaction(duck_table.ParentCatalog(), context);
-		duck_table.ScanTriggers(transaction, [&](CatalogEntry &trigger) {
+		auto &table_entry = table.get();
+		auto transaction = table_entry.ParentCatalog().GetCatalogTransaction(context);
+		table_entry.ScanTriggers(transaction, [&](CatalogEntry &trigger) {
 			result->entries.push_back(trigger.Cast<TriggerCatalogEntry>());
 		});
 	}

--- a/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/duck_table_entry.hpp
@@ -78,7 +78,7 @@ public:
 	//! Scan all triggers without a transaction (used by checkpoint writer)
 	void ScanTriggersNonTransactional(const std::function<void(CatalogEntry &)> &callback);
 	//! Drop a trigger by name
-	bool DropTrigger(CatalogTransaction transaction, const Identifier &name, bool cascade);
+	bool DropTrigger(CatalogTransaction transaction, const Identifier &name, bool cascade) override;
 
 private:
 	unique_ptr<CatalogEntry> RenameColumn(ClientContext &context, RenameColumnInfo &info);

--- a/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -156,6 +156,8 @@ public:
 	                          const std::function<void(CatalogEntry &)> &callback) const;
 	//! Get the trigger with the given name on this table
 	virtual optional_ptr<CatalogEntry> GetTrigger(CatalogTransaction transaction, const Identifier &name) const;
+	//! Drop a trigger from this table (throws for table types that don't support triggers)
+	virtual bool DropTrigger(CatalogTransaction transaction, const Identifier &name, bool cascade);
 	//! Collect triggers matching the given event type and for_each granularity, regardless of timing
 	vector<const_reference<TriggerCatalogEntry>>
 	GetTriggersForEvent(CatalogTransaction transaction, TriggerEventType event_type, TriggerForEach for_each) const;


### PR DESCRIPTION
## Summary

- add a virtual TableCatalogEntry::DropTrigger hook and route DROP TRIGGER through it
- make duckdb_triggers() scan every TableCatalogEntry through the existing virtual ScanTriggers hook
- obtain each trigger operation transaction from the table entry's owning catalog

## Motivation

TableCatalogEntry already provides virtual CreateTrigger, ScanTriggers, and GetTrigger hooks, but DROP TRIGGER hard-casts its target to DuckTableEntry and duckdb_triggers() filters out non-DuckTableEntry tables. Those native-table assumptions prevent storage extensions with custom table catalog entries from implementing the full trigger lifecycle and appearing in trigger introspection.

The default DropTrigger implementation mirrors the existing trigger hooks by rejecting unsupported table types; DuckTableEntry overrides it with its current implementation.

## Testing

- make reldebug (remote Linux ARM host; 627/627 targets)
- build/reldebug/test/unittest 'test/sql/trigger/*' (28 test cases, 1,899 assertions passed; one environment-gated skip)