### PR TITLE
Fix rolled-back DELETE poisoning uncheckpointed_delete_commit

### DIFF
--- a/src/storage/table/row_version_manager.cpp
+++ b/src/storage/table/row_version_manager.cpp
@@ -199,8 +199,12 @@ idx_t RowVersionManager::DeleteRows(idx_t vector_idx, transaction_t transaction_
 void RowVersionManager::CommitDelete(idx_t vector_idx, transaction_t commit_id, const DeleteInfo &info) {
 	lock_guard<mutex> lock(version_lock);
 	needs_compression_check = true;
-	if (!uncheckpointed_delete_commit.IsValid() || commit_id > uncheckpointed_delete_commit.GetIndex()) {
-		uncheckpointed_delete_commit = commit_id;
+	// `uncheckpointed_delete_commit` is used to decide whether there're uncommitted deletes, no need to overwrite on
+	// rollback-ed transaction.
+	if (commit_id != NOT_DELETED_ID) {
+		if (!uncheckpointed_delete_commit.IsValid() || commit_id > uncheckpointed_delete_commit.GetIndex()) {
+			uncheckpointed_delete_commit = commit_id;
+		}
 	}
 	GetVectorInfo(vector_idx).CommitDelete(commit_id, info);
 }

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -56,7 +56,8 @@ set(TEST_API_OBJECTS
     test_object_cache.cpp
     test_partial_executor.cpp
     test_buffer_pool_eviction.cpp
-    test_block_allocator_tls.cpp)
+    test_block_allocator_tls.cpp
+    test_rollback_delete_checkpoint_flag.cpp)
 
 if(NOT WIN32)
   set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp)

--- a/test/api/test_rollback_delete_checkpoint_flag.cpp
+++ b/test/api/test_rollback_delete_checkpoint_flag.cpp
@@ -1,0 +1,45 @@
+#include "catch.hpp"
+#include "duckdb.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/table/row_group.hpp"
+#include "duckdb/storage/table/row_group_collection.hpp"
+#include "duckdb/storage/table/row_version_manager.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb; // NOLINT
+
+TEST_CASE("Rolled-back DELETE must not stick uncheckpointed_delete_commit flag", "[storage][rollback][checkpoint]") {
+	DuckDB db;
+	Connection con(db);
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t(k INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("INSERT INTO t SELECT range FROM range(1000)"));
+	REQUIRE_NO_FAIL(con.Query("DELETE FROM t WHERE k < 500"));
+	REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+
+	auto has_unserialized_changes = [&]() {
+		bool result = false;
+		con.context->RunFunctionInTransaction([&]() {
+			auto &table = Catalog::GetEntry<TableCatalogEntry>(*con.context, QualifiedName::Parse("t"));
+			auto &storage = table.Cast<DuckTableEntry>().GetStorage();
+			auto row_group = storage.GetRowGroupCollection()->GetRowGroup(0);
+			REQUIRE(row_group);
+			result = row_group->GetOrCreateVersionInfo().HasUnserializedChanges();
+		});
+		return result;
+	};
+
+	// After a real DELETE + CHECKPOINT the flag is cleared.
+	REQUIRE(!has_unserialized_changes());
+
+	// Rolled-back DELETE followed by CHECKPOINT: the flag must still be clear.
+	REQUIRE_NO_FAIL(con.Query("BEGIN"));
+	REQUIRE_NO_FAIL(con.Query("DELETE FROM t WHERE k = 999"));
+	REQUIRE_NO_FAIL(con.Query("ROLLBACK"));
+	REQUIRE_NO_FAIL(con.Query("CHECKPOINT"));
+
+	REQUIRE(!has_unserialized_changes());
+}

--- a/test/api/test_rollback_delete_checkpoint_flag.cpp
+++ b/test/api/test_rollback_delete_checkpoint_flag.cpp
@@ -11,7 +11,7 @@
 
 using namespace duckdb; // NOLINT
 
-TEST_CASE("Rolled-back DELETE must not stick uncheckpointed_delete_commit flag",           "[storage][rollback][checkpoint]") {
+TEST_CASE("Rolled-back DELETE must not stick uncheckpointed_delete_commit flag", "[storage][rollback][checkpoint]") {
 	auto path = TestCreatePath("rollback_delete_checkpoint_flag.db");
 	DeleteDatabase(path);
 	DuckDB db(path);

--- a/test/api/test_rollback_delete_checkpoint_flag.cpp
+++ b/test/api/test_rollback_delete_checkpoint_flag.cpp
@@ -11,8 +11,10 @@
 
 using namespace duckdb; // NOLINT
 
-TEST_CASE("Rolled-back DELETE must not stick uncheckpointed_delete_commit flag", "[storage][rollback][checkpoint]") {
-	DuckDB db;
+TEST_CASE("Rolled-back DELETE must not stick uncheckpointed_delete_commit flag",           "[storage][rollback][checkpoint]") {
+	auto path = TestCreatePath("rollback_delete_checkpoint_flag.db");
+	DeleteDatabase(path);
+	DuckDB db(path);
 	Connection con(db);
 
 	REQUIRE_NO_FAIL(con.Query("CREATE TABLE t(k INTEGER)"));


### PR DESCRIPTION
TLDR: In the current implementation, whenever we have a rollback-ed deletion operation, row group checkpoint cannot enter into fast path.

Background introduction
- `uncheckpointed_delete_commit` is used to decide whether the current row group has uncommitted delete operations, and could be used to [reuse metadata](https://github.com/duckdb/duckdb/blob/0691eeb9d699640f272ab4e52a7aaf2ec8afe85c/src/storage/table/row_group.cpp#L1615) on checkpoint
- Checkpoint reusing metadata is the fast path and is extremely beneficial to write performance, for example, it contains segment stats (i.e., min/max/count) and compression method, etc, so we don't need to re-calculate

In the current implementation, 
- Deletion rollback is implemented as record deletion commit id as [`NOT_DELETE_ID`](https://github.com/duckdb/duckdb/blob/0691eeb9d699640f272ab4e52a7aaf2ec8afe85c/src/transaction/rollback_state.cpp#L37-L42), and [updates the `uncheckpointed_delete_commit`](https://github.com/duckdb/duckdb/blob/0691eeb9d699640f272ab4e52a7aaf2ec8afe85c/src/storage/table/row_version_manager.cpp#L202-L204) regardless
- Later on, even if we perform a checkpoint operation, the `uncheckpointed_delete_commit` won't be reset because `NOT_DELETE_ID` is the [largest integer](https://github.com/duckdb/duckdb/blob/0691eeb9d699640f272ab4e52a7aaf2ec8afe85c/src/common/constants.cpp#L22) and [visibility bound, as a normal transaction id, won't be able to reset](https://github.com/duckdb/duckdb/blob/0691eeb9d699640f272ab4e52a7aaf2ec8afe85c/src/storage/table/row_version_manager.cpp#L277-L281)
- Conclusion: all later checkpoints won't be able to enter into the fast path

In this PR, I propose a small code change, `NOT_DELETE_ID` is a well-known constant to represent unreachable deletion commit id, we special handle it and skip updating `uncheckpointed_delete_commit`.