### PR TITLE
Fix WAL replay crash for failed table rename

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -331,7 +331,6 @@ unique_ptr<CatalogEntry> DuckTableEntry::AlterEntry(ClientContext &context, Alte
 		auto &rename_info = table_info.Cast<RenameTableInfo>();
 		auto copied_table = Copy(context);
 		copied_table->name = rename_info.new_table_name;
-		storage->SetTableName(rename_info.new_table_name);
 		return copied_table;
 	}
 	case AlterTableType::ADD_COLUMN: {

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -391,6 +391,9 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 		// in that case we are able to just directly destroy the child (if there is any)
 		entry_to_destroy = new_entry->TakeChild();
 	}
+	if (new_entry->name != entry->name) {
+		new_entry->SetAsRoot();
+	}
 
 	read_lock.unlock();
 	write_lock.unlock();

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -365,7 +365,7 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 	// Preserve the oid across the alter: an altered entry is the same logical object as before
 	value->oid = entry->oid;
 
-	if (!(value->name == entry->name)) {
+	if (value->name != entry->name) {
 		if (!RenameEntryInternal(transaction, *entry, value->name, alter_info, read_lock)) {
 			return false;
 		}
@@ -391,6 +391,8 @@ bool CatalogSet::AlterEntry(CatalogTransaction transaction, const Identifier &na
 		// in that case we are able to just directly destroy the child (if there is any)
 		entry_to_destroy = new_entry->TakeChild();
 	}
+
+	// Update shared entry state only after the alter is installed and rollbackable.
 	if (new_entry->name != entry->name) {
 		new_entry->SetAsRoot();
 	}

--- a/test/sql/alter/rename_table/test_rename_table_conflict_storage_name.test
+++ b/test/sql/alter/rename_table/test_rename_table_conflict_storage_name.test
@@ -30,9 +30,30 @@ COMMIT
 statement ok
 INSERT INTO ta VALUES (42)
 
+statement ok
+CREATE TABLE rollback_table(i INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE rollback_table RENAME TO rollback_table_new
+
+statement ok
+ROLLBACK
+
+# The restored DataTable name is used for the WAL SET_TABLE entry.
+statement ok
+INSERT INTO rollback_table VALUES (84)
+
 restart
 
 query I
 SELECT * FROM ta ORDER BY i
 ----
 42
+
+query I
+SELECT * FROM rollback_table ORDER BY i
+----
+84

--- a/test/sql/alter/rename_table/test_rename_table_conflict_storage_name.test
+++ b/test/sql/alter/rename_table/test_rename_table_conflict_storage_name.test
@@ -1,0 +1,38 @@
+# name: test/sql/alter/rename_table/test_rename_table_conflict_storage_name.test
+# description: a failed concurrent RENAME TO must not mutate the shared DataTable's stored name
+# group: [rename_table]
+
+load {TEST_DIR}/rename_conflict_storage_name.db
+
+statement ok
+PRAGMA disable_checkpoint_on_shutdown
+
+statement ok
+PRAGMA wal_autocheckpoint='1TB'
+
+statement ok
+CREATE TABLE t(i INTEGER)
+
+statement ok con1
+BEGIN
+
+statement ok con1
+ALTER TABLE t RENAME TO ta
+
+statement error con2
+ALTER TABLE t RENAME TO tb
+----
+<REGEX>:.*write-write conflict.*
+
+statement ok con1
+COMMIT
+
+statement ok
+INSERT INTO ta VALUES (42)
+
+restart
+
+query I
+SELECT * FROM ta ORDER BY i
+----
+42


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25548

The root cause is, in the current implementation, `DataTable` is shared among multiple connections, it [gets updated](https://github.com/duckdb/duckdb/blob/668f94740b280bf44c7c081df664ae1eb310c090/src/catalog/catalog_entry/duck_table_entry.cpp#L334) directly on rename. All later table operations use the incorrectly updated table name, even if the rename transaction gets rollback-ed due to write conflicts.

Some concepts on data structures involved
- `DataTable` is not versioned, so we cannot roll it back on conflict writes
- The old table name is not recorded anywhere either, so the old table name gets lost forever

In DuckDB, `DuckTableEntry`, which also contains the table name information, is versioned; so in this PR, I defer the table rename to `DuckTableEntry`, so it could be rolled back on transaction rollback.

Pseudocode for rename process in the PR
```sh
Create candidate:
  DuckTableEntry.name = new
  DataTableInfo.table = old

Install the catalog change and register undo:
  new_entry.SetAsRoot()
  DataTableInfo.table = new

Rollback:
  old_entry.SetAsRoot()
  DataTableInfo.table = old

Commit:
  No further update is needed; DataTableInfo.table is already new
```

Proposed long-term solution I'd like to followup (I'd like to avoid large refactor before v2.0 release)
```cpp
class DuckTableEntry : public CatalogEntry {
	Identifier name;                  // only source of logical table name
	shared_ptr<DataTable> storage;

	QualifiedName GetQualifiedName() const {
		return QualifiedName(schema.GetSchemaPath(), name);
	}
};
class DataTable {
	shared_ptr<DataTableInfo> info;
};
struct DataTableInfo {
	// No logical table name.
	shared_ptr<TableIOManager> table_io_manager;
	TableIndexList indexes;
	StorageLock checkpoint_lock;
	TableId stable_table_id;
};
```
The core idea of the design is to split table name outside of `DataTable`, so we could make a copy for `DuckTableEntry` on [`DuckTableEntry::AlterEntry`](https://github.com/duckdb/duckdb/blob/668f94740b280bf44c7c081df664ae1eb310c090/src/catalog/catalog_entry/duck_table_entry.cpp#L308), as we did for other alter table operations.