### PR TITLE
Fix overflow from reassociating integer +/*

### DIFF
--- a/src/include/duckdb/optimizer/rule/constant_order_normalization.hpp
+++ b/src/include/duckdb/optimizer/rule/constant_order_normalization.hpp
@@ -13,8 +13,9 @@
 namespace duckdb {
 
 // Group constant expression parameters together in commutative arithmetic expressions to expose
-// constant folding opportunities. After folding collapses multiplication constants into a single
-// value, keep that constant on the right to match the canonical binary operator shape.
+// constant folding opportunities, but only when reassociation cannot introduce integer overflow.
+// After folding collapses multiplication constants into a single value, keep that constant on the
+// right to match the canonical binary operator shape.
 class ConstantOrderNormalizationRule : public Rule {
 public:
 	explicit ConstantOrderNormalizationRule(ExpressionRewriter &rewriter);

--- a/src/optimizer/rule/constant_order_normalization.cpp
+++ b/src/optimizer/rule/constant_order_normalization.cpp
@@ -1,13 +1,66 @@
 #include "duckdb/optimizer/rule/constant_order_normalization.hpp"
 
-#include "duckdb/optimizer/expression_rewriter.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/optimizer/expression_rewriter.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
 
 namespace duckdb {
 
 static bool MultiplicationConstantBelongsAtEnd(const BoundFunctionExpression &expr) {
 	return expr.Function().GetName() == "*";
+}
+
+// Integer +/* are not associative once overflow is an error. Only pull constants together when
+// folding them cannot change overflow of the remaining (non-constant) operands.
+static bool ConstantsSafeToReassociate(ClientContext &context, const BoundFunctionExpression &root,
+                                       const vector<reference<Expression>> &constants) {
+	const bool is_multiply = MultiplicationConstantBelongsAtEnd(root);
+	const bool check_sign = root.GetReturnType().IsSigned();
+
+	int8_t sign = 0;
+	unique_ptr<Expression> folded;
+	FunctionBinder binder(context);
+	ErrorData error;
+	for (auto &binding : constants) {
+		Value value;
+		if (!ExpressionExecutor::TryEvaluateScalar(context, binding.get(), value)) {
+			return false;
+		}
+		if (!value.IsNull() && check_sign) {
+			const auto integral = IntegralValue::Get(value);
+			if (is_multiply && integral < 0) {
+				return false;
+			}
+			if (integral != 0) {
+				const int8_t value_sign = integral > 0 ? 1 : -1;
+				if (sign != 0 && sign != value_sign) {
+					return false;
+				}
+				sign = value_sign;
+			}
+		}
+		auto constant_expr = make_uniq<BoundConstantExpression>(std::move(value));
+		if (!folded) {
+			folded = std::move(constant_expr);
+			continue;
+		}
+		vector<unique_ptr<Expression>> children;
+		children.push_back(std::move(folded));
+		children.push_back(std::move(constant_expr));
+		folded = binder.BindScalarFunction(Identifier::DefaultSchema(), root.Function().GetName(), std::move(children),
+		                                   error, root.IsOperator());
+		if (!folded) {
+			return false;
+		}
+		Value folded_value;
+		if (!ExpressionExecutor::TryEvaluateScalar(context, *folded, folded_value)) {
+			return false;
+		}
+		folded = make_uniq<BoundConstantExpression>(std::move(folded_value));
+	}
+	return true;
 }
 
 class RecursiveFunctionExpressionMatcher : public ExpressionMatcher {
@@ -50,7 +103,7 @@ private:
 };
 
 ConstantOrderNormalizationRule::ConstantOrderNormalizationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
-	// '+' and '*' satisfy commutative law and associative law.
+	// '+' and '*' are commutative; association is only valid when overflow cannot change.
 	auto add_matcher = make_uniq<FunctionExpressionMatcher>();
 	add_matcher->function = make_uniq<SpecificFunctionMatcher>("+");
 	add_matcher->type = make_uniq<IntegerTypeMatcher>();
@@ -100,6 +153,16 @@ unique_ptr<Expression> ConstantOrderNormalizationRule::Apply(LogicalOperator &op
 	}
 
 	if (ordered_bindings.empty()) {
+		return nullptr;
+	}
+
+	// Swapping a single multiply is commutative. Pulling constants across multiple non-constants
+	// changes association, e.g. (a + 1) + (b + 2) => (3 + a) + b, which can overflow.
+	if (remain_bindings.size() > 1) {
+		return nullptr;
+	}
+
+	if (ordered_bindings.size() > 1 && !ConstantsSafeToReassociate(rewriter.context, root, ordered_bindings)) {
 		return nullptr;
 	}
 

--- a/test/optimizer/constant_order_normalization.test
+++ b/test/optimizer/constant_order_normalization.test
@@ -42,19 +42,12 @@ query I nosort mult_test
 EXPLAIN SELECT 2 * col0  FROM test
 ----
 
-# addition mixed multiplication
-query I nosort add_mult
-EXPLAIN SELECT col0 * 1 * 2 + col1 + 1 + 2 FROM test
+# mixed * and +: multiply constants still fold, but addends are not pulled across
+# multiple non-constants (that reassociation can overflow)
+query I nosort add_mult_mul
+EXPLAIN SELECT col0 * 1 * 2 + col1 FROM test
 ----
 
-query I nosort add_mult
-EXPLAIN SELECT 1 * col0 * 2 + 1 + col1 + 2 FROM test
-----
-
-query I nosort add_mult
-EXPLAIN SELECT 1 * 2 * col0 + 1 + 2 + col1 FROM test
-----
-
-query I nosort add_mult
-EXPLAIN SELECT 3 + 2 * col0 + col1 FROM test
+query I nosort add_mult_mul
+EXPLAIN SELECT 2 * col0 + col1 FROM test
 ----

--- a/test/sql/optimizer/expression/test_constant_order_overflow.test
+++ b/test/sql/optimizer/expression/test_constant_order_overflow.test
@@ -1,0 +1,37 @@
+# name: test/sql/optimizer/expression/test_constant_order_overflow.test
+# description: Constant order normalization must not introduce integer overflow
+# group: [expression]
+
+statement ok
+CREATE TABLE t(a INTEGER, b INTEGER);
+
+statement ok
+INSERT INTO t VALUES (2147483645, -2);
+
+query I
+SELECT (a + 1) + (b + 2) FROM t;
+----
+2147483646
+
+statement ok
+SET disabled_optimizers = 'expression_rewriter';
+
+query I
+SELECT (a + 1) + (b + 2) FROM t;
+----
+2147483646
+
+statement ok
+SET disabled_optimizers = '';
+
+# mixed-sign constants: written order overflows, folding them first would not
+statement error
+SELECT x + 2147483647 + (-1) FROM (VALUES (1)) v(x);
+----
+Overflow
+
+# same-sign constants next to a single column are still folded
+query I
+SELECT x + 1 + 2 FROM (VALUES (10)) v(x);
+----
+13


### PR DESCRIPTION
Fixes #25532.

`(a + 1) + (b + 2)` was getting rewritten to `(3 + a) + b`. Fine in math class, not so much when overflow is an error.

Only pull constants together when there's a single non-constant and folding them can't change overflow (same sign, the combined constant still fits).