### PR TITLE
Make EXPORT DATABASE round-trip quoted empty strings and null strings

### DIFF
--- a/src/execution/operator/persistent/physical_export.cpp
+++ b/src/execution/operator/persistent/physical_export.cpp
@@ -71,6 +71,8 @@ static void WriteCopyStatement(FileSystem &fs, stringstream &ss, CopyInfo &info,
 		for (auto &not_null_column : exported_table.not_null_columns) {
 			info.options["force_not_null"].push_back(not_null_column);
 		}
+		// the writer quotes empty strings and the null string so they can be told apart from NULL
+		info.options["allow_quoted_nulls"] = {Value::BOOLEAN(false)};
 	}
 	for (auto &copy_option : info.options) {
 		if (copy_option.second.empty()) {

--- a/src/planner/binder/statement/bind_export.cpp
+++ b/src/planner/binder/statement/bind_export.cpp
@@ -278,6 +278,7 @@ BoundStatement Binder::Bind(ExportStatement &stmt) {
 	                                          stmt.info->GetQualifiedName().Name()));
 	// prepare the options for export
 	auto &format = stmt.info->format;
+	format = StringUtil::Lower(format);
 	auto &options = stmt.info->options;
 	if (format == "csv") {
 		// insert default csv options, if not specified

--- a/test/sql/copy/csv/test_export_not_null.test
+++ b/test/sql/copy/csv/test_export_not_null.test
@@ -56,4 +56,4 @@ IMPORT DATABASE '{TEST_DIR}/multiple';
 query IIII
 select * from tbl_2
 ----
-(empty)	(empty)	(empty)	NULL
+(empty)	(empty)	(empty)	(empty)

--- a/test/sql/export/export_quoted_nulls.test
+++ b/test/sql/export/export_quoted_nulls.test
@@ -1,0 +1,66 @@
+# name: test/sql/export/export_quoted_nulls.test
+# description: Test that EXPORT/IMPORT DATABASE round-trips NULL, empty strings and the null string
+# group: [export]
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+CREATE TABLE tbl(v VARCHAR)
+
+statement ok
+INSERT INTO tbl VALUES (NULL), (''), ('NULL')
+
+statement ok
+EXPORT DATABASE '{TEST_DIR}/export_quoted_nulls'
+
+statement ok
+ROLLBACK
+
+# the generated load.sql must not read the quoted values back as NULL
+query I
+SELECT contains(content, 'allow_quoted_nulls false') FROM read_text('{TEST_DIR}/export_quoted_nulls/load.sql')
+----
+true
+
+statement ok
+IMPORT DATABASE '{TEST_DIR}/export_quoted_nulls'
+
+query III
+SELECT count(*) FILTER (WHERE v IS NULL), count(*) FILTER (WHERE v = ''), count(*) FILTER (WHERE v = 'NULL') FROM tbl
+----
+1	1	1
+
+# same with an explicit null string: the string 'NULL' is written quoted and must survive the round trip
+statement ok
+DROP TABLE tbl
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+CREATE TABLE tbl2(i INTEGER, v VARCHAR)
+
+statement ok
+INSERT INTO tbl2 VALUES (1, NULL), (2, ''), (3, 'NULL')
+
+statement ok
+EXPORT DATABASE '{TEST_DIR}/export_quoted_nulls_nullstr' (FORMAT CSV, NULLSTR 'NULL')
+
+statement ok
+ROLLBACK
+
+statement ok
+IMPORT DATABASE '{TEST_DIR}/export_quoted_nulls_nullstr'
+
+query III
+SELECT i, v IS NULL, length(v) FROM tbl2 ORDER BY i
+----
+1	true	NULL
+2	false	0
+3	false	4
+
+query III
+SELECT count(*) FILTER (WHERE v IS NULL), count(*) FILTER (WHERE v = ''), count(*) FILTER (WHERE v = 'NULL') FROM tbl2
+----
+1	1	1


### PR DESCRIPTION
Fixes #25501.

`EXPORT DATABASE` followed by `IMPORT DATABASE` with the default CSV format reads every empty string back as `NULL`:

```sql
CREATE TABLE t(v VARCHAR);
INSERT INTO t VALUES (NULL), (''), ('NULL');
EXPORT DATABASE 'out';
-- fresh database
IMPORT DATABASE 'out';
SELECT count(*) FILTER (WHERE v IS NULL), count(*) FILTER (WHERE v = ''), count(*) FILTER (WHERE v = 'NULL') FROM t;
-- 2 | 0 | 1, expected 1 | 1 | 1
```

`EXPORT DATABASE 'out' (FORMAT CSV, NULLSTR 'NULL')` on the same table gives `2 | 0 | 0`: the empty string and the string `'NULL'` both come back as `NULL`.

`test/sql/copy/csv/test_export_not_null.test` already shows the first case: it exports four empty strings and expects the nullable column to come back as `NULL`.

### Cause

`CSVWriter::RequiresQuotes` quotes any value equal to the null string, so the writer emits `""` for an empty string (or `"NULL"` under `NULLSTR 'NULL'`) and a bare marker for `NULL`. The `load.sql` generated by `EXPORT DATABASE` does not set `allow_quoted_nulls false`, so the reader's default of `true` (chosen in #7162 for foreign CSV files) turns the quoted value back into `NULL`.

A second gap makes the `FORMAT CSV` case worse. `EXPORT DATABASE` keeps the format string as written, while `COPY` lowercases it (`bind_copy.cpp`). Both places that add CSV-specific read options compare against `"csv"`, so with `FORMAT CSV` the generated `load.sql` carries neither the `header`, `delimiter` and `quote` defaults nor the `force_not_null` list, and the import falls back to sniffing. On main the `NULLSTR` example above produces `COPY t FROM 't.csv' (FORMAT 'CSV', nullstr 'NULL');`.

### Change

- `WriteCopyStatement` adds `allow_quoted_nulls false` to the `COPY ... FROM` statements it writes for CSV exports, next to the `force_not_null` list it already adds. `allow_quoted_nulls` is a read-only CSV option, so `EXPORT DATABASE` rejects it and there is no user value to override. The reader default does not change.
- `Binder::Bind(ExportStatement)` lowercases the format before the CSV checks, matching `COPY`. `FORMAT CSV` now gets the same `load.sql` options as `FORMAT csv`.

With the change, the first example generates `COPY t FROM 't.csv' (FORMAT 'csv', allow_quoted_nulls false, quote '"', delimiter ',', header 1);` and returns `1 | 1 | 1`.

### Tests

- `test/sql/export/export_quoted_nulls.test` (new) round-trips `NULL`, `''` and `'NULL'` with the default options and, on a two-column table, with `(FORMAT CSV, NULLSTR 'NULL')`, and checks that `load.sql` contains the flag.
- `test/sql/copy/csv/test_export_not_null.test`: the last expected row changes from `(empty) (empty) (empty) NULL` to four `(empty)`.

On main, the new test fails at the `load.sql` check; with that check removed, the default round trip returns `2 | 0 | 1`, and reading the two-column CSV with the options main writes into `load.sql` turns row 3 (`'NULL'`) into a real `NULL`.

### Validation

- `make reldebug` (WSL2, gcc), then `build/reldebug/test/unittest "test/sql/export/*"` (25 cases) and `"test/sql/copy/csv/test_export*"`: all pass.
- `build/reldebug/test/unittest` (fast suite): 6286 cases, 6268 passed, 18 failed. 17 of the failures are CSV sniffing/rejects tests that fail on this Windows-mounted checkout because the CSV fixtures had CRLF line endings; after normalizing the fixtures to LF they all pass (`"test/sql/copy/csv/*"`: 311/312, the remaining one is a symlink-based `.test_slow`). The 18th, `test/sql/secrets/create_secret_filesystem_logging.test`, fails on a secret-file permission check that the mounted filesystem cannot satisfy. None of the 18 use `EXPORT`/`IMPORT DATABASE`.
- `clang-format` 11.0.1 on both changed source files: no changes.
- Not run: `make allunit`, `test_configs`, `test_vector`.

### Notes

Under `NULLSTR 'NULL'`, an empty string in a single-column table is still written as an empty line, which the reader skips as a blank line. That is writer/reader behaviour for blank lines and is unchanged here; the new test uses a two-column table for the `NULLSTR` case so the empty string sits in a field.
