### PR TITLE
Prune row group for greatest with all NULL

### DIFF
--- a/extension/core_functions/scalar/generic/least.cpp
+++ b/extension/core_functions/scalar/generic/least.cpp
@@ -203,6 +203,9 @@ unique_ptr<BaseStatistics> PropagateLeastGreatestStats(ClientContext &context, F
 	Value anchored_fallback; // over all inputs; used only when every input is nullable
 	bool has_nonnull_input = false;
 	for (auto &cs : child_stats) {
+		if (!cs.CanHaveNoNull()) {
+			continue;
+		}
 		if (cs.GetStatsType() != StatisticsType::NUMERIC_STATS || !NumericStats::HasMinMax(cs)) {
 			return nullptr;
 		}
@@ -217,6 +220,9 @@ unique_ptr<BaseStatistics> PropagateLeastGreatestStats(ClientContext &context, F
 			has_nonnull_input = true;
 			merge(anchored, anchored_val, /*keep_smaller=*/IS_LEAST);
 		}
+	}
+	if (loose.IsNull()) {
+		return BaseStatistics::FromConstant(Value(return_type)).ToUnique();
 	}
 	if (!has_nonnull_input) {
 		anchored = std::move(anchored_fallback);

--- a/src/function/scalar/generic/constant_or_null.cpp
+++ b/src/function/scalar/generic/constant_or_null.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
 
 namespace duckdb {
 
@@ -70,6 +71,16 @@ static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vect
 	}
 }
 
+static FilterPropagateResult ConstantOrNullFilterPrune(const FunctionStatisticsPruneInput &input) {
+	for (idx_t i = 0; i < input.function.GetChildren().size(); i++) {
+		auto stats = input.ChildStats(i);
+		if (stats && !stats->CanHaveNoNull()) {
+			return FilterPropagateResult::FILTER_FALSE_OR_NULL;
+		}
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
 unique_ptr<FunctionData> ConstantOrNullBind(BindScalarFunctionInput &input) {
 	auto &arguments = input.GetArguments();
 	auto &function = input.GetBoundFunction();
@@ -100,6 +111,7 @@ ScalarFunction ConstantOrNullFun::GetFunction() {
 	auto fun = ScalarFunction("constant_or_null", {{"arg1", LogicalType::ANY}, {"arg2", LogicalType::ANY}},
 	                          LogicalType::ANY, ConstantOrNullFunction);
 	fun.SetBindCallback(ConstantOrNullBind);
+	fun.SetFilterPruneCallback(ConstantOrNullFilterPrune);
 	fun.SetVarArgs(LogicalType::ANY);
 	return fun;
 }

--- a/test/optimizer/statistics/statistics_least_greatest.test
+++ b/test/optimizer/statistics/statistics_least_greatest.test
@@ -90,3 +90,29 @@ query I
 SELECT count(*) FROM nullable_pairs WHERE least(a, b) > 2000000;
 ----
 0
+
+statement ok
+ATTACH '{TEST_DIR}/least_greatest_pruning.duckdb' AS rg (ROW_GROUP_SIZE 2048);
+
+statement ok
+USE rg;
+
+# RGs 1 and 2 are all NULL; RG 3 contains values 4096 through 6143.
+statement ok
+CREATE TABLE metrics AS
+SELECT CASE WHEN i < 4096 THEN NULL ELSE i END AS value FROM range(6144) t(i);
+
+# Ignore all-NULL arguments; if every argument is NULL, the result stays NULL.
+foreach predicate greatest(value,0)>100 least(value,10000)<10000 greatest(value,NULL)>100 least(value,NULL)>100
+
+query I
+SELECT count(*) FROM metrics WHERE {predicate};
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT value FROM metrics WHERE {predicate};
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
+
+endloop

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -232,7 +232,7 @@ EXPLAIN ANALYZE SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
 WHERE prefix(s, '') OR prefix(s, 'zz')
 ----
-analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 4 / 4.*
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 3 / 4.*
 
 query I
 SELECT count(*)


### PR DESCRIPTION
Hi team, I found in the current implementation, `greatest`/`least` function doesn't prune row groups with all NULL values; for example,
```sql
memory D CREATE TABLE metrics AS SELECT CASE WHEN i < 202752 THEN NULL ELSE i END AS value FROM range(204800) t(i);

-- should only access the second row group
memory D EXPLAIN ANALYZE SELECT sum(value) FROM metrics WHERE greatest(value, 0) > 100;
╭─ Summary ───────────╮
│ Total Time: 0.0017s │
╰─────────────────────╯
╭─ Ungrouped Aggregate ─────────────╮
│ Aggregates: sum\_no\_overflow(#0)   │
│ 1 row                         0µs │
╰─────────────────┒┎────────────────╯
╭─ Projection ────┚┖────────────────╮
│ Projections: value                │
│ 2,048 rows                    0µs │
╰─────────────────┒┎────────────────╯
╭─ Table Scan ────┚┖────────────────╮
│ Table: memory.main.metrics        │
│ Type: Sequential Scan             │
│ Projections: value                │
│ Filters: greatest(value, 0) > 100 │
│ Row Groups Scanned: 2 / 2         │
│ 2,048 rows                    0µs │
╰───────────────────────────────────╯
```