### PR TITLE
Specify node256 leaf method as `const`

### DIFF
--- a/src/execution/index/art/node.cpp
+++ b/src/execution/index/art/node.cpp
@@ -303,7 +303,7 @@ bool NodePtr::HasByte(const ART &art, const uint8_t byte) const {
 	case NType::NODE_15_LEAF:
 		return Ref<const Node15Leaf>(art, *this, NType::NODE_15_LEAF).HasByte(byte);
 	case NType::NODE_256_LEAF:
-		return Ref<Node256Leaf>(art, *this, NType::NODE_256_LEAF).HasByte(byte);
+		return Ref<const Node256Leaf>(art, *this, NType::NODE_256_LEAF).HasByte(byte);
 	default:
 		throw InternalException("Invalid node type for GetNextByte: %d.", type);
 	}
@@ -319,7 +319,7 @@ bool NodePtr::GetNextByte(const ART &art, uint8_t &byte) const {
 	case NType::NODE_15_LEAF:
 		return Ref<const Node15Leaf>(art, *this, NType::NODE_15_LEAF).GetNextByte(byte);
 	case NType::NODE_256_LEAF:
-		return Ref<Node256Leaf>(art, *this, NType::NODE_256_LEAF).GetNextByte(byte);
+		return Ref<const Node256Leaf>(art, *this, NType::NODE_256_LEAF).GetNextByte(byte);
 	default:
 		throw InternalException("Invalid node type for GetNextByte: %d.", type);
 	}

--- a/src/execution/index/art/node256_leaf.cpp
+++ b/src/execution/index/art/node256_leaf.cpp
@@ -46,9 +46,11 @@ void Node256Leaf::DeleteByte(ART &art, NodePtr &node, const uint8_t byte) {
 	Node15Leaf::ShrinkNode256Leaf(art, node, node256);
 }
 
-bool Node256Leaf::HasByte(const uint8_t byte) {
-	ValidityMask v_mask(&mask[0], Node256::CAPACITY);
-	return v_mask.RowIsValid(byte);
+bool Node256Leaf::HasByte(const uint8_t byte) const {
+	idx_t entry_idx = 0;
+	idx_t idx_in_entry = 0;
+	ValidityMask::GetEntryIndex(byte, entry_idx, idx_in_entry);
+	return ValidityMask::RowIsValid(mask[entry_idx], idx_in_entry);
 }
 
 array_ptr<uint8_t> Node256Leaf::GetBytes(ArenaAllocator &arena) {
@@ -66,10 +68,12 @@ array_ptr<uint8_t> Node256Leaf::GetBytes(ArenaAllocator &arena) {
 	return bytes;
 }
 
-bool Node256Leaf::GetNextByte(uint8_t &byte) {
-	ValidityMask v_mask(&mask[0], Node256::CAPACITY);
+bool Node256Leaf::GetNextByte(uint8_t &byte) const {
 	for (uint16_t i = byte; i < CAPACITY; i++) {
-		if (v_mask.RowIsValid(i)) {
+		idx_t entry_idx = 0;
+		idx_t idx_in_entry = 0;
+		ValidityMask::GetEntryIndex(i, entry_idx, idx_in_entry);
+		if (ValidityMask::RowIsValid(mask[entry_idx], idx_in_entry)) {
 			byte = UnsafeNumericCast<uint8_t>(i);
 			return true;
 		}

--- a/src/include/duckdb/execution/index/art/node256_leaf.hpp
+++ b/src/include/duckdb/execution/index/art/node256_leaf.hpp
@@ -43,7 +43,7 @@ public:
 	static void DeleteByte(ART &art, NodePtr &node, const uint8_t byte);
 
 	//! Returns true, if the byte exists, else false.
-	bool HasByte(const uint8_t byte);
+	bool HasByte(const uint8_t byte) const;
 
 	//! Returns a pointer to the bytes in the leaf.
 	//! The pointer data is valid as long as the arena is valid.
@@ -51,7 +51,7 @@ public:
 
 	//! Get the first byte greater or equal to the byte.
 	//! Returns true, if such a byte exists, else false.
-	bool GetNextByte(uint8_t &byte);
+	bool GetNextByte(uint8_t &byte) const;
 
 private:
 	static void GrowNode15Leaf(ART &art, NodePtr &node256_leaf, NodePtr &node15_leaf);


### PR DESCRIPTION
Hi team, I found the inconsistency between different node leaves here
https://github.com/duckdb/duckdb/blob/f2895015f7041a3830cd793d3d212e9549f50624/src/execution/index/art/node.cpp#L301-L306

I think having `const` actually improves performance and IO operations
- When we [get node reference](https://github.com/duckdb/duckdb/blob/f2895015f7041a3830cd793d3d212e9549f50624/src/include/duckdb/execution/index/art/node.hpp#L135-L140), whether the leaf node is const or not decides the `dirty` argument's value
- [Whether or not the node is dirty](https://github.com/duckdb/duckdb/blob/f2895015f7041a3830cd793d3d212e9549f50624/src/include/duckdb/execution/index/fixed_size_allocator.hpp#L59-L77) decides whether the buffer needs to be flushed in WAL and checkpoint, even if there's no actual change