### PR TITLE
Skip parse/plan/optimize for Connection::BeginTransaction/Commit/Rollback

### DIFF
--- a/src/execution/operator/helper/physical_transaction.cpp
+++ b/src/execution/operator/helper/physical_transaction.cpp
@@ -1,89 +1,12 @@
 #include "duckdb/execution/operator/helper/physical_transaction.hpp"
 
-#include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/main/client_context.hpp"
-#include "duckdb/main/config.hpp"
-#include "duckdb/main/database_manager.hpp"
-#include "duckdb/main/valid_checker.hpp"
-#include "duckdb/transaction/meta_transaction.hpp"
-#include "duckdb/transaction/transaction_manager.hpp"
-#include "duckdb/main/settings.hpp"
 
 namespace duckdb {
 
 SourceResultType PhysicalTransaction::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                       OperatorSourceInput &input) const {
-	auto &client = context.client;
-
-	auto type = info->type;
-	if (type == TransactionType::COMMIT && ValidChecker::IsInvalidated(client.ActiveTransaction())) {
-		// transaction is invalidated - turn COMMIT into ROLLBACK
-		type = TransactionType::ROLLBACK;
-	}
-	switch (type) {
-	case TransactionType::BEGIN_TRANSACTION: {
-		if (client.transaction.IsAutoCommit()) {
-			// start the active transaction
-			// if autocommit is active, we have already called
-			// BeginTransaction by setting autocommit to false we
-			// prevent it from being closed after this query, hence
-			// preserving the transaction context for the next query
-			client.transaction.SetAutoCommit(false);
-			if (info->modifier == TransactionModifierType::TRANSACTION_READ_ONLY) {
-				client.transaction.SetReadOnly();
-			}
-			client.transaction.SetInvalidationPolicy(info->invalidation_policy);
-			client.transaction.SetAutoRollback(info->auto_rollback);
-			if (Settings::Get<ImmediateTransactionModeSetting>(context.client)) {
-				// if immediate transaction mode is enabled then start all transactions immediately
-				auto databases = DatabaseManager::Get(client).GetDatabases(client);
-				for (auto &db : databases) {
-					if (ValidChecker::IsInvalidated(*db)) {
-						continue;
-					}
-					context.client.transaction.ActiveTransaction().GetTransaction(*db);
-				}
-			}
-		} else {
-			throw TransactionException("cannot start a transaction within a transaction");
-		}
-		break;
-	}
-	case TransactionType::COMMIT: {
-		if (client.transaction.IsAutoCommit()) {
-			throw TransactionException("cannot commit - no transaction is active");
-		} else {
-			// explicitly commit the current transaction
-			client.transaction.Commit();
-			// Suppress further interrupts for the remainder of this query.
-			// A committed transaction is irreversible. If a concurrent Interrupt()
-			// arrives after the physical commit, it must be silently discarded —
-			// otherwise the caller sees a failed COMMIT even though the data
-			// is already durably committed.
-			client.SuppressInterrupts();
-		}
-		break;
-	}
-	case TransactionType::ROLLBACK: {
-		if (client.transaction.IsAutoCommit()) {
-			throw TransactionException("cannot rollback - no transaction is active");
-		} else {
-			// Explicitly rollback the current transaction
-			// If it is because of an invalidated transaction, we need to rollback with an error
-			auto &valid_checker = ValidChecker::Get(client.transaction.ActiveTransaction());
-			if (valid_checker.IsInvalidated()) {
-				ErrorData error(ExceptionType::TRANSACTION, valid_checker.InvalidatedMessage());
-				client.transaction.Rollback(error);
-			} else {
-				client.transaction.Rollback(nullptr);
-			}
-		}
-		break;
-	}
-	default:
-		throw NotImplementedException("Unrecognized transaction type!");
-	}
-
+	context.client.RunTransactionStatementInternal(*info);
 	return SourceResultType::FINISHED;
 }
 

--- a/src/include/duckdb/main/client_context.hpp
+++ b/src/include/duckdb/main/client_context.hpp
@@ -57,7 +57,10 @@ class SimpleBufferedData;
 class BufferedData;
 struct ClientData;
 class ClientContextState;
+class Connection;
+class PhysicalTransaction;
 class RegisteredStateManager;
