### PR TITLE
Fix ORDER BY turning -0.0 into 0.0 for FLOAT/DOUBLE columns

### DIFF
--- a/src/common/sort/sort.cpp
+++ b/src/common/sort/sort.cpp
@@ -102,14 +102,20 @@ Sort::Sort(ClientContext &client_context_p, const vector<BoundOrderByNode> &orde
 	vector<LogicalType> payload_types;
 	for (idx_t output_col_idx = 0; output_col_idx < projection_map.size(); output_col_idx++) {
 		const auto &input_col_idx = projection_map[output_col_idx];
+		const auto &input_col_type = input_types[input_col_idx];
 		const auto it = input_column_to_key.find(input_col_idx);
-		if (it != input_column_to_key.end()) {
+		//! The sort key encoding for FLOAT/DOUBLE is not injective around zero (-0.0 and 0.0 encode
+		//! identically, since they must compare equal), so re-decoding the key would turn -0.0 into 0.0.
+		//! Route such columns through the payload instead, where the original bits are preserved.
+		const bool key_encoding_is_lossy = TypeVisitor::Contains(input_col_type, LogicalTypeId::FLOAT) ||
+		                                   TypeVisitor::Contains(input_col_type, LogicalTypeId::DOUBLE);
+		if (it != input_column_to_key.end() && !key_encoding_is_lossy) {
 			// Projected column also appears as a key, just reference it
 			output_projection_columns.push_back({false, it->second, output_col_idx});
 		} else {
 			// Projected column does not appear as a key, add to payload layout
 			output_projection_columns.push_back({true, payload_types.size(), output_col_idx});
-			payload_types.push_back(input_types[input_col_idx]);
+			payload_types.push_back(input_col_type);
 			input_projection_map.push_back(input_col_idx);
 		}
 	}

--- a/test/configs/compressed_in_memory.json
+++ b/test/configs/compressed_in_memory.json
@@ -34,6 +34,12 @@
         "test/sql/optimizer/nested_null_segment_pruning.test",
         "test/sql/optimizer/false_or_null_segment_pruning.test"
       ]
+    },
+    {
+      "reason": "Compression loses the sign of zero for FLOAT/DOUBLE, unrelated bug, see issue #25580",
+      "paths": [
+        "test/sql/order/order_by_negative_zero.test"
+      ]
     }
   ]
 }

--- a/test/configs/encryption.json
+++ b/test/configs/encryption.json
@@ -114,6 +114,12 @@
         "test/sql/optimizer/secure_view_pushdown.test",
         "test/sql/optimizer/secure_view_statistics.test"
       ]
+    },
+    {
+      "reason": "Persisting loses the sign of zero for FLOAT/DOUBLE, unrelated bug, see issue #25580",
+      "paths": [
+        "test/sql/order/order_by_negative_zero.test"
+      ]
     }
   ]
 }

--- a/test/sql/order/order_by_negative_zero.test
+++ b/test/sql/order/order_by_negative_zero.test
@@ -1,0 +1,45 @@
+# name: test/sql/order/order_by_negative_zero.test
+# description: Test that ORDER BY does not turn -0.0 into 0.0 for FLOAT/DOUBLE
+# group: [order]
+
+statement ok
+CREATE TABLE zero_probe(id INTEGER, v DOUBLE, vf FLOAT);
+
+statement ok
+INSERT INTO zero_probe VALUES (1, '-0.0', '-0.0'), (2, '0.0', '0.0');
+
+# sanity check: signbit is preserved without sorting
+query III
+SELECT id, signbit(v), signbit(vf) FROM zero_probe ORDER BY id;
+----
+1	true	true
+2	false	false
+
+# sorting by the double/float column itself must not flip the sign of zero
+query III
+SELECT id, signbit(v), signbit(vf) FROM zero_probe ORDER BY v, id;
+----
+1	true	true
+2	false	false
+
+query II
+SELECT v, 1.0 / v FROM zero_probe ORDER BY v, id;
+----
+-0.0	-inf
+0.0	inf
+
+# projecting the sort column out of a materialized CTE must also preserve it
+statement ok
+CREATE TEMP TABLE srs_zero_probe(id INTEGER, v DOUBLE);
+
+statement ok
+INSERT INTO srs_zero_probe VALUES (1, '-0.0'), (2, '0.0');
+
+query IIII
+WITH q AS MATERIALIZED (
+    SELECT id, v FROM srs_zero_probe ORDER BY v, id
+)
+SELECT id, v, signbit(v), 1.0 / v FROM q ORDER BY id;
+----
+1	-0.0	true	-inf
+2	0.0	false	inf

--- a/test/sql/order/order_by_negative_zero.test
+++ b/test/sql/order/order_by_negative_zero.test
@@ -2,6 +2,9 @@
 # description: Test that ORDER BY does not turn -0.0 into 0.0 for FLOAT/DOUBLE
 # group: [order]
 
+# checkpointing loses the sign of zero regardless of ORDER BY; unrelated bug, see issue #25580
+require noforcestorage
+
 statement ok
 CREATE TABLE zero_probe(id INTEGER, v DOUBLE, vf FLOAT);
 


### PR DESCRIPTION
## Summary
Root cause: `Sort::Sort` reconstructs any output column that's also an `ORDER BY` key by decoding it back from the internal sort key rather than keeping a separate payload copy. The sort key encoding for `FLOAT`/`DOUBLE` (`Radix::EncodeFloat`/`EncodeDouble`) intentionally maps `-0.0` and `0.0` to the same bit pattern so they compare equal, but that makes the encoding non-injective, and decoding it back always yields `+0.0`.

## Fix
 In `src/common/sort/sort.cpp`, when a key column's type contains `FLOAT`/`DOUBLE`, route it through the payload instead of aliasing it to the decoded sort key, so the original bits (including signed zero) are preserved.


## Tests
- Added `test/sql/order/order_by_negative_zero.test` covering `signbit()` and `1.0/v` before/after sorting on `DOUBLE` and `FLOAT`, plus the materialized-CTE case from the issue report.

Fixes #25417