### PR TITLE
Drop repeated ORDER BY expressions

### DIFF
--- a/src/planner/binder/query_node/bind_select_node.cpp
+++ b/src/planner/binder/query_node/bind_select_node.cpp
@@ -400,6 +400,9 @@ void Binder::BindModifiers(BoundQueryNode &result, TableIndex table_index, const
 				}
 				ExpressionBinder::PushCollation(context, order_node.expression, order_node.expression->GetReturnType());
 			}
+			// an ORDER BY expression that already appeared cannot refine the ordering any further - the rows
+			// it would compare are exactly the rows the earlier occurrence already tied together
+			BoundOrderModifier::Simplify(order.orders, vector<unique_ptr<Expression>>(), nullptr);
 			break;
 		}
 		default:

--- a/test/sql/order/order_by_duplicate_keys.test
+++ b/test/sql/order/order_by_duplicate_keys.test
@@ -1,0 +1,85 @@
+# name: test/sql/order/order_by_duplicate_keys.test
+# description: Test that a repeated ORDER BY expression is dropped
+# group: [order]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+PRAGMA explain_output = OPTIMIZED_ONLY;
+
+statement ok
+CREATE TABLE t(a INTEGER, b VARCHAR);
+
+statement ok
+INSERT INTO t VALUES (2, 'y'), (1, 'x'), (2, 'x');
+
+# a repeated key cannot refine the ordering: the rows it would compare are the rows the
+# earlier occurrence already tied together
+query II
+EXPLAIN SELECT * FROM t ORDER BY a, a
+----
+logical_opt	<!REGEX>:.*Order By: a, a.*
+
+query II
+EXPLAIN SELECT * FROM t ORDER BY b, a, b
+----
+logical_opt	<!REGEX>:.*Order By: b, a, b.*
+
+# ... the same holds when the repetition is spelled differently
+query II
+EXPLAIN SELECT a FROM t ORDER BY a, 1
+----
+logical_opt	<!REGEX>:.*Order By: a, a.*
+
+query II
+EXPLAIN SELECT * FROM t ORDER BY a, t.a
+----
+logical_opt	<!REGEX>:.*Order By: a, a.*
+
+# the sort order of the first occurrence is the one that applies
+query I
+SELECT a FROM t ORDER BY a, a
+----
+1
+2
+2
+
+query I
+SELECT a FROM t ORDER BY a DESC, a
+----
+2
+2
+1
+
+query I
+SELECT a FROM t ORDER BY a, a DESC LIMIT 1
+----
+1
+
+# keys that are not repeated are all kept
+query II
+EXPLAIN SELECT * FROM t ORDER BY b, a
+----
+logical_opt	<REGEX>:.*Order By: b, a.*
+
+query II
+SELECT * FROM t ORDER BY b, a
+----
+1	x
+2	x
+2	y
+
+# a collated key is a different expression, so it is not a repetition and both keys are kept
+# (the collation function carries the alias of its argument, so both render as "b")
+query II
+EXPLAIN SELECT b FROM t ORDER BY b, b COLLATE NOCASE
+----
+logical_opt	<REGEX>:.*Order By: b, b.*
+
+query I
+SELECT b FROM t ORDER BY b, b COLLATE NOCASE
+----
+x
+x
+y


### PR DESCRIPTION
Fixes #23994.

`ORDER BY a, a` keeps both keys in the plan, so the sort compares every row on `a` twice:

```
EXPLAIN SELECT * FROM (VALUES (2), (1)) AS t(a) ORDER BY a, a;
╭─ Order By ─────────╮
│ Order By: a ASC,   │
│           a ASC    │
╰──────────┬─────────╯
```

A repeated ORDER BY expression cannot refine the ordering. The rows the second key would compare are exactly the rows the first occurrence already tied together, so it never decides anything - it only costs a comparison per row and, for the sort key layout, an extra column.

`BoundOrderModifier::Simplify` already drops repeated expressions. It was called for the ORDER BY of an aggregate (`ordered_aggregate_optimizer.cpp`, `sorted_aggregate_function.cpp`) and for the argument orders of a window function, but not for the ORDER BY of a query. This calls it there as well, in `Binder::BindModifiers`.

It runs after the collation has been pushed, so a key that differs only by collation is still a different expression and is kept:

```sql
-- one key
SELECT * FROM t ORDER BY a, a;
SELECT * FROM t ORDER BY a, t.a;
SELECT a FROM t ORDER BY a, 1;
-- two keys: a and lower(a)
SELECT * FROM t ORDER BY a, a COLLATE NOCASE;
```

The sort order and null order of the first occurrence are the ones that apply, so `ORDER BY a DESC, a` sorts descending. `LIMIT` is unaffected, the same simplification reaches `Top N`.

New test `test/sql/order/order_by_duplicate_keys.test`. `build/release/test/unittest` passes (6103 test cases, 1449566 assertions).