+struct TransactionInfo;
 
 struct PendingQueryParameters {
 	//! Prepared statement parameters (if any)
@@ -94,6 +97,8 @@ class ClientContext : public enable_shared_from_this<ClientContext> {
 	friend class BatchedBufferedData; // ExecuteTaskInternal
 	friend class StreamQueryResult;   // LockContext
 	friend class ConnectionManager;
+	friend class Connection;
+	friend class PhysicalTransaction;
 
 public:
 	DUCKDB_API explicit ClientContext(shared_ptr<DatabaseInstance> db);
@@ -281,6 +286,11 @@ public:
 	DUCKDB_API LogicalType ParseLogicalType(const string &type);
 
 private:
+	//! Runs a transaction statement without going through the local query processing pipeline.
+	void RunTransactionStatement(const TransactionInfo &info);
+	//! Same as RunTransactionStatement, but does not obtain a lock or route CONNECT statements.
+	void RunTransactionStatementInternal(const TransactionInfo &info);
+
 	//! Issues a query to the database and returns a Pending Query Result
 	unique_ptr<PendingQueryResult> PendingQueryInternal(ClientContextLock &lock, unique_ptr<SQLStatement> statement,
 	                                                    const PendingQueryParameters &parameters, bool verify = true);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1389,6 +1389,86 @@ void ClientContext::RegisterFunction(CreateFunctionInfo &info) {
 	});
 }
 
