### PR TITLE
Fix row_number gaps in vector-sized parallel scans

### DIFF
--- a/src/include/duckdb/storage/table/row_group.hpp
+++ b/src/include/duckdb/storage/table/row_group.hpp
@@ -206,6 +206,8 @@ public:
 	idx_t GetCommittedRowCount();
 	//! Returns the number of rows visible to the given transaction
 	idx_t GetVisibleRowCount(TransactionData transaction);
+	//! Count visible rows in a scan assignment starting at a vector boundary
+	idx_t GetVisibleRowCount(TransactionData transaction, idx_t start_vector, idx_t scan_count);
 	bool CanReuseMetadata(RowGroupWriter &writer) const;
 	RowGroupWriteData WriteToDisk(RowGroupWriter &writer);
 	RowGroupPointer Checkpoint(RowGroupWriteData write_data, RowGroupWriter &writer, TableStatistics &global_stats,

--- a/src/include/duckdb/storage/table/row_version_manager.hpp
+++ b/src/include/duckdb/storage/table/row_version_manager.hpp
@@ -26,6 +26,8 @@ public:
 
 	//! Returns the number of non-deleted rows in this segment
 	idx_t GetRowCount(ScanOptions options, idx_t count);
+	//! Count visible rows starting at a vector boundary, including a partial final vector
+	idx_t GetRowCount(ScanOptions options, idx_t start_vector, idx_t count);
 
 	idx_t GetSelVector(ScanOptions options, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count);
 	//! Bulk visibility check. Returns the number of visible rows.

--- a/src/storage/table/row_group.cpp
+++ b/src/storage/table/row_group.cpp
@@ -1521,11 +1521,17 @@ idx_t RowGroup::GetCommittedRowCount() {
 }
 
 idx_t RowGroup::GetVisibleRowCount(TransactionData transaction) {
+	return GetVisibleRowCount(transaction, 0, count);
+}
+
+idx_t RowGroup::GetVisibleRowCount(TransactionData transaction, idx_t start_vector, idx_t scan_count) {
+	D_ASSERT(start_vector * STANDARD_VECTOR_SIZE <= count);
+	D_ASSERT(scan_count <= count - start_vector * STANDARD_VECTOR_SIZE);
 	auto vinfo = GetVersionInfo();
 	if (!vinfo) {
-		return count;
+		return scan_count;
 	}
-	return vinfo->GetRowCount(transaction, count);
+	return vinfo->GetRowCount(transaction, start_vector, scan_count);
 }
 
 bool RowGroup::HasUnloadedDeletes() const {

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -406,11 +406,11 @@ optional_idx RowGroupCollection::NextParallelScan(ClientContext &context, Parall
 				state.row_number_base = scan_state.row_number_base.GetIndex();
 			}
 			if (state.row_number_base.IsValid()) {
-				// if we are scanning the row_number virtual column - shift the base based on the number of visible rows
-				// (i.e. non-deleted rows) for the current transaction
+				// Reserve numbers only for visible rows in this assignment, which may be part of a row group.
 				scan_state.row_number_base = state.row_number_base.GetIndex();
 				auto &tx = DuckTransaction::Get(context, GetAttached());
-				state.row_number_base = state.row_number_base.GetIndex() + current_row_group.GetVisibleRowCount(tx);
+				state.row_number_base = state.row_number_base.GetIndex() +
+				                        current_row_group.GetVisibleRowCount(tx, vector_index, assignment_rows);
 			}
 		}
 		D_ASSERT(collection);

--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -13,9 +13,14 @@ RowVersionManager::RowVersionManager(BufferManager &buffer_manager_p) noexcept
 }
 
 idx_t RowVersionManager::GetRowCount(ScanOptions options, idx_t count) {
+	return GetRowCount(options, 0, count);
+}
+
+idx_t RowVersionManager::GetRowCount(ScanOptions options, idx_t start_vector, idx_t count) {
 	lock_guard<mutex> l(version_lock);
 	idx_t total_count = 0;
-	for (idx_t r = 0, i = 0; r < count; r += STANDARD_VECTOR_SIZE, i++) {
+	// Only visit version vectors belonging to this scan assignment.
+	for (idx_t r = 0, i = start_vector; r < count; r += STANDARD_VECTOR_SIZE, i++) {
 		idx_t segment_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, count - r);
 		if (segment_count == 0) {
 			break;

--- a/test/optimizer/row_number_virtual_column.test
+++ b/test/optimizer/row_number_virtual_column.test
@@ -243,3 +243,146 @@ query II
 EXPLAIN SELECT x, ROW_NUMBER() OVER () FROM read_duckdb('{TEST_DIR}/row_number_read_duckdb.db', table_name='t')
 ----
 physical_plan	<REGEX>:.*WINDOW.*
+
+# Issue #25553: vector-sized assignments must reserve only their visible rows.
+foreach parallelism verify_parallelism disable_verify_parallelism
+
+statement ok
+PRAGMA {parallelism};
+
+foreach threads 1 4
+
+statement ok
+SET threads = {threads};
+
+foreach row_count 2047 2048 2049 2050 130000
+
+statement ok
+CREATE OR REPLACE TABLE rn_batches AS SELECT range AS i FROM range({row_count});
+
+query I
+SELECT count(*) = {row_count} AND min(rn) = 1 AND max(rn) = {row_count} AND count(DISTINCT rn) = {row_count}
+FROM (SELECT row_number() OVER () AS rn FROM rn_batches);
+----
+true
+
+# Keep the scan optimization enabled: correctness must not come from a fallback.
+query II
+EXPLAIN SELECT row_number() OVER () FROM rn_batches;
+----
+physical_plan	<!REGEX>:.*WINDOW.*
+
+statement ok
+DELETE FROM rn_batches WHERE i < 5;
+
+query I
+SELECT count(*) = {row_count} - 5 AND min(rn) = 1 AND max(rn) = {row_count} - 5 AND count(DISTINCT rn) = {row_count} - 5
+FROM (SELECT row_number() OVER () AS rn FROM rn_batches);
+----
+true
+
+# The final base of the table scan is also the initial base for local rows.
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO rn_batches VALUES (-1), (-2);
+
+query I
+SELECT count(*) = {row_count} - 3 AND min(rn) = 1 AND max(rn) = {row_count} - 3 AND count(DISTINCT rn) = {row_count} - 3
+FROM (SELECT row_number() OVER () AS rn FROM rn_batches);
+----
+true
+
+statement ok
+ROLLBACK;
+
+# Entirely invisible assignments must not consume any row numbers.
+statement ok
+DELETE FROM rn_batches WHERE i < 2048;
+
+query I
+SELECT count(*) = greatest({row_count} - 2048, 0)
+       AND coalesce(min(rn), 1) = 1
+       AND coalesce(max(rn), 0) = greatest({row_count} - 2048, 0)
+       AND count(DISTINCT rn) = greatest({row_count} - 2048, 0)
+FROM (SELECT row_number() OVER () AS rn FROM rn_batches);
+----
+true
+
+endloop
+
+# Local storage can itself span multiple scan assignments, with no visible base rows.
+statement ok
+CREATE OR REPLACE TABLE rn_local(i BIGINT);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO rn_local SELECT range FROM range(2050);
+
+statement ok
+DELETE FROM rn_local WHERE i < 5;
+
+query IIII
+SELECT count(*), min(rn), max(rn), count(DISTINCT rn)
+FROM (SELECT row_number() OVER () AS rn FROM rn_local);
+----
+2045	1	2045	2045
+
+statement ok
+ROLLBACK;
+
+endloop
+
+endloop
+
+# A reader's snapshot keeps rows deleted by a later committed transaction visible.
+statement ok con1
+PRAGMA verify_parallelism;
+
+statement ok con1
+CREATE TABLE rn_snapshot AS SELECT range AS i FROM range(2050);
+
+statement ok con1
+BEGIN;
+
+query I con1
+SELECT count(*) FROM rn_snapshot;
+----
+2050
+
+statement ok con2
+DELETE FROM rn_snapshot WHERE i < 2048;
+
+query IIII con1
+SELECT count(*), min(rn), max(rn), count(DISTINCT rn)
+FROM (SELECT row_number() OVER () AS rn FROM rn_snapshot);
+----
+2050	1	2050	2050
+
+# Later inserts must also remain invisible to the existing snapshot.
+statement ok con2
+INSERT INTO rn_snapshot SELECT range FROM range(2050, 4100);
+
+query IIII con1
+SELECT count(*), min(rn), max(rn), count(DISTINCT rn)
+FROM (SELECT row_number() OVER () AS rn FROM rn_snapshot);
+----
+2050	1	2050	2050
+
+statement ok con1
+COMMIT;
+
+query IIII con1
+SELECT count(*), min(rn), max(rn), count(DISTINCT rn)
+FROM (SELECT row_number() OVER () AS rn FROM rn_snapshot);
+----
+2052	1	2052	2052
+
+statement ok
+PRAGMA disable_verify_parallelism;
+
+statement ok
+RESET threads;


### PR DESCRIPTION
Fixes #25553.

With `PRAGMA verify_parallelism`, `ROW_NUMBER() OVER ()` on a 2,050-row table returns a maximum of 2,052 instead of 2,050. Each vector-sized scan assignment advances the row-number base by the visible count of the entire row group.

Count transaction-visible rows within each assignment instead. Preserve the existing whole-row-group counting interfaces and reuse the current visibility checks and locking.
