### PR TITLE
Fix async readahead deadlock in parquet multi file scan

### DIFF
--- a/src/include/duckdb/parallel/scan_read_ahead.hpp
+++ b/src/include/duckdb/parallel/scan_read_ahead.hpp
@@ -157,7 +157,7 @@ public:
 	void ScheduleFileOpen(std::function<void()> open_fn);
 	//! Whether another file-open may be scheduled without exceeding the open-ahead window
 	bool CanScheduleOpen() const;
-	//! Run one queued async task inline, returns false when none is queued
+	//! Run one queued async task inline, throwing any recorded async error; returns false when none is queued
 	bool TryRunPendingTask();
 
 private:

--- a/src/parallel/scan_read_ahead.cpp
+++ b/src/parallel/scan_read_ahead.cpp
@@ -300,11 +300,13 @@ bool ScanReadAhead::CanScheduleOpen() const {
 }
 
 bool ScanReadAhead::TryRunPendingTask() {
+	ThrowIfError();
 	shared_ptr<Task> task;
 	if (!executor->GetTask(task)) {
 		return false;
 	}
 	task->Execute(TaskExecutionMode::PROCESS_ALL);
+	ThrowIfError();
 	return true;
 }
 

--- a/test/api/test_read_ahead_progress.cpp
+++ b/test/api/test_read_ahead_progress.cpp
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include "duckdb/parallel/scan_read_ahead.hpp"
 #include "test_helpers.hpp"
 
 using namespace duckdb;
@@ -43,4 +44,13 @@ TEST_CASE("Read-ahead progress only counts the assignments a thread is decoding"
 	REQUIRE(percentage > 0);
 	REQUIRE(percentage < 5);
 	stream.reset();
+}
+
+TEST_CASE("Read-ahead inline task draining surfaces async errors", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	ScanReadAhead read_ahead(*con.context, 1, nullptr);
+	read_ahead.PushError(ErrorData("injected read-ahead error"));
+	REQUIRE_THROWS(read_ahead.TryRunPendingTask());
 }


### PR DESCRIPTION
### Root cause

An async read-ahead I/O task can fail[[1](https://github.com/duckdb/duckdb/actions/runs/34548620845/job/103153591832#step:7:154), [2](https://github.com/duckdb/duckdb/actions/runs/34548620845/job/103153591832#step:7:303), [3](https://github.com/duckdb/duckdb/actions/runs/34548620845/job/103153591835#step:7:120), [4](https://github.com/duckdb/duckdb/actions/runs/34548620845/job/103153591835#step:7:205), [5](https://github.com/duckdb/duckdb/actions/runs/34548620845/job/103153591816#step:7:17)] with OOM while file-open tasks remain queued on the same `TaskExecutor`.

Once the executor contains an error, `BaseExecutorTask::Execute()` skips queued tasks. A skipped `FileOpenTask` therefore never runs its callback, leaving the corresponding reader permanently in `MultiFileFileState::OPENING`.

`WaitForAsyncOpen()` continued polling that state without checking the executor error. With no runnable async work remaining, scan threads yielded forever.

### Sample trace

A local stress run reproduced the hang. The main thread and a worker were both spinning while claiming the next read-ahead job:

```text
MultiFileFunction<ParquetMultiFileInfo>::ClaimNextJobInternal
  ScanReadAhead::TryRunPendingTask
  TaskScheduler::YieldThread
```

Meanwhile, all async scheduler threads were idle:

```text
TaskScheduler::ExecuteForever
  semaphore_wait_trap
```

This confirms that the scan was waiting for a file-open callback that had already been cancelled.

### Fix

`ScanReadAhead::TryRunPendingTask()` now propagates recorded executor errors:

```cpp
ThrowIfError();
if (!executor->GetTask(task)) {
    return false;
}
task->Execute(TaskExecutionMode::PROCESS_ALL);
ThrowIfError();
```

Checking both before and after inline execution ensures that:

- an existing I/O error aborts the wait before cancelled file-open work is dequeued;
- an error raised by the task being executed is surfaced immediately.