### PR TITLE
Cleanup deprecated loop iterator

### DIFF
--- a/test/sql/aggregate/aggregates/arg_min_max_nulls_last.test
+++ b/test/sql/aggregate/aggregates/arg_min_max_nulls_last.test
@@ -68,7 +68,7 @@ foreach fp_type FLOAT DOUBLE
 
 query II
 WITH floating_values(id, val) AS (
-	VALUES (1, 0::${fp_type}), (2, 'NaN'::${fp_type}), (3, -1::${fp_type}), (4, NULL::${fp_type})
+	VALUES (1, 0::{fp_type}), (2, 'NaN'::{fp_type}), (3, -1::{fp_type}), (4, NULL::{fp_type})
 )
 SELECT arg_min_nulls_last(id, val, 4), arg_max_nulls_last(id, val, 4) FROM floating_values
 ----
@@ -77,7 +77,7 @@ SELECT arg_min_nulls_last(id, val, 4), arg_max_nulls_last(id, val, 4) FROM float
 # Check that heap ordering does not depend on input order
 query II
 WITH floating_values(id, val) AS (
-	VALUES (2, 'NaN'::${fp_type}), (4, NULL::${fp_type}), (3, -1::${fp_type}), (1, 0::${fp_type})
+	VALUES (2, 'NaN'::{fp_type}), (4, NULL::{fp_type}), (3, -1::{fp_type}), (1, 0::{fp_type})
 )
 SELECT arg_min_nulls_last(id, val, 4), arg_max_nulls_last(id, val, 4) FROM floating_values
 ----

--- a/test/sql/index/art/storage/test_art_checkpoint_delta_revert_stress.test_slow
+++ b/test/sql/index/art/storage/test_art_checkpoint_delta_revert_stress.test_slow
@@ -23,7 +23,7 @@ loop run 0 5
 
 statement ok
 INSERT INTO checkpoint_data
-SELECT ${run} * 1000000 + i, md5(i::VARCHAR)
+SELECT {run} * 1000000 + i, md5(i::VARCHAR)
 FROM range(1000000) t(i);
 
 concurrentloop role 0 3
@@ -34,7 +34,7 @@ BEGIN TRANSACTION;
 
 onlyif role=0
 statement maybe
-INSERT INTO t SELECT ${run} * 10000 + range FROM range(2049);
+INSERT INTO t SELECT {run} * 10000 + range FROM range(2049);
 ----
 
 onlyif role=1
@@ -43,7 +43,7 @@ SELECT sum(hash(i)) FROM range(500000) t(i);
 
 onlyif role=1
 statement maybe
-INSERT INTO t VALUES (${run} * 10000 + 2048);
+INSERT INTO t VALUES ({run} * 10000 + 2048);
 ----
 
 onlyif role=0
@@ -72,10 +72,10 @@ ROLLBACK;
 endloop
 
 statement ok
-INSERT OR IGNORE INTO t VALUES (${run} * 10000);
+INSERT OR IGNORE INTO t VALUES ({run} * 10000);
 
 query I
-SELECT count(*) FROM t WHERE i = ${run} * 10000;
+SELECT count(*) FROM t WHERE i = {run} * 10000;
 ----
 1
 

--- a/test/sql/json/scalar/test_json_extract_input_types.test
+++ b/test/sql/json/scalar/test_json_extract_input_types.test
@@ -39,12 +39,12 @@ INSERT INTO tricky VALUES
 foreach path $.a $.b $.a.b $.b.c $[0] $[2] $[7] $.a[0] $.a[1] $.b.c[0].d $."a\"b" $.日本 $.missing $.a.a.a $.tail $[0][1] $
 
 query I
-SELECT count(*) FROM tricky WHERE json_extract(v, '${path}') IS DISTINCT FROM json_extract(v::JSON, '${path}')
+SELECT count(*) FROM tricky WHERE json_extract(v, '{path}') IS DISTINCT FROM json_extract(v::JSON, '{path}')
 ----
 0
 
 query I
