### PR TITLE
Fix virtual columns being treated as type pushdown candidates

### DIFF
--- a/src/include/duckdb/optimizer/type_pushdown.hpp
+++ b/src/include/duckdb/optimizer/type_pushdown.hpp
@@ -116,9 +116,8 @@ unique_ptr<LogicalOperator> PushdownOptimize(ClientContext &context, unique_ptr<
 			if (expr == nullptr) { // Conflict for column
 				continue;
 			}
-			if (analysis.get.GetColumnIds()[column_index].IsVirtualColumn()) {
-				continue;
-			}
+			// Resolve() never yields a virtual column as a candidate
+			D_ASSERT(!analysis.get.GetColumnIds()[column_index].IsVirtualColumn());
 			TableFunctionProjectionExpressionInput input {analysis.get, *expr, column_index};
 			if (analysis.get.function.projection_expression_pushdown(context, input)) {
 				analysis.get.returned_types[analysis.StorageIndex(column_index)] = expr->GetReturnType();

--- a/src/optimizer/type_pushdown.cpp
+++ b/src/optimizer/type_pushdown.cpp
@@ -87,11 +87,19 @@ void FindGetsAndProjections(LogicalOperator &op, Analyses &analyses, Projections
 	}
 }
 
+// A column binding into a GET is an index into its column ids, not a column id
+// itself. Virtual columns (e.g. "filename") have no entry in returned_types, so
+// nothing can be pushed into them.
+static bool IsRealGetColumn(const LogicalGet &get, ProjectionIndex column_index) {
+	const auto &column_ids = get.GetColumnIds();
+	return column_index < column_ids.size() && !column_ids[column_index].IsVirtualColumn();
+}
+
 optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Projections &projections) {
-	if (IsVirtualColumn(binding.column_index)) {
-		return nullopt;
-	}
 	if (const auto it = analyses.find(binding.table_index); it != analyses.end()) {
+		if (!IsRealGetColumn(it->second.get, binding.column_index)) {
+			return nullopt;
+		}
 		return {{it->second, binding.column_index, nullptr}};
 	}
 
@@ -106,10 +114,10 @@ optional<GetBinding> Resolve(ColumnBinding binding, Analyses &analyses, const Pr
 		return nullopt;
 	}
 	const ColumnBinding get_binding = inner->Cast<BoundColumnRefExpression>().Binding();
-	if (IsVirtualColumn(get_binding.column_index)) {
-		return nullopt;
-	}
 	if (const auto it = analyses.find(get_binding.table_index); it != analyses.end()) {
+		if (!IsRealGetColumn(it->second.get, get_binding.column_index)) {
+			return nullopt;
+		}
 		return {{it->second, get_binding.column_index, &projection}};
 	}
 	return nullopt;

--- a/test/optimizer/pushdown/type_pushdown_virtual_column.test
+++ b/test/optimizer/pushdown/type_pushdown_virtual_column.test
@@ -1,0 +1,47 @@
+# name: test/optimizer/pushdown/type_pushdown_virtual_column.test
+# description: Type pushdown must not push casts into virtual columns
+# group: [pushdown]
+
+statement ok
+COPY (SELECT 42 AS col1) TO '{TEST_DIR}/virtual_column_pushdown.csv' (HEADER false);
+
+# a cast on a virtual column is not a pushdown candidate, even when a sibling
+# cast on a real column is pushed down
+statement error
+SELECT CAST(col1 AS BIGINT), CAST(filename AS BIGINT)
+FROM read_csv('{TEST_DIR}/virtual_column_pushdown.csv', columns={'col1': 'INTEGER'});
+----
+<REGEX>:Conversion Error.*virtual_column_pushdown.csv.*
+
+query II
+SELECT CAST(col1 AS BIGINT), CAST(filename AS VARCHAR) LIKE '%virtual_column_pushdown.csv'
+FROM read_csv('{TEST_DIR}/virtual_column_pushdown.csv', columns={'col1': 'INTEGER'});
+----
+42	true
+
+query II
+SELECT CAST(col1 AS BIGINT), filename LIKE '%virtual_column_pushdown.csv'
+FROM read_csv('{TEST_DIR}/virtual_column_pushdown.csv', columns={'col1': 'INTEGER'});
+----
+42	true
+
+# the same through a passthrough projection (a view over the reader)
+statement ok
+CREATE VIEW v AS
+SELECT col1, filename FROM read_csv('{TEST_DIR}/virtual_column_pushdown.csv', columns={'col1': 'INTEGER'});
+
+statement error
+SELECT CAST(col1 AS BIGINT), CAST(filename AS BIGINT) FROM v;
+----
+<REGEX>:Conversion Error.*virtual_column_pushdown.csv.*
+
+query II
+SELECT CAST(col1 AS BIGINT), CAST(filename AS VARCHAR) LIKE '%virtual_column_pushdown.csv' FROM v;
+----
+42	true
+
+# the cast on the real column is still pushed into the reader
+query II
+EXPLAIN SELECT CAST(col1 AS BIGINT) FROM read_csv('{TEST_DIR}/virtual_column_pushdown.csv', columns={'col1': 'INTEGER'});
+----
+physical_plan	<!REGEX>:.*PROJECTION.*


### PR DESCRIPTION
Fixes #25275.

`Resolve()` tried to skip virtual columns with `IsVirtualColumn(binding.column_index)`, but a `ColumnBinding` into a `LogicalGet` holds an index into `column_ids`, not a column id so the check never fired. Looks like it got missed in the `ProjectionIndex` refactor.

That let `CAST(filename AS BIGINT)` become a pushdown candidate, and once a sibling real column pushed successfully the replace pass indexed `returned_types` with the `2^63` sentinel and crashed.

Now `Resolve()` checks virtual-ness through the GET's column ids, so these never enter the candidate map. The scalar function pushdown pass shares `Resolve()` and had the same hole.