### PR TITLE
Drain pending tasks in the TaskExecutor destructor

### DIFF
--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -14,6 +14,12 @@ TaskExecutor::TaskExecutor(ClientContext &context_p, TaskSchedulerType type_p)
 }
 
 TaskExecutor::~TaskExecutor() {
+	// tasks can still be queued if we unwound between scheduling them and draining them
+	// they hold a reference to this executor, so they must not outlive it
+	try {
+		CancelAndDrain();
+	} catch (...) { // NOLINT
+	}
 }
 
 void TaskExecutor::PushError(ErrorData error) {


### PR DESCRIPTION
Tasks hold a reference to the TaskExecutor, and in the threaded build destroying the ProducerToken does not remove queued tasks from the scheduler queue - a worker can still dequeue and run them. Unwinding between ScheduleTask and WorkOnTasks therefore left tasks running against a destroyed executor, and against whatever the task references in the caller frame.

Drain in the destructor so that the tasks can never outlive the executor. Tasks that have not started yet bail out immediately.

---

I have not reproed any actual issue, but the shape of the problem would be like (pseudocode)
```c++
TaskExecutor executor(...);
for (int i=0; i<50; i++) {
      executor.ScheduleTask(...);
      if (i == 42) throw std::exception();
}
executor.WorkOnTask();
```
now, executor would be destroyed, while some 40 tasks have been scheduled, their callback will reach for a non-available destructor, and bad things might happen.

There are callsites (like https://github.com/duckdb/duckdb/blob/v2.0-cyanoptera/src/common/serializer/async_task_queue.cpp#L307) that protect from this manually, probably since it hit already, but attempting a best effort `CancelAndDrain()` in the destructor allows via RAII to ensure this in a better way. I have not changed any callsite yet, could be done as follow up.

Bumped into this while working on a task pointed by @lnkuiper, https://github.com/duckdb/duckdb/pull/25560, but not a blocker for that.