### PR TITLE
Propagate expression stats for constant row group

### DIFF
--- a/src/include/duckdb/optimizer/statistics_propagator.hpp
+++ b/src/include/duckdb/optimizer/statistics_propagator.hpp
@@ -46,6 +46,10 @@ public:
 		return removed_expressions;
 	}
 
+	//! Evaluate a function when every argument is known to be constant from its statistics.
+	static unique_ptr<BaseStatistics> PropagateConstantInputs(ClientContext &context,
+	                                                          const BoundFunctionExpression &func,
+	                                                          const vector<BaseStatistics> &child_stats);
 	//! Derive output statistics of a monotone function by evaluating it at the corners of its
 	//! argument ranges (see ArgProperties). Returns nullptr when the bounds cannot be derived.
 	static unique_ptr<BaseStatistics> PropagateMonotoneBounds(ClientContext &context,

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -24,9 +24,19 @@ bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionExpressio
 	return ExpressionExecutor::TryEvaluateScalar(context, *clone, result);
 }
 
-// Equal bounds need not imply identical inputs for certain types, so we skip this optimization for them.
-bool CanInferConstantFromNumericBounds(PhysicalType type) {
-	return type != PhysicalType::FLOAT && type != PhysicalType::DOUBLE && type != PhysicalType::INTERVAL;
+// Equal bounds need not imply identical inputs for certain types, so we skip this optimization for those values.
+// Floating-point bounds only lose information for the sign of zero.
+bool CanInferConstantFromNumericBounds(const Value &value) {
+	switch (value.type().InternalType()) {
+	case PhysicalType::FLOAT:
+		return value.GetValue<float>() != 0.0F;
+	case PhysicalType::DOUBLE:
+		return value.GetValue<double>() != 0.0;
+	case PhysicalType::INTERVAL:
+		return false;
+	default:
+		return true;
+	}
 }
 } // namespace
 
