### PR TITLE
Address a few compilation warnings

### DIFF
--- a/src/optimizer/rule/string_prefix.cpp
+++ b/src/optimizer/rule/string_prefix.cpp
@@ -147,7 +147,8 @@ unique_ptr<Expression> StringPrefixRule::Apply(LogicalOperator &op, vector<refer
 	}
 
 	const auto constant_str = StringValue::Get(constant.GetValue());
-	const auto constant_length = Length<string_t, int64_t>(string_t(constant_str.c_str(), constant_str.size()));
+	const auto constant_length =
+	    Length<string_t, int64_t>(string_t(constant_str.c_str(), NumericCast<uint32_t>(constant_str.size())));
 
 	// The constant is longer than the extracted prefix, so the comparison can only be FALSE
 	if (constant_length > num_characters) {

--- a/src/optimizer/topn_window_elimination.cpp
+++ b/src/optimizer/topn_window_elimination.cpp
@@ -1210,7 +1210,7 @@ TopNWindowElimination::TryPrepareLateMaterialization(const LogicalWindow &window
 				for (const auto &rowid_binding : rhs_rowid_bindings) {
 					auto entry = std::find(child_bindings.begin(), child_bindings.end(), rowid_binding);
 					D_ASSERT(entry != child_bindings.end());
-					const ProjectionIndex projection_idx(entry - child_bindings.begin());
+					const ProjectionIndex projection_idx(NumericCast<idx_t>(entry - child_bindings.begin()));
 					if (std::find(filter.projection_map.begin(), filter.projection_map.end(), projection_idx) ==
 					    filter.projection_map.end()) {
 						filter.projection_map.push_back(projection_idx);
@@ -1232,7 +1232,7 @@ TopNWindowElimination::TryPrepareLateMaterialization(const LogicalWindow &window
 					for (const auto &rowid_binding : rhs_rowid_bindings) {
 						auto entry = std::find(child_bindings.begin(), child_bindings.end(), rowid_binding);
 						D_ASSERT(entry != child_bindings.end());
-						const ProjectionIndex projection_idx(entry - child_bindings.begin());
+						const ProjectionIndex projection_idx(NumericCast<idx_t>(entry - child_bindings.begin()));
 						if (std::find(projection_map.begin(), projection_map.end(), projection_idx) ==
 						    projection_map.end()) {
 							projection_map.push_back(projection_idx);

--- a/src/planner/collation_binding.cpp
+++ b/src/planner/collation_binding.cpp
@@ -149,7 +149,7 @@ static bool PushNestedCollation(ClientContext &context, unique_ptr<Expression> &
 	}
 
 	auto bound_lambda =
-	    make_uniq<BoundLambdaExpression>(ExpressionType::LAMBDA, LogicalType::LAMBDA, std::move(lambda_body), 1);
+	    make_uniq<BoundLambdaExpression>(ExpressionType::LAMBDA, LogicalType::LAMBDA, std::move(lambda_body), idx_t(1));
 	bound_lambda->SetParameterNames({lambda_parameter});
 	vector<unique_ptr<Expression>> children;
 	children.push_back(std::move(source));


### PR DESCRIPTION
Spot a few warnings when build
```sh
/Users/haojiang/Desktop/duckdb/build/debug/src/optimizer/rule/../../../../../src/optimizer/rule/string_prefix.cpp:150:101: warning: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
  150 |         const auto constant_length = Length<string_t, int64_t>(string_t(constant_str.c_str(), constant_str.size()));
      |                                                                ~~~~~~~~                       ~~~~~~~~~~~~~^~~~~~
1 warning generated.

/Users/haojiang/Desktop/duckdb/src/include/duckdb/common/helper.hpp:77:86: warning: implicit conversion changes signedness: 'int' to 'idx_t' (aka 'unsigned long long') [-Wsign-conversion]
   77 |     return unique_ptr<DATA_TYPE, std::default_delete<DATA_TYPE>, true>(new DATA_TYPE(std::forward<ARGS>(args)...));
      |                                                                            ~~~~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/haojiang/Desktop/duckdb/build/debug/src/planner/../../../../src/planner/collation_binding.cpp:152:6: note: in instantiation offunction template specialization 'duckdb::make_uniq<duckdb::BoundLambdaExpression, duckdb::ExpressionType, const duckdb::LogicalTypeId &, duckdb::unique_ptr<duckdb::Expression>, int>' requested here
  152 |             make_uniq<BoundLambdaExpression>(ExpressionType::LAMBDA, LogicalType::LAMBDA, std::move(lambda_body), 1);
      |             ^
1 warning generated.

/Users/haojiang/Desktop/duckdb/build/debug/src/optimizer/../../../../src/optimizer/topn_window_elimination.cpp:1213:49: warning: implicit conversion changes signedness: 'decltype(__x.base() - __y.base())' (aka 'long') to 'idx_t' (aka 'unsigned long long') [-Wsign-conversion]
 1213 |                                         const ProjectionIndex projection_idx(entry - child_bindings.begin());
      |                                                               ~~~~~~~~~~~~~~ ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/Users/haojiang/Desktop/duckdb/build/debug/src/optimizer/../../../../src/optimizer/topn_window_elimination.cpp:1235:50: warning: implicit conversion changes signedness: 'decltype(__x.base() - __y.base())' (aka 'long') to 'idx_t' (aka 'unsigned long long') [-Wsign-conversion]
 1235 |                                                 const ProjectionIndex projection_idx(entry - child_bindings.begin());
      |                                                                       ~~~~~~~~~~~~~~ ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```