### PR TITLE
Fix checkpoint corrupting -0.0 into 0.0 for FLOAT/DOUBLE columns

### DIFF
--- a/src/storage/compression/rle.cpp
+++ b/src/storage/compression/rle.cpp
@@ -14,6 +14,23 @@ namespace duckdb {
 
 using rle_count_t = uint16_t;
 
+template <class T>
+static inline bool RLEValueEqual(const T &a, const T &b) {
+	return a == b;
+}
+
+template <>
+inline bool RLEValueEqual(const float &a, const float &b) {
+	// avoid folding -0.0 and 0.0 (or differently-signed NaNs) into a single run: they compare
+	// equal but are not bit-identical
+	return Load<uint32_t>(const_data_ptr_cast(&a)) == Load<uint32_t>(const_data_ptr_cast(&b));
+}
+
+template <>
+inline bool RLEValueEqual(const double &a, const double &b) {
+	return Load<uint64_t>(const_data_ptr_cast(&a)) == Load<uint64_t>(const_data_ptr_cast(&b));
+}
+
 //===--------------------------------------------------------------------===//
 // Analyze
 //===--------------------------------------------------------------------===//
@@ -53,7 +70,7 @@ public:
 				seen_count++;
 				last_seen_count++;
 				all_null = false;
-			} else if (last_value == data[idx]) {
+			} else if (RLEValueEqual<T>(last_value, data[idx])) {
 				// the last value is identical to this value: increment the last_seen_count
 				last_seen_count++;
 			} else {

--- a/src/storage/statistics/numeric_stats.cpp
+++ b/src/storage/statistics/numeric_stats.cpp
@@ -322,6 +322,13 @@ bool NumericStats::ConstantsCoverRange(const BaseStatistics &stats, array_ptr<co
 }
 
 bool NumericStats::IsConstant(const BaseStatistics &stats) {
+	auto physical_type = stats.GetType().InternalType();
+	if ((physical_type == PhysicalType::FLOAT || physical_type == PhysicalType::DOUBLE) &&
+	    NumericStats::Min(stats) == 0) {
+		// -0.0 and 0.0 compare equal but are not bit-identical, so min == max == 0 does not
+		// guarantee that all values in the segment have the same sign
+		return false;
+	}
 	return NumericStats::Max(stats) <= NumericStats::Min(stats);
 }
 

--- a/test/sql/storage/compression/constant/constant_negative_zero.test
+++ b/test/sql/storage/compression/constant/constant_negative_zero.test
@@ -1,0 +1,71 @@
+# name: test/sql/storage/compression/constant/constant_negative_zero.test
+# description: Test that checkpointing a FLOAT/DOUBLE column with mixed -0.0/0.0 does not lose the sign of zero
+# group: [constant]
+
+require no_alternative_verify
+
+load {TEST_DIR}/constant_negative_zero.db
+
+# min == max == 0 for these columns even though the values are not bit-identical:
+# -0.0 and 0.0 compare equal, so this must not be treated as a constant segment
+statement ok
+CREATE TABLE zero_probe(id INTEGER, v DOUBLE, vf FLOAT);
+
+statement ok
+INSERT INTO zero_probe VALUES (1, '-0.0', '-0.0'), (2, '0.0', '0.0');
+
+statement ok
+checkpoint;
+
+query III
+SELECT id, signbit(v), signbit(vf) FROM zero_probe ORDER BY id;
+----
+1	true	true
+2	false	false
+
+query I
+SELECT compression FROM pragma_storage_info('zero_probe') WHERE column_name = 'v' AND segment_type = 'DOUBLE';
+----
+Uncompressed
+
+restart
+
+query III
+SELECT id, signbit(v), signbit(vf) FROM zero_probe ORDER BY id;
+----
+1	true	true
+2	false	false
+
+# an RLE-compressed column with a mixed-zero run must also keep the sign of each run
+statement ok
+PRAGMA force_compression = 'rle'
+
+statement ok
+CREATE TABLE zero_probe_rle(id INTEGER, v DOUBLE);
+
+statement ok
+INSERT INTO zero_probe_rle VALUES (1, '-0.0'), (2, '0.0'), (3, 1.5);
+
+statement ok
+checkpoint;
+
+query II
+SELECT id, signbit(v) FROM zero_probe_rle ORDER BY id;
+----
+1	true
+2	false
+3	false
+
+query I
+SELECT compression FROM pragma_storage_info('zero_probe_rle') WHERE column_name = 'v' AND segment_type = 'DOUBLE';
+----
+RLE
+
+restart
+
+query II
+SELECT id, signbit(v) FROM zero_probe_rle ORDER BY id;
+----
+1	true
+2	false
+3	false


### PR DESCRIPTION
## Summary
`NumericStats::IsConstant()` treats `min == max` as proof a segment is constant, but `-0.0 == 0.0` for floats without being bit-identical. Checkpoint then collapses such segments to one value, losing the sign of zero. RLE has the same flaw: it merges adjacent values with `==`, folding a `-0.0` run into a `0.0` run.

## Fix
- `numeric_stats.cpp`: `IsConstant()` returns `false` for `FLOAT`/`DOUBLE` when min is zero.
- `rle.cpp`: added `RLEValueEqual<T>`, comparing bits instead of `==` for `float`/`double`.

## Tests
- `constant_negative_zero.test`: checks `signbit()` survives checkpoint/restart for both the constant-segment and forced-RLE paths.

Fixes #25580