### PR TITLE
Prune boolean function filters with statistics

### DIFF
--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -537,6 +537,29 @@ static FilterPropagateResult CheckBetweenStatistics(optional_ptr<ClientContext> 
 	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 }
 
+static FilterPropagateResult CheckBoolStatistics(const BaseStatistics &stats, bool negated) {
+	if (stats.GetType().id() != LogicalTypeId::BOOLEAN) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	if (!stats.CanHaveNoNull()) {
+		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
+	}
+	if (!NumericStats::HasMinMax(stats)) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	const auto min_v = NumericStats::Min(stats).GetValue<bool>();
+	const auto max_v = NumericStats::Max(stats).GetValue<bool>();
+	if (min_v != max_v) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	const bool value = negated ? !min_v : min_v;
+	if (!value) {
+		return stats.CanHaveNull() ? FilterPropagateResult::FILTER_FALSE_OR_NULL
+		                           : FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	return stats.CanHaveNull() ? FilterPropagateResult::FILTER_TRUE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+}
+
 static FilterPropagateResult CheckFunctionStatistics(optional_ptr<ClientContext> context_p,
                                                      const BoundFunctionExpression &func_expr,
                                                      array_ptr<const BaseStatistics> input_stats) {
@@ -551,7 +574,15 @@ static FilterPropagateResult CheckFunctionStatistics(optional_ptr<ClientContext>
 		return CheckComparisonStatistics(context_p, func_expr, input_stats);
 	}
 	if (!func_expr.Function().HasFilterPruneCallback()) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		if (func_expr.GetReturnType().id() != LogicalTypeId::BOOLEAN || !func_expr.Function().HasStatisticsCallback()) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		vector<unique_ptr<BaseStatistics>> owned_stats;
+		const auto function_stats = TryGetFilterStats(context_p, func_expr, input_stats, owned_stats);
+		if (!function_stats) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+		return CheckBoolStatistics(*function_stats, /*negated=*/false);
 	}
 	// Derive the statistics of each argument. This lets a callback prune regardless of which argument is the column and
 	// which is the constant (e.g. `foo(col, const)` vs `foo(const, col`).
@@ -647,24 +678,7 @@ static FilterPropagateResult CheckBoolRefStatistics(const Expression &expr, arra
 	if (index >= input_stats.size()) {
 		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 	}
-	const auto &stats = input_stats[index];
-	if (!stats.CanHaveNoNull()) {
-		return FilterPropagateResult::FILTER_FALSE_OR_NULL;
-	}
-	if (!NumericStats::HasMinMax(stats)) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-	const auto min_v = NumericStats::Min(stats).GetValue<bool>();
-	const auto max_v = NumericStats::Max(stats).GetValue<bool>();
-	if (min_v != max_v) {
-		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
-	}
-	const bool value = negated ? !min_v : min_v;
-	if (!value) {
-		return stats.CanHaveNull() ? FilterPropagateResult::FILTER_FALSE_OR_NULL
-		                           : FilterPropagateResult::FILTER_ALWAYS_FALSE;
-	}
-	return stats.CanHaveNull() ? FilterPropagateResult::FILTER_TRUE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	return CheckBoolStatistics(input_stats[index], negated);
 }
 
 static FilterPropagateResult CheckNotOperatorStatistics(optional_ptr<ClientContext> context_p,

--- a/test/sql/optimizer/bool_ref_row_group_pruning.test
+++ b/test/sql/optimizer/bool_ref_row_group_pruning.test
@@ -1,5 +1,5 @@
 # name: test/sql/optimizer/bool_ref_row_group_pruning.test
-# description: Bare boolean column filters (WHERE b, WHERE NOT b) should prune row groups
+# description: Bare boolean column and function filters should prune row groups
 # group: [optimizer]
 
 statement ok
@@ -128,3 +128,33 @@ query I
 SELECT count(*) FROM nullable_tb WHERE NOT b;
 ----
 2048
+
+# Boolean function statistics should prune finite row groups for isnan.
+# Row groups 0 and 1 contain finite values or NULL; row group 2 contains only NaN.
+statement ok
+CREATE TABLE isnan_tb AS SELECT
+  CASE WHEN range // 2048 = 2 THEN 'NaN'::DOUBLE
+       WHEN range % 2 = 0 THEN range::DOUBLE
+       ELSE NULL END AS d,
+  CASE WHEN range // 2048 = 2 THEN 'NaN'::FLOAT
+       WHEN range % 2 = 0 THEN range::FLOAT
+       ELSE NULL END AS f
+FROM range(6144);
+
+statement ok
+CHECKPOINT;
+
+query II
+SELECT count(*) FILTER (WHERE isnan(d)), count(*) FILTER (WHERE isnan(f)) FROM isnan_tb;
+----
+2048	2048
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM isnan_tb WHERE isnan(d);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+query II
+EXPLAIN ANALYZE SELECT count(*) FROM isnan_tb WHERE isnan(f);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*


### PR DESCRIPTION
## Summary

Currently, Boolean statistics produced by functions cannot be used for row-group pruning. This PR allows bare Boolean function filters to leverage these statistics for pruning.

## Results

```sql
ATTACH 'isnan_pruning.duckdb' AS db (ROW_GROUP_SIZE 2048);
USE db;

CREATE TABLE t AS
SELECT CASE
         WHEN range // 2048 = 2 THEN 'NaN'::DOUBLE
         WHEN range % 2 = 0 THEN range::DOUBLE
         ELSE NULL
       END AS value
FROM range(6144);

CHECKPOINT;

EXPLAIN ANALYZE
SELECT count(*) FROM t WHERE isnan(value);
```

### Before

```sql
╭─ Summary ───────────╮
│ Total Time: 0.0005s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────╮
│ Aggregates: count_star()  │
│ 1 row                 0µs │
╰─────────────┒┎────────────╯
╭─ Table Scan ┚┖────────────╮
│ Table: db.main.t          │
│ Type: Sequential Scan     │
│ Filters: isnan(value)     │
│ Row Groups Scanned: 3 / 3 │
│ 2,048 rows            0µs │
╰───────────────────────────╯
```

### After

```sql
╭─ Summary ───────────╮
│ Total Time: 0.0004s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────╮
│ Aggregates: count_star()  │
│ 1 row                 0µs │
╰─────────────┒┎────────────╯
╭─ Table Scan ┚┖────────────╮
│ Table: db.main.t          │
│ Type: Sequential Scan     │
│ Filters: isnan(value)     │
│ Row Groups Scanned: 1 / 3 │
│ 2,048 rows            0µs │
╰───────────────────────────╯
```
