### PR TITLE
Improve exception message

### DIFF
--- a/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -815,19 +815,18 @@ void DuckTableEntry::UpdateConstraintsOnColumnDrop(const LogicalIndex &removed_i
 			if (unique.HasIndex()) {
 				// Single-column UNIQUE constraint
 				if (unique.GetIndex() == removed_index) {
-					throw CatalogException(
-					    "Cannot drop column %s because there is a UNIQUE constraint that depends on it",
-					    info.removed_column);
+					string constraint_type = unique.IsPrimaryKey() ? "PRIMARY KEY" : "UNIQUE";
+					throw CatalogException("Cannot drop column %s because there is a %s constraint that depends on it",
+					                       info.removed_column, constraint_type);
 				}
 				unique.SetIndex(adjusted_indices[unique.GetIndex().index]);
 			} else {
 				// Multi-column UNIQUE constraint - check if any column matches the one being dropped
 				for (const auto &col_name : unique.GetColumnNames()) {
 					if (col_name == info.removed_column) {
-						// Build constraint string for error message: UNIQUE(col1, col2, ...)
-						auto constraint_str = "UNIQUE(" + StringUtil::Join(unique.GetColumnNames(), ", ") + ")";
-						throw CatalogException("Cannot drop column %s because it is referenced in unique constraint %s",
-						                       info.removed_column, constraint_str);
+						string constraint_kind = unique.IsPrimaryKey() ? "primary key" : "unique";
+						throw CatalogException("Cannot drop column %s because it is referenced in %s constraint %s",
+						                       info.removed_column, constraint_kind, unique.ToString());
 					}
 				}
 			}

--- a/src/planner/binder/statement/bind_create_table.cpp
+++ b/src/planner/binder/statement/bind_create_table.cpp
@@ -191,7 +191,8 @@ unique_ptr<BoundConstraint> Binder::BindUniqueConstraint(const Constraint &const
 		}
 		auto &col = columns.GetColumn(col_name);
 		if (col.Generated()) {
-			throw BinderException("cannot create a PRIMARY KEY on a generated column: %s",
+			string constraint_type = unique.IsPrimaryKey() ? "PRIMARY KEY" : "UNIQUE constraint";
+			throw BinderException("cannot create a %s on a generated column: %s", constraint_type,
 			                      SQLIdentifier(col.GetName()));
 		}
 

--- a/test/sql/alter/add_unique/test_add_unique.test
+++ b/test/sql/alter/add_unique/test_add_unique.test
@@ -41,3 +41,17 @@ ROLLBACK;
 
 statement ok
 INSERT INTO r VALUES (1), (1);
+
+# cannot add a UNIQUE constraint on a generated column
+statement ok
+CREATE TABLE g(a INT, g INT GENERATED ALWAYS AS (a + 1));
+
+statement error
+ALTER TABLE g ADD UNIQUE (g);
+----
+<REGEX>:Binder Error.*cannot create a UNIQUE constraint on a generated column: g.*
+
+statement error
+ALTER TABLE g ADD PRIMARY KEY (g);
+----
+<REGEX>:Binder Error.*cannot create a PRIMARY KEY on a generated column: g.*

--- a/test/sql/alter/drop_col/test_drop_col_failure.test
+++ b/test/sql/alter/drop_col/test_drop_col_failure.test
@@ -40,3 +40,18 @@ statement error
 ALTER TABLE test2 DROP COLUMN age
 ----
 Catalog Error: Cannot drop column "age" because it is referenced in unique constraint UNIQUE(surname, age)
+
+# dropping a single-column PRIMARY KEY reports the PRIMARY KEY constraint
+statement error
+ALTER TABLE test2 DROP COLUMN id
+----
+Catalog Error: Cannot drop column "id" because there is a PRIMARY KEY constraint that depends on it
+
+# dropping a column of a multi-column PRIMARY KEY reports the PRIMARY KEY constraint
+statement ok
+CREATE TABLE test3 (a INT, b INT, c INT, PRIMARY KEY(a, b))
+
+statement error
+ALTER TABLE test3 DROP COLUMN a
+----
+Catalog Error: Cannot drop column "a" because it is referenced in primary key constraint PRIMARY KEY(a, b)

--- a/test/sql/constraints/foreignkey/test_fk_self_referencing.test
+++ b/test/sql/constraints/foreignkey/test_fk_self_referencing.test
@@ -122,7 +122,7 @@ ALTER TABLE employee ALTER COLUMN name_new SET DATA TYPE TEXT;
 statement error
 ALTER TABLE employee DROP COLUMN id;
 ----
-<REGEX>:Catalog Error.*there is a UNIQUE constraint that depends on it.*
+<REGEX>:Catalog Error.*there is a PRIMARY KEY constraint that depends on it.*
 
 statement error
 ALTER TABLE employee DROP COLUMN managerid;


### PR DESCRIPTION
Hi team, I found some exception message doesn't represent the actual violation accurately; for example
```sql
memory D CREATE TABLE t(a INT, b INT, c INT, PRIMARY KEY(a, b));
-- should be "primary key" instead of "unique constraint" 
memory D ALTER TABLE t DROP COLUMN a;
Catalog Error:
Cannot drop column "a" because it is referenced in unique constraint UNIQUE(a, b)

memory D CREATE TABLE t(a INT, g INT GENERATED ALWAYS AS (a + 1));
-- should be "unique constraint" instead of "primary key"
memory D ALTER TABLE t ADD UNIQUE(g);
Binder Error:
cannot create a PRIMARY KEY on a generated column: g
```