### PR TITLE
TaskExecutor: allow interruptible drain

### DIFF
--- a/src/common/enum_util.cpp
+++ b/src/common/enum_util.cpp
@@ -183,6 +183,7 @@
 #include "duckdb/parallel/pipeline_schedule.hpp"
 #include "duckdb/parallel/scan_read_ahead.hpp"
 #include "duckdb/parallel/task.hpp"
+#include "duckdb/parallel/task_executor.hpp"
 #include "duckdb/parser/constraint.hpp"
 #include "duckdb/parser/expression/lambda_expression.hpp"
 #include "duckdb/parser/expression/parameter_expression.hpp"
@@ -6399,6 +6400,24 @@ const char* EnumUtil::ToChars<TaskExecutionResult>(TaskExecutionResult value) {
 template<>
 TaskExecutionResult EnumUtil::FromString<TaskExecutionResult>(const char *value) {
 	return static_cast<TaskExecutionResult>(StringUtil::StringToEnum(GetTaskExecutionResultValues(), 4, "TaskExecutionResult", value));
+}
+
+const StringUtil::EnumStringLiteral *GetTaskExecutorModeValues() {
+	static constexpr StringUtil::EnumStringLiteral values[] {
+		{ static_cast<uint32_t>(TaskExecutorMode::BACKGROUND), "BACKGROUND" },
+		{ static_cast<uint32_t>(TaskExecutorMode::JOINED), "JOINED" }
+	};
+	return values;
+}
+
+template<>
+const char* EnumUtil::ToChars<TaskExecutorMode>(TaskExecutorMode value) {
+	return StringUtil::EnumToString(GetTaskExecutorModeValues(), 2, "TaskExecutorMode", static_cast<uint32_t>(value));
+}
+
+template<>
+TaskExecutorMode EnumUtil::FromString<TaskExecutorMode>(const char *value) {
+	return static_cast<TaskExecutorMode>(StringUtil::StringToEnum(GetTaskExecutorModeValues(), 2, "TaskExecutorMode", value));
 }
 
 const StringUtil::EnumStringLiteral *GetTaskSchedulerTypeValues() {

--- a/src/include/duckdb/common/enum_util.hpp
+++ b/src/include/duckdb/common/enum_util.hpp
@@ -576,6 +576,8 @@ enum class TaskExecutionMode : uint8_t;
 
 enum class TaskExecutionResult : uint8_t;
 
+enum class TaskExecutorMode : uint8_t;
+
 enum class TaskSchedulerType : uint8_t;
 
 enum class TemporaryBufferSize : uint64_t;
@@ -1458,6 +1460,9 @@ const char* EnumUtil::ToChars<TaskExecutionMode>(TaskExecutionMode value);
 
 template<>
 const char* EnumUtil::ToChars<TaskExecutionResult>(TaskExecutionResult value);
+
+template<>
+const char* EnumUtil::ToChars<TaskExecutorMode>(TaskExecutorMode value);
 
 template<>
 const char* EnumUtil::ToChars<TaskSchedulerType>(TaskSchedulerType value);
@@ -2374,6 +2379,9 @@ TaskExecutionMode EnumUtil::FromString<TaskExecutionMode>(const char *value);
 
 template<>
 TaskExecutionResult EnumUtil::FromString<TaskExecutionResult>(const char *value);
+
+template<>
+TaskExecutorMode EnumUtil::FromString<TaskExecutorMode>(const char *value);
 
 template<>
 TaskSchedulerType EnumUtil::FromString<TaskSchedulerType>(const char *value);

--- a/src/include/duckdb/parallel/task_executor.hpp
+++ b/src/include/duckdb/parallel/task_executor.hpp
@@ -17,11 +17,20 @@
 
 namespace duckdb {
 
+enum class TaskExecutorMode : uint8_t {
+	//! Tasks are dispatched to the scheduler, the owner does not necessarily join
+	BACKGROUND,
+	//! The owner blocks in WorkOnTasks, so one task is kept back for the joining thread to execute
+	JOINED
+};
+
 //! The TaskExecutor is a helper class that enables parallel scheduling and execution of tasks
 class TaskExecutor {
 public:
-	explicit TaskExecutor(ClientContext &context, TaskSchedulerType type = TaskSchedulerType::REGULAR);
-	explicit TaskExecutor(TaskScheduler &scheduler, TaskSchedulerType type = TaskSchedulerType::REGULAR);
+	explicit TaskExecutor(ClientContext &context, TaskSchedulerType type = TaskSchedulerType::REGULAR,
+	                      TaskExecutorMode mode = TaskExecutorMode::BACKGROUND);
+	explicit TaskExecutor(TaskScheduler &scheduler, TaskSchedulerType type = TaskSchedulerType::REGULAR,
+	                      TaskExecutorMode mode = TaskExecutorMode::BACKGROUND);
 	~TaskExecutor();
 
 	//! Push an error into the TaskExecutor
@@ -31,7 +40,7 @@ public:
 	//! Throw an error that was encountered during execution (if HasError() is true)
 	void ThrowError();
 
-	//! Schedule a new task
+	//! Schedule a new task. In JOINED mode the first task is parked instead, and executed by the joining thread
 	void ScheduleTask(unique_ptr<Task> task);
 	//! Label a task as finished
 	void FinishTask();
@@ -53,8 +62,11 @@ private:
 
 	TaskScheduler &scheduler;
 	const TaskSchedulerType type;
+	const TaskExecutorMode mode;
 	TaskErrorManager error_manager;
 	unique_ptr<ProducerToken> token;
+	//! Task that is kept back for the thread that drains this executor (JOINED mode only)
+	unique_ptr<Task> parked_task DUCKDB_GUARDED_BY(token->producer_lock);
 	idx_t completed_tasks DUCKDB_GUARDED_BY(token->producer_lock) = 0;
 	idx_t total_tasks DUCKDB_GUARDED_BY(token->producer_lock) = 0;
 	atomic<bool> cancelled {false};

--- a/src/include/duckdb/parallel/task_executor.hpp
+++ b/src/include/duckdb/parallel/task_executor.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/query_context.hpp"
 #include "duckdb/parallel/task.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/execution/task_error_manager.hpp"
@@ -30,7 +31,8 @@ public:
 	explicit TaskExecutor(ClientContext &context, TaskSchedulerType type = TaskSchedulerType::REGULAR,
 	                      TaskExecutorMode mode = TaskExecutorMode::BACKGROUND);
 	explicit TaskExecutor(TaskScheduler &scheduler, TaskSchedulerType type = TaskSchedulerType::REGULAR,
-	                      TaskExecutorMode mode = TaskExecutorMode::BACKGROUND);
+	                      TaskExecutorMode mode = TaskExecutorMode::BACKGROUND,
+	                      QueryContext query_context = QueryContext());
 	~TaskExecutor();
 
 	//! Push an error into the TaskExecutor

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -1,11 +1,17 @@
 #include "duckdb/parallel/task_executor.hpp"
+
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/parallel/task_notifier.hpp"
 #include "duckdb/parallel/task_scheduler.hpp"
 
+#include <chrono>
+
 namespace duckdb {
 
-TaskExecutor::TaskExecutor(TaskScheduler &scheduler, TaskSchedulerType type_p, TaskExecutorMode mode_p)
-    : scheduler(scheduler), type(type_p), mode(mode_p), token(scheduler.CreateProducer()) {
+TaskExecutor::TaskExecutor(TaskScheduler &scheduler, TaskSchedulerType type_p, TaskExecutorMode mode_p,
+                           QueryContext query_context)
+    : scheduler(scheduler), type(type_p), mode(mode_p), token(scheduler.CreateProducer()),
+      context(query_context.GetClientContext()) {
 }
 
 TaskExecutor::TaskExecutor(ClientContext &context_p, TaskSchedulerType type_p, TaskExecutorMode mode_p)
@@ -74,17 +80,28 @@ void TaskExecutor::DrainTasks() {
 	}
 
 	// wait for all active tasks to finish, executing queued tasks on this thread where possible
+	static constexpr std::chrono::milliseconds INTERRUPT_CHECK_INTERVAL = std::chrono::milliseconds(20);
+
 	shared_ptr<Task> task_from_producer;
 	while (true) {
+		bool waited = false;
 		{
 			annotated_unique_lock<annotated_mutex> lk(token->producer_lock);
 			if (completed_tasks == total_tasks) {
 				break;
 			}
 			if (!scheduler.GetTaskFromProducerLocked(*token, task_from_producer)) {
-				token->producer_cv.wait(lk);
-				continue;
+				// wait for a bounded time, so that we can check for interruption in between waits
+				token->producer_cv.wait_for(lk, INTERRUPT_CHECK_INTERVAL);
+				waited = true;
 			}
+		}
+		if (waited) {
+			// a drain that cancels must always run to completion, so it is never allowed to throw
+			if (!cancelled && context) {
+				context->InterruptCheck();
+			}
+			continue;
 		}
 
 		const auto res = task_from_producer->Execute(TaskExecutionMode::PROCESS_ALL);

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -4,12 +4,12 @@
 
 namespace duckdb {
 
-TaskExecutor::TaskExecutor(TaskScheduler &scheduler, TaskSchedulerType type_p)
-    : scheduler(scheduler), type(type_p), token(scheduler.CreateProducer()) {
+TaskExecutor::TaskExecutor(TaskScheduler &scheduler, TaskSchedulerType type_p, TaskExecutorMode mode_p)
+    : scheduler(scheduler), type(type_p), mode(mode_p), token(scheduler.CreateProducer()) {
 }
 
-TaskExecutor::TaskExecutor(ClientContext &context_p, TaskSchedulerType type_p)
-    : TaskExecutor(TaskScheduler::GetScheduler(context_p), type_p) {
+TaskExecutor::TaskExecutor(ClientContext &context_p, TaskSchedulerType type_p, TaskExecutorMode mode_p)
+    : TaskExecutor(TaskScheduler::GetScheduler(context_p), type_p, mode_p) {
 	context = context_p;
 }
 
@@ -31,6 +31,11 @@ void TaskExecutor::ThrowError() {
 void TaskExecutor::ScheduleTask(unique_ptr<Task> task) {
 	{
 		const annotated_lock_guard<annotated_mutex> lock(token->producer_lock);
+		if (mode == TaskExecutorMode::JOINED && !parked_task) {
+			// the joining thread has to wait for the other tasks anyway - park this one for it to execute
+			parked_task = std::move(task);
+			return;
+		}
 		++total_tasks;
 	}
 	try {
@@ -51,6 +56,23 @@ void TaskExecutor::FinishTask() {
 }
 
 void TaskExecutor::DrainTasks() {
+	// execute the parked task (if any) on this thread - if we are cancelling we discard it instead
+	unique_ptr<Task> parked;
+	{
+		const annotated_lock_guard<annotated_mutex> lock(token->producer_lock);
+		if (parked_task && !cancelled) {
+			parked = std::move(parked_task);
+			++total_tasks;
+		} else {
+			parked_task.reset();
+		}
+	}
+	if (parked) {
+		// Execute finishes the task, also when it bails out because another task has errored
+		parked->Execute(TaskExecutionMode::PROCESS_ALL);
+		parked.reset();
+	}
+
 	// wait for all active tasks to finish, executing queued tasks on this thread where possible
 	shared_ptr<Task> task_from_producer;
 	while (true) {

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -365,7 +365,7 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	// Schedule block fetch tasks for all blocks.
 	vector<BufferHandle> pins(num_blocks);
 	auto &scheduler = TaskScheduler::GetScheduler(caching_file_system.db);
-	TaskExecutor executor(scheduler, TaskSchedulerType::ASYNC, TaskExecutorMode::JOINED);
+	TaskExecutor executor(scheduler, TaskSchedulerType::ASYNC, TaskExecutorMode::JOINED, context);
 
 	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		executor.ScheduleTask(make_uniq<FetchBlockTask>(*this, executor, context,

--- a/src/storage/external_file_cache/caching_file_system.cpp
+++ b/src/storage/external_file_cache/caching_file_system.cpp
@@ -365,7 +365,7 @@ FileBufferHandleGroup CachingFileHandle::Read(const idx_t nr_bytes, const idx_t 
 	// Schedule block fetch tasks for all blocks.
 	vector<BufferHandle> pins(num_blocks);
 	auto &scheduler = TaskScheduler::GetScheduler(caching_file_system.db);
-	TaskExecutor executor(scheduler, TaskSchedulerType::ASYNC);
+	TaskExecutor executor(scheduler, TaskSchedulerType::ASYNC, TaskExecutorMode::JOINED);
 
 	for (idx_t idx = 0; idx < num_blocks; idx++) {
 		executor.ScheduleTask(make_uniq<FetchBlockTask>(*this, executor, context,


### PR DESCRIPTION
Single commit on top of https://github.com/duckdb/duckdb/pull/25560, since both change the same file.

----

Commit diff viewable at https://github.com/duckdb/duckdb/commit/4d2504965101ece9805701ce65a993f40e6105f7

DrainTasks waited on the producer condition variable with no timeout and no interrupt check, so a thread that had handed all of its work to other threads was unreachable: cancelling the query, or hitting max_execution_time, could not get it out of the wait.

Wait for a bounded time instead and check for interruption in between waits, when the executor was given a client context. A drain that cancels never checks, because it must always run to completion - it is what keeps tasks from outliving the executor. An interrupt thrown out of WorkOnTasks unwinds into the destructor, which cancels and drains, so the tasks that have not started bail out immediately.

Pass the query context through in CachingFileHandle::Read, which is the one JOINED user that constructs its executor from the scheduler.