### PR TITLE
Fix external file cache spill

### DIFF
--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -166,7 +166,7 @@ public:
 
 	//! Read/Write temporary buffers at given positions in this file (potentially compressed)
 	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, const TemporaryFileIndex &index_in_file,
-	                                           unique_ptr<FileBuffer> reusable_buffer) const;
+	                                           unique_ptr<FileBuffer> buffer) const;
 	void WriteTemporaryBuffer(QueryContext context, FileBuffer &buffer, idx_t block_index,
 	                          AllocatedData &compressed_buffer) const;
 
@@ -307,8 +307,8 @@ public:
 	//! Create/Read/Update/Delete operations for temporary buffers
 	idx_t WriteTemporaryBuffer(QueryContext context, block_id_t block_id, FileBuffer &buffer);
 	bool HasTemporaryBuffer(block_id_t block_id);
-	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, block_id_t id,
-	                                           unique_ptr<FileBuffer> reusable_buffer, idx_t *eviction_size = nullptr);
+	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, block_id_t id, unique_ptr<FileBuffer> buffer,
+	                                           idx_t *eviction_size = nullptr);
 	idx_t DeleteTemporaryBuffer(block_id_t id);
 	bool IsEncrypted() const;
 

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -311,8 +311,7 @@ public:
 	idx_t WriteTemporaryBuffer(QueryContext context, block_id_t block_id, FileBuffer &buffer);
 	bool HasTemporaryBuffer(block_id_t block_id);
 	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, block_id_t id,
-	                                           unique_ptr<FileBuffer> reusable_buffer,
-	                                           idx_t *eviction_size = nullptr);
+	                                           unique_ptr<FileBuffer> reusable_buffer, idx_t *eviction_size = nullptr);
 	idx_t DeleteTemporaryBuffer(block_id_t id);
 	bool IsEncrypted() const;
 

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -88,7 +88,8 @@ public:
 struct TemporaryFileIndex {
 public:
 	TemporaryFileIndex();
-	TemporaryFileIndex(TemporaryFileIdentifier identifier, idx_t block_index, idx_t block_header_size);
+	TemporaryFileIndex(TemporaryFileIdentifier identifier, idx_t block_index, idx_t block_header_size,
+	                   FileBufferType buffer_type);
 
 public:
 	//! Whether this temporary file index is valid (fields have been set)
@@ -101,6 +102,8 @@ public:
 	optional_idx block_index;
 	//! The block header size
 	optional_idx block_header_size;
+	//! The buffer type
+	FileBufferType buffer_type = FileBufferType::MANAGED_BUFFER;
 };
 
 //===--------------------------------------------------------------------===//
@@ -160,7 +163,7 @@ public:
 
 public:
 	//! Try to get an index of where to write in this file. Returns an invalid index if full
-	TemporaryFileIndex TryGetBlockIndex(idx_t block_header_size);
+	TemporaryFileIndex TryGetBlockIndex(idx_t block_header_size, FileBufferType buffer_type);
 	//! Remove block index from this TemporaryFileHandle
 	void EraseBlockIndex(block_id_t block_index);
 
@@ -307,7 +310,8 @@ public:
 	//! Create/Read/Update/Delete operations for temporary buffers
 	idx_t WriteTemporaryBuffer(QueryContext context, block_id_t block_id, FileBuffer &buffer);
 	bool HasTemporaryBuffer(block_id_t block_id);
