### PR TITLE
Experiment: Flatten ParserResult and MatchStack

### DIFF
--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -102,12 +102,12 @@ enum class MatchMode : uint8_t { BUILD_PARSE_RESULT, RECOGNIZE_ONLY };
 
 class MatcherResult {
 public:
-	static MatcherResult Success(optional_ptr<ParseResult> parse_result = nullptr) {
+	static MatcherResult Success(ParseResultRef parse_result = ParseResultRef()) {
 		return MatcherResult(true, parse_result);
 	}
 
 	static MatcherResult Failure() {
-		return MatcherResult(false, nullptr);
+		return MatcherResult(false, ParseResultRef());
 	}
 
 	bool IsSuccess() const {
@@ -115,21 +115,21 @@ public:
 	}
 
 	bool HasParseResult() const {
-		return parse_result != nullptr;
+		return parse_result.IsValid();
 	}
 
-	optional_ptr<ParseResult> GetParseResult() const {
+	ParseResultRef GetParseResult() const {
+		D_ASSERT(HasParseResult());
 		return parse_result;
 	}
 
 private:
-	MatcherResult(bool success_p, optional_ptr<ParseResult> parse_result_p)
-	    : success(success_p), parse_result(parse_result_p) {
+	MatcherResult(bool success_p, ParseResultRef parse_result_p) : success(success_p), parse_result(parse_result_p) {
 	}
 
 private:
 	bool success;
-	optional_ptr<ParseResult> parse_result;
+	ParseResultRef parse_result;
 };
 
 struct MatcherSuggestion {
@@ -400,14 +400,6 @@ private:
 	vector<unique_ptr<Matcher>> matchers;
 };
 
-class ParseResultAllocator {
-public:
-	optional_ptr<ParseResult> Allocate(unique_ptr<ParseResult> parse_result);
-
-private:
-	vector<unique_ptr<ParseResult>> parse_results;
-};
-
 template <class PROCESS, class... ARGS>
 arena_ptr<MatchProcess> MatchState::Make(ARGS &&... args) {
 	static_assert(std::is_base_of<MatchProcess, PROCESS>::value, "Expected a matcher process");
@@ -425,10 +417,11 @@ MatcherResult MatchState::AllocateParseResult(ARGS &&... args) {
 	if (!BuildParseResult()) {
 		return MatcherResult::Success();
 	}
-	auto result = context.allocator.Allocate(make_uniq<RESULT>(std::forward<ARGS>(args)...));
+	auto result = context.allocator.Allocate<RESULT>(std::forward<ARGS>(args)...);
 	if (rule) {
-		result->SetRule(*rule);
-		result->name = rule->name;
+		auto &parse_result = context.allocator.Get(result);
+		parse_result.SetRule(*rule);
+		parse_result.name = rule->name;
 	}
 	return MatcherResult::Success(result);
 }

--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -30,6 +30,7 @@ class ParseResultAllocator;
 class Matcher;
 class MatcherAllocator;
 class MatchProcess;
+class MatchProcessInlineStorage;
 
 enum class SuggestionState : uint8_t {
 	SUGGEST_KEYWORD,
@@ -163,6 +164,8 @@ struct MatchContext {
 	idx_t &max_token_index;
 	IdentifierCaseMode identifier_case_mode;
 	ParserPackratCache *packrat_cache;
+	//! Optional storage supplied by the iterative driver while constructing a stack frame.
+	optional_ptr<MatchProcessInlineStorage> process_inline_storage;
 	MatchMode mode;
 	bool use_heap_based_parser;
 };
@@ -250,6 +253,34 @@ public:
 	//! Resume matching, optionally with the result of the previously requested child.
 	virtual MatchStep Resume(optional<MatcherResult> child_result) = 0;
 };
+
+//! Non-owning storage offered by the iterative driver for a single MatchProcess.
+class MatchProcessInlineStorage {
+public:
+	MatchProcessInlineStorage(data_ptr_t data_p, idx_t capacity_p, idx_t alignment_p)
+	    : data(data_p), capacity(capacity_p), alignment(alignment_p) {
+	}
+
+	template <class PROCESS, class... ARGS>
+	PROCESS *Make(ARGS &&... args) {
+		if (occupied || sizeof(PROCESS) > capacity || alignof(PROCESS) > alignment) {
+			return nullptr;
+		}
+		auto result = new (data) PROCESS(std::forward<ARGS>(args)...);
+		occupied = true;
+		return result;
+	}
+
+private:
+	data_ptr_t data;
+	idx_t capacity;
+	idx_t alignment;
+	bool occupied = false;
+};
+
+//! Size and alignment required to inline every built-in non-atomic MatchProcess.
+idx_t BuiltinMatchProcessSize();
+idx_t BuiltinMatchProcessAlignment();
 
 enum class MatcherType {
 	KEYWORD,
@@ -380,6 +411,12 @@ private:
 template <class PROCESS, class... ARGS>
 arena_ptr<MatchProcess> MatchState::Make(ARGS &&... args) {
 	static_assert(std::is_base_of<MatchProcess, PROCESS>::value, "Expected a matcher process");
+	if (context.process_inline_storage) {
+		auto process = context.process_inline_storage->Make<PROCESS>(std::forward<ARGS>(args)...);
+		if (process) {
+			return arena_ptr<MatchProcess>(process);
+		}
+	}
 	return arena_ptr<MatchProcess>(context.process_allocator.Make<PROCESS>(std::forward<ARGS>(args)...));
 }
 

--- a/src/include/duckdb/parser/peg/matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher.hpp
@@ -119,7 +119,6 @@ public:
 	}
 
 	ParseResultRef GetParseResult() const {
-		D_ASSERT(HasParseResult());
 		return parse_result;
 	}
 

--- a/src/include/duckdb/parser/peg/matcher/keyword_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/keyword_matcher.hpp
@@ -27,7 +27,7 @@ public:
 		}
 		auto result = state.AllocateParseResult<KeywordParseResult>(token_text, start_offset, token_length);
 		if (result.HasParseResult()) {
-			result.GetParseResult()->name = name;
+			state.context.allocator.Get(result.GetParseResult()).name = name;
 		}
 		return result;
 	}

--- a/src/include/duckdb/parser/peg/matcher/number_literal_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/number_literal_matcher.hpp
@@ -29,7 +29,7 @@ public:
 		state.token_iterator.SetPreviousTokenType(TokenType::NUMBER_LITERAL);
 		auto result = state.AllocateParseResult<NumberParseResult>(token_text, start_offset, token_length);
 		if (result.HasParseResult()) {
-			result.GetParseResult()->name = name;
+			state.context.allocator.Get(result.GetParseResult()).name = name;
 		}
 		return result;
 	}

--- a/src/include/duckdb/parser/peg/matcher/string_literal_matcher.hpp
+++ b/src/include/duckdb/parser/peg/matcher/string_literal_matcher.hpp
@@ -55,7 +55,7 @@ public:
 		auto result = state.AllocateParseResult<StringLiteralParseResult>(stripped_string, string_info.type,
 		                                                                  start_offset, token_length);
 		if (result.HasParseResult()) {
-			result.GetParseResult()->name = name;
+			state.context.allocator.Get(result.GetParseResult()).name = name;
 		}
 		return result;
 	}

