### PR TITLE
Fix missing encryption header size in temporary file manager

### DIFF
--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -137,7 +137,7 @@ private:
 	set<idx_t> indexes_in_use;
 	//! The TemporaryFileManager that "owns" this BlockIndexManager
 	optional_ptr<TemporaryFileManager> manager;
-	//! Whether the tracked file is encrypted (adds a per-block header on disk)
+	//! Whether the tracked file is encrypted
 	bool encrypted;
 };
 

--- a/src/include/duckdb/storage/temporary_file_manager.hpp
+++ b/src/include/duckdb/storage/temporary_file_manager.hpp
@@ -109,7 +109,7 @@ public:
 struct BlockIndexManager {
 public:
 	BlockIndexManager();
-	explicit BlockIndexManager(TemporaryFileManager &manager);
+	explicit BlockIndexManager(TemporaryFileManager &manager, bool encrypted = false);
 
 public:
 	//! Obtains a new block index from the index manager
@@ -137,6 +137,8 @@ private:
 	set<idx_t> indexes_in_use;
 	//! The TemporaryFileManager that "owns" this BlockIndexManager
 	optional_ptr<TemporaryFileManager> manager;
+	//! Whether the tracked file is encrypted (adds a per-block header on disk)
+	bool encrypted;
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -101,10 +101,18 @@ bool TemporaryFileIndex::IsValid() const {
 //===--------------------------------------------------------------------===//
 // BlockIndexManager
 //===--------------------------------------------------------------------===//
-BlockIndexManager::BlockIndexManager() : max_index(0), manager(nullptr) {
+BlockIndexManager::BlockIndexManager() : max_index(0), manager(nullptr), encrypted(false) {
 }
 
-BlockIndexManager::BlockIndexManager(TemporaryFileManager &manager) : max_index(0), manager(&manager) {
+BlockIndexManager::BlockIndexManager(TemporaryFileManager &manager, bool encrypted)
+    : max_index(0), manager(&manager), encrypted(encrypted) {
+}
+
+//! Physical stride of one block on disk: payload + (per-block encryption header, if encrypted).
+static idx_t PhysicalBlockSize(const TemporaryBufferSize size, const bool encrypted) {
+	const auto base = size == TemporaryBufferSize::DEFAULT ? DEFAULT_BLOCK_ALLOC_SIZE : TemporaryBufferSizeToSize(size);
+	const auto header_size = encrypted ? DEFAULT_ENCRYPTED_BUFFER_HEADER_SIZE : 0;
+	return base + header_size;
 }
 
 idx_t BlockIndexManager::GetNewBlockIndex(const TemporaryBufferSize size) {
@@ -167,8 +175,7 @@ idx_t BlockIndexManager::GetNewBlockIndexInternal(const TemporaryBufferSize size
 }
 
 void BlockIndexManager::SetMaxIndex(const idx_t new_index, const TemporaryBufferSize size) {
-	const auto temp_file_block_size =
-	    size == TemporaryBufferSize::DEFAULT ? DEFAULT_BLOCK_ALLOC_SIZE : TemporaryBufferSizeToSize(size);
+	const auto temp_file_block_size = PhysicalBlockSize(size, encrypted);
 	if (!manager) {
 		max_index = new_index;
 	} else {
@@ -194,7 +201,7 @@ void BlockIndexManager::SetMaxIndex(const idx_t new_index, const TemporaryBuffer
 TemporaryFileHandle::TemporaryFileHandle(TemporaryFileManager &manager, TemporaryFileIdentifier identifier_p,
                                          idx_t temp_file_count)
     : db(manager.db), identifier(identifier_p), max_allowed_index((1 << temp_file_count) * MAX_ALLOWED_INDEX_BASE),
-      path(manager.CreateTemporaryFileName(identifier)), index_manager(manager) {
+      path(manager.CreateTemporaryFileName(identifier)), index_manager(manager, identifier.encrypted) {
 }
 
 TemporaryFileHandle::~TemporaryFileHandle() {
@@ -549,7 +556,7 @@ idx_t TemporaryFileManager::WriteTemporaryBuffer(QueryContext context, block_id_
 	handle->WriteTemporaryBuffer(context, buffer, index.block_index.GetIndex(), compressed_buffer);
 
 	compression_adaptivity.Update(compression_result.level, time_before);
-	return static_cast<idx_t>(compression_result.size);
+	return PhysicalBlockSize(compression_result.size, handle->IsEncrypted());
 }
 
 TemporaryFileManager::CompressionResult
@@ -665,9 +672,10 @@ unique_ptr<FileBuffer> TemporaryFileManager::ReadTemporaryBuffer(QueryContext co
 		handle = GetFileHandle(lock, index.identifier);
 	}
 
-	// If eviction size requested, set it to the size of the block (compressed size if applicable).
+	// If eviction size requested, set it to the physical stride on disk (payload + per-block
+	// encryption header if applicable) so the caller's accounting stays in sync with the writer.
 	if (eviction_size) {
-		*eviction_size = NumericCast<idx_t>(index.identifier.size);
+		*eviction_size = PhysicalBlockSize(index.identifier.size, index.identifier.encrypted);
 	}
 
 	// before the reusable buffer is given,
@@ -685,7 +693,7 @@ idx_t TemporaryFileManager::DeleteTemporaryBuffer(block_id_t id) {
 	auto index = GetTempBlockIndex(lock, id);
 	auto handle = GetFileHandle(lock, index.identifier);
 	EraseUsedBlock(lock, id, *handle, index);
-	return static_cast<idx_t>(index.identifier.size);
+	return PhysicalBlockSize(index.identifier.size, index.identifier.encrypted);
 }
 
 vector<TemporaryFileInformation> TemporaryFileManager::GetTemporaryFiles() {

--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -672,8 +672,7 @@ unique_ptr<FileBuffer> TemporaryFileManager::ReadTemporaryBuffer(QueryContext co
 		handle = GetFileHandle(lock, index.identifier);
 	}
 
-	// If eviction size requested, set it to the physical stride on disk (payload + per-block
-	// encryption header if applicable) so the caller's accounting stays in sync with the writer.
+	// If eviction size requested, set it to the size of the block (compressed size if applicable).
 	if (eviction_size) {
 		*eviction_size = PhysicalBlockSize(index.identifier.size, index.identifier.encrypted);
 	}

--- a/test/sql/storage/encryption/temp_files/encrypted_size_on_disk_undercount.test
+++ b/test/sql/storage/encryption/temp_files/encrypted_size_on_disk_undercount.test
@@ -1,0 +1,39 @@
+# name: test/sql/storage/encryption/temp_files/encrypted_size_on_disk_undercount.test
+# description: Encrypted temp files: internal usage counters must include the per-block encryption header.
+# group: [temp_files]
+
+# httpfs is required to enable temp file encryption
+require httpfs
+
+require block_size 262144
+
+load {TEST_DIR}/encrypted_size_on_disk_undercount.db
+
+# Isolate the temp directory so `duckdb_temporary_files()` only reports this test's spill
+statement ok
+SET temp_directory='{TEST_DIR}/encrypted_size_on_disk_undercount_tmp'
+
+statement ok
+SET temp_file_encryption=true
+
+statement ok
+SET memory_limit='16MB'
+
+# Force a spill. A TEMPORARY table keeps the payload alive after CREATE completes,
+# so both accounting sources have data to report when we probe them below.
+statement ok
+CREATE TEMPORARY TABLE big AS
+    SELECT i AS k, repeat('x', 200)::VARCHAR AS v
+    FROM range(500000) t(i)
+
+query I
+SELECT count(*) > 0 FROM duckdb_temporary_files()
+----
+true
+
+query I
+SELECT
+    (SELECT COALESCE(sum(size), 0)::BIGINT FROM duckdb_temporary_files())
+  = (SELECT COALESCE(sum(temporary_storage_bytes), 0)::BIGINT FROM duckdb_memory())
+----
+true

--- a/test/sql/storage/encryption/temp_files/encrypted_temp_file_size_accounting.test
+++ b/test/sql/storage/encryption/temp_files/encrypted_temp_file_size_accounting.test
@@ -1,6 +1,5 @@
 # name: test/sql/storage/encryption/temp_files/encrypted_temp_file_size_accounting.test
-# description: With temp_file_encryption on, temp-directory usage reported by duckdb_memory
-#              agrees with the on-disk footprint in duckdb_temporary_files().
+# description: Verify encrypted temp-file accounting matches the on-disk footprint
 # group: [temp_files]
 
 # httpfs is required to enable temp file encryption

--- a/test/sql/storage/encryption/temp_files/encrypted_temp_file_size_accounting.test
+++ b/test/sql/storage/encryption/temp_files/encrypted_temp_file_size_accounting.test
@@ -1,5 +1,6 @@
-# name: test/sql/storage/encryption/temp_files/encrypted_size_on_disk_undercount.test
-# description: Encrypted temp files: internal usage counters must include the per-block encryption header.
+# name: test/sql/storage/encryption/temp_files/encrypted_temp_file_size_accounting.test
+# description: With temp_file_encryption on, temp-directory usage reported by duckdb_memory
+#              agrees with the on-disk footprint in duckdb_temporary_files().
 # group: [temp_files]
 
 # httpfs is required to enable temp file encryption
@@ -7,11 +8,11 @@ require httpfs
 
 require block_size 262144
 
-load {TEST_DIR}/encrypted_size_on_disk_undercount.db
+load {TEST_DIR}/encrypted_temp_file_size_accounting.db
 
 # Isolate the temp directory so `duckdb_temporary_files()` only reports this test's spill
 statement ok
-SET temp_directory='{TEST_DIR}/encrypted_size_on_disk_undercount_tmp'
+SET temp_directory='{TEST_DIR}/encrypted_temp_file_size_accounting_tmp'
 
 statement ok
 SET temp_file_encryption=true


### PR DESCRIPTION
Hi team, for encrypted temporary files, each block has an extra encryption header. Example storage layout
```sh
offset:  0        32     262176   262208    524352   ...
         ┌────────┬──────────────┬────────┬──────────────┬─
         │ hdr0   │  payload0    │ hdr1   │  payload1    │ ...
         │ 32 B   │  256 KB      │ 32 B   │  256 KB      │
         └────────┴──────────────┴────────┴──────────────┴─
         └── block 0 ──────────┘└── block 1 ──────────┘
```
But `TemporaryFileManager` doesn't account for header size, which leads to storage bytes under-counted.