-SELECT count(*) FROM tricky WHERE json_extract_string(v, '${path}') IS DISTINCT FROM json_extract_string(v::JSON, '${path}')
+SELECT count(*) FROM tricky WHERE json_extract_string(v, '{path}') IS DISTINCT FROM json_extract_string(v::JSON, '{path}')
 ----
 0
 

--- a/test/sql/storage/metadata_reuse_optimistic_write.test_slow
+++ b/test/sql/storage/metadata_reuse_optimistic_write.test_slow
@@ -25,7 +25,7 @@ CREATE TABLE sink(i BIGINT, s VARCHAR);
 loop i 0 6000
 
 statement ok
-CREATE OR REPLACE VIEW v${i} AS SELECT i, s FROM base WHERE i % 7 = ${i} % 7;
+CREATE OR REPLACE VIEW v{i} AS SELECT i, s FROM base WHERE i % 7 = {i} % 7;
 
 endloop
 
@@ -36,7 +36,7 @@ CHECKPOINT;
 loop i 0 1500
 
 statement ok
-DROP VIEW v${i};
+DROP VIEW v{i};
 
 endloop
 
@@ -54,7 +54,7 @@ loop j 1500 1800
 
 onlyif threadid=0
 statement maybe
-DROP VIEW IF EXISTS v${j};
+DROP VIEW IF EXISTS v{j};
 ----
 
 endloop
@@ -69,7 +69,7 @@ loop k 0 20
 
 onlyif threadid<>0
 statement maybe
-INSERT INTO sink SELECT i, hash(i * ${threadid} + ${k})::VARCHAR FROM range(${k} * 300000, ${k} * 300000 + 300000) t(i);
+INSERT INTO sink SELECT i, hash(i * {threadid} + {k})::VARCHAR FROM range({k} * 300000, {k} * 300000 + 300000) t(i);
 ----
 
 endloop

--- a/test/sql/storage/optimistic_write/concurrent_bulk_append_commits.test_slow
+++ b/test/sql/storage/optimistic_write/concurrent_bulk_append_commits.test_slow
@@ -10,12 +10,12 @@ SET checkpoint_threshold='999999GB';
 loop i 0 8
 
 statement ok
-CREATE TABLE t${i} (r BIGINT, s VARCHAR);
+CREATE TABLE t{i} (r BIGINT, s VARCHAR);
 
 # seed row: the table being non-empty forces the commit off the empty-table fast path, so
 # the bulk-append decision depends on the append being at least one row group
 statement ok
-INSERT INTO t${i} VALUES (-1, 'seed');
+INSERT INTO t{i} VALUES (-1, 'seed');
 
 endloop
 
@@ -25,14 +25,14 @@ endloop
 concurrentloop i 0 8
 
 statement ok
-INSERT INTO t${i} SELECT r, repeat('abcdefgh', 25) || r FROM range(245000) tt(r);
+INSERT INTO t{i} SELECT r, repeat('abcdefgh', 25) || r FROM range(245000) tt(r);
 
 endloop
 
 loop i 0 8
 
 query III
-SELECT COUNT(*), MIN(r), MAX(r) FROM t${i}
+SELECT COUNT(*), MIN(r), MAX(r) FROM t{i}
 ----
 245001	-1	244999
 
@@ -43,12 +43,12 @@ restart
 loop i 0 8
 
 query III
-SELECT COUNT(*), MIN(r), MAX(r) FROM t${i}
+SELECT COUNT(*), MIN(r), MAX(r) FROM t{i}
 ----
 245001	-1	244999
 
 query I
-SELECT s = repeat('abcdefgh', 25) || r FROM t${i} WHERE r = 122880
+SELECT s = repeat('abcdefgh', 25) || r FROM t{i} WHERE r = 122880
 ----
 true
 


### PR DESCRIPTION
Saw test warning as below, as my agents to do a repo-wise cleanup.
```sh
Replacing deprecated loop iterator ${j} in test "test/sql/storage/metadata_reuse_optimistic_write.test_slow" - please use the new loop iterator {j}
Replacing deprecated loop iterator ${j} in test "test/sql/storage/meta
```