### PR TITLE
Fix foreign key constraint violation error message

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -743,9 +743,9 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 		if (!global_conflicts && !local_conflicts) {
 			conflict = 0;
 		} else if (!global_conflicts && local_conflicts) {
-			conflict = local_conflict_manager.GetFirstInvalidIndex(count);
+			conflict = local_conflict_manager.GetFirstInvalidIndex(count, /*negate=*/true);
 		} else if (global_conflicts && !local_conflicts) {
-			conflict = global_conflict_manager.GetFirstInvalidIndex(count);
+			conflict = global_conflict_manager.GetFirstInvalidIndex(count, /*negate=*/true);
 		} else {
 			auto &global_validity = global_conflict_manager.GetFirstValidity();
 			auto &local_validity = local_conflict_manager.GetFirstValidity();

--- a/test/sql/constraints/foreignkey/fk_19469.test
+++ b/test/sql/constraints/foreignkey/fk_19469.test
@@ -104,3 +104,23 @@ INSERT INTO fk_19990_data BY NAME
     FROM fk_19990_temp_data;
 ----
 Constraint Error: Violates foreign key constraint because key "reference_id: 3" does not exist in the referenced table
+
+statement ok
+CREATE TABLE fk_local_p(id INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE fk_local_c(pid INT, FOREIGN KEY (pid) REFERENCES fk_local_p(id));
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO fk_local_p VALUES (10), (20);
+
+statement error
+INSERT INTO fk_local_c VALUES (10), (30), (20);
+----
+Constraint Error: Violates foreign key constraint because key "id: 30" does not exist in the referenced table
+
+statement ok
+ROLLBACK;


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25588

The root cause is for `GetFirstInvalidIndex`, 
- when `negate=true`(default), it's getting the first matching value (in our case, it's the first key which exists in the parent table)
- when `negate=false`(our fix), it's getting the first value which doesn't exist