### PR TITLE
Propagate expression stats for all NULL constant row group

### DIFF
--- a/extension/core_functions/scalar/debug/vector_type.cpp
+++ b/extension/core_functions/scalar/debug/vector_type.cpp
@@ -19,6 +19,7 @@ ScalarFunction VectorTypeFun::GetFunction() {
 	                                      LogicalType::VARCHAR, // return type
 	                                      VectorTypeFunction);
 	vector_type_fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	vector_type_fun.SetStability(FunctionStability::VOLATILE);
 	return vector_type_fun;
 }
 

--- a/src/optimizer/statistics/expression/propagate_function.cpp
+++ b/src/optimizer/statistics/expression/propagate_function.cpp
@@ -40,6 +40,10 @@ bool CanInferConstantFromNumericBounds(const Value &value) {
 }
 
 bool TryInferConstantBounds(const BaseStatistics &stats, Value &constant) {
+	if (stats.CanHaveNull() && !stats.CanHaveNoNull()) {
+		constant = Value(stats.GetType());
+		return true;
+	}
 	if (stats.CanHaveNull()) {
 		return false;
 	}

--- a/test/sql/copy/parquet/parquet_expression_filter_pruning.test
+++ b/test/sql/copy/parquet/parquet_expression_filter_pruning.test
@@ -232,7 +232,7 @@ EXPLAIN ANALYZE SELECT count(*)
 FROM '{TEST_DIR}/expr_prune_prefix_corner.parquet'
 WHERE prefix(s, '') OR prefix(s, 'zz')
 ----
-analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 4 / 4.*
+analyzed_plan	<REGEX>:(?s).*Row Groups Scanned: 3 / 4.*
 
 query I
 SELECT count(*)

--- a/test/sql/optimizer/constant_function_zonemap_pruning.test
+++ b/test/sql/optimizer/constant_function_zonemap_pruning.test
@@ -70,7 +70,7 @@ SELECT CASE WHEN i < 2048 THEN NULL WHEN i < 4096 THEN 'alpha'
             WHEN i < 6144 THEN 'beta' ELSE 'abcdefghijkl' || (i % 2)::VARCHAR END AS s
 FROM range(8192) t(i);
 
-# RGs 1 and 4 remain unknown; regexp_matches also exercises direct BOOLEAN pruning.
+# RG 4 remains unknown; regexp_matches also exercises direct BOOLEAN pruning.
 foreach predicate hash(s)=hash('beta') reverse(s)='ateb' regexp_matches(s,'(t|z)')
 
 query I
@@ -81,7 +81,7 @@ SELECT count(*) FROM const_db.constant_strings WHERE {predicate};
 query II
 EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE {predicate};
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 3 / 4.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
 
 endloop
 
@@ -127,7 +127,7 @@ SELECT count(*) FROM const_db.constant_strings WHERE reverse(s) = '0lkjihgfedcba
 query II
 EXPLAIN ANALYZE SELECT s FROM const_db.constant_strings WHERE reverse(s) = '0lkjihgfedcba';
 ----
-analyzed_plan	<REGEX>:.*Row Groups Scanned: 2 / 4.*
+analyzed_plan	<REGEX>:.*Row Groups Scanned: 1 / 4.*
 
 # Equal intervals can have different month/day components.
 statement ok


### PR DESCRIPTION
Followup PR for https://github.com/duckdb/duckdb/pull/25591 to propagate expression stats for row group with all NULL values -- previously unimplemented due to a pre-dating bug for NULL stats propagation.