### PR TITLE
Fix wrong key reported in foreign key constraint error message

### DIFF
--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -743,9 +743,12 @@ void DataTable::VerifyForeignKeyConstraint(optional_ptr<LocalTableStorage> stora
 		if (!global_conflicts && !local_conflicts) {
 			conflict = 0;
 		} else if (!global_conflicts && local_conflicts) {
-			conflict = local_conflict_manager.GetFirstInvalidIndex(count);
+			// The validity array records which rows were found, so we need
+			// to negate: the first row without a hit is the first missing
+			// one, which is the row the error message should report.
+			conflict = local_conflict_manager.GetFirstInvalidIndex(count, true);
 		} else if (global_conflicts && !local_conflicts) {
-			conflict = global_conflict_manager.GetFirstInvalidIndex(count);
+			conflict = global_conflict_manager.GetFirstInvalidIndex(count, true);
 		} else {
 			auto &global_validity = global_conflict_manager.GetFirstValidity();
 			auto &local_validity = local_conflict_manager.GetFirstValidity();

--- a/test/sql/constraints/foreignkey/fk_error_message_key.test
+++ b/test/sql/constraints/foreignkey/fk_error_message_key.test
@@ -1,0 +1,42 @@
+# name: test/sql/constraints/foreignkey/fk_error_message_key.test
+# description: Issue #25588: the foreign key constraint error message must report the key of the first missing row, not the key of an earlier row that exists only in the transaction-local index of the referenced table.
+# group: [foreignkey]
+
+statement ok
+CREATE TABLE fk_local_p(id INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE fk_local_c(pid INT, FOREIGN KEY (pid) REFERENCES fk_local_p(id));
+
+# the parent keys are inserted in the same transaction, so they only exist
+# in the transaction-local index; the reported key must still be the
+# missing one (30), not the first row of the insert (10)
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+INSERT INTO fk_local_p VALUES (10), (20);
+
+statement error
+INSERT INTO fk_local_c VALUES (10), (20), (30);
+----
+<REGEX>:Violates foreign key constraint because key "id: 30" does not exist in the referenced table.*
+
+statement ok
+ROLLBACK;
+
+# the parent table is empty again, so the first missing key is 10
+statement error
+INSERT INTO fk_local_c VALUES (10), (20), (30);
+----
+<REGEX>:Violates foreign key constraint because key "id: 10" does not exist in the referenced table.*
+
+# parent keys committed in an earlier transaction: missing key 30 is
+# reported correctly
+statement ok
+INSERT INTO fk_local_p VALUES (10), (20);
+
+statement error
+INSERT INTO fk_local_c VALUES (10), (20), (30);
+----
+<REGEX>:Violates foreign key constraint because key "id: 30" does not exist in the referenced table.*


### PR DESCRIPTION
Fixes #25588

When the referenced parent keys are inserted in the same transaction, the constraint error reports the key of the first row of the insert instead of the key that is actually missing. On current master:

```sql
CREATE TABLE fk_local_p(id INT PRIMARY KEY);
CREATE TABLE fk_local_c(pid INT, FOREIGN KEY (pid) REFERENCES fk_local_p(id));
BEGIN;
INSERT INTO fk_local_p VALUES (10), (20);
INSERT INTO fk_local_c VALUES (10), (20), (30);
-- Violates foreign key constraint because key "id: 10" does not exist ...  <- 30 is the missing one
```

The cause is in the append-FK error handling in `DataTable::VerifyForeignKeyConstraint` (`data_table.cpp`): the validity array of the `ConflictManager` records which rows were *found*, so the "local hits, global misses" branch needs the first row *without* a hit. The call there was `GetFirstInvalidIndex(count)`, which with the default `negate = false` returns the first row that *was* found — exactly backwards for this purpose. `FirstMissingMatch`, used by the no-local-verification path, already passes `negate = true`; this branch just missed it. The same one-word fix applies to the mirrored `global_conflicts && !local_conflicts` branch.

Verified locally by rebuilding the CLI and re-running the reproduction (now reports `"id: 30"`), plus the committed-parents case, the single-row case, the delete-side FK check, and a normal insert (all unchanged). `test/sql/constraints/foreignkey/fk_error_message_key.test` covers all of these.
