### PR TITLE
Seven independent fixes

### DIFF
--- a/extension/core_functions/scalar/map/switch.cpp
+++ b/extension/core_functions/scalar/map/switch.cpp
@@ -32,22 +32,14 @@ struct SwitchFunctionBindData : FunctionData {
 	}
 };
 
-idx_t FindMapArgumentIndex(const vector<unique_ptr<Expression>> &arguments) {
-	for (idx_t i = 0; i < arguments.size(); i++) {
-		if (arguments[i]->GetReturnType().id() == LogicalTypeId::MAP) {
-			return i;
-		}
-	}
-	return DConstants::INVALID_INDEX;
-}
-
+//! Which argument holds the cases map is a property of the overload that was resolved, not of the
+//! argument types: a MAP-typed key argument makes the types ambiguous. Each variation binds its own index.
+template <idx_t MAP_INDEX>
 unique_ptr<FunctionData> SwitchBindReturnType(BindScalarFunctionInput &input) {
 	auto &context = input.GetClientContext();
 	auto &arguments = input.GetArguments();
-	auto map_index = FindMapArgumentIndex(arguments);
-	if (map_index == DConstants::INVALID_INDEX) {
-		throw BinderException("Switch: No map argument found");
-	}
+	constexpr idx_t map_index = MAP_INDEX;
+	D_ASSERT(map_index < arguments.size());
 	auto &cases = arguments[map_index];
 	if (cases->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
 		throw BinderException("SWITCH expected a constant map for the cases");
@@ -154,13 +146,15 @@ ScalarFunctionSet SwitchFun::GetFunctions() {
 	auto val_type = LogicalType::TEMPLATE("V");
 	ScalarFunctionSet func_set;
 
-	vector<vector<LogicalType>> function_variations = {{key_type, LogicalType::MAP(key_type, val_type)},
-	                                                   {key_type, LogicalType::MAP(key_type, val_type), val_type},
-	                                                   {LogicalType::MAP(key_type, val_type), val_type},
-	                                                   {LogicalType::MAP(key_type, val_type)}};
+	// each variation is paired with the position of its MAP(K, V) parameter
+	vector<pair<vector<LogicalType>, bind_scalar_function_t>> function_variations = {
+	    {{key_type, LogicalType::MAP(key_type, val_type)}, SwitchBindReturnType<1>},
+	    {{key_type, LogicalType::MAP(key_type, val_type), val_type}, SwitchBindReturnType<1>},
+	    {{LogicalType::MAP(key_type, val_type), val_type}, SwitchBindReturnType<0>},
+	    {{LogicalType::MAP(key_type, val_type)}, SwitchBindReturnType<0>}};
 
 	for (const auto &variation : function_variations) {
-		auto switch_expression = ScalarFunction(variation, val_type, nullptr, SwitchBindReturnType, nullptr);
+		auto switch_expression = ScalarFunction(variation.first, val_type, nullptr, variation.second, nullptr);
 		switch_expression.SetBindExpressionCallback(SwitchBindExpression);
 		func_set.AddFunction(std::move(switch_expression));
 	}

--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -426,7 +426,9 @@ static bool StringToNestedTypeCast(Vector &source, Vector &result, idx_t count, 
 		auto &source_mask = ConstantVector::Validity(source);
 		auto &result_mask = FlatVector::ValidityMutable(result);
 		auto ret = T::StringToNestedTypeCastLoop(source_data, source_mask, result, result_mask, 1, parameters, nullptr);
-		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		// a child may be neither flat nor constant - a VARIANT child is shredded - and setting the type
+		// directly would propagate into a buffer that cannot represent it
+		result.FlattenAndSetConstant();
 		return ret;
 	}
 	default: {

--- a/src/function/cast/variant/from_variant.cpp
+++ b/src/function/cast/variant/from_variant.cpp
@@ -294,6 +294,9 @@ static bool ConvertVariantToList(FromVariantConversionData &conversion_data, Vec
 
 		FindValues(conversion_data.variant, row_index, new_sel, child_data_entry);
 		if (!CastVariant(conversion_data, child, new_sel, entry.offset, child_data_entry.child_count, row_index)) {
+			// a TRY_CAST reports the failure by returning false rather than throwing, so the writer has to be
+			// told it is deliberately short of count before it goes out of scope
+			result_data.Truncate();
 			return false;
 		}
 	}
@@ -521,11 +524,15 @@ static bool CastVariantToJSON(FromVariantConversionData &conversion_data, Vector
 		    VariantCasts::ConvertVariantToJSON(holder.GetDocument(), conversion_data.variant, row_index, sel[i]);
 		if (!json_val) {
 			error = StringUtil::Format("Failed to convert to JSON object");
+			// same as the list path: a TRY_CAST returns false instead of throwing, so the writer must be
+			// told it is deliberately short of count
+			result_data.Truncate();
 			return false;
 		}
 
 		const auto serialized = holder.Serialize(json_val, error);
 		if (!serialized) {
+			result_data.Truncate();
 			return false;
 		}
 

--- a/src/main/settings/custom_settings.cpp
+++ b/src/main/settings/custom_settings.cpp
@@ -1058,7 +1058,9 @@ void HomeDirectorySetting::OnSet(SettingCallbackInfo &info, Value &input) {
 void ForceMbedtlsUnsafeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
 	config.options.force_mbedtls = input.GetValue<bool>();
 
-	if (!config.options.force_mbedtls) {
+	// db is null when the option is set on a DBConfig before the database is opened (e.g. duckdb_set_config),
+	// in which case nothing is attached yet
+	if (!config.options.force_mbedtls && db) {
 		// check if there are attached databases encrypted that are not read only
 		bool encrypted_db_attached = false;
 		for (auto &database : db->GetDatabaseManager().GetDatabases()) {

--- a/src/optimizer/join_elimination.cpp
+++ b/src/optimizer/join_elimination.cpp
@@ -127,7 +127,16 @@ void JoinElimination::OptimizeChildren(LogicalOperator &op, optional_ptr<Logical
 	}
 
 	if (op.children.size() == 1) {
+		// UNNEST emits multiple rows per input row, so a distinct group found below it does not hold above it
+		const auto invalidates_distinct = op.type == LogicalOperatorType::LOGICAL_UNNEST;
+		unordered_map<TableIndex, column_binding_set_t> distinct_groups_above;
+		if (invalidates_distinct) {
+			distinct_groups_above = pipe_info.distinct_groups;
+		}
 		OptimizeChildren(*op.children[0], op, idx);
+		if (invalidates_distinct) {
+			pipe_info.distinct_groups = std::move(distinct_groups_above);
+		}
 	} else {
 		children_root = op;
 		for (auto &child : op.children) {

--- a/src/optimizer/rule/comparison_simplification.cpp
+++ b/src/optimizer/rule/comparison_simplification.cpp
@@ -78,6 +78,12 @@ static bool ConstantCastIsInvertible(BoundFunctionExpression &expr, BoundFunctio
 	if (cast_constant.IsNull() || BoundCastExpression::CastIsInvertible(cast_expression.GetReturnType(), target_type)) {
 		return true;
 	}
+	// This asks about the constant, not the column, and the constant was cast strictly just above - for
+	// integers that already proves it is exactly representable, so no type-level guarantee is needed. The
+	// column side is checked separately by the caller.
+	if (cast_expression.GetReturnType().IsIntegral() && target_type.IsIntegral()) {
+		return true;
+	}
 	if (target_type.id() != LogicalTypeId::DATE || cast_expression.GetReturnType().id() != LogicalTypeId::TIMESTAMP) {
 		return false;
 	}

--- a/src/planner/binder/query_node/plan_subquery.cpp
+++ b/src/planner/binder/query_node/plan_subquery.cpp
@@ -88,12 +88,19 @@ static unique_ptr<Expression> PlanExtremumRewrite(Binder &binder, BoundSubqueryE
 	auto &compare_type = expr.GetChildTargets()[0];
 	vector<unique_ptr<Expression>> min_max_children;
 	auto min_max_child = bound_colref->Copy();
-	ExpressionBinder::PushCollation(binder.context, min_max_child, compare_type);
+	// The comparison may carry a collation the subquery column does not, and the extremum has to be taken
+	// under that collation, so it is pushed here. BIT and VARIANT are the exception: min/max pushes its own
+	// collation for those, and doing it first makes that branch a no-op, after which the aggregate falls
+	// through to its binary-key implementation whose return type is BLOB.
+	if (compare_type.id() != LogicalTypeId::BIT && compare_type.id() != LogicalTypeId::VARIANT) {
+		ExpressionBinder::PushCollation(binder.context, min_max_child, compare_type);
+	}
 	min_max_children.push_back(std::move(min_max_child));
 
 	auto extremum_aggr =
 	    function_binder.BindAggregateFunction(is_min ? MinFunction::GetFunction() : MaxFunction::GetFunction(),
 	                                          std::move(min_max_children), nullptr, AggregateType::NON_DISTINCT);
+	auto extremum_type = extremum_aggr->GetReturnType();
 	aggregate_list.push_back(std::move(extremum_aggr));
 
 	// 2. count_star = COUNT(*)
@@ -117,7 +124,9 @@ static unique_ptr<Expression> PlanExtremumRewrite(Binder &binder, BoundSubqueryE
 	    make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, ColumnBinding(aggr_index, ProjectionIndex(1)));
 	auto count_child_ref =
 	    make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, ColumnBinding(aggr_index, ProjectionIndex(2)));
-	auto extremum_ref = make_uniq<BoundColumnRefExpression>(child_type, ColumnBinding(aggr_index, ProjectionIndex(0)));
+	// reference the aggregate by the type it actually produces, not by the subquery column type
+	auto extremum_ref =
+	    make_uniq<BoundColumnRefExpression>(extremum_type, ColumnBinding(aggr_index, ProjectionIndex(0)));
 
 	auto &x_expr = *expr.GetChildrenMutable()[0];
 

--- a/src/planner/expression/bound_cast_expression.cpp
+++ b/src/planner/expression/bound_cast_expression.cpp
@@ -196,6 +196,17 @@ bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const
 	if (source_type.IsSigned() && target_type.IsUnsigned()) {
 		return false;
 	}
+	if (source_type.IsIntegral() && target_type.IsIntegral()) {
+		// a narrowing integer cast is not invertible: a source value outside the target's range does not
+		// survive the cast, so comparing in the target type is not the same as comparing in the source type
+		auto source_size = GetTypeIdSize(source_type.InternalType());
+		auto target_size = GetTypeIdSize(target_type.InternalType());
+		if (source_type.IsUnsigned() && target_type.IsSigned()) {
+			// the sign bit costs a byte of range, so equal widths are not enough
+			return target_size > source_size;
+		}
+		return target_size >= source_size;
+	}
 	return true;
 }
 

--- a/test/api/capi/v1/capi_config_options.cpp
+++ b/test/api/capi/v1/capi_config_options.cpp
@@ -107,3 +107,16 @@ TEST_CASE("Test Custom Configuration Options in C API", "[capi]") {
 	duckdb_destroy_value(&default_str_value);
 	duckdb_destroy_value(&default_int_value);
 }
+
+TEST_CASE("Issue #25056: duckdb_set_config crashes on a boolean option set to false", "[capi]") {
+	// debug_force_mbedtls_unsafe consults the attached databases when it is disabled, but there is no
+	// database instance yet when the option is set on a config
+	for (const auto &alias : {"force_mbedtls_unsafe", "debug_force_mbedtls_unsafe"}) {
+		for (const auto &value : {"true", "false", "1", "0"}) {
+			duckdb_config config;
+			REQUIRE(duckdb_create_config(&config) == DuckDBSuccess);
+			REQUIRE(duckdb_set_config(config, alias, value) == DuckDBSuccess);
+			duckdb_destroy_config(&config);
+		}
+	}
+}

--- a/test/configs/storage_compatibility.json
+++ b/test/configs/storage_compatibility.json
@@ -10,6 +10,7 @@
   "skip_error_messages": [
     "Aggregate state columns are not supported in storage versions prior to v2.0.0",
     "TUPLE columns are not supported in storage versions prior to v2.0.0",
+    "VARIANT columns are not supported in storage versions prior to v1.5.0",
     "CREATE SECURE VIEW is only supported for storage versions v2.0.0 and higher"
   ],
   "skip_compiled": "true",

--- a/test/optimizer/join_elimination.test
+++ b/test/optimizer/join_elimination.test
@@ -244,3 +244,51 @@ query II
 explain select a.ida from b right join (select ida from a group by ida) as a on ida < idb;
 ----
 physical_plan	<REGEX>:.*JOIN.*
+
+# unnest emits multiple rows per input row, so a distinct group below it does not survive above it
+# (issue #25213)
+
+statement ok
+create table dup_keys(k int);
+
+statement ok
+insert into dup_keys values (1),(1),(2),(3);
+
+statement ok
+create table probe_keys(idb int);
+
+statement ok
+insert into probe_keys values (1),(1),(2),(3),(4),(NULL),(2),(3);
+
+query I
+select count(*) from probe_keys left join (select k, unnest([1,2,3]) e from (select distinct k from dup_keys) s) t on t.k=probe_keys.idb;
+----
+20
+
+query II
+explain select count(*) from probe_keys left join (select k, unnest([1,2,3]) e from (select distinct k from dup_keys) s) t on t.k=probe_keys.idb;
+----
+physical_plan	<REGEX>:.*JOIN.*
+
+# same through group by instead of distinct
+query I
+select count(*) from probe_keys left join (select k, unnest([1,2,3]) e from (select k from dup_keys group by k) s) t on t.k=probe_keys.idb;
+----
+20
+
+# same through a nested unnest
+query I
+select count(*) from probe_keys left join (select k, unnest([[1,2],[3]], recursive := true) e from (select distinct k from dup_keys) s) t on t.k=probe_keys.idb;
+----
+20
+
+# a distinct ABOVE the unnest still makes the inner side unique, so the join is still eliminated
+query I
+select count(*) from probe_keys left join (select distinct k from (select k, unnest([1,2,3]) e from dup_keys) u) t on t.k=probe_keys.idb;
+----
+8
+
+query II
+explain select count(*) from probe_keys left join (select distinct k from (select k, unnest([1,2,3]) e from dup_keys) u) t on t.k=probe_keys.idb;
+----
+physical_plan	<!REGEX>:.*JOIN.*

--- a/test/sql/cast/string_to_struct_variant_child.test
+++ b/test/sql/cast/string_to_struct_variant_child.test
@@ -1,0 +1,61 @@
+# name: test/sql/cast/string_to_struct_variant_child.test
+# description: A string-to-struct cast whose child is a shredded VARIANT must not flip the child's vector type
+# group: [cast]
+
+# the constant path used to set the result type directly, which propagated into the VARIANT child's
+# shredded buffer and raised an INTERNAL error
+
+query I
+SELECT '{"v":"hello"}'::STRUCT(v VARIANT);
+----
+{'v': hello}
+
+query I
+SELECT '{"v":42}'::STRUCT(v VARIANT);
+----
+{'v': 42}
+
+query I
+SELECT '{"a":"x","b":"y"}'::STRUCT(a VARIANT, b VARIANT);
+----
+{'a': x, 'b': y}
+
+query I
+SELECT '{"v":null}'::STRUCT(v VARIANT);
+----
+{'v': NULL}
+
+query I
+SELECT NULL::VARCHAR::STRUCT(v VARIANT);
+----
+NULL
+
+# a nested struct with a VARIANT leaf
+
+query I
+SELECT '{"s":{"v":"deep"}}'::STRUCT(s STRUCT(v VARIANT));
+----
+{'s': {'v': deep}}
+
+# the non-constant path, several rows through a table
+
+statement ok
+CREATE TABLE s(x VARCHAR);
+
+statement ok
+INSERT INTO s VALUES ('{"v":"one"}'), ('{"v":"two"}'), (NULL), ('{"v":"three"}');
+
+query I
+SELECT x::STRUCT(v VARIANT) FROM s;
+----
+{'v': one}
+{'v': two}
+NULL
+{'v': three}
+
+# a struct with a VARIANT child alongside an ordinary child
+
+query I
+SELECT '{"v":"a","n":"1"}'::STRUCT(v VARIANT, n INTEGER);
+----
+{'v': a, 'n': 1}

--- a/test/sql/optimizer/narrowing_cast_not_invertible.test
+++ b/test/sql/optimizer/narrowing_cast_not_invertible.test
@@ -1,0 +1,69 @@
+# name: test/sql/optimizer/narrowing_cast_not_invertible.test
+# description: A narrowing cast must not be peeled off a comparison during pushdown
+# group: [optimizer]
+
+statement ok
+CREATE TABLE t(a INTEGER);
+
+statement ok
+INSERT INTO t VALUES (51),(127),(128),(200),(300),(-200);
+
+# 128, 200 and 300 are outside TINYINT, so TRY_CAST makes them NULL and the predicate is not true
+
+query I
+SELECT list(a ORDER BY a) FROM t WHERE TRY_CAST(a AS TINYINT) > 50;
+----
+[51, 127]
+
+query II
+EXPLAIN SELECT count(*) FROM t WHERE TRY_CAST(a AS TINYINT) > 50;
+----
+physical_plan	<REGEX>:.*TRY_CAST.*
+
+# UTINYINT reaches 255, so 128 and 200 survive but 300 and -200 do not
+
+query I
+SELECT list(a ORDER BY a) FROM t WHERE TRY_CAST(a AS UTINYINT) > 50;
+----
+[51, 127, 128, 200]
+
+# SMALLINT holds every value here, so nothing is filtered by the cast
+
+query I
+SELECT list(a ORDER BY a) FROM t WHERE TRY_CAST(a AS SMALLINT) > 50;
+----
+[51, 127, 128, 200, 300]
+
+# the IN rewrite goes through the same invertibility check
+
+query I
+SELECT list(a ORDER BY a) FROM t WHERE TRY_CAST(a AS TINYINT) IN (51, 127, 128);
+----
+[51, 127]
+
+# a widening cast is still invertible and must still be peeled off, so the optimization is not lost
+
+query I
+SELECT list(a ORDER BY a) FROM t WHERE CAST(a AS BIGINT) > 50;
+----
+[51, 127, 128, 200, 300]
+
+query II
+EXPLAIN SELECT count(*) FROM t WHERE CAST(a AS BIGINT) > 50;
+----
+physical_plan	<!REGEX>:.*CAST.*
+
+# the optimized and unoptimized answers must agree
+
+statement ok
+PRAGMA disable_optimizer;
+
+query I
+SELECT list(a ORDER BY a) FROM t WHERE TRY_CAST(a AS TINYINT) > 50;
+----
+[51, 127]
+
+query I
+SELECT list(a ORDER BY a) FROM t WHERE TRY_CAST(a AS UTINYINT) > 50;
+----
+[51, 127, 128, 200]

--- a/test/sql/parser/switch_case.test
+++ b/test/sql/parser/switch_case.test
@@ -112,3 +112,42 @@ statement error
 SELECT switch(i, MAP {i : 1}) FROM (SELECT 1 i);
 ----
 Binder Error: SWITCH expected a constant map for the cases
+
+# which argument holds the cases map comes from the resolved overload, not from scanning for the
+# first MAP-typed argument - a MAP-typed key argument makes the types ambiguous (issue #25379)
+
+statement error
+SELECT switch(map([false],[10]), map([map([false],[10])],[999]), 777);
+----
+<REGEX>:.*Only constant expressions are supported for keys inside SWITCH.*
+
+# all four overloads still resolve to the right argument
+
+query I
+SELECT switch(2, map([1,2,3],['a','b','c']));
+----
+b
+
+query I
+SELECT switch(9, map([1,2],['a','b']), 'dflt');
+----
+dflt
+
+query I
+SELECT switch(map([true],[10]), 99);
+----
+10
+
+query I
+SELECT switch(map([true],[10]));
+----
+10
+
+# a MAP-typed key is only well-typed when the cases map's key type matches it, and building such a
+# cases map needs map() calls as keys, which SWITCH does not accept - so the shape above is the only
+# reachable one. Guard that the key type is still checked rather than silently ignored.
+
+statement error
+SELECT switch(map([1],[2]), map([true],[7]), 55);
+----
+<REGEX>:.*Cannot deduce template type 'K'.*

--- a/test/sql/subquery/any_all_variant_extremum.test
+++ b/test/sql/subquery/any_all_variant_extremum.test
@@ -1,0 +1,108 @@
+# name: test/sql/subquery/any_all_variant_extremum.test
+# description: ANY/ALL with an ordering comparison over types whose min/max keeps its own collation
+# group: [subquery]
+
+# an ordering comparison rewrites the subquery into MIN/MAX, and min/max over VARIANT or BIT binds
+# its own collation handling to keep the result in the input type
+
+statement ok
+CREATE TABLE v AS SELECT x::INTEGER::VARIANT AS v FROM (VALUES (7),(15)) s(x);
+
+query I
+SELECT 127::INTEGER::VARIANT >= ALL (SELECT v FROM v);
+----
+true
+
+query I
+SELECT 127::INTEGER::VARIANT > ALL (SELECT v FROM v);
+----
+true
+
+query I
+SELECT 127::INTEGER::VARIANT <= ALL (SELECT v FROM v);
+----
+false
+
+query I
+SELECT 127::INTEGER::VARIANT < ALL (SELECT v FROM v);
+----
+false
+
+query I
+SELECT 127::INTEGER::VARIANT >= ANY (SELECT v FROM v);
+----
+true
+
+query I
+SELECT 127::INTEGER::VARIANT <= ANY (SELECT v FROM v);
+----
+false
+
+# equality-based quantifiers went through the mark join and always worked - keep them covered
+
+query I
+SELECT 127::INTEGER::VARIANT = ANY (SELECT v FROM v);
+----
+false
+
+query I
+SELECT 7::INTEGER::VARIANT = ANY (SELECT v FROM v);
+----
+true
+
+# BIT takes the same branch inside min/max
+
+query I
+SELECT '1010'::BIT >= ALL (SELECT x::BIT FROM (VALUES ('0101'),('1001')) s(x));
+----
+true
+
+# the collation can sit on the OUTER side only, and the extremum must still be taken under it:
+# 'b' > ANY('Z','a') is true iff 'b' > min(x), and under NOCASE that min is 'a', not 'Z'
+
+query I
+SELECT 'b' COLLATE NOCASE > ANY(SELECT x FROM (VALUES ('Z'), ('a')) t(x));
+----
+true
+
+# collated VARCHAR must be unchanged
+
+statement ok
+CREATE TABLE c(x VARCHAR);
+
+statement ok
+INSERT INTO c VALUES ('a'), ('b');
+
+query I
+SELECT 'B' COLLATE NOCASE >= ALL (SELECT x COLLATE NOCASE FROM c);
+----
+true
+
+query I
+SELECT 'B' COLLATE NOCASE >= ALL (SELECT x COLLATE NOCASE FROM (VALUES ('a'),('c')) s(x));
+----
+false
+
+query I
+SELECT 'z' >= ALL (SELECT x FROM c);
+----
+true
+
+# NULL in the subquery still makes the answer unknown
+
+query I
+SELECT 5 > ALL (SELECT x FROM (VALUES (1),(2),(NULL)) s(x));
+----
+NULL
+
+query I
+SELECT 5 > ALL (SELECT x FROM (VALUES (1),(2)) s(x));
+----
+true
+
+# an empty subquery is vacuously true for ALL
+
+query I
+SELECT 5 > ALL (SELECT x FROM (VALUES (1)) s(x) WHERE x > 100);
+----
+true

--- a/test/sql/types/variant/try_cast_nested_list_writer.test
+++ b/test/sql/types/variant/try_cast_nested_list_writer.test
@@ -1,0 +1,46 @@
+# name: test/sql/types/variant/try_cast_nested_list_writer.test
+# description: A failing element under TRY_CAST must leave the row writer at full count
+# group: [variant]
+
+# the writer's destructor asserts that exactly count rows were written, and TRY reports failure by
+# returning false rather than throwing, so bailing out mid-loop trips the assert on a debug build
+
+query I
+select try_cast([['bad'], ['2']]::variant as INTEGER[][]);
+----
+NULL
+
+query I
+select try_cast([['1'], ['bad'], ['3']]::variant as INTEGER[][]);
+----
+NULL
+
+# several rows, so the writer is short by more than one
+
+statement ok
+CREATE TABLE v AS SELECT * FROM (VALUES
+	([['1'],['2']]::variant),
+	([['bad'],['2']]::variant),
+	([['3'],['4']]::variant),
+	([['5'],['nope']]::variant)
+) t(x);
+
+query I
+SELECT count(*) FROM v WHERE try_cast(x AS INTEGER[][]) IS NULL
+----
+2
+
+query I
+SELECT try_cast(x AS INTEGER[][]) FROM v
+----
+[[1], [2]]
+NULL
+[[3], [4]]
+NULL
+
+# a plain CAST still reports the failure rather than returning NULL
+
+statement error
+SELECT CAST([['bad'], ['2']]::variant AS INTEGER[][]);
+----
+<REGEX>:.*Conversion Error.*


### PR DESCRIPTION
Fixes duckdb/duckdb#24255.
Fixes duckdb/duckdb#23687.
Fixes duckdb/duckdb#24192.
Fixes duckdb/duckdb#25298.
Fixes duckdb/duckdb#25480.
Fixes duckdb/duckdb#25056.
Fixes duckdb/duckdb#25213.

All reproed, and adding a test that, possibly in relassert, fails without the fixes, and works with them.

Commits can / should be reviewed individually, uncertain if better single PR or multiple independent ones.