### PR TITLE
Fix integer truncation in ArgMinMaxValueAssign::Assign

### DIFF
--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -29,7 +29,7 @@ struct ArgMinMaxValueAssign {
 template <>
 struct ArgMinMaxValueAssign<string_t> {
 	//! The size of the arena allocation for a non-inlined string value
-	uint32_t alloc_size;
+	idx_t alloc_size;
 
 	void Assign(string_t &target, string_t new_value, AggregateInputData &aggregate_input_data) {
 		if (new_value.IsInlined()) {
@@ -41,7 +41,9 @@ struct ArgMinMaxValueAssign<string_t> {
 			if (alloc_size >= len) {
 				ptr = target.GetDataWriteable();
 			} else {
-				alloc_size = UnsafeNumericCast<uint32_t>(NextPowerOfTwo(len));
+				// NextPowerOfTwo(len) can exceed UINT32_MAX for len close to it, so alloc_size
+				// must not be narrowed back to uint32_t here
+				alloc_size = NextPowerOfTwo(len);
 				ptr = char_ptr_cast(aggregate_input_data.allocator.Allocate(alloc_size));
 			}
 			memcpy(ptr, new_value.GetData(), len);

--- a/test/sql/aggregate/aggregates/arg_min_max_string_truncation_overflow.test_slow
+++ b/test/sql/aggregate/aggregates/arg_min_max_string_truncation_overflow.test_slow
@@ -1,0 +1,20 @@
+# name: test/sql/aggregate/aggregates/arg_min_max_string_truncation_overflow.test_slow
+# description: Regression test for integer truncation in ArgMinMaxValueAssign<string_t>::Assign
+# group: [aggregates]
+
+# For a non-inlined string with a length just above 2^31, NextPowerOfTwo(len) is 2^32.
+# Before the fix, casting that back to uint32_t truncated the arena allocation size to 0,
+# so the following memcpy overflowed the heap instead of failing cleanly.
+# A memory_limit below the (correct) 4GB allocation makes this deterministic regardless of
+# how much physical memory is actually available.
+
+statement ok
+SET threads=1;
+
+statement ok
+SET memory_limit='3GB';
+
+statement error
+SELECT length(arg_min(s, 1)) FROM (SELECT repeat('A', 2147483649) AS s) t;
+----
+Out of Memory Error


### PR DESCRIPTION
## Summary
`ArgMinMaxValueAssign<string_t>::Assign()` computed the arena allocation size via `UnsafeNumericCast<uint32_t>(NextPowerOfTwo(len))`. For a string length in `(2^31, 2^32-1]`, this returns `2^32`, which truncates to `0`, causing a zero-size allocation followed by a heap-overflowing `memcpy`.

## Fix
Widened `alloc_size` from `uint32_t` to `idx_t` in `arg_min_max.cpp`, dropping the truncating cast.

## Tests
- `arg_min_max_string_truncation_overflow.test_slow`: reproduces the truncation under a `memory_limit` too small to satisfy the correct allocation, so it deterministically fails cleanly (fixed) or crashes (unfixed).

Fixes #25577