@@ -53,11 +63,11 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateConstantInputs(ClientC
 		} else if (stats.CanHaveNull()) {
 			return nullptr;
 		} else if (stats.GetStatsType() == StatisticsType::NUMERIC_STATS && NumericStats::HasMinMax(stats)) {
-			if (!CanInferConstantFromNumericBounds(stats.GetType().InternalType()) ||
-			    NumericStats::Min(stats) != NumericStats::Max(stats)) {
+			auto min = NumericStats::Min(stats);
+			if (min != NumericStats::Max(stats) || !CanInferConstantFromNumericBounds(min)) {
 				return nullptr;
 			}
-			value = NumericStats::Min(stats);
+			value = std::move(min);
 		} else if ((stats.GetType().id() == LogicalTypeId::VARCHAR || stats.GetType().id() == LogicalTypeId::BLOB) &&
 		           StringStats::HasMinMax(stats) && StringStats::GetMinType(stats) == StringStatsType::EXACT_STATS &&
 		           StringStats::GetMaxType(stats) == StringStatsType::EXACT_STATS &&

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -18,9 +18,10 @@ bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionExpressio
 	for (auto &v : arg_values) {
 		children.push_back(make_uniq<BoundConstantExpression>(v));
 	}
-	auto bind_info_clone = func.BindInfo() ? func.BindInfo()->Copy() : nullptr;
-	BoundFunctionExpression clone(func.Function(), std::move(children), std::move(bind_info_clone), func.IsOperator());
-	return ExpressionExecutor::TryEvaluateScalar(context, clone, result);
+	// Functions such as alias() inspect expression metadata during execution.
+	auto clone = func.Copy();
+	clone->Cast<BoundFunctionExpression>().GetChildrenMutable() = std::move(children);
+	return ExpressionExecutor::TryEvaluateScalar(context, *clone, result);
 }
 
 // Equal bounds need not imply identical inputs for certain types, so we skip this optimization for them.
@@ -49,9 +50,6 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateConstantInputs(ClientC
 			if (!ExpressionExecutor::TryEvaluateScalar(context, child, value)) {
 				return nullptr;
 			}
-		} else if (!stats.CanHaveNoNull()) {
-			// Evaluate NULL arguments too.
-			value = Value(child.GetReturnType());
 		} else if (stats.CanHaveNull()) {
 			return nullptr;
 		} else if (stats.GetStatsType() == StatisticsType::NUMERIC_STATS && NumericStats::HasMinMax(stats)) {

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -6,11 +6,13 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/storage/statistics/numeric_stats.hpp"
+#include "duckdb/storage/statistics/string_stats.hpp"
 
 namespace duckdb {
 
-static bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionExpression &func,
-                                   const vector<Value> &arg_values, Value &result) {
+namespace {
+bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionExpression &func,
+                            const vector<Value> &arg_values, Value &result) {
 	vector<unique_ptr<Expression>> children;
 	children.reserve(arg_values.size());
 	for (auto &v : arg_values) {
@@ -19,6 +21,56 @@ static bool TryEvaluateAtConstants(ClientContext &context, const BoundFunctionEx
 	auto bind_info_clone = func.BindInfo() ? func.BindInfo()->Copy() : nullptr;
 	BoundFunctionExpression clone(func.Function(), std::move(children), std::move(bind_info_clone), func.IsOperator());
 	return ExpressionExecutor::TryEvaluateScalar(context, clone, result);
+}
+
+// Equal bounds need not imply identical inputs for certain types, so we skip this optimization for them.
+bool CanInferConstantFromNumericBounds(PhysicalType type) {
+	return type != PhysicalType::FLOAT && type != PhysicalType::DOUBLE && type != PhysicalType::INTERVAL;
+}
+} // namespace
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateConstantInputs(ClientContext &context,
+                                                                         const BoundFunctionExpression &func,
+                                                                         const vector<BaseStatistics> &child_stats) {
+	if (func.Function().GetStability() != FunctionStability::CONSISTENT || func.GetChildren().empty()) {
+		return nullptr;
+	}
+	vector<Value> values;
+	values.reserve(func.GetChildren().size());
+	for (idx_t idx = 0; idx < func.GetChildren().size(); ++idx) {
+		auto &child = *func.GetChildren()[idx];
+		auto &stats = child_stats[idx];
+		Value value;
+		if (child.IsFoldable()) {
+			if (!ExpressionExecutor::TryEvaluateScalar(context, child, value)) {
+				return nullptr;
+			}
+		} else if (!stats.CanHaveNoNull()) {
+			// Evaluate NULL arguments too.
+			value = Value(child.GetReturnType());
+		} else if (stats.CanHaveNull()) {
+			return nullptr;
+		} else if (stats.GetStatsType() == StatisticsType::NUMERIC_STATS && NumericStats::HasMinMax(stats)) {
+			if (!CanInferConstantFromNumericBounds(stats.GetType().InternalType()) ||
+			    NumericStats::Min(stats) != NumericStats::Max(stats)) {
+				return nullptr;
+			}
+			value = NumericStats::Min(stats);
+		} else if ((stats.GetType().id() == LogicalTypeId::VARCHAR || stats.GetType().id() == LogicalTypeId::BLOB) &&
+		           StringStats::HasMinMax(stats) && StringStats::GetMinType(stats) == StringStatsType::EXACT_STATS &&
+		           StringStats::GetMaxType(stats) == StringStatsType::EXACT_STATS &&
+		           StringStats::Min(stats) == StringStats::Max(stats)) {
+			value = Value::BLOB_RAW(StringStats::Min(stats)).WithType(stats.GetType());
+		} else {
+			return nullptr;
+		}
+		values.emplace_back(std::move(value));
+	}
+	Value result;
+	if (!TryEvaluateAtConstants(context, func, values, result)) {
+		return nullptr;
+	}
+	return BaseStatistics::FromConstant(result).ToUnique();
 }
 
 //! Evaluate `func` at the lo/hi corner of each child's value range to derive output min/max.
@@ -143,6 +195,10 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFuncti
 		} else {
 			stats.push_back(stat->Copy());
 		}
+	}
+	auto constant_stats = PropagateConstantInputs(context, func, stats);
+	if (constant_stats) {
+		return constant_stats;
 	}
 	if (func.Function().HasStatisticsCallback()) {
 		FunctionStatisticsInput input(func, func.BindInfo().get(), stats, &expr_ptr);

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -38,6 +38,29 @@ bool CanInferConstantFromNumericBounds(const Value &value) {
 		return true;
 	}
 }
+
+bool TryInferConstantBounds(const BaseStatistics &stats, Value &constant) {
+	if (stats.CanHaveNull()) {
+		return false;
+	}
+	if (stats.GetStatsType() == StatisticsType::NUMERIC_STATS && NumericStats::HasMinMax(stats)) {
+		auto min = NumericStats::Min(stats);
+		auto max = NumericStats::Max(stats);
+		if (min != max || !CanInferConstantFromNumericBounds(min)) {
+			return false;
+		}
+		constant = std::move(min);
+		return true;
+	}
+	if ((stats.GetType().id() == LogicalTypeId::VARCHAR || stats.GetType().id() == LogicalTypeId::BLOB) &&
+	    StringStats::HasMinMax(stats) && StringStats::GetMinType(stats) == StringStatsType::EXACT_STATS &&
+	    StringStats::GetMaxType(stats) == StringStatsType::EXACT_STATS &&
+	    StringStats::Min(stats) == StringStats::Max(stats)) {
+		constant = Value::BLOB_RAW(StringStats::Min(stats)).WithType(stats.GetType());
+		return true;
+	}
+	return false;
+}
 } // namespace
 
 unique_ptr<BaseStatistics> StatisticsPropagator::PropagateConstantInputs(ClientContext &context,
@@ -60,20 +83,7 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateConstantInputs(ClientC
 			if (!ExpressionExecutor::TryEvaluateScalar(context, child, value)) {
 				return nullptr;
 			}
-		} else if (stats.CanHaveNull()) {
-			return nullptr;
-		} else if (stats.GetStatsType() == StatisticsType::NUMERIC_STATS && NumericStats::HasMinMax(stats)) {
-			auto min = NumericStats::Min(stats);
-			if (min != NumericStats::Max(stats) || !CanInferConstantFromNumericBounds(min)) {
-				return nullptr;
-			}
-			value = std::move(min);
-		} else if ((stats.GetType().id() == LogicalTypeId::VARCHAR || stats.GetType().id() == LogicalTypeId::BLOB) &&
-		           StringStats::HasMinMax(stats) && StringStats::GetMinType(stats) == StringStatsType::EXACT_STATS &&
-		           StringStats::GetMaxType(stats) == StringStatsType::EXACT_STATS &&
-		           StringStats::Min(stats) == StringStats::Max(stats)) {
-			value = Value::BLOB_RAW(StringStats::Min(stats)).WithType(stats.GetType());
-		} else {
+		} else if (!TryInferConstantBounds(stats, value)) {
 			return nullptr;
 		}
 		values.emplace_back(std::move(value));

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -35,6 +35,10 @@ unique_ptr<BaseStatistics> StatisticsPropagator::PropagateConstantInputs(ClientC
 	if (func.Function().GetStability() != FunctionStability::CONSISTENT || func.GetChildren().empty()) {
 		return nullptr;
 	}
+	// Lambda arguments are placeholders, not SQL values that can be evaluated independently.
+	if (func.Function().HasBindLambdaCallback()) {
+		return nullptr;
+	}
 	vector<Value> values;
 	values.reserve(func.GetChildren().size());
 	for (idx_t idx = 0; idx < func.GetChildren().size(); ++idx) {

--- a/src/planner/filter/expression_filter.cpp
+++ b/src/planner/filter/expression_filter.cpp
@@ -273,6 +273,11 @@ static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<Cli
 				child_stats.push_back(child_stat->Copy());
 			}
 
+			auto constant_stats = StatisticsPropagator::PropagateConstantInputs(*context_p, func, child_stats);
+			if (constant_stats) {
+				owned_stats.push_back(std::move(constant_stats));
+				return owned_stats.back().get();
+			}
 			// Use copy to avoid expression rewritten
 			auto expr_copy = func.Copy();
 			auto &func_copy = expr_copy->Cast<BoundFunctionExpression>();
@@ -284,7 +289,7 @@ static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<Cli
 		// No custom callback: fall back to the declared monotonicity (ArgProperties) and derive output
 		// bounds by evaluating the function at the corners of each argument's range. This lets a
 		// f(col) OP const filter prune row groups via the zonemap of the base column.
-		if (func.Function().HasArgProperties()) {
+		if (func.Function().GetStability() == FunctionStability::CONSISTENT) {
 			vector<BaseStatistics> child_stats;
 			child_stats.reserve(func.GetChildren().size());
 			for (auto &child_expr : func.GetChildren()) {
@@ -292,7 +297,10 @@ static optional_ptr<const BaseStatistics> TryGetExpressionStats(optional_ptr<Cli
 				child_stats.push_back(child_stat ? child_stat->Copy()
 				                                 : BaseStatistics::CreateUnknown(child_expr->GetReturnType()));
 			}
-			auto derived = StatisticsPropagator::PropagateMonotoneBounds(*context_p, func, child_stats);
+			auto derived = StatisticsPropagator::PropagateConstantInputs(*context_p, func, child_stats);
+			if (!derived) {
+				derived = StatisticsPropagator::PropagateMonotoneBounds(*context_p, func, child_stats);
+			}
 			if (derived) {
 				owned_stats.push_back(std::move(derived));
 				return owned_stats.back().get();
@@ -574,7 +582,7 @@ static FilterPropagateResult CheckFunctionStatistics(optional_ptr<ClientContext>
 		return CheckComparisonStatistics(context_p, func_expr, input_stats);
 	}
 	if (!func_expr.Function().HasFilterPruneCallback()) {
-		if (func_expr.GetReturnType().id() != LogicalTypeId::BOOLEAN || !func_expr.Function().HasStatisticsCallback()) {
+		if (func_expr.GetReturnType().id() != LogicalTypeId::BOOLEAN) {
 			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
 		}
 		vector<unique_ptr<BaseStatistics>> owned_stats;

--- a/test/api/capi/v1/capi_scalar_functions.cpp
+++ b/test/api/capi/v1/capi_scalar_functions.cpp
@@ -660,6 +660,11 @@ static void CounterFunctionBind(duckdb_bind_info info) {
 	bind_data = extra_info + 10;
 
 	duckdb_scalar_function_set_bind_data(info, bind_data_ptr, free);
+	duckdb_scalar_function_set_bind_data_copy(info, [](void *ptr) -> void * {
+		auto copy = static_cast<int64_t *>(malloc(sizeof(int64_t)));
+		*copy = *static_cast<int64_t *>(ptr);
+		return copy;
+	});
 }
 
 static void CounterFunctionInit(duckdb_init_info info) {
@@ -709,6 +714,8 @@ static void CAPIRegisterCounterFunction(duckdb_connection connection, const char
 
 	auto function = duckdb_create_scalar_function();
 	duckdb_scalar_function_set_name(function, name);
+	// The counter advances on every row, even when its argument is constant.
+	duckdb_scalar_function_set_volatile(function);
 
 	auto bigint_type = duckdb_create_logical_type(DUCKDB_TYPE_BIGINT);
 	duckdb_scalar_function_add_parameter(function, bigint_type);
@@ -734,6 +741,12 @@ TEST_CASE("Test Scalar Functions - Local State", "[capi]") {
 	CAPIRegisterCounterFunction(tester.connection, "my_counter", 5);
 
 	result = tester.Query("SELECT my_counter(i) FROM range(3) r(i)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(result->Fetch<idx_t>(0, 0) == 5);
+	REQUIRE(result->Fetch<idx_t>(0, 1) == 6);
+	REQUIRE(result->Fetch<idx_t>(0, 2) == 7);
+
+	result = tester.Query("SELECT my_counter(0) FROM range(3)");
 	REQUIRE_NO_FAIL(*result);
 	REQUIRE(result->Fetch<idx_t>(0, 0) == 5);
 	REQUIRE(result->Fetch<idx_t>(0, 1) == 6);

--- a/test/sql/optimizer/constant_function_zonemap_pruning.test
+++ b/test/sql/optimizer/constant_function_zonemap_pruning.test
@@ -46,6 +46,23 @@ SELECT count(*) FILTER (WHERE atan2(x, -1) < 0), count(*) FILTER (WHERE atan2(x,
 statement ok
 DROP TABLE signed_zeros;
 
+# Nonzero floating-point constants can be propagated; zero remains inconclusive because its sign is not in the stats.
+statement ok
+CREATE TABLE const_db.constant_doubles AS
+SELECT CASE WHEN i < 2048 THEN -1::DOUBLE WHEN i < 4096 THEN 1::DOUBLE
+            WHEN i < 6144 THEN 0::DOUBLE ELSE (i % 2)::DOUBLE END AS x
+FROM range(8192) t(i);
+
+query I
+SELECT count(*) FROM const_db.constant_doubles WHERE atan2(x, -1) < 0;
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT x FROM const_db.constant_doubles WHERE atan2(x, -1) < 0;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 4.*
+
 # RG 1: all NULL; RG 2: alpha; RG 3: beta; RG 4: two strings sharing a truncated 12-byte prefix.
 statement ok
 CREATE TABLE const_db.constant_strings AS

--- a/test/sql/optimizer/constant_function_zonemap_pruning.test
+++ b/test/sql/optimizer/constant_function_zonemap_pruning.test
@@ -1,0 +1,108 @@
+# name: test/sql/optimizer/constant_function_zonemap_pruning.test
+# description: Constant function inputs propagate statistics for row group pruning
+# group: [optimizer]
+
+statement ok
+ATTACH '{TEST_DIR}/constant_function_pruning.duckdb' AS const_db (ROW_GROUP_SIZE 2048);
+
+# RG 1: only 17; RG 2: only 42; RG 3: 17 and NULL; RG 4: values 0 through 63.
+statement ok
+CREATE TABLE const_db.constant_inputs AS
+SELECT CASE WHEN i < 2048 THEN 17 WHEN i < 4096 THEN 42
+            WHEN i < 6144 THEN CASE WHEN i % 2 = 0 THEN 17 END ELSE i % 64 END AS x
+FROM range(8192) t(i);
+
+# No callback: constants produce stats; nullable and varying inputs fail both propagation paths.
+foreach predicate x%100=42 hash(x)=hash(42::BIGINT)
+
+query I
+SELECT count(*) FROM const_db.constant_inputs WHERE {predicate};
+----
+2080
+
+query II
+EXPLAIN ANALYZE SELECT x FROM const_db.constant_inputs WHERE {predicate};
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 4.*
+
+endloop
+
+# hash(NULL) is a non-NULL value: min = max = 17 does not describe the NULL rows.
+query I
+SELECT count(*) FROM const_db.constant_inputs WHERE hash(x) = hash(NULL::BIGINT);
+----
+1024
+
+# Equal floating-point bounds do not distinguish signed zeros, but atan2 does.
+statement ok
+CREATE TABLE signed_zeros AS SELECT x FROM (VALUES ('0'::DOUBLE), ('-0'::DOUBLE)) t(x);
+
+query II
+SELECT count(*) FILTER (WHERE atan2(x, -1) < 0), count(*) FILTER (WHERE atan2(x, -1) > 0) FROM signed_zeros;
+----
+1	1
+
+# RG 1: all NULL; RG 2: alpha; RG 3: beta; RG 4: two strings sharing a truncated 12-byte prefix.
+statement ok
+CREATE TABLE const_db.constant_strings AS
+SELECT CASE WHEN i < 2048 THEN NULL WHEN i < 4096 THEN 'alpha'
+            WHEN i < 6144 THEN 'beta' ELSE 'abcdefghijkl' || (i % 2)::VARCHAR END AS s
+FROM range(8192) t(i);
+
+# regexp_matches exercises direct BOOLEAN pruning without a statistics callback, including unknown stats in RG 4.
+foreach predicate hash(s)=hash('beta') reverse(s)='ateb' hash(s)=hash(NULL::VARCHAR) regexp_matches(s,'(t|z)')
+
+query I
+SELECT count(*) FROM const_db.constant_strings WHERE {predicate};
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE {predicate};
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+endloop
+
+# With a callback: RGs 1-3 use constant evaluation; RG 4 falls back to string-length statistics.
+query I
+SELECT count(*) FROM const_db.constant_strings WHERE length_grapheme(s) = 4;
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE length_grapheme(s) = 4;
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 4.*
+
+# CONSISTENT_WITHIN_QUERY fails the CONSISTENT guard: no statistics are derived, so every RG is scanned.
+query I
+SELECT count(*) FROM const_db.constant_strings WHERE in_search_path('const_db', s);
+----
+0
+
+query II
+EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE in_search_path('const_db', s);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 4 / 4.*
+
+# Identical inexact bounds must not be treated as a constant input.
+query I
+SELECT count(*) FROM const_db.constant_strings WHERE reverse(s) = '0lkjihgfedcba';
+----
+1024
+
+query II
+EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE reverse(s) = '0lkjihgfedcba';
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 4.*
+
+# Equal intervals can have different month/day components.
+statement ok
+CREATE TABLE equal_intervals AS SELECT x FROM (VALUES (INTERVAL '1 month'), (INTERVAL '30 days')) t(x);
+
+query II
+SELECT count(*) FILTER (WHERE x::VARCHAR = '1 month'),
+       count(*) FILTER (WHERE x::VARCHAR = '30 days') FROM equal_intervals;
+----
+1	1

--- a/test/sql/optimizer/constant_function_zonemap_pruning.test
+++ b/test/sql/optimizer/constant_function_zonemap_pruning.test
@@ -34,13 +34,17 @@ SELECT count(*) FROM const_db.constant_inputs WHERE hash(x) = hash(NULL::BIGINT)
 1024
 
 # Equal floating-point bounds do not distinguish signed zeros, but atan2 does.
+# Keep them in memory: constant compression can discard the sign of zero.
 statement ok
-CREATE TABLE signed_zeros AS SELECT x FROM (VALUES ('0'::DOUBLE), ('-0'::DOUBLE)) t(x);
+CREATE TEMP TABLE signed_zeros AS SELECT x FROM (VALUES ('0'::DOUBLE), ('-0'::DOUBLE)) t(x);
 
 query II
 SELECT count(*) FILTER (WHERE atan2(x, -1) < 0), count(*) FILTER (WHERE atan2(x, -1) > 0) FROM signed_zeros;
 ----
 1	1
+
+statement ok
+DROP TABLE signed_zeros;
 
 # RG 1: all NULL; RG 2: alpha; RG 3: beta; RG 4: two strings sharing a truncated 12-byte prefix.
 statement ok
@@ -49,8 +53,8 @@ SELECT CASE WHEN i < 2048 THEN NULL WHEN i < 4096 THEN 'alpha'
             WHEN i < 6144 THEN 'beta' ELSE 'abcdefghijkl' || (i % 2)::VARCHAR END AS s
 FROM range(8192) t(i);
 
-# regexp_matches exercises direct BOOLEAN pruning without a statistics callback, including unknown stats in RG 4.
-foreach predicate hash(s)=hash('beta') reverse(s)='ateb' hash(s)=hash(NULL::VARCHAR) regexp_matches(s,'(t|z)')
+# RGs 1 and 4 remain unknown; regexp_matches also exercises direct BOOLEAN pruning.
+foreach predicate hash(s)=hash('beta') reverse(s)='ateb' regexp_matches(s,'(t|z)')
 
 query I
 SELECT count(*) FROM const_db.constant_strings WHERE {predicate};
@@ -60,11 +64,22 @@ SELECT count(*) FROM const_db.constant_strings WHERE {predicate};
 query II
 EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE {predicate};
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 4.*
 
 endloop
 
-# With a callback: RGs 1-3 use constant evaluation; RG 4 falls back to string-length statistics.
+# Literal NULL remains foldable; the all-NULL row group is scanned.
+query I
+SELECT count(*) FROM const_db.constant_strings WHERE hash(s) = hash(NULL::VARCHAR);
+----
+2048
+
+query II
+EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE hash(s) = hash(NULL::VARCHAR);
+----
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+
+# With a callback: RGs 2-3 use constant evaluation; RGs 1 and 4 use string-length statistics.
 query I
 SELECT count(*) FROM const_db.constant_strings WHERE length_grapheme(s) = 4;
 ----
@@ -95,7 +110,7 @@ SELECT count(*) FROM const_db.constant_strings WHERE reverse(s) = '0lkjihgfedcba
 query II
 EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE reverse(s) = '0lkjihgfedcba';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 4.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
 
 # Equal intervals can have different month/day components.
 statement ok

--- a/test/sql/optimizer/upper_lower_zonemap_pruning.test
+++ b/test/sql/optimizer/upper_lower_zonemap_pruning.test
@@ -53,17 +53,15 @@ SELECT count(*) FROM case_mixed WHERE upper(s) = 'V004000';
 ----
 1
 
-# Unicode case conversion can lengthen a string beyond the stored zonemap prefix:
-# upper('ɐɐɐɐɐɐ') is the 18-byte 'ⱯⱯⱯⱯⱯⱯ', so the propagated stats must be marked
-# truncated. The 'ɐ' row group stays inconclusive (scanned and matched), while the
-# other row groups are still pruned.
+# Unicode case conversion can lengthen a string beyond the stored zonemap prefix.
+# Constant evaluation preserves the full 18-byte upper('ɐɐɐɐɐɐ') value.
 statement ok
 CREATE TABLE case_lengthening AS
 SELECT i::INTEGER AS i, CASE WHEN i < 2048 THEN 'ɐɐɐɐɐɐ' WHEN i < 4096 THEN 'oooooo' ELSE 'zzzzzz' END AS s
 FROM range(6144) r(i);
 
 query II
-EXPLAIN ANALYZE SELECT count(*) FROM case_lengthening WHERE upper(s) = 'ⱯⱯⱯⱯⱯⱯ';
+EXPLAIN ANALYZE SELECT i FROM case_lengthening WHERE upper(s) = 'ⱯⱯⱯⱯⱯⱯ';
 ----
 analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 3.*
 


### PR DESCRIPTION
Hi team, I think for row groups of the same value (either NULL or real values), as long as the expression is consistent, we should be able to propagate the expression stats directly. Currently it's not implemented, for example,
```sql
memory D ATTACH '/tmp/constant_pruning.duckdb' AS rg (ROW_GROUP_SIZE 2048);
memory D USE rg;
rg D CREATE TABLE tenants AS SELECT i // 2048 AS tenant_id FROM range(204800) t(i);
rg D EXPLAIN ANALYZE SELECT * FROM tenants WHERE hash(tenant_id) = hash(42::BIGINT);
╭─ Summary ───────────╮
│ Total Time: 0.0006s │
╰─────────────────────╯
╭─ Table Scan ──────────────────────────╮
│ Table: rg.main.tenants                │
│ Type: Sequential Scan                 │
│ Projections: tenant_id                │
│ Filters:                              │
│ hash(tenant_id) = 7199933130570745587 │
│ Row Groups Scanned: 100 / 100         │
│ 2,048 rows                        0µs │
╰───────────────────────────────────────╯
```
In this PR, when such constant row group detected, I calculate the stats for the constant expression value and propagate.