--- a/src/include/duckdb/parser/peg/matcher_stack.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack.hpp
@@ -23,15 +23,13 @@ class MatchStack;
 struct MatchStateReference {
 	explicit MatchStateReference(MatchState &state_p) : external_state(state_p) {
 	}
-	MatchStateReference(match_frame_index_t frame_index_p, idx_t frame_offset_p)
-	    : frame_index(frame_index_p), frame_offset(frame_offset_p) {
+	explicit MatchStateReference(idx_t frame_offset_p) : frame_offset(frame_offset_p) {
 	}
 
-	MatchState &Get(MatchStack &stack);
+	MatchState &Get(MatchStack &stack, match_frame_index_t frame_index);
 
 private:
 	optional_ptr<MatchState> external_state;
-	optional_idx frame_index;
 	idx_t frame_offset = 0;
 };
 
@@ -55,7 +53,7 @@ public:
 
 public:
 	bool IsInitialized() const;
-	MatchState &GetMatchState(MatchStack &stack);
+	MatchState &GetMatchState(MatchStack &stack, match_frame_index_t frame_index);
 
 public:
 	const Matcher &matcher;
@@ -86,10 +84,10 @@ private:
 	void SetActiveFrameSegment(idx_t segment_index);
 	data_ptr_t GetFrameSlot(match_frame_index_t frame_index) const;
 	MatchStackFrame &GetFrame(match_frame_index_t frame_index) const;
-	MatchStateReference CreateStateReference(MatchState &state, optional_idx parent_frame) const;
+	MatchStateReference CreateStateReference(MatchState &state) const;
 	MatcherResult ExecuteAtomicMatcher(MatchInput input);
 	void DestroyTopFrame();
-	void PushFrame(MatchInput input, optional_idx parent_frame = optional_idx());
+	void PushFrame(MatchInput input);
 	void InitializeFrame(MatchStackFrame &frame);
 	//! Returns true when the frame has completed.
 	bool ExecuteFrame(MatchStackFrame &frame);

--- a/src/include/duckdb/parser/peg/matcher_stack.hpp
+++ b/src/include/duckdb/parser/peg/matcher_stack.hpp
@@ -7,11 +7,33 @@
 
 #pragma once
 
+#include "duckdb/common/array.hpp"
 #include "duckdb/common/optional.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/parser/peg/matcher.hpp"
+#include "duckdb/storage/arena_allocator.hpp"
 
 namespace duckdb {
+
+using match_frame_index_t = idx_t;
+
+class MatchStack;
+
+//! Locates a MatchState either outside the stack or within a stable frame slot.
+struct MatchStateReference {
+	explicit MatchStateReference(MatchState &state_p) : external_state(state_p) {
+	}
+	MatchStateReference(match_frame_index_t frame_index_p, idx_t frame_offset_p)
+	    : frame_index(frame_index_p), frame_offset(frame_offset_p) {
+	}
+
+	MatchState &Get(MatchStack &stack);
+
+private:
+	optional_ptr<MatchState> external_state;
+	optional_idx frame_index;
+	idx_t frame_offset = 0;
+};
 
 struct PackratMatchState {
 	static bool IsEnabled(const Matcher &matcher, const MatchState &state) {
@@ -28,14 +50,17 @@ private:
 
 struct MatchStackFrame {
 public:
-	explicit MatchStackFrame(MatchInput input);
+	MatchStackFrame(const Matcher &matcher_p, MatchStateReference match_state_p, data_ptr_t process_storage_p,
+	                idx_t process_capacity, idx_t process_alignment);
 
 public:
 	bool IsInitialized() const;
+	MatchState &GetMatchState(MatchStack &stack);
 
 public:
 	const Matcher &matcher;
-	MatchState &match_state;
+	MatchStateReference match_state;
+	MatchProcessInlineStorage process_inline_storage;
 	arena_ptr<MatchProcess> process;
 	optional<MatcherResult> child_result;
 	optional<MatcherResult> result;
@@ -50,18 +75,35 @@ public:
 	MatcherResult Execute(MatchInput input);
 
 private:
-	static constexpr idx_t INITIAL_FRAME_CAPACITY = 64;
+	static constexpr idx_t FRAME_SEGMENT_CAPACITY = 64;
+	static constexpr idx_t INLINE_FRAME_SEGMENT_COUNT = 2;
 
+	static idx_t FrameHeaderSize();
+	static idx_t FrameSlotSize();
+	static idx_t FrameSegmentSize();
+	void AllocateFrameSegment();
+	data_ptr_t GetFrameSegment(idx_t segment_index) const;
+	void SetActiveFrameSegment(idx_t segment_index);
+	data_ptr_t GetFrameSlot(match_frame_index_t frame_index) const;
+	MatchStackFrame &GetFrame(match_frame_index_t frame_index) const;
+	MatchStateReference CreateStateReference(MatchState &state, optional_idx parent_frame) const;
 	MatcherResult ExecuteAtomicMatcher(MatchInput input);
 	void DestroyTopFrame();
-	void PushFrame(MatchInput input);
+	void PushFrame(MatchInput input, optional_idx parent_frame = optional_idx());
 	void InitializeFrame(MatchStackFrame &frame);
 	//! Returns true when the frame has completed.
 	bool ExecuteFrame(MatchStackFrame &frame);
 	MatcherResult FinalizeFrame(MatchStackFrame &frame);
 
 private:
-	vector<MatchStackFrame> frames;
+	friend struct MatchStateReference;
+	ArenaAllocator frame_allocator;
+	array<data_ptr_t, INLINE_FRAME_SEGMENT_COUNT> inline_frame_segments {};
+	vector<data_ptr_t> overflow_frame_segments;
+	idx_t frame_segment_count = 0;
+	idx_t frame_count = 0;
+	data_ptr_t active_frame_segment = nullptr;
+	idx_t active_frame_segment_index = DConstants::INVALID_INDEX;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/parser_packrat.hpp
+++ b/src/include/duckdb/parser/peg/parser_packrat.hpp
@@ -10,10 +10,10 @@
 #include "duckdb/common/common.hpp"
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/unordered_map.hpp"
+#include "duckdb/parser/peg/transformer/parse_result.hpp"
 
 namespace duckdb {
 class Matcher;
-class ParseResult;
 
 struct ParserPackratKey {
 	idx_t matcher_id;
@@ -32,7 +32,7 @@ struct ParserPackratEntry {
 	bool success = false;
 	idx_t token_index_after = 0;
 	idx_t max_token_index_seen = 0;
-	optional_ptr<ParseResult> result;
+	ParseResultRef result;
 };
 
 class ParserPackratCache {

--- a/src/include/duckdb/parser/peg/transformer/parse_result.hpp
+++ b/src/include/duckdb/parser/peg/transformer/parse_result.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/parser/peg/special_string_utils.hpp"
 #include "duckdb/parser/peg/token_type.hpp"
 #include "duckdb/common/windows_undefs.hpp"
+#include <type_traits>
 
 namespace duckdb {
 
@@ -61,7 +62,44 @@ inline string TokenTypeToString(TokenType type) {
 }
 
 class PEGTransformer; // Forward declaration
+class ParseResultAllocator;
 struct CompiledGrammarRule;
+
+class ParseResultRef {
+public:
+	ParseResultRef() = default;
+
+	bool IsValid() const {
+		return index != INVALID_INDEX;
+	}
+
+	uint32_t GetIndex() const {
+		D_ASSERT(IsValid());
+		return index;
+	}
+
+	bool operator==(const ParseResultRef &other) const {
+		return index == other.index;
+	}
+
+	bool operator!=(const ParseResultRef &other) const {
+		return !(*this == other);
+	}
+
+private:
+	static constexpr uint32_t INVALID_INDEX = NumericLimits<uint32_t>::Maximum();
+	explicit ParseResultRef(uint32_t index_p) : index(index_p) {
+	}
+
+private:
+	friend class ParseResultAllocator;
+	uint32_t index = INVALID_INDEX;
+};
+
+struct ParseResultRange {
+	uint32_t offset = 0;
+	uint32_t count = 0;
+};
 
 enum class ParseResultType : uint8_t {
 	LIST,
@@ -116,13 +154,16 @@ inline const char *ParseResultToString(ParseResultType type) {
 
 class ParseResult {
 public:
-	explicit ParseResult(ParseResultType type, optional_idx offset, optional_idx length = optional_idx())
-	    : type(type), offset(offset), length(length) {
+	explicit ParseResult(ParseResultAllocator &allocator_p, ParseResultType type, optional_idx offset,
+	                     optional_idx length = optional_idx())
+	    : allocator(allocator_p), type(type), offset(offset), length(length) {
 	}
 	virtual ~ParseResult() = default;
 
 	ParseResult(const ParseResult &) = delete;
 	ParseResult &operator=(const ParseResult &) = delete;
+	ParseResult(ParseResult &&) = default;
+	ParseResult &operator=(ParseResult &&) = delete;
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -133,6 +174,8 @@ public:
 		return reinterpret_cast<TARGET &>(*this);
 	}
 
+	ParseResultAllocator &allocator;
+	ParseResultRef result_reference;
 	ParseResultType type;
 	string name;
 	optional_ptr<const CompiledGrammarRule> rule;
@@ -145,6 +188,10 @@ public:
 	}
 	optional_ptr<const CompiledGrammarRule> GetRule() const {
 		return rule;
+	}
+	ParseResultRef GetReference() const {
+		D_ASSERT(result_reference.IsValid());
+		return result_reference;
 	}
 
 	//! Returns the source location [offset, offset+length) of this parse result (length 0 when unknown)
@@ -188,8 +235,9 @@ struct IdentifierParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::IDENTIFIER;
 	Identifier identifier;
 
-	explicit IdentifierParseResult(string identifier_p, optional_idx offset, optional_idx length = optional_idx())
-	    : ParseResult(TYPE, offset, length), identifier(std::move(identifier_p)) {
+	explicit IdentifierParseResult(ParseResultAllocator &allocator, string identifier_p, optional_idx offset,
+	                               optional_idx length = optional_idx())
+	    : ParseResult(allocator, TYPE, offset, length), identifier(std::move(identifier_p)) {
 	}
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
@@ -202,7 +250,7 @@ struct IdentifierParseResult : ParseResult {
 struct EndOfInputParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::END_OF_INPUT;
 
-	EndOfInputParseResult() : ParseResult(TYPE, optional_idx()) {
+	explicit EndOfInputParseResult(ParseResultAllocator &allocator) : ParseResult(allocator, TYPE, optional_idx()) {
 	}
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
@@ -216,8 +264,9 @@ struct KeywordParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::KEYWORD;
 	string keyword;
 
-	explicit KeywordParseResult(string keyword_p, optional_idx offset, optional_idx length = optional_idx())
-	    : ParseResult(TYPE, offset, length), keyword(std::move(keyword_p)) {
+	explicit KeywordParseResult(ParseResultAllocator &allocator, string keyword_p, optional_idx offset,
+	                            optional_idx length = optional_idx())
+	    : ParseResult(allocator, TYPE, offset, length), keyword(std::move(keyword_p)) {
 	}
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
@@ -231,24 +280,11 @@ struct ListParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::LIST;
 
 public:
-	explicit ListParseResult(vector<reference<ParseResult>> results_p, string name_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), children(std::move(results_p)) {
-		name = std::move(name_p);
-		for (auto &child : children) {
-			EncloseChild(child.get());
-		}
-	}
+	explicit ListParseResult(ParseResultAllocator &allocator, vector<ParseResultRef> results_p, string name_p,
+	                         optional_idx offset);
 
-	vector<reference<ParseResult>> GetChildren() const {
-		return children;
-	}
-
-	ParseResult &GetChild(idx_t index) {
-		if (index >= children.size()) {
-			throw InternalException("Child index out of bounds");
-		}
-		return children[index].get();
-	}
+	vector<reference<ParseResult>> GetChildren() const;
+	ParseResult &GetChild(idx_t index);
 
 	template <class T>
 	T &Child(idx_t index) {
@@ -269,39 +305,35 @@ public:
 		if (!name.empty()) {
 			ss << " (" << name << ")";
 		}
-		ss << " [" << children.size() << " children]\n";
+		ss << " [" << children.count << " children]\n";
 
 		std::string child_indent = indent + (is_last ? "   " : "│  ");
-		for (size_t i = 0; i < children.size(); ++i) {
-			children[i].get().ToStringInternal(ss, visited, child_indent, i == children.size() - 1);
+		auto child_results = GetChildren();
+		for (idx_t i = 0; i < child_results.size(); ++i) {
+			child_results[i].get().ToStringInternal(ss, visited, child_indent, i == child_results.size() - 1);
 		}
 	}
 
 private:
-	vector<reference<ParseResult>> children;
+	ParseResultRange children;
 };
 
 struct RepeatParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::REPEAT;
 
-	explicit RepeatParseResult(vector<reference<ParseResult>> results_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), children(std::move(results_p)) {
-		for (auto &child : children) {
-			EncloseChild(child.get());
-		}
-	}
+	explicit RepeatParseResult(ParseResultAllocator &allocator, vector<ParseResultRef> results_p, optional_idx offset);
 
-	vector<reference<ParseResult>> GetChildren() const {
-		return children;
-	}
+	vector<reference<ParseResult>> GetChildren() const;
 
 	template <class T>
 	T &Child(idx_t index) {
-		if (index >= children.size()) {
+		if (index >= children.count) {
 			throw InternalException("Child index out of bounds");
 		}
-		return children[index].get().Cast<T>();
+		return GetChild(index).Cast<T>();
 	}
+
+	ParseResult &GetChild(idx_t index);
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
 	                      const std::string &indent, bool is_last) const override {
@@ -317,51 +349,41 @@ struct RepeatParseResult : ParseResult {
 		if (!name.empty()) {
 			ss << " (" << name << ")";
 		}
-		ss << " [" << children.size() << " children]\n";
+		ss << " [" << children.count << " children]\n";
 
 		std::string child_indent = indent + (is_last ? "   " : "│  ");
-		for (size_t i = 0; i < children.size(); ++i) {
-			children[i].get().ToStringInternal(ss, visited, child_indent, i == children.size() - 1);
+		auto child_results = GetChildren();
+		for (idx_t i = 0; i < child_results.size(); ++i) {
+			child_results[i].get().ToStringInternal(ss, visited, child_indent, i == child_results.size() - 1);
 		}
 	}
 
 private:
-	vector<reference<ParseResult>> children;
+	ParseResultRange children;
 };
 
 struct OptionalParseResult : ParseResult {
 	static constexpr ParseResultType TYPE = ParseResultType::OPTIONAL;
 
-	explicit OptionalParseResult() : ParseResult(TYPE, optional_idx()), optional_result(nullptr) {
+	explicit OptionalParseResult(ParseResultAllocator &allocator) : ParseResult(allocator, TYPE, optional_idx()) {
 	}
-	explicit OptionalParseResult(optional_ptr<ParseResult> result_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), optional_result(result_p) {
-		name = result_p->name;
-		EncloseChild(*result_p);
-	}
+	explicit OptionalParseResult(ParseResultAllocator &allocator, ParseResultRef result_p, optional_idx offset);
 
 	bool HasResult() const {
-		return optional_result != nullptr;
+		return optional_result.IsValid();
 	}
 
-	ParseResult &GetResultUnsafe() {
-		D_ASSERT(optional_result);
-		return *optional_result;
-	}
-
-	ParseResult &GetResult() {
-		if (!optional_result) {
-			throw InternalException("OptionalParseResult is null");
-		}
-		return *optional_result;
-	}
+	ParseResult &GetResultUnsafe();
+	const ParseResult &GetResultUnsafe() const;
+	ParseResult &GetResult();
+	const ParseResult &GetResult() const;
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
 	                      const std::string &indent, bool is_last) const override {
 		if (HasResult()) {
 			// The optional node has a value, so we "collapse" it by just printing its child.
 			// We pass the same indentation and is_last status, so it takes the place of the Optional node.
-			optional_result->ToStringInternal(ss, visited, indent, is_last);
+			GetResultUnsafe().ToStringInternal(ss, visited, indent, is_last);
 		} else {
 			// The optional node is empty, which is useful information, so we print it.
 			ss << indent << (is_last ? "└─" : "├─") << " " << ParseResultToString(type) << " [empty]\n";
@@ -369,22 +391,18 @@ struct OptionalParseResult : ParseResult {
 	}
 
 private:
-	optional_ptr<ParseResult> optional_result;
+	ParseResultRef optional_result;
 };
 
 class ChoiceParseResult : public ParseResult {
 public:
 	static constexpr ParseResultType TYPE = ParseResultType::CHOICE;
 
-	explicit ChoiceParseResult(ParseResult &parse_result_p, idx_t selected_idx_p, optional_idx offset)
-	    : ParseResult(TYPE, offset), result(parse_result_p), selected_idx(selected_idx_p) {
-		name = parse_result_p.name;
-		EncloseChild(parse_result_p);
-	}
+	explicit ChoiceParseResult(ParseResultAllocator &allocator, ParseResultRef parse_result_p, idx_t selected_idx_p,
+	                           optional_idx offset);
 
-	ParseResult &GetResult() {
-		return result;
-	}
+	ParseResult &GetResult();
+	const ParseResult &GetResult() const;
 
 	void ToStringInternal(std::stringstream &ss, std::unordered_set<const ParseResult *> &visited,
 	                      const std::string &indent, bool is_last) const override {
@@ -394,11 +412,11 @@ public:
 
 		// The child is now on a new indentation level and is the only child of our marker.
 		std::string child_indent = indent + (is_last ? "   " : "│  ");
-		result.ToStringInternal(ss, visited, child_indent, true);
+		GetResult().ToStringInternal(ss, visited, child_indent, true);
 	}
 
 private:
-	ParseResult &result;
+	ParseResultRef result;
 	idx_t selected_idx;
 };
 
@@ -406,8 +424,9 @@ class NumberParseResult : public ParseResult {
 public:
 	static constexpr ParseResultType TYPE = ParseResultType::NUMBER;
 
-	explicit NumberParseResult(string number_p, optional_idx offset, optional_idx length = optional_idx())
-	    : ParseResult(TYPE, offset, length), number(std::move(number_p)) {
+	explicit NumberParseResult(ParseResultAllocator &allocator, string number_p, optional_idx offset,
+	                           optional_idx length = optional_idx())
+	    : ParseResult(allocator, TYPE, offset, length), number(std::move(number_p)) {
 	}
 	string number;
 
@@ -422,9 +441,10 @@ class StringLiteralParseResult : public ParseResult {
 public:
 	static constexpr ParseResultType TYPE = ParseResultType::STRING;
 
-	explicit StringLiteralParseResult(string string_p, SpecialStringCharacter string_type_p, optional_idx offset,
+	explicit StringLiteralParseResult(ParseResultAllocator &allocator, string string_p,
+	                                  SpecialStringCharacter string_type_p, optional_idx offset,
 	                                  optional_idx length = optional_idx())
-	    : ParseResult(TYPE, offset, length), result(std::move(string_p)), string_type(string_type_p) {
+	    : ParseResult(allocator, TYPE, offset, length), result(std::move(string_p)), string_type(string_type_p) {
 	}
 
 	string GetRawString() const {
@@ -553,8 +573,9 @@ class OperatorParseResult : public ParseResult {
 public:
 	static constexpr ParseResultType TYPE = ParseResultType::OPERATOR;
 
-	explicit OperatorParseResult(string operator_p, optional_idx offset, optional_idx length = optional_idx())
-	    : ParseResult(TYPE, offset, length), operator_token(std::move(operator_p)) {
+	explicit OperatorParseResult(ParseResultAllocator &allocator, string operator_p, optional_idx offset,
+	                             optional_idx length = optional_idx())
+	    : ParseResult(allocator, TYPE, offset, length), operator_token(std::move(operator_p)) {
 	}
 	string operator_token;
 
@@ -564,5 +585,241 @@ public:
 		ss << ": " << operator_token << "\n";
 	}
 };
+
+template <class T>
+struct IsBuiltinParseResult
+    : std::disjunction<std::is_same<T, IdentifierParseResult>, std::is_same<T, EndOfInputParseResult>,
+                       std::is_same<T, KeywordParseResult>, std::is_same<T, ListParseResult>,
+                       std::is_same<T, RepeatParseResult>, std::is_same<T, OptionalParseResult>,
+                       std::is_same<T, ChoiceParseResult>, std::is_same<T, NumberParseResult>,
+                       std::is_same<T, StringLiteralParseResult>, std::is_same<T, OperatorParseResult>> {};
+
+class ParseResultSlot {
+public:
+	template <class RESULT, class... ARGS>
+	explicit ParseResultSlot(std::in_place_type_t<RESULT>, ParseResultAllocator &allocator, ARGS &&... args) {
+		static_assert(IsBuiltinParseResult<RESULT>::value, "Only built-in parse results can be flattened");
+		new (&storage) RESULT(allocator, std::forward<ARGS>(args)...);
+	}
+
+	ParseResultSlot(ParseResultSlot &&other) {
+		MoveFrom(other);
+	}
+
+	ParseResultSlot(const ParseResultSlot &) = delete;
+	ParseResultSlot &operator=(const ParseResultSlot &) = delete;
+	ParseResultSlot &operator=(ParseResultSlot &&) = delete;
+
+	~ParseResultSlot() {
+		Get().~ParseResult();
+	}
+
+	ParseResult &Get() {
+		return *reinterpret_cast<ParseResult *>(&storage);
+	}
+
+	const ParseResult &Get() const {
+		return *reinterpret_cast<const ParseResult *>(&storage);
+	}
+
+private:
+	void MoveFrom(ParseResultSlot &other) {
+		auto &result = other.Get();
+		switch (result.type) {
+		case ParseResultType::IDENTIFIER:
+			new (&storage) IdentifierParseResult(std::move(result.Cast<IdentifierParseResult>()));
+			break;
+		case ParseResultType::END_OF_INPUT:
+			new (&storage) EndOfInputParseResult(std::move(result.Cast<EndOfInputParseResult>()));
+			break;
+		case ParseResultType::KEYWORD:
+			new (&storage) KeywordParseResult(std::move(result.Cast<KeywordParseResult>()));
+			break;
+		case ParseResultType::LIST:
+			new (&storage) ListParseResult(std::move(result.Cast<ListParseResult>()));
+			break;
+		case ParseResultType::REPEAT:
+			new (&storage) RepeatParseResult(std::move(result.Cast<RepeatParseResult>()));
+			break;
+		case ParseResultType::OPTIONAL:
+			new (&storage) OptionalParseResult(std::move(result.Cast<OptionalParseResult>()));
+			break;
+		case ParseResultType::CHOICE:
+			new (&storage) ChoiceParseResult(std::move(result.Cast<ChoiceParseResult>()));
+			break;
+		case ParseResultType::NUMBER:
+			new (&storage) NumberParseResult(std::move(result.Cast<NumberParseResult>()));
+			break;
+		case ParseResultType::STRING:
+			new (&storage) StringLiteralParseResult(std::move(result.Cast<StringLiteralParseResult>()));
+			break;
+		case ParseResultType::OPERATOR:
+			new (&storage) OperatorParseResult(std::move(result.Cast<OperatorParseResult>()));
+			break;
+		default:
+			throw InternalException("Unsupported parse result type in flattened pool");
+		}
+	}
+
+private:
+	using storage_t =
+	    typename std::aligned_union<0, IdentifierParseResult, EndOfInputParseResult, KeywordParseResult,
+	                                ListParseResult, RepeatParseResult, OptionalParseResult, ChoiceParseResult,
+	                                NumberParseResult, StringLiteralParseResult, OperatorParseResult>::type;
+	storage_t storage;
+};
+
+class ParseResultAllocator {
+public:
+	template <class RESULT, class... ARGS>
+	ParseResultRef Allocate(ARGS &&... args) {
+		static_assert(IsBuiltinParseResult<RESULT>::value, "Only built-in parse results can be flattened");
+		if (parse_results.size() >= NumericLimits<uint32_t>::Maximum()) {
+			throw InternalException("Too many parse results");
+		}
+		auto result = ParseResultRef(NumericCast<uint32_t>(parse_results.size()));
+		parse_results.emplace_back(std::in_place_type<RESULT>, *this, std::forward<ARGS>(args)...);
+		Get(result).result_reference = result;
+		return result;
+	}
+
+	ParseResult &Get(ParseResultRef result) {
+		if (!result.IsValid() || result.GetIndex() >= parse_results.size()) {
+			throw InternalException("Parse result index out of bounds");
+		}
+		return parse_results[result.GetIndex()].Get();
+	}
+
+	const ParseResult &Get(ParseResultRef result) const {
+		if (!result.IsValid() || result.GetIndex() >= parse_results.size()) {
+			throw InternalException("Parse result index out of bounds");
+		}
+		return parse_results[result.GetIndex()].Get();
+	}
+
+	idx_t Count() const {
+		return parse_results.size();
+	}
+
+private:
+	ParseResultRange StoreChildren(const vector<ParseResultRef> &results) {
+		if (child_results.size() + results.size() > NumericLimits<uint32_t>::Maximum()) {
+			throw InternalException("Too many parse result children");
+		}
+		ParseResultRange range {NumericCast<uint32_t>(child_results.size()), NumericCast<uint32_t>(results.size())};
+		for (auto result : results) {
+			if (!result.IsValid() || result.GetIndex() >= parse_results.size()) {
+				throw InternalException("Parse result child must precede its parent");
+			}
+			child_results.push_back(result);
+		}
+		return range;
+	}
+
+	ParseResult &GetChild(ParseResultRange range, idx_t index) {
+		if (index >= range.count || idx_t(range.offset) + index >= child_results.size()) {
+			throw InternalException("Parse result child index out of bounds");
+		}
+		return Get(child_results[range.offset + index]);
+	}
+
+	vector<reference<ParseResult>> GetChildren(ParseResultRange range) {
+		vector<reference<ParseResult>> result;
+		result.reserve(range.count);
+		for (idx_t index = 0; index < range.count; index++) {
+			result.push_back(GetChild(range, index));
+		}
+		return result;
+	}
+
+private:
+	friend struct ListParseResult;
+	friend struct RepeatParseResult;
+	friend struct OptionalParseResult;
+	friend class ChoiceParseResult;
+	vector<ParseResultSlot> parse_results;
+	vector<ParseResultRef> child_results;
+};
+
+inline ListParseResult::ListParseResult(ParseResultAllocator &allocator, vector<ParseResultRef> results_p,
+                                        string name_p, optional_idx offset)
+    : ParseResult(allocator, TYPE, offset), children(allocator.StoreChildren(results_p)) {
+	name = std::move(name_p);
+	for (auto child : results_p) {
+		EncloseChild(allocator.Get(child));
+	}
+}
+
+inline vector<reference<ParseResult>> ListParseResult::GetChildren() const {
+	return allocator.GetChildren(children);
+}
+
+inline ParseResult &ListParseResult::GetChild(idx_t index) {
+	return allocator.GetChild(children, index);
+}
+
+inline RepeatParseResult::RepeatParseResult(ParseResultAllocator &allocator, vector<ParseResultRef> results_p,
+                                            optional_idx offset)
+    : ParseResult(allocator, TYPE, offset), children(allocator.StoreChildren(results_p)) {
+	for (auto child : results_p) {
+		EncloseChild(allocator.Get(child));
+	}
+}
+
+inline vector<reference<ParseResult>> RepeatParseResult::GetChildren() const {
+	return allocator.GetChildren(children);
+}
+
+inline ParseResult &RepeatParseResult::GetChild(idx_t index) {
+	return allocator.GetChild(children, index);
+}
+
+inline ParseResult &OptionalParseResult::GetResultUnsafe() {
+	D_ASSERT(optional_result.IsValid());
+	return allocator.Get(optional_result);
+}
+
+inline OptionalParseResult::OptionalParseResult(ParseResultAllocator &allocator, ParseResultRef result_p,
+                                                optional_idx offset)
+    : ParseResult(allocator, TYPE, offset), optional_result(result_p) {
+	auto &result = allocator.Get(result_p);
+	name = result.name;
+	EncloseChild(result);
+}
+
+inline const ParseResult &OptionalParseResult::GetResultUnsafe() const {
+	D_ASSERT(optional_result.IsValid());
+	return allocator.Get(optional_result);
+}
+
+inline ParseResult &OptionalParseResult::GetResult() {
+	if (!optional_result.IsValid()) {
+		throw InternalException("OptionalParseResult is null");
+	}
+	return allocator.Get(optional_result);
+}
+
+inline const ParseResult &OptionalParseResult::GetResult() const {
+	if (!optional_result.IsValid()) {
+		throw InternalException("OptionalParseResult is null");
+	}
+	return allocator.Get(optional_result);
+}
+
+inline ChoiceParseResult::ChoiceParseResult(ParseResultAllocator &allocator, ParseResultRef parse_result_p,
+                                            idx_t selected_idx_p, optional_idx offset)
+    : ParseResult(allocator, TYPE, offset), result(parse_result_p), selected_idx(selected_idx_p) {
+	auto &parse_result = allocator.Get(parse_result_p);
+	name = parse_result.name;
+	EncloseChild(parse_result);
+}
+
+inline ParseResult &ChoiceParseResult::GetResult() {
+	return allocator.Get(result);
+}
+
+inline const ParseResult &ChoiceParseResult::GetResult() const {
+	return allocator.Get(result);
+}
 
 } // namespace duckdb

--- a/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
+++ b/src/include/duckdb/parser/peg/transformer/peg_transformer.hpp
@@ -263,18 +263,19 @@ unique_ptr<TypedTransformResult<T>> TryBridgeTransformResultValue(TransformResul
 
 //! Input to start a transformer execution. The rule can be supplied explicitly for transparent parse nodes.
 struct TransformInput {
-	TransformInput(ParseResult &parse_result_p) : parse_result(parse_result_p) {
+	TransformInput(ParseResult &parse_result_p)
+	    : rule(parse_result_p.GetRule()), parse_result(parse_result_p.GetReference()) {
 	}
 	TransformInput(const CompiledGrammarRule &rule_p, ParseResult &parse_result_p)
-	    : rule(rule_p), parse_result(parse_result_p) {
+	    : rule(rule_p), parse_result(parse_result_p.GetReference()) {
 	}
 
 	optional_ptr<const CompiledGrammarRule> GetRule() const {
-		return rule ? rule : parse_result.GetRule();
+		return rule;
 	}
 
 	optional_ptr<const CompiledGrammarRule> rule;
-	ParseResult &parse_result;
+	ParseResultRef parse_result;
 };
 
 //! Essentially a std::variant<TransformInput, unique_ptr<TransformResultValue>>.
@@ -386,7 +387,7 @@ struct TransformStackFrame {
 	explicit TransformStackFrame(TransformInput input);
 
 	optional_ptr<const CompiledGrammarRule> rule;
-	ParseResult &parse_result;
+	ParseResultRef parse_result;
 	unique_ptr<TransformProcess> process;
 	unique_ptr<TransformResultValue> child_result;
 };
@@ -407,7 +408,8 @@ public:
 		auto base_result = Execute(input);
 		auto *result_value = TryGetTransformResult<T>(*base_result);
 		if (!result_value) {
-			throw InternalException("Unexpected transformer result type for root rule '%s'", input.parse_result.name);
+			throw InternalException("Unexpected transformer result type for root rule '%s'",
+			                        GetParseResultName(input.parse_result));
 		}
 		return std::move(*result_value);
 	}
@@ -420,6 +422,7 @@ private:
 	void PushFrame(TransformInput input);
 	void InitializeFrame(TransformStackFrame &frame);
 	unique_ptr<TransformResultValue> ExecuteFrame(TransformStackFrame &frame);
+	const string &GetParseResultName(ParseResultRef result) const;
 
 private:
 	PEGTransformer &transformer;
@@ -428,12 +431,16 @@ private:
 
 class PEGTransformer {
 public:
-	PEGTransformer(ArenaAllocator &allocator, TokenIterator &token_iterator, ParserOptions &options_p,
-	               const CompiledGrammar &grammar_p)
-	    : allocator(allocator), token_iterator(token_iterator), options(options_p), grammar(grammar_p) {
+	PEGTransformer(ArenaAllocator &allocator, ParseResultAllocator &parse_results_p, TokenIterator &token_iterator,
+	               ParserOptions &options_p, const CompiledGrammar &grammar_p)
+	    : allocator(allocator), parse_results(parse_results_p), token_iterator(token_iterator), options(options_p),
+	      grammar(grammar_p) {
 	}
 
 	const CompiledGrammarRule &GetRule(const string &rule_name) const;
+	ParseResult &GetParseResult(ParseResultRef result) {
+		return parse_results.Get(result);
+	}
 
 public:
 	template <typename T>
@@ -527,6 +534,7 @@ private:
 
 public:
 	ArenaAllocator &allocator;
+	ParseResultAllocator &parse_results;
 	TokenIterator &token_iterator;
 	identifier_map_t<idx_t> named_parameter_map;
 	idx_t prepared_statement_parameter_index = 0;

--- a/src/parser/peg/matcher.cpp
+++ b/src/parser/peg/matcher.cpp
@@ -89,10 +89,4 @@ Matcher &MatcherAllocator::Allocate(unique_ptr<Matcher> matcher) {
 	return result;
 }
 
-optional_ptr<ParseResult> ParseResultAllocator::Allocate(unique_ptr<ParseResult> parse_result) {
-	auto result_ptr = parse_result.get();
-	parse_results.push_back(std::move(parse_result));
-	return optional_ptr<ParseResult>(result_ptr);
-}
-
 } // namespace duckdb

--- a/src/parser/peg/matcher_process.cpp
+++ b/src/parser/peg/matcher_process.cpp
@@ -256,4 +256,20 @@ arena_ptr<MatchProcess> RepeatMatcher::StartMatch(MatchState &state) const {
 	return state.Make<RepeatMatchProcess>(*this, state);
 }
 
+idx_t BuiltinMatchProcessSize() {
+	idx_t result = sizeof(ListMatchProcess);
+	result = MaxValue<idx_t>(result, sizeof(ChoiceMatchProcess));
+	result = MaxValue<idx_t>(result, sizeof(OptionalMatchProcess));
+	result = MaxValue<idx_t>(result, sizeof(RepeatMatchProcess));
+	return result;
+}
+
+idx_t BuiltinMatchProcessAlignment() {
+	idx_t result = alignof(ListMatchProcess);
+	result = MaxValue<idx_t>(result, alignof(ChoiceMatchProcess));
+	result = MaxValue<idx_t>(result, alignof(OptionalMatchProcess));
+	result = MaxValue<idx_t>(result, alignof(RepeatMatchProcess));
+	return result;
+}
+
 } // namespace duckdb

--- a/src/parser/peg/matcher_process.cpp
+++ b/src/parser/peg/matcher_process.cpp
@@ -65,7 +65,7 @@ public:
 				return MatchStep::Complete(MatcherResult::Failure());
 			}
 			if (child_result->HasParseResult()) {
-				results.push_back(*child_result->GetParseResult());
+				results.push_back(child_result->GetParseResult());
 			}
 			child_index++;
 		}
@@ -108,7 +108,7 @@ private:
 	const ListMatcher &matcher;
 	MatchState &state;
 	MatchState list_state;
-	vector<reference<ParseResult>> results;
+	vector<ParseResultRef> results;
 	idx_t child_index = 0;
 	idx_t saved_suggestion_size = 0;
 	optional_idx start_offset;
@@ -137,7 +137,7 @@ public:
 				if (!child_result->HasParseResult()) {
 					return MatchStep::Complete(MatcherResult::Success());
 				}
-				return MatchStep::Complete(state.AllocateParseResult<ChoiceParseResult>(*child_result->GetParseResult(),
+				return MatchStep::Complete(state.AllocateParseResult<ChoiceParseResult>(child_result->GetParseResult(),
 				                                                                        child_index, start_offset));
 			}
 			child_index++;
@@ -224,7 +224,7 @@ public:
 			}
 			matched_once = true;
 			if (child_result->HasParseResult()) {
-				results.push_back(*child_result->GetParseResult());
+				results.push_back(child_result->GetParseResult());
 			}
 			state.token_iterator.SetPosition(repeat_state.token_iterator);
 			auto current = repeat_state.token_iterator.Current();
@@ -246,7 +246,7 @@ private:
 	const RepeatMatcher &matcher;
 	MatchState &state;
 	MatchState repeat_state;
-	vector<reference<ParseResult>> results;
+	vector<ParseResultRef> results;
 	bool matched_once = false;
 	optional_idx start_offset;
 	bool awaiting_child = false;

--- a/src/parser/peg/matcher_stack.cpp
+++ b/src/parser/peg/matcher_stack.cpp
@@ -23,14 +23,13 @@ private:
 
 } // namespace
 
-MatchState &MatchStateReference::Get(MatchStack &stack) {
-	if (!frame_index.IsValid()) {
-		D_ASSERT(external_state);
+MatchState &MatchStateReference::Get(MatchStack &stack, match_frame_index_t frame_index) {
+	if (external_state) {
 		return *external_state;
 	}
-	D_ASSERT(!external_state);
+	D_ASSERT(frame_index > 0);
 	D_ASSERT(frame_offset < MatchStack::FrameSlotSize());
-	auto frame_slot = stack.GetFrameSlot(frame_index.GetIndex());
+	auto frame_slot = stack.GetFrameSlot(frame_index - 1);
 	return *reinterpret_cast<MatchState *>(frame_slot + frame_offset);
 }
 
@@ -96,13 +95,13 @@ MatchStackFrame &MatchStack::GetFrame(match_frame_index_t frame_index) const {
 	return *reinterpret_cast<MatchStackFrame *>(GetFrameSlot(frame_index));
 }
 
-MatchStateReference MatchStack::CreateStateReference(MatchState &state, optional_idx parent_frame) const {
-	if (parent_frame.IsValid()) {
-		auto frame_slot = GetFrameSlot(parent_frame.GetIndex());
+MatchStateReference MatchStack::CreateStateReference(MatchState &state) const {
+	if (frame_count > 0) {
+		auto frame_slot = GetFrameSlot(frame_count - 1);
 		auto state_address = reinterpret_cast<uintptr_t>(&state);
 		auto slot_address = reinterpret_cast<uintptr_t>(frame_slot);
 		if (state_address >= slot_address && state_address < slot_address + FrameSlotSize()) {
-			return MatchStateReference(parent_frame.GetIndex(), state_address - slot_address);
+			return MatchStateReference(state_address - slot_address);
 		}
 	}
 	return MatchStateReference(state);
@@ -155,8 +154,8 @@ bool MatchStackFrame::IsInitialized() const {
 	return process || result;
 }
 
-MatchState &MatchStackFrame::GetMatchState(MatchStack &stack) {
-	return match_state.Get(stack);
+MatchState &MatchStackFrame::GetMatchState(MatchStack &stack, match_frame_index_t frame_index) {
+	return match_state.Get(stack, frame_index);
 }
 
 MatcherResult MatchStack::ExecuteAtomicMatcher(MatchInput input) {
@@ -178,7 +177,7 @@ MatcherResult MatchStack::ExecuteAtomicMatcher(MatchInput input) {
 	return result;
 }
 
-void MatchStack::PushFrame(MatchInput input, optional_idx parent_frame) {
+void MatchStack::PushFrame(MatchInput input) {
 	input.state.rule = input.matcher.GetRule();
 	auto frame_index = frame_count;
 	auto segment_index = frame_index / FRAME_SEGMENT_CAPACITY;
@@ -187,7 +186,7 @@ void MatchStack::PushFrame(MatchInput input, optional_idx parent_frame) {
 	}
 	auto frame_slot = GetFrameSlot(frame_index);
 	auto process_storage = frame_slot + FrameHeaderSize();
-	auto state_reference = CreateStateReference(input.state, parent_frame);
+	auto state_reference = CreateStateReference(input.state);
 	new (frame_slot) MatchStackFrame(input.matcher, state_reference, process_storage, BuiltinMatchProcessSize(),
 	                                 BuiltinMatchProcessAlignment());
 	frame_count++;
@@ -195,7 +194,7 @@ void MatchStack::PushFrame(MatchInput input, optional_idx parent_frame) {
 
 void MatchStack::InitializeFrame(MatchStackFrame &frame) {
 	auto &matcher = frame.matcher;
-	auto &state = frame.GetMatchState(*this);
+	auto &state = frame.GetMatchState(*this, frame_count - 1);
 	if (PackratMatchState::IsEnabled(matcher, state)) {
 		auto cached_result = frame.packrat_state.TryLoadCachedResult(matcher, state);
 		if (cached_result) {
@@ -227,7 +226,7 @@ bool MatchStack::ExecuteFrame(MatchStackFrame &frame) {
 		frame.child_result = ExecuteAtomicMatcher(*child);
 		return false;
 	}
-	PushFrame(*child, optional_idx(frame_count - 1));
+	PushFrame(*child);
 	return false;
 }
 
@@ -237,7 +236,7 @@ MatcherResult MatchStack::FinalizeFrame(MatchStackFrame &frame) {
 	}
 	auto result = *frame.result;
 	auto &matcher = frame.matcher;
-	auto &state = frame.GetMatchState(*this);
+	auto &state = frame.GetMatchState(*this, frame_count - 1);
 	frame.packrat_state.StoreResult(matcher, state, result);
 	return result;
 }

--- a/src/parser/peg/matcher_stack.cpp
+++ b/src/parser/peg/matcher_stack.cpp
@@ -3,20 +3,116 @@
 
 namespace duckdb {
 
-MatchStack::MatchStack() {
-	frames.reserve(INITIAL_FRAME_CAPACITY);
+namespace {
+
+class InlineProcessStorageScope {
+public:
+	InlineProcessStorageScope(MatchContext &context_p, MatchProcessInlineStorage &storage)
+	    : context(context_p), previous(context.process_inline_storage) {
+		context.process_inline_storage = storage;
+	}
+
+	~InlineProcessStorageScope() {
+		context.process_inline_storage = previous;
+	}
+
+private:
+	MatchContext &context;
+	optional_ptr<MatchProcessInlineStorage> previous;
+};
+
+} // namespace
+
+MatchState &MatchStateReference::Get(MatchStack &stack) {
+	if (!frame_index.IsValid()) {
+		D_ASSERT(external_state);
+		return *external_state;
+	}
+	D_ASSERT(!external_state);
+	D_ASSERT(frame_offset < MatchStack::FrameSlotSize());
+	auto frame_slot = stack.GetFrameSlot(frame_index.GetIndex());
+	return *reinterpret_cast<MatchState *>(frame_slot + frame_offset);
+}
+
+MatchStack::MatchStack() : frame_allocator(Allocator::DefaultAllocator(), FrameSegmentSize()) {
 }
 
 MatchStack::~MatchStack() {
 	// Child processes can reference state owned by their parents.
-	while (!frames.empty()) {
+	while (frame_count > 0) {
 		DestroyTopFrame();
 	}
 }
 
+idx_t MatchStack::FrameHeaderSize() {
+	auto process_alignment = BuiltinMatchProcessAlignment();
+	D_ASSERT(process_alignment <= alignof(idx_t));
+	return AlignValue<idx_t>(sizeof(MatchStackFrame), process_alignment);
+}
+
+idx_t MatchStack::FrameSlotSize() {
+	return AlignValue<idx_t>(FrameHeaderSize() + BuiltinMatchProcessSize());
+}
+
+idx_t MatchStack::FrameSegmentSize() {
+	return FrameSlotSize() * FRAME_SEGMENT_CAPACITY;
+}
+
+void MatchStack::AllocateFrameSegment() {
+	auto frame_segment = frame_allocator.AllocateAligned(FrameSegmentSize());
+	if (frame_segment_count < INLINE_FRAME_SEGMENT_COUNT) {
+		inline_frame_segments[frame_segment_count] = frame_segment;
+	} else {
+		overflow_frame_segments.push_back(frame_segment);
+	}
+	frame_segment_count++;
+}
+
+data_ptr_t MatchStack::GetFrameSegment(idx_t segment_index) const {
+	D_ASSERT(segment_index < frame_segment_count);
+	if (segment_index < INLINE_FRAME_SEGMENT_COUNT) {
+		return inline_frame_segments[segment_index];
+	}
+	return overflow_frame_segments[segment_index - INLINE_FRAME_SEGMENT_COUNT];
+}
+
+void MatchStack::SetActiveFrameSegment(idx_t segment_index) {
+	while (segment_index >= frame_segment_count) {
+		AllocateFrameSegment();
+	}
+	active_frame_segment = GetFrameSegment(segment_index);
+	active_frame_segment_index = segment_index;
+}
+
+data_ptr_t MatchStack::GetFrameSlot(match_frame_index_t frame_index) const {
+	D_ASSERT(frame_index < frame_segment_count * FRAME_SEGMENT_CAPACITY);
+	auto segment_index = frame_index / FRAME_SEGMENT_CAPACITY;
+	auto slot_index = frame_index % FRAME_SEGMENT_CAPACITY;
+	return GetFrameSegment(segment_index) + slot_index * FrameSlotSize();
+}
+
+MatchStackFrame &MatchStack::GetFrame(match_frame_index_t frame_index) const {
+	D_ASSERT(frame_index < frame_count);
+	return *reinterpret_cast<MatchStackFrame *>(GetFrameSlot(frame_index));
+}
+
+MatchStateReference MatchStack::CreateStateReference(MatchState &state, optional_idx parent_frame) const {
+	if (parent_frame.IsValid()) {
+		auto frame_slot = GetFrameSlot(parent_frame.GetIndex());
+		auto state_address = reinterpret_cast<uintptr_t>(&state);
+		auto slot_address = reinterpret_cast<uintptr_t>(frame_slot);
+		if (state_address >= slot_address && state_address < slot_address + FrameSlotSize()) {
+			return MatchStateReference(parent_frame.GetIndex(), state_address - slot_address);
+		}
+	}
+	return MatchStateReference(state);
+}
+
 void MatchStack::DestroyTopFrame() {
-	D_ASSERT(!frames.empty());
-	frames.pop_back();
+	D_ASSERT(frame_count > 0);
+	auto &frame = GetFrame(frame_count - 1);
+	frame.~MatchStackFrame();
+	frame_count--;
 }
 
 optional<MatcherResult> PackratMatchState::TryLoadCachedResult(const Matcher &matcher, MatchState &state) {
@@ -49,11 +145,18 @@ void PackratMatchState::StoreResult(const Matcher &matcher, MatchState &state, c
 	state.context.packrat_cache->Store(matcher, token_index_before.GetIndex(), cache_entry);
 }
 
-MatchStackFrame::MatchStackFrame(MatchInput input) : matcher(input.matcher), match_state(input.state) {
+MatchStackFrame::MatchStackFrame(const Matcher &matcher_p, MatchStateReference match_state_p,
+                                 data_ptr_t process_storage_p, idx_t process_capacity, idx_t process_alignment)
+    : matcher(matcher_p), match_state(std::move(match_state_p)),
+      process_inline_storage(process_storage_p, process_capacity, process_alignment) {
 }
 
 bool MatchStackFrame::IsInitialized() const {
 	return process || result;
+}
+
+MatchState &MatchStackFrame::GetMatchState(MatchStack &stack) {
+	return match_state.Get(stack);
 }
 
 MatcherResult MatchStack::ExecuteAtomicMatcher(MatchInput input) {
@@ -75,14 +178,24 @@ MatcherResult MatchStack::ExecuteAtomicMatcher(MatchInput input) {
 	return result;
 }
 
-void MatchStack::PushFrame(MatchInput input) {
+void MatchStack::PushFrame(MatchInput input, optional_idx parent_frame) {
 	input.state.rule = input.matcher.GetRule();
-	frames.emplace_back(input);
+	auto frame_index = frame_count;
+	auto segment_index = frame_index / FRAME_SEGMENT_CAPACITY;
+	if (segment_index != active_frame_segment_index) {
+		SetActiveFrameSegment(segment_index);
+	}
+	auto frame_slot = GetFrameSlot(frame_index);
+	auto process_storage = frame_slot + FrameHeaderSize();
+	auto state_reference = CreateStateReference(input.state, parent_frame);
+	new (frame_slot) MatchStackFrame(input.matcher, std::move(state_reference), process_storage,
+	                                 BuiltinMatchProcessSize(), BuiltinMatchProcessAlignment());
+	frame_count++;
 }
 
 void MatchStack::InitializeFrame(MatchStackFrame &frame) {
 	auto &matcher = frame.matcher;
-	auto &state = frame.match_state;
+	auto &state = frame.GetMatchState(*this);
 	if (PackratMatchState::IsEnabled(matcher, state)) {
 		auto cached_result = frame.packrat_state.TryLoadCachedResult(matcher, state);
 		if (cached_result) {
@@ -90,6 +203,7 @@ void MatchStack::InitializeFrame(MatchStackFrame &frame) {
 			return;
 		}
 	}
+	InlineProcessStorageScope storage_scope(state.context, frame.process_inline_storage);
 	frame.process = matcher.StartMatch(state);
 }
 
@@ -113,7 +227,7 @@ bool MatchStack::ExecuteFrame(MatchStackFrame &frame) {
 		frame.child_result = ExecuteAtomicMatcher(*child);
 		return false;
 	}
-	PushFrame(*child);
+	PushFrame(*child, optional_idx(frame_count - 1));
 	return false;
 }
 
@@ -123,27 +237,27 @@ MatcherResult MatchStack::FinalizeFrame(MatchStackFrame &frame) {
 	}
 	auto result = *frame.result;
 	auto &matcher = frame.matcher;
-	auto &state = frame.match_state;
+	auto &state = frame.GetMatchState(*this);
 	frame.packrat_state.StoreResult(matcher, state, result);
 	return result;
 }
 
 MatcherResult MatchStack::Execute(MatchInput input) {
-	D_ASSERT(frames.empty());
+	D_ASSERT(frame_count == 0);
 	if (input.matcher.IsAtomic()) {
 		return ExecuteAtomicMatcher(input);
 	}
 	PushFrame(input);
-	while (!frames.empty()) {
-		if (!ExecuteFrame(frames.back())) {
+	while (frame_count > 0) {
+		if (!ExecuteFrame(GetFrame(frame_count - 1))) {
 			continue;
 		}
-		auto result = FinalizeFrame(frames.back());
+		auto result = FinalizeFrame(GetFrame(frame_count - 1));
 		DestroyTopFrame();
-		if (frames.empty()) {
+		if (frame_count == 0) {
 			return result;
 		}
-		auto &parent = frames.back();
+		auto &parent = GetFrame(frame_count - 1);
 		D_ASSERT(!parent.child_result);
 		parent.child_result = result;
 	}

--- a/src/parser/peg/matcher_stack.cpp
+++ b/src/parser/peg/matcher_stack.cpp
@@ -147,7 +147,7 @@ void PackratMatchState::StoreResult(const Matcher &matcher, MatchState &state, c
 
 MatchStackFrame::MatchStackFrame(const Matcher &matcher_p, MatchStateReference match_state_p,
                                  data_ptr_t process_storage_p, idx_t process_capacity, idx_t process_alignment)
-    : matcher(matcher_p), match_state(std::move(match_state_p)),
+    : matcher(matcher_p), match_state(match_state_p),
       process_inline_storage(process_storage_p, process_capacity, process_alignment) {
 }
 
@@ -188,8 +188,8 @@ void MatchStack::PushFrame(MatchInput input, optional_idx parent_frame) {
 	auto frame_slot = GetFrameSlot(frame_index);
 	auto process_storage = frame_slot + FrameHeaderSize();
 	auto state_reference = CreateStateReference(input.state, parent_frame);
-	new (frame_slot) MatchStackFrame(input.matcher, std::move(state_reference), process_storage,
-	                                 BuiltinMatchProcessSize(), BuiltinMatchProcessAlignment());
+	new (frame_slot) MatchStackFrame(input.matcher, state_reference, process_storage, BuiltinMatchProcessSize(),
+	                                 BuiltinMatchProcessAlignment());
 	frame_count++;
 }
 

--- a/src/parser/peg/transformer/peg_transformer.cpp
+++ b/src/parser/peg/transformer/peg_transformer.cpp
@@ -29,7 +29,7 @@ unique_ptr<TransformResultValue> TransformStep::TakeResult() {
 
 GeneratedTransformProcess::GeneratedTransformProcess(PEGTransformer &transformer_p, TransformInput input,
                                                      const TransformFrameOps &info_p)
-    : parse_result(input.parse_result), info(info_p), transformer(transformer_p) {
+    : parse_result(transformer_p.GetParseResult(input.parse_result)), info(info_p), transformer(transformer_p) {
 	if (!info.initialize || !info.finalize) {
 		throw InternalException("Incomplete transformer process for rule '%s'", info.name);
 	}
@@ -124,15 +124,20 @@ TransformStackFrame::TransformStackFrame(TransformInput input)
 TransformStack::TransformStack(PEGTransformer &transformer_p) : transformer(transformer_p) {
 }
 
+const string &TransformStack::GetParseResultName(ParseResultRef result) const {
+	return transformer.GetParseResult(result).name;
+}
+
 void TransformStack::PushFrame(TransformInput input) {
 	frames.emplace(input);
 }
 
 void TransformStack::InitializeFrame(TransformStackFrame &frame) {
+	auto &parse_result = transformer.GetParseResult(frame.parse_result);
 	if (!frame.rule) {
-		throw InternalException("No registered data exists for rule '%s'", frame.parse_result.name);
+		throw InternalException("No registered data exists for rule '%s'", parse_result.name);
 	}
-	frame.process = frame.rule->StartTransform(transformer, frame.parse_result);
+	frame.process = frame.rule->StartTransform(transformer, parse_result);
 }
 
 unique_ptr<TransformResultValue> TransformStack::ExecuteFrame(TransformStackFrame &frame) {
@@ -151,8 +156,9 @@ unique_ptr<TransformResultValue> TransformStack::ExecuteFrame(TransformStackFram
 
 unique_ptr<TransformResultValue> TransformStack::Execute(TransformInput input) {
 	D_ASSERT(frames.empty());
+	auto &input_parse_result = transformer.GetParseResult(input.parse_result);
 	if (!input.GetRule()) {
-		throw InternalException("No registered data exists for rule '%s'", input.parse_result.name);
+		throw InternalException("No registered data exists for rule '%s'", input_parse_result.name);
 	}
 	PushFrame(input);
 	while (!frames.empty()) {
@@ -161,7 +167,7 @@ unique_ptr<TransformResultValue> TransformStack::Execute(TransformInput input) {
 		if (!result) {
 			continue;
 		}
-		transformer.SetResultLocation(frame.parse_result, *result);
+		transformer.SetResultLocation(transformer.GetParseResult(frame.parse_result), *result);
 		frames.pop();
 		if (frames.empty()) {
 			return result;
@@ -180,7 +186,7 @@ string TransformStack::FormatStack() const {
 		if (i > 0) {
 			result << "\n";
 		}
-		auto &parse_result = frames[i].parse_result;
+		auto &parse_result = transformer.GetParseResult(frames[i].parse_result);
 		result << "#" << i << " " << parse_result.name;
 		if (parse_result.offset.IsValid()) {
 			result << " offset=" << parse_result.offset.GetIndex();
@@ -192,17 +198,18 @@ string TransformStack::FormatStack() const {
 
 unique_ptr<TransformResultValue> PEGTransformer::ExecuteRecursive(TransformInput input) {
 	auto rule = input.GetRule();
+	auto &parse_result = GetParseResult(input.parse_result);
 	if (!rule) {
-		throw InternalException("No registered data exists for rule '%s'", input.parse_result.name);
+		throw InternalException("No registered data exists for rule '%s'", parse_result.name);
 	}
-	auto process = rule->StartTransform(*this, input.parse_result);
+	auto process = rule->StartTransform(*this, parse_result);
 	unique_ptr<TransformResultValue> child_result;
 	while (true) {
 		auto step = process->Resume(std::move(child_result));
 		auto child = step.GetChild();
 		if (!child) {
 			auto result = step.TakeResult();
-			SetResultLocation(input.parse_result, *result);
+			SetResultLocation(parse_result, *result);
 			return result;
 		}
 		child_result = ExecuteRecursive(*child);

--- a/src/parser/peg/transformer/peg_transformer_factory.cpp
+++ b/src/parser/peg/transformer/peg_transformer_factory.cpp
@@ -99,7 +99,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(Token
 	// TopLevelStatement <- Statement? (';'+ / EndOfInput)
 	//   child 0: Optional<Statement>
 	//   child 1: bracket-wrapper list around Choice<';'+ | EndOfInput>
-	auto &tls = match_result.GetParseResult()->Cast<ListParseResult>();
+	auto &tls = parse_result_allocator.Get(match_result.GetParseResult()).Cast<ListParseResult>();
 	auto &stmt_opt = tls.Child<OptionalParseResult>(0);
 	if (!stmt_opt.HasResult()) {
 		// separator-only or EOI-only TopLevelStatement — no statement to yield
@@ -116,7 +116,7 @@ unique_ptr<SQLStatement> PEGTransformerFactory::TransformTopLevelStatement(Token
 	}
 
 	ArenaAllocator transformer_allocator(Allocator::DefaultAllocator());
-	PEGTransformer transformer(transformer_allocator, token_iterator, options, grammar);
+	PEGTransformer transformer(transformer_allocator, parse_result_allocator, token_iterator, options, grammar);
 
 	return ExtractAndTransformStatement(transformer, token_iterator, stmt_opt.GetResult(), terminator_offset);
 }

--- a/test/api/test_grammar_extension.cpp
+++ b/test/api/test_grammar_extension.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/parser/peg/matcher/list_matcher.hpp"
 #include "duckdb/parser/peg/matcher_stack.hpp"
 #include "duckdb/parser/peg/parsed_grammar.hpp"
+#include "duckdb/parser/peg/tokenizer/parser_tokenizer.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/tableref/emptytableref.hpp"
@@ -270,7 +271,7 @@ private:
 	MatchProcessLifetimeState &lifetime;
 };
 
-TEST_CASE("Heap matcher vector growth preserves custom process lifetimes", "[api][grammar_extension]") {
+TEST_CASE("Heap matcher segment growth preserves custom process lifetimes", "[api][grammar_extension]") {
 	vector<MatcherToken> tokens;
 	TokenIterator iterator(tokens);
 	vector<MatcherSuggestion> suggestions;
@@ -283,7 +284,7 @@ TEST_CASE("Heap matcher vector growth preserves custom process lifetimes", "[api
 	lifetime.destroyed.reserve(2049);
 	NestedTestMatcher matcher(lifetime);
 
-	SECTION("Completed frames are reused across vector growth boundaries") {
+	SECTION("Completed frames are reused across segment boundaries") {
 		MatchStack stack;
 		lifetime.create_result = true;
 		for (idx_t depth : {idx_t(1), idx_t(64), idx_t(65), idx_t(128), idx_t(129), idx_t(256), idx_t(257), idx_t(1025),
@@ -356,6 +357,26 @@ TEST_CASE("Heap matcher vector growth preserves custom process lifetimes", "[api
 		REQUIRE(lifetime.state_valid);
 		REQUIRE(lifetime.started == lifetime.depth);
 	}
+}
+
+TEST_CASE("Heap matcher inlines fitting processes", "[api][grammar_extension]") {
+	vector<MatcherToken> tokens;
+	TokenIterator iterator(tokens);
+	vector<MatcherSuggestion> suggestions;
+	ParseResultAllocator parse_results;
+	idx_t max_token_index = 0;
+	ArenaAllocator process_allocator(Allocator::DefaultAllocator());
+	MatchContext context(suggestions, parse_results, process_allocator, max_token_index);
+	MatchState state(iterator, context);
+	MatchProcessLifetimeState lifetime;
+	lifetime.depth = 65;
+	NestedTestMatcher matcher(lifetime);
+	MatchStack stack;
+
+	REQUIRE(stack.Execute({matcher, state}).IsSuccess());
+	REQUIRE(process_allocator.IsEmpty());
+	REQUIRE(lifetime.active == 0);
+	REQUIRE(lifetime.started == lifetime.depth);
 }
 
 class DerivedListTestMatcher final : public ListMatcher {
@@ -641,6 +662,27 @@ TEST_CASE("Compiled grammar processes use arena ownership", "[api][grammar_exten
 	process.reset();
 	process_allocator.Reset();
 	REQUIRE(process_allocator.SizeInBytes() == 0);
+}
+
+TEST_CASE("Heap matcher inlines compiled grammar processes", "[api][grammar_extension]") {
+	auto grammar = CompiledGrammar::Create();
+	vector<MatcherToken> tokens;
+	const string sql = "SELECT 42";
+	ParserTokenizerBehavior tokenizer_behavior(sql, tokens);
+	grammar->GetTokenizer().TokenizeInput(tokenizer_behavior);
+	TokenIterator iterator(tokens);
+	vector<MatcherSuggestion> suggestions;
+	ParseResultAllocator parse_results;
+	idx_t max_token_index = 0;
+	ArenaAllocator process_allocator(Allocator::DefaultAllocator());
+	MatchContext context(suggestions, parse_results, process_allocator, max_token_index);
+	MatchState state(iterator, context);
+	MatchStack stack;
+
+	auto result = stack.Execute({grammar->TopLevelStatementMatcher(), state});
+	REQUIRE(result.IsSuccess());
+	REQUIRE(result.HasParseResult());
+	REQUIRE(process_allocator.IsEmpty());
 }
 
 TEST_CASE("Grammar changes expose structured metadata", "[api][grammar_extension]") {

--- a/test/api/test_grammar_extension.cpp
+++ b/test/api/test_grammar_extension.cpp
@@ -235,7 +235,7 @@ public:
 		}
 		if (lifetime.create_result) {
 			return MatchStep::Complete(child_state.AllocateParseResult<ListParseResult>(
-			    vector<reference<ParseResult>>(), string("nested result"), optional_idx()));
+			    vector<ParseResultRef>(), string("nested result"), optional_idx()));
 		}
 		return MatchStep::Complete(MatcherResult::Success());
 	}
@@ -296,7 +296,7 @@ TEST_CASE("Heap matcher segment growth preserves custom process lifetimes", "[ap
 			auto result = stack.Execute({matcher, state});
 			REQUIRE(result.IsSuccess());
 			REQUIRE(result.HasParseResult());
-			REQUIRE(result.GetParseResult()->name == "nested result");
+			REQUIRE(allocator.Get(result.GetParseResult()).name == "nested result");
 			REQUIRE(lifetime.active == 0);
 			REQUIRE(lifetime.state_valid);
 			REQUIRE(lifetime.started == depth);
@@ -635,14 +635,14 @@ TEST_CASE("Packrat results outlive reset process arenas", "[api][grammar_extensi
 	lifetime.started = 0;
 	auto cached = stack.Execute({matcher, state});
 	REQUIRE(cached.IsSuccess() == first.IsSuccess());
-	REQUIRE(cached.GetParseResult().get() == first.GetParseResult().get());
+	REQUIRE(cached.GetParseResult() == first.GetParseResult());
 	REQUIRE(lifetime.started == 0);
 	REQUIRE(lifetime.active == 0);
 	REQUIRE(lifetime.storage_valid);
 	REQUIRE(lifetime.state_valid);
 	if (cached.IsSuccess()) {
 		REQUIRE(cached.HasParseResult());
-		REQUIRE(cached.GetParseResult()->name == "nested result");
+		REQUIRE(parse_results.Get(cached.GetParseResult()).name == "nested result");
 	}
 }
 


### PR DESCRIPTION
Follow up of [PR](https://github.com/duckdb/duckdb/pull/25520). This PR also flattens the `ParseResult`. See [flattening](https://www.cs.cornell.edu/~asampson/blog/flattening.html).

- Replaced individually allocated `ParseResult` objects with a contiguous slot pool.
- Added stable 32-bit `ParseResultRef` identifiers, so references remain valid when the pool grows.
- Stored list and repeat children in a shared packed child-reference pool.
- Changed matcher results and packrat entries to carry IDs instead of pointers.
- Changed transformer stack frames and inputs to carry IDs, resolving objects only when accessed.
- Preserved the existing typed transformer interface for `ListParseResult`, `OptionalParseResult`, and other result types.
- Restricted pooled allocation to the built-in `ParseResult` types at compile time.

Removes one heap allocation per `ParseResult` and reduces pointer chasing.
Preserves `ParseResult` lifetimes across matcher arena resets.

## Benchmarks

### Bench [H2OAI](https://github.com/duckdb/duckdb/actions/runs/34566349300/job/103161463553)

```
FASTER
benchmark  base median                   PR median                     delta median      runs
---------  ----------------------------  ----------------------------  ----------------  ----
join/q01   687.1 ms [682.3 ms…756.3 ms]  670.9 ms [662.1 ms…736.2 ms]  -16.2 ms (-2.4%)    40
join/q04   768.0 ms [761.6 ms…783.3 ms]  746.0 ms [739.9 ms…753.4 ms]  -22.0 ms (-2.9%)    40
join/q03   996.1 ms [988.8 ms…  1.0 s ]  963.9 ms [955.2 ms…979.8 ms]  -32.3 ms (-3.2%)    40
join/q02   841.3 ms [832.1 ms…850.4 ms]  811.3 ms [804.4 ms…820.4 ms]  -30.0 ms (-3.6%)    40

geomean: 289.0 ms -> 284.5 ms  -4.5 ms (-1.6%)  (initial 10 samples)
```


### Bench [AoC24](https://github.com/duckdb/duckdb/actions/runs/34566349300/job/103161463492)

```
FASTER
benchmark  base median                   PR median                     delta median       runs
---------  ----------------------------  ----------------------------  -----------------  ----
day15      648.3 ms [619.7 ms…699.9 ms]  630.5 ms [609.2 ms…666.2 ms]  -17.8 ms ( -2.7%)    40
day03      110.6 ms [108.8 ms…162.7 ms]  105.6 ms [103.4 ms…154.7 ms]   -5.0 ms ( -4.5%)    40
day02       43.6 ms [ 43.0 ms… 51.1 ms]   41.6 ms [ 40.5 ms… 46.7 ms]   -2.0 ms ( -4.6%)    85
day01       34.3 ms [ 32.1 ms… 43.6 ms]   31.8 ms [ 31.1 ms… 36.1 ms]   -2.5 ms ( -7.2%)   105
day23      150.2 ms [139.4 ms…153.1 ms]  137.2 ms [134.3 ms…143.3 ms]  -13.0 ms ( -8.6%)    40
day19      934.0 ms [921.4 ms…951.5 ms]  840.9 ms [828.6 ms…859.4 ms]  -93.1 ms (-10.0%)    40
day13       45.9 ms [ 44.7 ms… 53.2 ms]   40.9 ms [ 39.8 ms… 47.4 ms]   -5.0 ms (-11.0%)    85
day25      156.3 ms [148.1 ms…161.6 ms]  139.1 ms [137.5 ms…148.0 ms]  -17.2 ms (-11.0%)    40

geomean: 145.1 ms -> 141.7 ms  -3.4 ms (-2.3%)  (initial 10 samples)
```