-	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, block_id_t id, unique_ptr<FileBuffer> buffer,
+	unique_ptr<FileBuffer> ReadTemporaryBuffer(QueryContext context, block_id_t id,
+	                                           unique_ptr<FileBuffer> reusable_buffer,
 	                                           idx_t *eviction_size = nullptr);
 	idx_t DeleteTemporaryBuffer(block_id_t id);
 	bool IsEncrypted() const;

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -583,9 +583,12 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	if (temporary_directory.handle->GetTempFile().HasTemporaryBuffer(id)) {
 		// This is a block that was offloaded to a regular .tmp file, the file contains blocks of a fixed size
 
+		auto block_header_size = block.GetBlockHeaderSize();
+		auto buffer = ConstructManagedBuffer(GetBlockAllocSize() - block_header_size, block_header_size,
+		                                     std::move(reusable_buffer), block.GetMemory().GetBufferType());
 		idx_t eviction_size = 0;
-		auto buffer = temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(
-		    context, id, std::move(reusable_buffer), &eviction_size);
+		buffer = temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(context, id, std::move(buffer),
+		                                                                       &eviction_size);
 
 		// Decrement evicted size.
 		evicted_data_per_tag[uint8_t(tag)] -= eviction_size;
@@ -622,7 +625,8 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	}
 
 	// Allocate a buffer of the file's size and read the data into that buffer.