+void ClientContext::RunTransactionStatementInternal(const TransactionInfo &info) {
+	auto type = info.type;
+	if (type == TransactionType::COMMIT && transaction.HasActiveTransaction() &&
+	    ValidChecker::IsInvalidated(ActiveTransaction())) {
+		// transaction is invalidated - turn COMMIT into ROLLBACK
+		type = TransactionType::ROLLBACK;
+	}
+	switch (type) {
+	case TransactionType::BEGIN_TRANSACTION: {
+		if (!transaction.IsAutoCommit()) {
+			throw TransactionException("cannot start a transaction within a transaction");
+		}
+		transaction.SetAutoCommit(false);
+		if (info.modifier == TransactionModifierType::TRANSACTION_READ_ONLY) {
+			transaction.SetReadOnly();
+		}
+		transaction.SetInvalidationPolicy(info.invalidation_policy);
+		transaction.SetAutoRollback(info.auto_rollback);
+		if (Settings::Get<ImmediateTransactionModeSetting>(*this)) {
+			auto databases = DatabaseManager::Get(*this).GetDatabases(*this);
+			for (auto &attached : databases) {
+				if (ValidChecker::IsInvalidated(*attached)) {
+					continue;
+				}
+				transaction.ActiveTransaction().GetTransaction(*attached);
+			}
+		}
+		break;
+	}
+	case TransactionType::COMMIT:
+		if (transaction.IsAutoCommit()) {
+			throw TransactionException("cannot commit - no transaction is active");
+		}
+		transaction.Commit();
+		// The commit is irreversible, so ignore interrupts until the next query.
+		SuppressInterrupts();
+		break;
+	case TransactionType::ROLLBACK: {
+		if (transaction.IsAutoCommit()) {
+			throw TransactionException("cannot rollback - no transaction is active");
+		}
+		auto &valid_checker = ValidChecker::Get(transaction.ActiveTransaction());
+		if (valid_checker.IsInvalidated()) {
+			ErrorData error(ExceptionType::TRANSACTION, valid_checker.InvalidatedMessage());
+			transaction.Rollback(error);
+		} else {
+			transaction.Rollback(nullptr);
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Unrecognized transaction type!");
+	}
+}
+
+void ClientContext::RunTransactionStatement(const TransactionInfo &info) {
+	auto lock = LockContext();
+	InitialCleanup(*lock);
+	if (is_connected) {
+		auto statement = make_uniq<TransactionStatement>(info.Copy());
+		statement->query = info.ToString();
+		PendingQueryParameters parameters;
+		parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+		auto result = RunStatementInternal(*lock, std::move(statement), parameters);
+		if (result->HasError()) {
+			if (transaction.HasActiveTransaction() && transaction.GetAutoRollback()) {
+				transaction.Rollback(result->GetErrorObject());
+			}
+			interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
+			result->ThrowError();
+		}
+		return;
+	}
+	auto &db_instance = DatabaseInstance::GetDatabase(*this);
+	if (ValidChecker::IsInvalidated(db_instance)) {
+		throw ErrorManager::InvalidatedDatabase(*this, ValidChecker::InvalidatedMessage(db_instance));
+	}
+	RunTransactionStatementInternal(info);
+}
+
 void ClientContext::RunFunctionInTransactionInternal(ClientContextLock &lock, const std::function<void(void)> &fun,
                                                      bool requires_valid_transaction) {
 	if (requires_valid_transaction && transaction.HasActiveTransaction() &&

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -1457,7 +1457,7 @@ void ClientContext::RunTransactionStatement(const TransactionInfo &info) {
 			if (transaction.HasActiveTransaction() && transaction.GetAutoRollback()) {
 				transaction.Rollback(result->GetErrorObject());
 			}
-			interrupt_state = ClientInterruptState::NOT_INTERRUPTED;
+			ClearInterrupt();
 			result->ThrowError();
 		}
 		return;

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/main/relation/table_relation.hpp"
 #include "duckdb/main/relation/value_relation.hpp"
 #include "duckdb/main/relation/view_relation.hpp"
+#include "duckdb/parser/parsed_data/transaction_info.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/main/statement_iterator.hpp"
@@ -339,24 +340,18 @@ shared_ptr<Relation> Connection::RelationFromQuery(unique_ptr<SelectStatement> s
 }
 
 void Connection::BeginTransaction() {
-	auto result = Query("BEGIN TRANSACTION");
-	if (result->HasError()) {
-		result->ThrowError();
-	}
+	TransactionInfo info(TransactionType::BEGIN_TRANSACTION);
+	context->RunTransactionStatement(info);
 }
 
 void Connection::Commit() {
-	auto result = Query("COMMIT");
-	if (result->HasError()) {
-		result->ThrowError();
-	}
+	TransactionInfo info(TransactionType::COMMIT);
+	context->RunTransactionStatement(info);
 }
 
 void Connection::Rollback() {
-	auto result = Query("ROLLBACK");
-	if (result->HasError()) {
-		result->ThrowError();
-	}
+	TransactionInfo info(TransactionType::ROLLBACK);
+	context->RunTransactionStatement(info);
 }
 
 void Connection::SetAutoCommit(bool auto_commit) {

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -462,7 +462,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 		return nullptr;
 	}
 
-	con.context->transaction.SetAutoCommit(false);
+	con.BeginTransaction();
 	MetaTransaction::Get(*con.context).ModifyDatabase(database, DatabaseModificationType());
 
 	auto &config = DBConfig::GetConfig(database.GetDatabase());
@@ -612,7 +612,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 			// read the current entry
 			auto deserializer = WriteAheadLogDeserializer::GetEntryDeserializer(state, wal_reader);
 			if (deserializer.ReplayEntry()) {
-				con.context->transaction.Commit();
+				con.Commit();
 
 				// Commit any outstanding indexes.
 				for (auto &info : state.replay_index_infos) {
@@ -627,7 +627,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 					all_succeeded = true;
 					break;
 				}
-				con.context->transaction.SetAutoCommit(false);
+				con.BeginTransaction();
 				MetaTransaction::Get(*con.context).ModifyDatabase(database, DatabaseModificationType());
 			}
 		}

--- a/src/storage/wal_replay.cpp
+++ b/src/storage/wal_replay.cpp
@@ -462,7 +462,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 		return nullptr;
 	}
 
-	con.BeginTransaction();
+	con.context->transaction.SetAutoCommit(false);
 	MetaTransaction::Get(*con.context).ModifyDatabase(database, DatabaseModificationType());
 
 	auto &config = DBConfig::GetConfig(database.GetDatabase());
@@ -612,7 +612,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 			// read the current entry
 			auto deserializer = WriteAheadLogDeserializer::GetEntryDeserializer(state, wal_reader);
 			if (deserializer.ReplayEntry()) {
-				con.Commit();
+				con.context->transaction.Commit();
 
 				// Commit any outstanding indexes.
 				for (auto &info : state.replay_index_infos) {
@@ -627,7 +627,7 @@ unique_ptr<WriteAheadLog> WriteAheadLogReplayer::ReplayLog(unique_ptr<FileHandle
 					all_succeeded = true;
 					break;
 				}
-				con.BeginTransaction();
+				con.context->transaction.SetAutoCommit(false);
 				MetaTransaction::Get(*con.context).ModifyDatabase(database, DatabaseModificationType());
 			}
 		}

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/main/connection_manager.hpp"
+#include "duckdb/main/valid_checker.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/storage/metadata/metadata_manager.hpp"
@@ -548,6 +549,35 @@ TEST_CASE("Test connection API", "[api]") {
 
 	con.SetAutoCommit(true);
 	REQUIRE(con.IsAutoCommit());
+}
+
+TEST_CASE("Test connection transaction API error scenarios", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+
+	// a failed nested BEGIN does not abort the outer transaction
+	REQUIRE_NOTHROW(con.BeginTransaction());
+	REQUIRE_THROWS(con.BeginTransaction());
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (42)"));
+	REQUIRE_NOTHROW(con.Commit());
+	auto result = con.Query("SELECT i FROM integers");
+	REQUIRE(CHECK_COLUMN(result, 0, {42}));
+
+	// COMMIT on an invalidated transaction rolls back instead of throwing
+	REQUIRE_NOTHROW(con.BeginTransaction());
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO integers VALUES (84)"));
+	ValidChecker::Invalidate(con.context->ActiveTransaction(), "test invalidation");
+	REQUIRE_FAIL(con.Query("SELECT 42"));
+	REQUIRE_NOTHROW(con.Commit());
+	// the transaction was rolled back and the connection is usable again
+	REQUIRE(con.IsAutoCommit());
+	result = con.Query("SELECT count(*) FROM integers");
+	REQUIRE(CHECK_COLUMN(result, 0, {1}));
+
+	// no transaction is active anymore - COMMIT and ROLLBACK throw again
+	REQUIRE_THROWS(con.Commit());
+	REQUIRE_THROWS(con.Rollback());
 }
 
 TEST_CASE("Test parser tokenize", "[api]") {


### PR DESCRIPTION
Hi team, I'm playing with WAL replay and found for small transactions (i.e., BEGIN; single row append; COMMIT;) replay latency is linear in the number of transactions

Example benchmark
```py
for n in (10000, 50000, 200000):
    with open(f'/tmp/wal_bench/A{n}.sql', 'w') as f:
        f.write("CREATE TABLE t(a INT, b VARCHAR);\n")
        for i in range(n):
            f.write(f"BEGIN; INSERT INTO t VALUES ({i}, 'row_{i}'); COMMIT;\n")
```
Checkpoint on shutdown is disabled, WAL auto checkpoint is set to an unreachably high value to guarantee replay takes all the insertions and transactions.

I did a flamegraph on WAL replay, from the rendered graph, we could easily tell most of the time is spent on `BeginTransaction` and `Commit`, with planner + optimizer + executor work inside, which is not necessary for WAL replay. The actual replay work takes only ~10% of the CPU time.
<img width="1171" height="311" alt="image" src="https://github.com/user-attachments/assets/829cb5c3-ef4e-464b-95df-d01504129a4e" />

The commit pseudocode looks like (asked opus-4.7 to draw the callstack), begin transaction looks alike
```sh
con.Commit()                                       ← what we call
 └─ Query("COMMIT")                                ← Connection::Commit implementation
     └─ Parser::ParseQuery("COMMIT")
     └─ Binder::Bind
     └─ Planner::CreatePlan
     └─ Optimizer::Optimizer(binder, context)      ← every rewrite rule is constructed!
        (ContainsToInClauseRule, EnumCompareSimplification,
         MoveConstantsRule, StringPrefixRule, ...)
     └─ PhysicalPlanGenerator::CreatePlan
     └─ Executor::ExecuteTask
        └─ PhysicalTransaction::GetDataInternal(COMMIT)
           └─ switch(type): case COMMIT:
                if (IsAutoCommit()) throw ...
                client.transaction.Commit();       ← the one line that does real work
                client.SuppressInterrupts();
```

So in this PR, I propose to simplify the replay to skip all the redundant work and only include necessary work
- Start a transaction with `TransactionContext::SetAutoCommit(false)`
- Commit a transaction with `TransactionContext::Commit`

Performance comparison before and after the change
| Scenario                        | Before   | After     | Speedup    |
|---------------------------------|---------:|----------:|-----------:|
| 10 k single-row transactions    | 0.72 s   | **0.11 s**| **6.5×**   |
| 50 k single-row transactions    | 3.65 s   | **0.59 s**| **6.2×**   |
| 200 k single-row transactions   | 14.16 s  | **2.04 s**| **6.9×**   |
| 2000 CREATE/INSERT/DROP cycles  | 0.48 s   | **0.06 s**| **8.0×**   |
| 5 M-row single INSERT           | 0.02 s   | 0.02 s    | no change  |
| 200 k rows + 10× UPDATE-all     | 0.05 s   | 0.05 s    | no change  |
