### PR TITLE
Fix spilled temp block file report

### DIFF
--- a/src/storage/standard_buffer_manager.cpp
+++ b/src/storage/standard_buffer_manager.cpp
@@ -734,13 +734,14 @@ vector<TemporaryFileInformation> StandardBufferManager::GetTemporaryFiles() {
 		}
 
 		// Another process or thread can delete the file before we can get its file size.
-		auto handle = fs.OpenFile(name, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+		auto path = fs.JoinPath(temporary_directory.path, name);
+		auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
 		if (!handle) {
 			return;
 		}
 
 		TemporaryFileInformation info;
-		info.path = name;
+		info.path = std::move(path);
 		info.size = NumericCast<idx_t>(fs.GetFileSize(*handle));
 		handle.reset();
 		result.push_back(info);

--- a/test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow
+++ b/test/sql/outofcore/block_file_evicted_bytes_accounting.test_slow
@@ -65,19 +65,19 @@ SELECT count(*) > 0 FROM glob('{TEST_DIR}/tmp_acct/*.block');
 ----
 true
 
-# Core invariant: with .block files on disk for OVERFLOW_STRINGS data, the per-tag
-# counter must be > 0. The buffer manager performs intra-INSERT read-backs of evicted
-# overflow strings, so this single assertion is sufficient to catch the double-decrement
-# bug — it failed before the fix at standard_buffer_manager.cpp:569 was removed.
+query I
+SELECT count(*) > 0 FROM duckdb_temporary_files() WHERE path LIKE '%.block';
+----
+true
+
 query I
 SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'OVERFLOW_STRINGS';
 ----
 true
 
-# Combined sanity: both signals must agree — files on disk implies tracked bytes.
 query II
 SELECT
-    (SELECT count(*) > 0 FROM glob('{TEST_DIR}/tmp_acct/*.block'))                                AS block_files_exist,
-    (SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'OVERFLOW_STRINGS')      AS bytes_tracked;
+    (SELECT count(*) > 0 FROM glob('{TEST_DIR}/tmp_acct/*.block')) AS block_files_exist,
+    (SELECT temporary_storage_bytes > 0 FROM duckdb_memory() WHERE tag = 'OVERFLOW_STRINGS') AS bytes_tracked;
 ----
 true	true


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25604

The root cause is, `LocalFileSystem::ListFiles` pass filename, instead of filepath, to the callback, so the open file handle [here](https://github.com/duckdb/duckdb/blob/88902aaa3972216c928c8e79a89217a413be414c/src/storage/standard_buffer_manager.cpp#L736-L737) cannot really locate the block file.
The process doesn't crash because non-existent files are skipped silently via `FileFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS`.