-	auto buffer = ConstructManagedBuffer(block_size, block_header_size, std::move(reusable_buffer));
+	auto buffer = ConstructManagedBuffer(block_size, block_header_size, std::move(reusable_buffer),
+	                                     block.GetMemory().GetBufferType());
 
 	if (EncryptTemporaryFiles()) {
 		// encrypted: the nonce/tag sit between the two size words and the payload (which starts at offset)

--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -583,12 +583,9 @@ unique_ptr<FileBuffer> StandardBufferManager::ReadTemporaryBuffer(QueryContext c
 	if (temporary_directory.handle->GetTempFile().HasTemporaryBuffer(id)) {
 		// This is a block that was offloaded to a regular .tmp file, the file contains blocks of a fixed size
 
-		auto block_header_size = block.GetBlockHeaderSize();
-		auto buffer = ConstructManagedBuffer(GetBlockAllocSize() - block_header_size, block_header_size,
-		                                     std::move(reusable_buffer), block.GetMemory().GetBufferType());
 		idx_t eviction_size = 0;
-		buffer = temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(context, id, std::move(buffer),
-		                                                                       &eviction_size);
+		auto buffer = temporary_directory.handle->GetTempFile().ReadTemporaryBuffer(
+		    context, id, std::move(reusable_buffer), &eviction_size);
 
 		// Decrement evicted size.
 		evicted_data_per_tag[uint8_t(tag)] -= eviction_size;

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -90,8 +90,9 @@ TemporaryFileIndex::TemporaryFileIndex() {
 }
 
 TemporaryFileIndex::TemporaryFileIndex(TemporaryFileIdentifier identifier_p, idx_t block_index_p,
-                                       idx_t block_header_size_p)
-    : identifier(identifier_p), block_index(block_index_p), block_header_size(block_header_size_p) {
+                                       idx_t block_header_size_p, FileBufferType buffer_type_p)
+    : identifier(identifier_p), block_index(block_index_p), block_header_size(block_header_size_p),
+      buffer_type(buffer_type_p) {
 }
 
 bool TemporaryFileIndex::IsValid() const {
@@ -203,7 +204,7 @@ TemporaryFileHandle::~TemporaryFileHandle() {
 TemporaryFileHandle::TemporaryFileLock::TemporaryFileLock(mutex &mutex) : lock(mutex) {
 }
 
-TemporaryFileIndex TemporaryFileHandle::TryGetBlockIndex(idx_t block_header_size) {
+TemporaryFileIndex TemporaryFileHandle::TryGetBlockIndex(idx_t block_header_size, FileBufferType buffer_type) {
 	TemporaryFileLock lock(file_lock);
 	if (index_manager.GetMaxIndex() >= max_allowed_index && !index_manager.HasFreeBlocks()) {
 		// file is at capacity
@@ -213,7 +214,7 @@ TemporaryFileIndex TemporaryFileHandle::TryGetBlockIndex(idx_t block_header_size
 	CreateFileIfNotExists(lock);
 	// fetch a new block index to write to
 	auto block_index = index_manager.GetNewBlockIndex(identifier.size);
-	return TemporaryFileIndex(identifier, block_index, block_header_size);
+	return TemporaryFileIndex(identifier, block_index, block_header_size, buffer_type);
 }
 
 unique_ptr<FileBuffer> TemporaryFileHandle::ReadTemporaryBuffer(QueryContext context,
@@ -508,6 +509,7 @@ idx_t TemporaryFileManager::WriteTemporaryBuffer(QueryContext context, block_id_
 	D_ASSERT(buffer.AllocSize() == BufferManager::GetBufferManager(db).GetBlockAllocSize());
 
 	auto header_size = buffer.GetHeaderSize();
+	auto buffer_type = buffer.GetBufferType();
 	const auto adaptivity_idx = TaskScheduler::GetEstimatedCPUId() % COMPRESSION_ADAPTIVITIES;
 	auto &compression_adaptivity = compression_adaptivities[adaptivity_idx];
 
@@ -522,7 +524,7 @@ idx_t TemporaryFileManager::WriteTemporaryBuffer(QueryContext context, block_id_
 		// first check if we can write to an open existing file
 		for (auto &entry : files.GetMapForSize(compression_result.size)) {
 			auto &temp_file = entry.second;
-			index = temp_file->TryGetBlockIndex(header_size);
+			index = temp_file->TryGetBlockIndex(header_size, buffer_type);
 			if (index.IsValid()) {
 				handle = entry.second.get();
 				break;
@@ -534,7 +536,7 @@ idx_t TemporaryFileManager::WriteTemporaryBuffer(QueryContext context, block_id_
 			const TemporaryFileIdentifier identifier(db, size, index_managers[size].GetNewBlockIndex(size),
 			                                         IsEncrypted());
 			auto &new_file = files.CreateFile(identifier);
-			index = new_file.TryGetBlockIndex(header_size);
+			index = new_file.TryGetBlockIndex(header_size, buffer_type);
 			handle = &new_file;
 		}
 		D_ASSERT(used_blocks.find(block_id) == used_blocks.end());
@@ -652,7 +654,8 @@ bool TemporaryFileManager::IsEncrypted() const {
 }
 
 unique_ptr<FileBuffer> TemporaryFileManager::ReadTemporaryBuffer(QueryContext context, block_id_t id,
-                                                                 unique_ptr<FileBuffer> buffer, idx_t *eviction_size) {
+                                                                 unique_ptr<FileBuffer> reusable_buffer,
+                                                                 idx_t *eviction_size) {
 	TemporaryFileIndex index;
 	optional_ptr<TemporaryFileHandle> handle;
 	{
@@ -666,6 +669,10 @@ unique_ptr<FileBuffer> TemporaryFileManager::ReadTemporaryBuffer(QueryContext co
 		*eviction_size = NumericCast<idx_t>(index.identifier.size);
 	}
 
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+	auto block_header_size = index.block_header_size.GetIndex();
+	auto buffer = buffer_manager.ConstructManagedBuffer(buffer_manager.GetBlockAllocSize() - block_header_size,
+	                                                    block_header_size, std::move(reusable_buffer), index.buffer_type);
 	buffer = handle->ReadTemporaryBuffer(context, index, std::move(buffer));
 	{
 		// remove the block (and potentially erase the temp file)

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -671,8 +671,9 @@ unique_ptr<FileBuffer> TemporaryFileManager::ReadTemporaryBuffer(QueryContext co
 
 	auto &buffer_manager = BufferManager::GetBufferManager(db);
 	auto block_header_size = index.block_header_size.GetIndex();
-	auto buffer = buffer_manager.ConstructManagedBuffer(buffer_manager.GetBlockAllocSize() - block_header_size,
-	                                                    block_header_size, std::move(reusable_buffer), index.buffer_type);
+	auto buffer =
+	    buffer_manager.ConstructManagedBuffer(buffer_manager.GetBlockAllocSize() - block_header_size, block_header_size,
+	                                          std::move(reusable_buffer), index.buffer_type);
 	buffer = handle->ReadTemporaryBuffer(context, index, std::move(buffer));
 	{
 		// remove the block (and potentially erase the temp file)

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -218,13 +218,10 @@ TemporaryFileIndex TemporaryFileHandle::TryGetBlockIndex(idx_t block_header_size
 
 unique_ptr<FileBuffer> TemporaryFileHandle::ReadTemporaryBuffer(QueryContext context,
                                                                 const TemporaryFileIndex &index_in_file,
-                                                                unique_ptr<FileBuffer> reusable_buffer) const {
-	auto &buffer_manager = BufferManager::GetBufferManager(db);
+                                                                unique_ptr<FileBuffer> buffer) const {
 	auto block_index = index_in_file.block_index.GetIndex();
 	auto block_header_size = index_in_file.block_header_size.GetIndex();
-
-	auto buffer = buffer_manager.ConstructManagedBuffer(buffer_manager.GetBlockAllocSize() - block_header_size,
-	                                                    block_header_size, std::move(reusable_buffer));
+	D_ASSERT(buffer->GetHeaderSize() == block_header_size);
 	AllocatedData compressed_buffer;
 	data_ptr_t read_buffer;
 	idx_t read_size;
@@ -655,8 +652,7 @@ bool TemporaryFileManager::IsEncrypted() const {
 }
 
 unique_ptr<FileBuffer> TemporaryFileManager::ReadTemporaryBuffer(QueryContext context, block_id_t id,
-                                                                 unique_ptr<FileBuffer> reusable_buffer,
-                                                                 idx_t *eviction_size) {
+                                                                 unique_ptr<FileBuffer> buffer, idx_t *eviction_size) {
 	TemporaryFileIndex index;
 	optional_ptr<TemporaryFileHandle> handle;
 	{
@@ -670,8 +666,7 @@ unique_ptr<FileBuffer> TemporaryFileManager::ReadTemporaryBuffer(QueryContext co
 		*eviction_size = NumericCast<idx_t>(index.identifier.size);
 	}
 
-	// before the reusable buffer is given,
-	auto buffer = handle->ReadTemporaryBuffer(context, index, std::move(reusable_buffer));
+	buffer = handle->ReadTemporaryBuffer(context, index, std::move(buffer));
 	{
 		// remove the block (and potentially erase the temp file)
 		TemporaryFileManagerLock lock(manager_lock);

--- a/test/sql/storage/external_file_cache/internal_issue_10700.test
+++ b/test/sql/storage/external_file_cache/internal_issue_10700.test
@@ -1,0 +1,39 @@
+# name: test/sql/storage/external_file_cache/internal_issue_10700.test
+# description: Internal issue 10700 - Reloading spilled external cache blocks preserves their buffer type
+# group: [external_file_cache]
+
+require parquet
+
+require httpfs
+
+require skip_reload
+
+statement ok
+SET external_file_cache_spill=true;
+
+statement ok
+SET memory_limit='200MB';
+
+statement ok
+SET temp_directory='{TEST_DIR}/internal_issue_10700';
+
+query I
+SELECT count(*)
+FROM read_parquet('https://github.com/duckdb/duckdb-data/releases/download/v1.0/city_temperature.parquet');
+----
+2905886
+
+statement ok
+SET memory_limit='1MB';
+
+statement ok
+SET memory_limit='200MB';
+
+query I
+SELECT count(*)
+FROM read_parquet('https://github.com/duckdb/duckdb-data/releases/download/v1.0/city_temperature.parquet');
+----
+2905886
+
+# Destroy the database while the reloaded cache blocks are still present.
+restart


### PR DESCRIPTION
Closes https://github.com/duckdblabs/duckdb-internal/issues/10700

The root cause is, spilled external cache blocks were reloaded as `MANAGED_BUFFER` type, conflicting with the `EXTERNAL_FILE` type retained by `BlockMemory`, which fails the type assertion [here](https://github.com/duckdb/duckdb/blob/668f94740b280bf44c7c081df664ae1eb310c090/src/storage/buffer/block_handle.cpp#L36). In this PR, I construct the destination buffer with the retained type before reading the temporary file into it.