### PR TITLE
Fix correlated CTE reference bindings by column identity

### DIFF
--- a/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
+++ b/src/include/duckdb/planner/subquery/flatten_dependent_join.hpp
@@ -97,8 +97,9 @@ private:
 	                             bool include_names) const;
 	void AddDelimColumnsToGroup(LogicalAggregate &aggr, const vector<ColumnBinding> &state) const;
 	void AddCorrelatedFirstAggregates(LogicalAggregate &aggr, const vector<ColumnBinding> &state) const;
+	vector<optional_idx> GetCTERefCorrelatedPositions(const LogicalCTERef &cteref) const;
 	void AddCTERefJoinConditions(LogicalComparisonJoin &join, const LogicalCTERef &cteref,
-	                             const vector<ColumnBinding> &state) const;
+	                             const vector<optional_idx> &positions, const vector<ColumnBinding> &state) const;
 	void AddCorrelatedJoinConditions(LogicalJoin &join, const vector<ColumnBinding> &left_state,
 	                                 const vector<ColumnBinding> &right_state) const;
 	vector<ColumnBinding> CreateDelimCrossProduct(unique_ptr<LogicalOperator> &plan,

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -514,11 +514,17 @@ vector<optional_idx> FlattenDependentJoins::GetCTERefCorrelatedPositions(const L
 	}
 	auto rec_cte = binder.recursive_ctes.find(cteref.cte_index);
 	if (rec_cte == binder.recursive_ctes.end()) {
-		throw InternalException("Correlated CTE reference has no CTE metadata");
+		throw InternalException(
+		    "Correlated CTE reference has no CTE metadata (CTE index: %llu, reference correlated columns: "
+		    "%llu, reference columns: %llu, required correlated columns: %llu)",
+		    cteref.cte_index.index, cteref.correlated_columns, cteref.chunk_types.size(), correlated_columns.size());
 	}
 	auto &cte_corr_cols = rec_cte->second->Cast<LogicalCTE>().correlated_columns;
 	if (cteref.correlated_columns > cte_corr_cols.size() || cteref.correlated_columns > cteref.chunk_types.size()) {
-		throw InternalException("Correlated CTE reference has inconsistent column counts");
+		throw InternalException("Correlated CTE reference has inconsistent column counts (CTE index: %llu, reference "
+		                        "correlated columns: %llu, CTE correlated columns: %llu, reference columns: %llu)",
+		                        cteref.cte_index.index, cteref.correlated_columns, cte_corr_cols.size(),
+		                        cteref.chunk_types.size());
 	}
 	// A nested dependent join can request a different order or subset of the CTE's correlated columns.
 	// Match their original bindings instead of assuming that both correlated column lists share positions.

--- a/src/planner/subquery/flatten_dependent_join.cpp
+++ b/src/planner/subquery/flatten_dependent_join.cpp
@@ -507,30 +507,44 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownChild(uniqu
 	return result;
 }
 
-void FlattenDependentJoins::AddCTERefJoinConditions(LogicalComparisonJoin &join, const LogicalCTERef &cteref,
-                                                    const vector<ColumnBinding> &state) const {
+vector<optional_idx> FlattenDependentJoins::GetCTERefCorrelatedPositions(const LogicalCTERef &cteref) const {
+	vector<optional_idx> positions(correlated_columns.size());
 	if (cteref.correlated_columns == 0) {
-		return;
+		return positions;
 	}
 	auto rec_cte = binder.recursive_ctes.find(cteref.cte_index);
 	if (rec_cte == binder.recursive_ctes.end()) {
-		return;
+		throw InternalException("Correlated CTE reference has no CTE metadata");
 	}
 	auto &cte_corr_cols = rec_cte->second->Cast<LogicalCTE>().correlated_columns;
-	D_ASSERT(cteref.correlated_columns <= cte_corr_cols.size());
+	if (cteref.correlated_columns > cte_corr_cols.size() || cteref.correlated_columns > cteref.chunk_types.size()) {
+		throw InternalException("Correlated CTE reference has inconsistent column counts");
+	}
+	// A nested dependent join can request a different order or subset of the CTE's correlated columns.
+	// Match their original bindings instead of assuming that both correlated column lists share positions.
 	auto cte_ref_offset = cteref.chunk_types.size() - cteref.correlated_columns;
 	auto cte_corr_start = cte_corr_cols.size() - cteref.correlated_columns;
 	for (idx_t i = 0; i < cteref.correlated_columns; i++) {
 		auto correlated_idx = GetCorrelatedIndex(cte_corr_cols[cte_corr_start + i].binding);
-		if (!correlated_idx.IsValid()) {
+		if (correlated_idx.IsValid()) {
+			positions[correlated_idx.GetIndex()] = cte_ref_offset + i;
+		}
+	}
+	return positions;
+}
+
+void FlattenDependentJoins::AddCTERefJoinConditions(LogicalComparisonJoin &join, const LogicalCTERef &cteref,
+                                                    const vector<optional_idx> &positions,
+                                                    const vector<ColumnBinding> &state) const {
+	for (idx_t i = 0; i < positions.size(); i++) {
+		if (!positions[i].IsValid()) {
 			continue;
 		}
-		auto j = correlated_idx.GetIndex();
-		JoinCondition cond(
-		    make_uniq<BoundColumnRefExpression>(correlated_columns[j].type,
-		                                        ColumnBinding(cteref.table_index, ProjectionIndex(cte_ref_offset + i))),
-		    make_uniq<BoundColumnRefExpression>(correlated_columns[j].type, state[j]),
-		    ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+		JoinCondition cond(make_uniq<BoundColumnRefExpression>(
+		                       correlated_columns[i].type,
+		                       ColumnBinding(cteref.table_index, ProjectionIndex(positions[i].GetIndex()))),
+		                   make_uniq<BoundColumnRefExpression>(correlated_columns[i].type, state[i]),
+		                   ExpressionType::COMPARE_NOT_DISTINCT_FROM);
 		join.conditions.push_back(std::move(cond));
 	}
 }
@@ -1395,22 +1409,32 @@ FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownCTE(unique_
 
 FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownCTERef(unique_ptr<LogicalOperator> &plan) {
 	auto &cteref = plan->Cast<LogicalCTERef>();
-	if (cteref.correlated_columns < correlated_columns.size()) {
-		auto delim_index = binder.GenerateTableIndex();
-		auto delim_state = CreateContiguousState(ColumnBinding(delim_index, ProjectionIndex(0)));
-		auto delim_scan = make_uniq<LogicalDelimGet>(delim_index, delim_types);
-		auto join = make_uniq<LogicalComparisonJoin>(JoinType::INNER);
-		AddCTERefJoinConditions(*join, cteref, delim_state);
-		if (!join->conditions.empty()) {
-			join->children.push_back(std::move(plan));
-			join->children.push_back(std::move(delim_scan));
-			plan = std::move(join);
-			return UnnestingState(std::move(delim_state));
+	auto positions = GetCTERefCorrelatedPositions(cteref);
+	vector<ColumnBinding> cte_state;
+	cte_state.reserve(positions.size());
+	for (auto &position : positions) {
+		if (!position.IsValid()) {
+			break;
 		}
-		return UnnestingState(CreateDelimCrossProduct(plan, std::move(delim_scan), std::move(delim_state)));
+		cte_state.emplace_back(cteref.table_index, ProjectionIndex(position.GetIndex()));
 	}
-	auto correlated_offset = cteref.chunk_types.size() - cteref.correlated_columns;
-	return UnnestingState(CreateContiguousState(ColumnBinding(cteref.table_index, ProjectionIndex(correlated_offset))));
+	if (cte_state.size() == correlated_columns.size()) {
+		return UnnestingState(std::move(cte_state));
+	}
+
+	// Missing correlations require a domain scan; constrain it by every correlation shared with the CTE.
+	auto delim_index = binder.GenerateTableIndex();
+	auto delim_state = CreateContiguousState(ColumnBinding(delim_index, ProjectionIndex(0)));
+	auto delim_scan = make_uniq<LogicalDelimGet>(delim_index, delim_types);
+	auto join = make_uniq<LogicalComparisonJoin>(JoinType::INNER);
+	AddCTERefJoinConditions(*join, cteref, positions, delim_state);
+	if (!join->conditions.empty()) {
+		join->children.push_back(std::move(plan));
+		join->children.push_back(std::move(delim_scan));
+		plan = std::move(join);
+		return UnnestingState(std::move(delim_state));
+	}
+	return UnnestingState(CreateDelimCrossProduct(plan, std::move(delim_scan), std::move(delim_state)));
 }
 
 FlattenDependentJoins::UnnestingState FlattenDependentJoins::PushDownCorrelatedNode(unique_ptr<LogicalOperator> &plan,

--- a/test/sql/cte/recursive_cte_correlated_bindings.test
+++ b/test/sql/cte/recursive_cte_correlated_bindings.test
@@ -1,0 +1,143 @@
+# name: test/sql/cte/recursive_cte_correlated_bindings.test
+# description: CTE references map correlated columns by binding rather than position (issue #25554)
+# group: [cte]
+
+foreach mode enable_optimizer disable_optimizer
+
+statement ok
+PRAGMA {mode};
+
+# The recurring subquery starts with b; the CTE stores a before b.
+query TTI
+SELECT *
+FROM (SELECT {x: 1} AS a, {y: 3} AS b) seed,
+LATERAL (
+    WITH RECURSIVE t(n) USING KEY (n) AS (
+        SELECT a.x
+        UNION ALL
+        SELECT n + 1 FROM t
+        WHERE n < b.y
+          AND NOT EXISTS (SELECT 1 FROM recurring.t r WHERE r.n = b.y)
+    )
+    SELECT * FROM t
+) q
+ORDER BY n;
+----
+{'x': 1}	{'y': 3}	1
+{'x': 1}	{'y': 3}	2
+{'x': 1}	{'y': 3}	3
+
+# Reverse the outer column order without changing the recursive result.
+query TTI
+SELECT *
+FROM (SELECT {y: 3} AS b, {x: 1} AS a) seed,
+LATERAL (
+    WITH RECURSIVE t(n) USING KEY (n) AS (
+        SELECT a.x
+        UNION ALL
+        SELECT n + 1 FROM t
+        WHERE n < b.y
+          AND NOT EXISTS (SELECT 1 FROM recurring.t r WHERE r.n = b.y)
+    )
+    SELECT * FROM t
+) q
+ORDER BY n;
+----
+{'y': 3}	{'x': 1}	1
+{'y': 3}	{'x': 1}	2
+{'y': 3}	{'x': 1}	3
+
+# Equal types must not hide swapped bindings. Preserve independent domains, duplicates and NULLs.
+query III rowsort
+SELECT a.x, b.x, n
+FROM (
+    SELECT {x: lo} AS a, {x: hi} AS b
+    FROM (VALUES (1, 3), (2, 4), (1, 3), (NULL, 3), (1, NULL)) bounds(lo, hi)
+) seed,
+LATERAL (
+    WITH RECURSIVE t(n) USING KEY (n) AS (
+        SELECT a.x
+        UNION ALL
+        SELECT n + 1 FROM t
+        WHERE n < b.x
+          AND NOT EXISTS (SELECT 1 FROM recurring.t r WHERE r.n = b.x)
+    )
+    SELECT * FROM t
+) q;
+----
+1	3	1
+1	3	1
+1	3	2
+1	3	2
+1	3	3
+1	3	3
+1	NULL	1
+2	4	2
+2	4	3
+2	4	4
+NULL	3	NULL
+
+# Ordinary recursive CTE references use the same correlation mapping.
+query TTI
+SELECT *
+FROM (SELECT {x: 1} AS a, {y: 3} AS b) seed,
+LATERAL (
+    WITH RECURSIVE t(n) AS (
+        SELECT a.x
+        UNION ALL
+        SELECT n + 1 FROM t
+        WHERE n < b.y
+          AND NOT EXISTS (SELECT 1 FROM t r WHERE r.n = b.y)
+    )
+    SELECT * FROM t
+) q
+ORDER BY n;
+----
+{'x': 1}	{'y': 3}	1
+{'x': 1}	{'y': 3}	2
+{'x': 1}	{'y': 3}	3
+
+# More than two outer correlations can have different discovery orders.
+query I
+SELECT n
+FROM (SELECT {x: 1} AS a, {y: 5} AS b, {z: 3} AS c) seed,
+LATERAL (
+    WITH RECURSIVE t(n) USING KEY (n) AS (
+        SELECT a.x
+        UNION ALL
+        SELECT n + 1 FROM t
+        WHERE n < b.y
+          AND NOT EXISTS (SELECT 1 FROM recurring.t r WHERE r.n = c.z)
+    )
+    SELECT * FROM t
+) q
+ORDER BY n;
+----
+1
+2
+3
+
+# The inner subquery also needs the current recursive row, which is not an outer CTE correlation.
+query I
+SELECT n
+FROM (SELECT {x: 1} AS a, {y: 3} AS b) seed,
+LATERAL (
+    WITH RECURSIVE t(n) USING KEY (n) AS (
+        SELECT a.x
+        UNION ALL
+        SELECT n + 1 FROM t
+        WHERE n < b.y
+          AND NOT EXISTS (SELECT 1 FROM recurring.t r WHERE r.n = b.y AND r.n = t.n)
+    )
+    SELECT * FROM t
+) q
+ORDER BY n;
+----
+1
+2
+3
+
+endloop
+
+statement ok
+PRAGMA enable_optimizer;


### PR DESCRIPTION
## Summary

Fixes #25554.

Correlated recursive CTEs can store outer columns in a different order from that expected by a nested dependent join. Previously, CTE references assumed matching positions when enough correlated columns were available, causing errors such as `STRUCT(y INTEGER) != STRUCT(x INTEGER)`.

Match correlated columns by binding identity using the existing alias resolution. Reuse the mapping for both direct CTE reads and domain join conditions, and select the direct path only when every required column is available.

