### PR TITLE
Add sql tokenizer to C API

### DIFF
--- a/api_spec/v2/tokenizer/tokenizer.yaml
+++ b/api_spec/v2/tokenizer/tokenizer.yaml
@@ -55,7 +55,8 @@ functions:
 
       Lexical tokenization, in the context of whatever grammar extensions are loaded on the given connection. Closing
       the connection or changing settings afterwards does not affect the tokens. The SQL string is borrowed for the call
-      only, the caller may free it once this call returns. Whitespace is not a token. Malformed input is not an error.
+      only, the caller may free it once this call returns. Whitespace is not a token. Malformed input is not an error;
+      `[[token_iterator_ends_unterminated]]` reports whether the input ended inside an open token.
 
       *out_iterator is set to NULL on failure.
     role: constructor
@@ -109,6 +110,35 @@ functions:
         indirection: 1
         kind: OUT
         description: Receives the token's byte length; 0 for END_OF_INPUT.
+      err:
+        type: error_info
+        indirection: 1
+        kind: OUT
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+    return_type: ERROR
+
+  token_iterator_ends_unterminated:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-11" ]
+    description: |
+      Reports whether the input ended before the closing delimiter of its last token.
+
+      True when the input ends inside an open string, quoted identifier, block comment or dollar-quoted string, or in a
+      line comment with no trailing newline; false otherwise, including for empty or whitespace-only input.
+      Equivalently, the last token `[[token_iterator_next]]` yields before TOKEN_TYPE_END_OF_INPUT is the open one, so
+      its class and lexeme say which delimiter is missing. A property of the input, not of the iterator position: the
+      answer is the same before, during and after draining. The only failure is a null argument.
+    role: getter
+    belongs_to: token_iterator
+    parameters:
+      iterator:
+        type: token_iterator
+        description: The iterator.
+      out_ends_unterminated:
+        type: bool
+        indirection: 1
+        kind: OUT
+        description: Receives whether the input ended inside an open token.
       err:
         type: error_info
         indirection: 1

--- a/api_spec/v2/tokenizer/tokenizer.yaml
+++ b/api_spec/v2/tokenizer/tokenizer.yaml
@@ -1,0 +1,131 @@
+module: tokenizer
+#
+# Lexical tokenization of SQL text, in the context of whatever grammar extensions are loaded on the given connection.
+# The connection is not used for anything else and `[[token_iterator]]` can outlive the connection. Offsets are byte
+# offsets into the input exactly as given, the input is not normalized or validated.
+#
+# The iterator yields one token per `[[token_iterator_next]]` call and reports the end of input as a
+# TOKEN_TYPE_END_OF_INPUT token (and will repeat it for any subsequent call).
+
+handles:
+  token_iterator:
+    description: |
+      An opaque, owned handle to an iterator over the tokens of a SQL string, produced by tokenize_sql.
+    cleanup_with: token_iterator_destroy
+
+enums:
+  TOKEN_TYPE:
+    description: |
+      The lexical class of a token.
+    values:
+      TOKEN_TYPE_INVALID:
+        value: 0
+        description: "Not an actual token class; out_type is set to this when `[[token_iterator_next]]` fails."
+      TOKEN_TYPE_KEYWORD:
+        value: 1
+        description: "A keyword of the connection's grammar."
+      TOKEN_TYPE_IDENTIFIER:
+        value: 2
+        description: "A bare or double-quoted identifier, quotes included."
+      TOKEN_TYPE_STRING_LITERAL:
+        value: 3
+        description: "A quoted or dollar-quoted string, delimiters included."
+      TOKEN_TYPE_NUMBER_LITERAL:
+        value: 4
+        description: "A numeric literal."
+      TOKEN_TYPE_OPERATOR:
+        value: 5
+        description: "An operator or punctuation run other than the statement terminator."
+      TOKEN_TYPE_COMMENT:
+        value: 6
+        description: "A line or block comment, delimiters included."
+      TOKEN_TYPE_TERMINATOR:
+        value: 7
+        description: "A statement-terminating semicolon."
+      TOKEN_TYPE_END_OF_INPUT:
+        value: 8
+        description: "Not a token; reported by token_iterator_next once the input is exhausted, with start equal to the input length and length 0."
+
+functions:
+  tokenize_sql:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-11" ]
+    description: |
+      Tokenizes a SQL string into an iterator over its tokens.
+
+      Lexical tokenization, in the context of whatever grammar extensions are loaded on the given connection. Closing
+      the connection or changing settings afterwards does not affect the tokens. The SQL string is borrowed for the call
+      only, the caller may free it once this call returns. Whitespace is not a token. Malformed input is not an error.
+
+      *out_iterator is set to NULL on failure.
+    role: constructor
+    belongs_to: token_iterator
+    parameters:
+      conn:
+        type: connection
+        description: The connection supplying the grammar.
+      sql:
+        type: str
+        description: The SQL text. Borrowed for the call only; may contain interior null bytes. {NULL, 0} is the empty input.
+      out_iterator:
+        type: token_iterator
+        indirection: 1
+        kind: OUT
+        description: Receives the new iterator handle. Destroy via token_iterator_destroy.
+      err:
+        type: error_info
+        indirection: 1
+        kind: OUT
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+    return_type: ERROR
+
+  token_iterator_next:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-11" ]
+    description: |
+      Yields the next token, or END_OF_INPUT once exhausted.
+
+      On success writes the token's class, byte offset and byte length into the out-parameters. The lexeme is the input
+      bytes [start, start + length). Once the input is exhausted, every call gives TOKEN_TYPE_END_OF_INPUT with start
+      equal to the input length and length 0. On failure out params are set to TOKEN_TYPE_INVALID, 0, 0.
+    role: method
+    belongs_to: token_iterator
+    parameters:
+      iterator:
+        type: token_iterator
+        description: The iterator to advance.
+      out_type:
+        type: TOKEN_TYPE
+        indirection: 1
+        kind: OUT
+        description: Receives the token's class, or TOKEN_TYPE_END_OF_INPUT once exhausted.
+      out_start:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the token's byte offset into the input; the input length for END_OF_INPUT.
+      out_length:
+        type: idx
+        indirection: 1
+        kind: OUT
+        description: Receives the token's byte length; 0 for END_OF_INPUT.
+      err:
+        type: error_info
+        indirection: 1
+        kind: OUT
+        description: Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+    return_type: ERROR
+
+  token_iterator_destroy:
+    lifecycle:
+      - [ "stable", "v2.0.0", "2026-09-11" ]
+    description: |
+      Destroys a token iterator handle.
+    role: destructor
+    belongs_to: token_iterator
+    parameters:
+      iterator:
+        type: token_iterator
+        indirection: 1
+        description: The iterator to destroy.
+    return_type: ERROR

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -1245,6 +1245,8 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_projection_pushdown)
 	(duckdb_v2_table_function_handle function, bool enable, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR (*duckdb_v2_token_iterator_destroy)(duckdb_v2_token_iterator_handle *iterator);
+	DUCKDB_V2_ERROR(*duckdb_v2_token_iterator_ends_unterminated)
+	(duckdb_v2_token_iterator_handle iterator, bool *out_ends_unterminated, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_token_iterator_next)
 	(duckdb_v2_token_iterator_handle iterator, DUCKDB_V2_TOKEN_TYPE *out_type, idx_t *out_start, idx_t *out_length,
 	 duckdb_v2_error_info_handle *err);
@@ -1804,6 +1806,7 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	    duckdb_v2_table_function_set_filter_pushdown_callback;
 	result.duckdb_v2_table_function_set_projection_pushdown = duckdb_v2_table_function_set_projection_pushdown;
 	result.duckdb_v2_token_iterator_destroy = duckdb_v2_token_iterator_destroy;
+	result.duckdb_v2_token_iterator_ends_unterminated = duckdb_v2_token_iterator_ends_unterminated;
 	result.duckdb_v2_token_iterator_next = duckdb_v2_token_iterator_next;
 	result.duckdb_v2_tokenize_sql = duckdb_v2_tokenize_sql;
 	return result;

--- a/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
+++ b/src/include/duckdb/main/capi_v2/extension_api_v2.hpp
@@ -1244,6 +1244,13 @@ typedef struct {
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_projection_pushdown)
 	(duckdb_v2_table_function_handle function, bool enable, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_token_iterator_destroy)(duckdb_v2_token_iterator_handle *iterator);
+	DUCKDB_V2_ERROR(*duckdb_v2_token_iterator_next)
+	(duckdb_v2_token_iterator_handle iterator, DUCKDB_V2_TOKEN_TYPE *out_type, idx_t *out_start, idx_t *out_length,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_tokenize_sql)
+	(duckdb_v2_connection_handle conn, duckdb_v2_str sql, duckdb_v2_token_iterator_handle *out_iterator,
+	 duckdb_v2_error_info_handle *err);
 } duckdb_ext_api_v2;
 
 //===--------------------------------------------------------------------===//
@@ -1796,6 +1803,9 @@ inline duckdb_ext_api_v2 CreateAPIv2(void) {
 	result.duckdb_v2_table_function_set_filter_pushdown_callback =
 	    duckdb_v2_table_function_set_filter_pushdown_callback;
 	result.duckdb_v2_table_function_set_projection_pushdown = duckdb_v2_table_function_set_projection_pushdown;
+	result.duckdb_v2_token_iterator_destroy = duckdb_v2_token_iterator_destroy;
+	result.duckdb_v2_token_iterator_next = duckdb_v2_token_iterator_next;
+	result.duckdb_v2_tokenize_sql = duckdb_v2_tokenize_sql;
 	return result;
 }
 

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1310,6 +1310,8 @@ typedef struct {
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_projection_pushdown)
 	(duckdb_v2_table_function_handle function, bool enable, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR (*duckdb_v2_token_iterator_destroy)(duckdb_v2_token_iterator_handle *iterator);
+	DUCKDB_V2_ERROR(*duckdb_v2_token_iterator_ends_unterminated)
+	(duckdb_v2_token_iterator_handle iterator, bool *out_ends_unterminated, duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_token_iterator_next)
 	(duckdb_v2_token_iterator_handle iterator, DUCKDB_V2_TOKEN_TYPE *out_type, idx_t *out_start, idx_t *out_length,
 	 duckdb_v2_error_info_handle *err);
@@ -1913,6 +1915,7 @@ typedef struct {
 	duckdb_ext_api.duckdb_v2_table_function_set_filter_pushdown_callback
 #define duckdb_v2_table_function_set_projection_pushdown duckdb_ext_api.duckdb_v2_table_function_set_projection_pushdown
 #define duckdb_v2_token_iterator_destroy                 duckdb_ext_api.duckdb_v2_token_iterator_destroy
+#define duckdb_v2_token_iterator_ends_unterminated       duckdb_ext_api.duckdb_v2_token_iterator_ends_unterminated
 #define duckdb_v2_token_iterator_next                    duckdb_ext_api.duckdb_v2_token_iterator_next
 #define duckdb_v2_tokenize_sql                           duckdb_ext_api.duckdb_v2_tokenize_sql
 // capigen:end appended

--- a/src/include/duckdb_extension_v2.h
+++ b/src/include/duckdb_extension_v2.h
@@ -1309,6 +1309,13 @@ typedef struct {
 	 duckdb_v2_error_info_handle *err);
 	DUCKDB_V2_ERROR(*duckdb_v2_table_function_set_projection_pushdown)
 	(duckdb_v2_table_function_handle function, bool enable, duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR (*duckdb_v2_token_iterator_destroy)(duckdb_v2_token_iterator_handle *iterator);
+	DUCKDB_V2_ERROR(*duckdb_v2_token_iterator_next)
+	(duckdb_v2_token_iterator_handle iterator, DUCKDB_V2_TOKEN_TYPE *out_type, idx_t *out_start, idx_t *out_length,
+	 duckdb_v2_error_info_handle *err);
+	DUCKDB_V2_ERROR(*duckdb_v2_tokenize_sql)
+	(duckdb_v2_connection_handle conn, duckdb_v2_str sql, duckdb_v2_token_iterator_handle *out_iterator,
+	 duckdb_v2_error_info_handle *err);
 	// capigen:end appended
 } duckdb_ext_api_v2;
 
@@ -1905,6 +1912,9 @@ typedef struct {
 #define duckdb_v2_table_function_set_filter_pushdown_callback                                                          \
 	duckdb_ext_api.duckdb_v2_table_function_set_filter_pushdown_callback
 #define duckdb_v2_table_function_set_projection_pushdown duckdb_ext_api.duckdb_v2_table_function_set_projection_pushdown
+#define duckdb_v2_token_iterator_destroy                 duckdb_ext_api.duckdb_v2_token_iterator_destroy
+#define duckdb_v2_token_iterator_next                    duckdb_ext_api.duckdb_v2_token_iterator_next
+#define duckdb_v2_tokenize_sql                           duckdb_ext_api.duckdb_v2_tokenize_sql
 // capigen:end appended
 #endif // DUCKDB_BUILD_STATIC_EXTENSION
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -3252,6 +3252,117 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_schema_destroy(duckdb_v2_schema_handle *s
 /* --- Struct definitions for schema --- */
 
 /* ============================================================================
+ * MODULE: tokenizer
+ * ============================================================================ */
+
+/* --- Enums for tokenizer --- */
+
+//! The lexical class of a token.
+typedef enum DUCKDB_V2_TOKEN_TYPE {
+	//! Not an actual token class; out_type is set to this when `duckdb_v2_token_iterator_next()` fails.
+	DUCKDB_V2_TOKEN_TYPE_INVALID = 0,
+
+	//! A keyword of the connection's grammar.
+	DUCKDB_V2_TOKEN_TYPE_KEYWORD = 1,
+
+	//! A bare or double-quoted identifier, quotes included.
+	DUCKDB_V2_TOKEN_TYPE_IDENTIFIER = 2,
+
+	//! A quoted or dollar-quoted string, delimiters included.
+	DUCKDB_V2_TOKEN_TYPE_STRING_LITERAL = 3,
+
+	//! A numeric literal.
+	DUCKDB_V2_TOKEN_TYPE_NUMBER_LITERAL = 4,
+
+	//! An operator or punctuation run other than the statement terminator.
+	DUCKDB_V2_TOKEN_TYPE_OPERATOR = 5,
+
+	//! A line or block comment, delimiters included.
+	DUCKDB_V2_TOKEN_TYPE_COMMENT = 6,
+
+	//! A statement-terminating semicolon.
+	DUCKDB_V2_TOKEN_TYPE_TERMINATOR = 7,
+
+	/*!
+	 * Not a token; reported by token_iterator_next once the input is exhausted, with start equal to the input length
+	 * and length 0.
+	 */
+	DUCKDB_V2_TOKEN_TYPE_END_OF_INPUT = 8,
+	DUCKDB_V2_TOKEN_TYPE_MAX_ENUM = 0x7FFFFFFF,
+} DUCKDB_V2_TOKEN_TYPE;
+
+/* --- Struct forward declarations for tokenizer --- */
+
+/* --- Types for tokenizer --- */
+
+//! An opaque, owned handle to an iterator over the tokens of a SQL string, produced by tokenize_sql.
+typedef struct _duckdb_v2_token_iterator {
+	void *internal_ptr;
+} * duckdb_v2_token_iterator_handle;
+
+/* --- Constants for tokenizer --- */
+
+/* --- Function pointer typedefs for tokenizer --- */
+
+/* --- Functions for tokenizer --- */
+
+/*!
+ * Tokenizes a SQL string into an iterator over its tokens.
+ *
+ * Lexical tokenization, in the context of whatever grammar extensions are loaded on the given connection. Closing the
+ * connection or changing settings afterwards does not affect the tokens. The SQL string is borrowed for the call only,
+ * the caller may free it once this call returns. Whitespace is not a token. Malformed input is not an error.
+ *
+ * *out_iterator is set to NULL on failure.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param conn The connection supplying the grammar.
+ * @param sql The SQL text. Borrowed for the call only; may contain interior null bytes. {NULL, 0} is the empty input.
+ * @param out_iterator Receives the new iterator handle. Destroy via token_iterator_destroy.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_tokenize_sql(duckdb_v2_connection_handle conn, duckdb_v2_str sql,
+                                                    duckdb_v2_token_iterator_handle *out_iterator,
+                                                    duckdb_v2_error_info_handle *err);
+
+/*!
+ * Yields the next token, or END_OF_INPUT once exhausted.
+ *
+ * On success writes the token's class, byte offset and byte length into the out-parameters. The lexeme is the input
+ * bytes [start, start + length). Once the input is exhausted, every call gives TOKEN_TYPE_END_OF_INPUT with start equal
+ * to the input length and length 0. On failure out params are set to TOKEN_TYPE_INVALID, 0, 0.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param iterator The iterator to advance.
+ * @param out_type Receives the token's class, or TOKEN_TYPE_END_OF_INPUT once exhausted.
+ * @param out_start Receives the token's byte offset into the input; the input length for END_OF_INPUT.
+ * @param out_length Receives the token's byte length; 0 for END_OF_INPUT.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_token_iterator_next(duckdb_v2_token_iterator_handle iterator,
+                                                           DUCKDB_V2_TOKEN_TYPE *out_type, idx_t *out_start,
+                                                           idx_t *out_length, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Destroys a token iterator handle.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param iterator The iterator to destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_token_iterator_destroy(duckdb_v2_token_iterator_handle *iterator);
+
+/* --- Struct definitions for tokenizer --- */
+
+/* ============================================================================
  * MODULE: vector
  * ============================================================================ */
 

--- a/src/include/duckdb_v2.h
+++ b/src/include/duckdb_v2.h
@@ -3311,7 +3311,8 @@ typedef struct _duckdb_v2_token_iterator {
  *
  * Lexical tokenization, in the context of whatever grammar extensions are loaded on the given connection. Closing the
  * connection or changing settings afterwards does not affect the tokens. The SQL string is borrowed for the call only,
- * the caller may free it once this call returns. Whitespace is not a token. Malformed input is not an error.
+ * the caller may free it once this call returns. Whitespace is not a token. Malformed input is not an error;
+ * `duckdb_v2_token_iterator_ends_unterminated()` reports whether the input ended inside an open token.
  *
  * *out_iterator is set to NULL on failure.
  *
@@ -3348,6 +3349,27 @@ DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_tokenize_sql(duckdb_v2_connection_handle 
 DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_token_iterator_next(duckdb_v2_token_iterator_handle iterator,
                                                            DUCKDB_V2_TOKEN_TYPE *out_type, idx_t *out_start,
                                                            idx_t *out_length, duckdb_v2_error_info_handle *err);
+
+/*!
+ * Reports whether the input ended before the closing delimiter of its last token.
+ *
+ * True when the input ends inside an open string, quoted identifier, block comment or dollar-quoted string, or in a
+ * line comment with no trailing newline; false otherwise, including for empty or whitespace-only input. Equivalently,
+ * the last token `duckdb_v2_token_iterator_next()` yields before TOKEN_TYPE_END_OF_INPUT is the open one, so its class
+ * and lexeme say which delimiter is missing. A property of the input, not of the iterator position: the answer is the
+ * same before, during and after draining. The only failure is a null argument.
+ *
+ * history:
+ * - stable: v2.0.0
+ *
+ * @param iterator The iterator.
+ * @param out_ends_unterminated Receives whether the input ended inside an open token.
+ * @param err Optional. On failure, receives an opaque info handle the caller must destroy via error_info_destroy.
+ * @return DUCKDB_V2_ERROR
+ */
+DUCKDB_C_API DUCKDB_V2_ERROR duckdb_v2_token_iterator_ends_unterminated(duckdb_v2_token_iterator_handle iterator,
+                                                                        bool *out_ends_unterminated,
+                                                                        duckdb_v2_error_info_handle *err);
 
 /*!
  * Destroys a token iterator handle.

--- a/src/main/capi/v2/CMakeLists.txt
+++ b/src/main/capi/v2/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library_unity(
   capi_v2_result.cpp
   capi_v2_schema.cpp
   capi_v2_statement.cpp
+  capi_v2_tokenizer.cpp
   capi_v2_value.cpp
   capi_v2_vector.cpp)
 

--- a/src/main/capi/v2/capi_v2_tokenizer.cpp
+++ b/src/main/capi/v2/capi_v2_tokenizer.cpp
@@ -1,0 +1,123 @@
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+
+#include "duckdb/parser/peg/compiled_grammar.hpp"
+#include "duckdb/parser/peg/tokenizer/highlight_tokenizer.hpp"
+
+namespace duckdb::capiv2 {
+namespace {
+
+struct TokenV2 {
+	DUCKDB_V2_TOKEN_TYPE type;
+	idx_t start;
+	idx_t length;
+};
+
+struct TokenIteratorWrapperV2 {
+	vector<TokenV2> tokens;
+	idx_t input_length = 0;
+	idx_t position = 0;
+};
+
+DUCKDB_V2_TOKEN_TYPE ConvertTokenType(TokenType type) {
+	switch (type) {
+	case TokenType::KEYWORD:
+		return DUCKDB_V2_TOKEN_TYPE_KEYWORD;
+	case TokenType::IDENTIFIER:
+		return DUCKDB_V2_TOKEN_TYPE_IDENTIFIER;
+	case TokenType::STRING_LITERAL:
+		return DUCKDB_V2_TOKEN_TYPE_STRING_LITERAL;
+	case TokenType::NUMBER_LITERAL:
+		return DUCKDB_V2_TOKEN_TYPE_NUMBER_LITERAL;
+	case TokenType::OPERATOR:
+		return DUCKDB_V2_TOKEN_TYPE_OPERATOR;
+	case TokenType::COMMENT:
+		return DUCKDB_V2_TOKEN_TYPE_COMMENT;
+	case TokenType::TERMINATOR:
+		return DUCKDB_V2_TOKEN_TYPE_TERMINATOR;
+	default:
+		// The raw tokenizer only assigns lexical classes; the semantic ones need the matcher pass.
+		throw InternalException("tokenizer emitted token type %d, which is not a lexical class",
+		                        static_cast<int>(type));
+	}
+}
+
+} // namespace
+
+auto Convert(duckdb_v2_token_iterator_handle ptr) -> TokenIteratorWrapperV2 * {
+	return reinterpret_cast<TokenIteratorWrapperV2 *>(ptr);
+}
+auto Convert(TokenIteratorWrapperV2 *ptr) -> duckdb_v2_token_iterator_handle {
+	return reinterpret_cast<duckdb_v2_token_iterator_handle>(ptr);
+}
+
+} // namespace duckdb::capiv2
+
+//----------------------------------------------------------------------------------------------------------------------
+// Public API
+//----------------------------------------------------------------------------------------------------------------------
+
+using namespace duckdb::capiv2;
+
+DUCKDB_V2_ERROR duckdb_v2_tokenize_sql(duckdb_v2_connection_handle conn, duckdb_v2_str sql,
+                                       duckdb_v2_token_iterator_handle *out_iterator,
+                                       duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(out_iterator);
+	*out_iterator = nullptr;
+	DUCKDB_CHECK_ARG(conn);
+	DUCKDB_CHECK_ARG(sql);
+	return WithErrorHandler(err, [&]() {
+		auto *connection = Convert(conn);
+		duckdb::string input(Convert(sql));
+		duckdb::vector<duckdb::MatcherToken> raw_tokens;
+		duckdb::HighlightTokenizerBehavior behavior(input, raw_tokens);
+		auto grammar = duckdb::CompiledGrammar::Get(*connection->context);
+		grammar->GetTokenizer().TokenizeInput(behavior);
+
+		auto wrapper = duckdb::make_uniq<TokenIteratorWrapperV2>();
+		wrapper->input_length = input.size();
+		wrapper->tokens.reserve(raw_tokens.size());
+		for (auto &token : raw_tokens) {
+			if (token.type == duckdb::TokenType::END_OF_INPUT ||
+			    token.type == duckdb::TokenType::END_OF_INPUT_AUTOCOMPLETE) {
+				continue;
+			}
+			wrapper->tokens.push_back({ConvertTokenType(token.type), token.offset, token.length});
+		}
+		*out_iterator = Convert(wrapper.release());
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_token_iterator_next(duckdb_v2_token_iterator_handle iterator, DUCKDB_V2_TOKEN_TYPE *out_type,
+                                              idx_t *out_start, idx_t *out_length, duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(out_type);
+	DUCKDB_CHECK_ARG(out_start);
+	DUCKDB_CHECK_ARG(out_length);
+	*out_type = DUCKDB_V2_TOKEN_TYPE_INVALID;
+	*out_start = 0;
+	*out_length = 0;
+	DUCKDB_CHECK_ARG(iterator);
+	return WithErrorHandler(err, [&]() {
+		auto &wrapper = *Convert(iterator);
+		if (wrapper.position >= wrapper.tokens.size()) {
+			*out_type = DUCKDB_V2_TOKEN_TYPE_END_OF_INPUT;
+			*out_start = wrapper.input_length;
+			return;
+		}
+		auto &token = wrapper.tokens[wrapper.position++];
+		*out_type = token.type;
+		*out_start = token.start;
+		*out_length = token.length;
+	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_token_iterator_destroy(duckdb_v2_token_iterator_handle *iterator) {
+	return WithErrorHandler(nullptr, [&]() {
+		if (!iterator) {
+			return;
+		}
+		if (*iterator) {
+			delete Convert(*iterator);
+			*iterator = nullptr;
+		}
+	});
+}

--- a/src/main/capi/v2/capi_v2_tokenizer.cpp
+++ b/src/main/capi/v2/capi_v2_tokenizer.cpp
@@ -16,6 +16,17 @@ struct TokenIteratorWrapperV2 {
 	vector<TokenV2> tokens;
 	idx_t input_length = 0;
 	idx_t position = 0;
+	bool ends_unterminated = false;
+};
+
+// With this terminator, TokenizeInput returns true exactly on a clean exit; both sentinels are dropped anyway.
+class CleanExitTokenizerBehavior : public HighlightTokenizerBehavior {
+public:
+	using HighlightTokenizerBehavior::HighlightTokenizerBehavior;
+
+	TokenType GetTerminator() const override {
+		return TokenType::END_OF_INPUT_AUTOCOMPLETE;
+	}
 };
 
 DUCKDB_V2_TOKEN_TYPE ConvertTokenType(TokenType type) {
@@ -69,20 +80,25 @@ DUCKDB_V2_ERROR duckdb_v2_tokenize_sql(duckdb_v2_connection_handle conn, duckdb_
 		auto *connection = Convert(conn);
 		duckdb::string input(Convert(sql));
 		duckdb::vector<duckdb::MatcherToken> raw_tokens;
-		duckdb::HighlightTokenizerBehavior behavior(input, raw_tokens);
+		CleanExitTokenizerBehavior behavior(input, raw_tokens);
 		auto grammar = duckdb::CompiledGrammar::Get(*connection->context);
-		grammar->GetTokenizer().TokenizeInput(behavior);
+		const bool clean_exit = grammar->GetTokenizer().TokenizeInput(behavior);
 
 		auto wrapper = duckdb::make_uniq<TokenIteratorWrapperV2>();
 		wrapper->input_length = input.size();
 		wrapper->tokens.reserve(raw_tokens.size());
+		bool last_unterminated = false;
 		for (auto &token : raw_tokens) {
 			if (token.type == duckdb::TokenType::END_OF_INPUT ||
 			    token.type == duckdb::TokenType::END_OF_INPUT_AUTOCOMPLETE) {
 				continue;
 			}
 			wrapper->tokens.push_back({ConvertTokenType(token.type), token.offset, token.length});
+			last_unterminated = token.unterminated;
 		}
+		// A trailing line comment is a dirty exit without the flag; an open string or quoted identifier is a clean
+		// exit with it.
+		wrapper->ends_unterminated = !clean_exit || last_unterminated;
 		*out_iterator = Convert(wrapper.release());
 	});
 }
@@ -108,6 +124,15 @@ DUCKDB_V2_ERROR duckdb_v2_token_iterator_next(duckdb_v2_token_iterator_handle it
 		*out_start = token.start;
 		*out_length = token.length;
 	});
+}
+
+DUCKDB_V2_ERROR duckdb_v2_token_iterator_ends_unterminated(duckdb_v2_token_iterator_handle iterator,
+                                                           bool *out_ends_unterminated,
+                                                           duckdb_v2_error_info_handle *err) {
+	DUCKDB_CHECK_ARG(out_ends_unterminated);
+	*out_ends_unterminated = false;
+	DUCKDB_CHECK_ARG(iterator);
+	return WithErrorHandler(err, [&]() { *out_ends_unterminated = Convert(iterator)->ends_unterminated; });
 }
 
 DUCKDB_V2_ERROR duckdb_v2_token_iterator_destroy(duckdb_v2_token_iterator_handle *iterator) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -369,6 +369,9 @@ vector<SimplifiedToken> Parser::Tokenize(const string &query) {
 	vector<SimplifiedToken> result;
 	result.reserve(tokens.size());
 	for (auto &token : tokens) {
+		if (token.type == TokenType::END_OF_INPUT || token.type == TokenType::END_OF_INPUT_AUTOCOMPLETE) {
+			continue;
+		}
 		SimplifiedToken simplified;
 		simplified.start = token.offset;
 		switch (token.type) {

--- a/test/api/capi/v2/CMakeLists.txt
+++ b/test/api/capi/v2/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library_unity(
   test_capi_v2_scalar_function.cpp
   test_capi_v2_statement.cpp
   test_capi_v2_table_function.cpp
+  test_capi_v2_tokenizer.cpp
   test_capi_v2_static_extension.cpp
   test_capi_v2_value.cpp
   test_capi_v2_vector_write.cpp)

--- a/test/api/capi/v2/test_capi_v2_tokenizer.cpp
+++ b/test/api/capi/v2/test_capi_v2_tokenizer.cpp
@@ -1,0 +1,402 @@
+#include "test_capi_v2.hpp"
+
+#include "duckdb/main/capi_v2/capi_v2_internal.hpp"
+#include "duckdb/parser/grammar_change.hpp"
+#include "duckdb/parser/grammar_extension.hpp"
+
+#include <ostream>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// V2 tokenizer tests: tokenize_sql and the token iterator. Every test pins the
+// exact (type, start, length) triples the engine tokenizer produces, so a
+// tokenizer change is visible here.
+// ---------------------------------------------------------------------------
+
+namespace test_capi_v2 {
+namespace {
+
+struct Tok {
+	DUCKDB_V2_TOKEN_TYPE type;
+	idx_t start;
+	idx_t length;
+
+	bool operator==(const Tok &other) const {
+		return type == other.type && start == other.start && length == other.length;
+	}
+};
+
+std::ostream &operator<<(std::ostream &os, const Tok &tok) {
+	return os << "(" << static_cast<int>(tok.type) << ", " << tok.start << ", " << tok.length << ")";
+}
+
+using Toks = std::vector<Tok>;
+
+constexpr auto KEYWORD = DUCKDB_V2_TOKEN_TYPE_KEYWORD;
+constexpr auto IDENTIFIER = DUCKDB_V2_TOKEN_TYPE_IDENTIFIER;
+constexpr auto STRING = DUCKDB_V2_TOKEN_TYPE_STRING_LITERAL;
+constexpr auto NUMBER = DUCKDB_V2_TOKEN_TYPE_NUMBER_LITERAL;
+constexpr auto OPERATOR = DUCKDB_V2_TOKEN_TYPE_OPERATOR;
+constexpr auto COMMENT = DUCKDB_V2_TOKEN_TYPE_COMMENT;
+constexpr auto TERMINATOR = DUCKDB_V2_TOKEN_TYPE_TERMINATOR;
+constexpr auto END = DUCKDB_V2_TOKEN_TYPE_END_OF_INPUT;
+
+// Sentinels the out-params are primed with, so a test can tell "written" from "left alone".
+constexpr auto STALE_TYPE = static_cast<DUCKDB_V2_TOKEN_TYPE>(99);
+constexpr idx_t STALE_IDX = 0xdead;
+
+// One next() call with primed out-params, asserting success.
+Tok TokNext(duckdb_v2_token_iterator_handle it) {
+	Tok tok {STALE_TYPE, STALE_IDX, STALE_IDX};
+	REQUIRE(duckdb_v2_token_iterator_next(it, &tok.type, &tok.start, &tok.length, nullptr) == DUCKDB_V2_ERROR_NONE);
+	return tok;
+}
+
+// Drains an iterator up to END_OF_INPUT, which is pinned at (len, 0) and not
+// included in the result. Every real token must lie inside the input.
+Toks TokDrain(duckdb_v2_token_iterator_handle it, idx_t len) {
+	Toks out;
+	for (idx_t guard = 0; guard <= len + 1; guard++) {
+		auto tok = TokNext(it);
+		if (tok.type == END) {
+			REQUIRE(tok.start == len);
+			REQUIRE(tok.length == 0);
+			return out;
+		}
+		REQUIRE(tok.start < len);
+		REQUIRE(tok.start + tok.length <= len);
+		out.push_back(tok);
+	}
+	FAIL("iterator yielded more tokens than the input has bytes");
+	return out;
+}
+
+// Tokenize a length-delimited view, drain, destroy.
+Toks TokenizeAll(duckdb_v2_connection_handle conn, duckdb_v2_str sql) {
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(conn, sql, &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(it != nullptr);
+	auto out = TokDrain(it, sql.len);
+	REQUIRE(duckdb_v2_token_iterator_destroy(&it) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(it == nullptr);
+	return out;
+}
+
+Toks TokenizeAll(duckdb_v2_connection_handle conn, const std::string &sql) {
+	return TokenizeAll(conn, Convert(sql));
+}
+
+// A grammar extension that adds one unreserved keyword and nothing else, so a
+// connection selecting it classifies that word differently from the base grammar.
+class TokenizerTestKeywordExtension final : public duckdb::GrammarExtension {
+public:
+	TokenizerTestKeywordExtension() : GrammarExtension("tokenizer_test_keyword", "adds the keyword ANSWER") {
+	}
+	duckdb::vector<duckdb::GrammarChange> GetChanges() const override {
+		duckdb::vector<duckdb::GrammarChange> changes;
+		changes.push_back(duckdb::GrammarChange::AddChoice("UnreservedKeyword", "'ANSWER'"));
+		return changes;
+	}
+};
+
+} // namespace
+
+// ===========================================================================
+// Classification
+// ===========================================================================
+
+TEST_CASE("V2 tokenizer: all seven lexical classes in one statement", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	std::string sql = "SELECT \"my col\", 'it''s', $$d$$, 1e5, a <> b -- c\n/* d */;";
+	REQUIRE(sql.size() == 58);
+	Toks expected {
+	    {KEYWORD, 0, 6},     // SELECT
+	    {IDENTIFIER, 7, 8},  // "my col", quotes included
+	    {OPERATOR, 15, 1},   // ,
+	    {STRING, 17, 7},     // 'it''s', delimiters and doubled quote included
+	    {OPERATOR, 24, 1},   // ,
+	    {STRING, 26, 5},     // $$d$$
+	    {OPERATOR, 31, 1},   // ,
+	    {NUMBER, 33, 3},     // 1e5
+	    {OPERATOR, 36, 1},   // ,
+	    {IDENTIFIER, 38, 1}, // a
+	    {OPERATOR, 40, 2},   // <>
+	    {IDENTIFIER, 43, 1}, // b
+	    {COMMENT, 45, 5},    // -- c\n, the newline is part of a line comment
+	    {COMMENT, 50, 7},    // /* d */
+	    {TERMINATOR, 57, 1}, // ;
+	};
+	REQUIRE(TokenizeAll(fx.conn, sql) == expected);
+}
+
+TEST_CASE("V2 tokenizer: keyword versus identifier follows the grammar", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	// Casing does not matter for keywords; a non-keyword word is an identifier.
+	REQUIRE(TokenizeAll(fx.conn, "select Select foo") == Toks {{KEYWORD, 0, 6}, {KEYWORD, 7, 6}, {IDENTIFIER, 14, 3}});
+	// Quoting a keyword makes it an identifier.
+	REQUIRE(TokenizeAll(fx.conn, "\"select\"") == Toks {{IDENTIFIER, 0, 8}});
+}
+
+TEST_CASE("V2 tokenizer: parameters", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	// The tokenizer pushes the '$' of a parameter as its own operator token.
+	Toks expected {
+	    {KEYWORD, 0, 6},     // SELECT
+	    {OPERATOR, 7, 1},    // $
+	    {NUMBER, 8, 1},      // 1
+	    {OPERATOR, 9, 1},    // ,
+	    {OPERATOR, 11, 1},   // $
+	    {IDENTIFIER, 12, 3}, // foo
+	};
+	REQUIRE(TokenizeAll(fx.conn, "SELECT $1, $foo") == expected);
+}
+
+TEST_CASE("V2 tokenizer: operators and the trailing-plus trimming rule", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	// An operator run cannot end in '+' unless it contains a special character, so '+-' splits.
+	REQUIRE(TokenizeAll(fx.conn, "a+-b") ==
+	        Toks {{IDENTIFIER, 0, 1}, {OPERATOR, 1, 1}, {OPERATOR, 2, 1}, {IDENTIFIER, 3, 1}});
+	// '~' is special, so '~+' stays one operator.
+	REQUIRE(TokenizeAll(fx.conn, "a~+b") == Toks {{IDENTIFIER, 0, 1}, {OPERATOR, 1, 2}, {IDENTIFIER, 3, 1}});
+	// Multi-character operators stay whole.
+	REQUIRE(TokenizeAll(fx.conn, "a->>b") == Toks {{IDENTIFIER, 0, 1}, {OPERATOR, 1, 3}, {IDENTIFIER, 4, 1}});
+	REQUIRE(TokenizeAll(fx.conn, "x::int") == Toks {{IDENTIFIER, 0, 1}, {OPERATOR, 1, 2}, {KEYWORD, 3, 3}});
+	// Parentheses and commas are operator tokens, one byte each.
+	REQUIRE(
+	    TokenizeAll(fx.conn, "f(1,2)") ==
+	    Toks {
+	        {IDENTIFIER, 0, 1}, {OPERATOR, 1, 1}, {NUMBER, 2, 1}, {OPERATOR, 3, 1}, {NUMBER, 4, 1}, {OPERATOR, 5, 1}});
+}
+
+// ===========================================================================
+// Statement boundaries and comments
+// ===========================================================================
+
+TEST_CASE("V2 tokenizer: terminators only at statement level", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	std::string sql = "SELECT 1; SELECT ';'; -- ;\nSELECT 2;";
+	REQUIRE(sql.size() == 36);
+	Toks expected {
+	    {KEYWORD, 0, 6},     // SELECT
+	    {NUMBER, 7, 1},      // 1
+	    {TERMINATOR, 8, 1},  // ;
+	    {KEYWORD, 10, 6},    // SELECT
+	    {STRING, 17, 3},     // ';' is a string, not a terminator
+	    {TERMINATOR, 20, 1}, // ;
+	    {COMMENT, 22, 5},    // -- ;\n, the ; is inside the comment
+	    {KEYWORD, 27, 6},    // SELECT
+	    {NUMBER, 34, 1},     // 2
+	    {TERMINATOR, 35, 1}, // ;
+	};
+	REQUIRE(TokenizeAll(fx.conn, sql) == expected);
+}
+
+TEST_CASE("V2 tokenizer: multi-statement input with a trailing comment", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	std::string sql = "SELECT 1; SELECT 2 -- x\n";
+	REQUIRE(sql.size() == 24);
+	Toks expected {
+	    {KEYWORD, 0, 6},    // SELECT
+	    {NUMBER, 7, 1},     // 1
+	    {TERMINATOR, 8, 1}, // ;
+	    {KEYWORD, 10, 6},   // SELECT
+	    {NUMBER, 17, 1},    // 2
+	    {COMMENT, 19, 5},   // -- x\n
+	};
+	REQUIRE(TokenizeAll(fx.conn, sql) == expected);
+}
+
+TEST_CASE("V2 tokenizer: line comment endings", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	// No newline: the comment runs to the end of the input, and END_OF_INPUT follows at len.
+	REQUIRE(TokenizeAll(fx.conn, "SELECT 1 -- end") == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {COMMENT, 9, 6}});
+	// \r\n: the comment ends after the \r; the \n is whitespace.
+	REQUIRE(TokenizeAll(fx.conn, "SELECT 1 -- x\r\n2") ==
+	        Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {COMMENT, 9, 5}, {NUMBER, 15, 1}});
+}
+
+// ===========================================================================
+// Malformed input never fails
+// ===========================================================================
+
+TEST_CASE("V2 tokenizer: unterminated tokens run to the end of the input", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	REQUIRE(TokenizeAll(fx.conn, "SELECT 'abc") == Toks {{KEYWORD, 0, 6}, {STRING, 7, 4}});
+	REQUIRE(TokenizeAll(fx.conn, "SELECT \"abc") == Toks {{KEYWORD, 0, 6}, {IDENTIFIER, 7, 4}});
+	REQUIRE(TokenizeAll(fx.conn, "SELECT /* abc") == Toks {{KEYWORD, 0, 6}, {COMMENT, 7, 6}});
+	REQUIRE(TokenizeAll(fx.conn, "SELECT $tag$abc") == Toks {{KEYWORD, 0, 6}, {STRING, 7, 8}});
+}
+
+TEST_CASE("V2 tokenizer: bytes, not characters", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	// SELECT 'héllo' AS ü: é and ü are two bytes each, and offsets count bytes.
+	std::string sql = "SELECT 'h\xc3\xa9llo' AS \xc3\xbc";
+	REQUIRE(sql.size() == 21);
+	REQUIRE(TokenizeAll(fx.conn, sql) == Toks {{KEYWORD, 0, 6}, {STRING, 7, 8}, {KEYWORD, 16, 2}, {IDENTIFIER, 19, 2}});
+
+	// Invalid UTF-8 is not validated: a lone 0xFF byte is an identifier character.
+	std::string invalid = "SELECT a\xff"
+	                      "b";
+	REQUIRE(invalid.size() == 10);
+	REQUIRE(TokenizeAll(fx.conn, invalid) == Toks {{KEYWORD, 0, 6}, {IDENTIFIER, 7, 3}});
+
+	// An interior NUL is an ordinary byte; the view's length, not a terminator, bounds the input.
+	std::string with_nul("SELECT 1\0SELECT 2", 17);
+	REQUIRE(TokenizeAll(fx.conn, with_nul) ==
+	        Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {IDENTIFIER, 8, 7}, {NUMBER, 16, 1}});
+}
+
+// ===========================================================================
+// Exhaustion
+// ===========================================================================
+
+TEST_CASE("V2 tokenizer: exhaustion is in-band and idempotent", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	std::string sql = "SELECT 1";
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert(sql), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	REQUIRE(TokNext(it) == Tok {KEYWORD, 0, 6});
+	REQUIRE(TokNext(it) == Tok {NUMBER, 7, 1});
+	// No token at len other than END_OF_INPUT, and every further call reports it again.
+	for (int i = 0; i < 3; i++) {
+		REQUIRE(TokNext(it) == Tok {END, sql.size(), 0});
+	}
+	duckdb_v2_token_iterator_destroy(&it);
+}
+
+TEST_CASE("V2 tokenizer: empty and whitespace-only input", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	REQUIRE(TokenizeAll(fx.conn, "") == Toks {});
+	REQUIRE(TokenizeAll(fx.conn, duckdb_v2_str {nullptr, 0}) == Toks {});
+	// Whitespace is not a token, and END_OF_INPUT still sits at the input length.
+	std::string blank = " \t\r\n ";
+	REQUIRE(TokenizeAll(fx.conn, blank) == Toks {});
+}
+
+// ===========================================================================
+// Lifetime
+// ===========================================================================
+
+TEST_CASE("V2 tokenizer: the input is borrowed for the call only", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	auto *buffer = new std::string("SELECT 42");
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert(*buffer), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+	// Clobber, then free, the caller's bytes before the first next().
+	buffer->assign(buffer->size(), 'x');
+	delete buffer;
+
+	REQUIRE(TokDrain(it, 9) == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 2}});
+	duckdb_v2_token_iterator_destroy(&it);
+}
+
+TEST_CASE("V2 tokenizer: the iterator outlives the connection and the database", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert("SELECT 1;"), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	REQUIRE(duckdb_v2_disconnect(&fx.conn) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_close(&fx.db) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_destroy_environment(&fx.env) == DUCKDB_V2_ERROR_NONE);
+
+	REQUIRE(TokDrain(it, 9) == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {TERMINATOR, 8, 1}});
+	duckdb_v2_token_iterator_destroy(&it);
+}
+
+TEST_CASE("V2 tokenizer: the keyword set is the connection's grammar", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	auto &instance = *duckdb::capiv2::Convert(fx.db)->database->instance;
+	duckdb::GrammarExtension::Register(instance, duckdb::make_shared_ptr<TokenizerTestKeywordExtension>());
+
+	// Base grammar: ANSWER is a plain identifier.
+	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Toks {{IDENTIFIER, 0, 6}});
+
+	// Selecting the extension makes it a keyword on that connection only.
+	ExecSQL(fx.conn, "SET active_grammar_extensions = ['tokenizer_test_keyword']");
+	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Toks {{KEYWORD, 0, 6}});
+
+	duckdb_v2_connection_handle other = nullptr;
+	REQUIRE(duckdb_v2_connect(fx.db, &other, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(TokenizeAll(other, "ANSWER") == Toks {{IDENTIFIER, 0, 6}});
+	duckdb_v2_disconnect(&other);
+
+	// The grammar is read when the iterator is created, not when it is stepped.
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert("ANSWER"), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+	ExecSQL(fx.conn, "RESET active_grammar_extensions");
+	REQUIRE(TokDrain(it, 6) == Toks {{KEYWORD, 0, 6}});
+	duckdb_v2_token_iterator_destroy(&it);
+	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Toks {{IDENTIFIER, 0, 6}});
+}
+
+// ===========================================================================
+// Argument checking and destruction
+// ===========================================================================
+
+TEST_CASE("V2 tokenizer: tokenize_sql argument checks", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	auto stale = reinterpret_cast<duckdb_v2_token_iterator_handle>(uintptr_t(STALE_IDX));
+	auto sql = Convert("SELECT 1");
+
+	// A null connection or a null view with a non-zero length is an input error, and the slot is reset.
+	auto it = stale;
+	REQUIRE(duckdb_v2_tokenize_sql(nullptr, sql, &it, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(it == nullptr);
+	it = stale;
+	duckdb_v2_error_info_handle err = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, duckdb_v2_str {nullptr, 3}, &it, &err) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(it == nullptr);
+	REQUIRE(err != nullptr);
+	duckdb_v2_str message = {nullptr, 0};
+	REQUIRE(duckdb_v2_error_info_get_text(err, &message) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(Convert(message).find("sql") != std::string::npos);
+	duckdb_v2_error_info_destroy(&err);
+
+	// A null out slot is an input error.
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, sql, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+}
+
+TEST_CASE("V2 tokenizer: next argument checks", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert("SELECT 1"), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	// All three out-params are required.
+	auto type = STALE_TYPE;
+	idx_t start = STALE_IDX;
+	idx_t length = STALE_IDX;
+	REQUIRE(duckdb_v2_token_iterator_next(it, nullptr, &start, &length, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_token_iterator_next(it, &type, nullptr, &length, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(duckdb_v2_token_iterator_next(it, &type, &start, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+
+	// A null iterator fails and resets the out-params.
+	REQUIRE(duckdb_v2_token_iterator_next(nullptr, &type, &start, &length, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE(type == DUCKDB_V2_TOKEN_TYPE_INVALID);
+	REQUIRE(start == 0);
+	REQUIRE(length == 0);
+
+	// The failed calls did not advance the iterator.
+	REQUIRE(TokDrain(it, 8) == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}});
+	duckdb_v2_token_iterator_destroy(&it);
+}
+
+TEST_CASE("V2 tokenizer: destroy is null-safe and idempotent", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	REQUIRE(duckdb_v2_token_iterator_destroy(nullptr) == DUCKDB_V2_ERROR_NONE);
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_token_iterator_destroy(&it) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(it == nullptr);
+
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert("SELECT 1"), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(it != nullptr);
+	// Destroying a half-consumed iterator, then destroying the emptied slot again.
+	REQUIRE(TokNext(it) == Tok {KEYWORD, 0, 6});
+	REQUIRE(duckdb_v2_token_iterator_destroy(&it) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(it == nullptr);
+	REQUIRE(duckdb_v2_token_iterator_destroy(&it) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(it == nullptr);
+}
+
+} // namespace test_capi_v2

--- a/test/api/capi/v2/test_capi_v2_tokenizer.cpp
+++ b/test/api/capi/v2/test_capi_v2_tokenizer.cpp
@@ -33,6 +33,32 @@ std::ostream &operator<<(std::ostream &os, const Tok &tok) {
 
 using Toks = std::vector<Tok>;
 
+// What tokenize_sql produces for one input: the tokens up to END_OF_INPUT, and the ends_unterminated flag.
+struct Lexed {
+	Toks tokens;
+	bool ends_unterminated;
+
+	bool operator==(const Lexed &other) const {
+		return tokens == other.tokens && ends_unterminated == other.ends_unterminated;
+	}
+};
+
+std::ostream &operator<<(std::ostream &os, const Lexed &lexed) {
+	os << (lexed.ends_unterminated ? "unterminated " : "complete ") << "{";
+	for (auto &tok : lexed.tokens) {
+		os << " " << tok;
+	}
+	return os << " }";
+}
+
+Lexed Complete(Toks tokens) {
+	return Lexed {std::move(tokens), false};
+}
+
+Lexed Unterminated(Toks tokens) {
+	return Lexed {std::move(tokens), true};
+}
+
 constexpr auto KEYWORD = DUCKDB_V2_TOKEN_TYPE_KEYWORD;
 constexpr auto IDENTIFIER = DUCKDB_V2_TOKEN_TYPE_IDENTIFIER;
 constexpr auto STRING = DUCKDB_V2_TOKEN_TYPE_STRING_LITERAL;
@@ -72,18 +98,28 @@ Toks TokDrain(duckdb_v2_token_iterator_handle it, idx_t len) {
 	return out;
 }
 
-// Tokenize a length-delimited view, drain, destroy.
-Toks TokenizeAll(duckdb_v2_connection_handle conn, duckdb_v2_str sql) {
-	duckdb_v2_token_iterator_handle it = nullptr;
-	REQUIRE(duckdb_v2_tokenize_sql(conn, sql, &it, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(it != nullptr);
-	auto out = TokDrain(it, sql.len);
-	REQUIRE(duckdb_v2_token_iterator_destroy(&it) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(it == nullptr);
+// The ends_unterminated flag, primed so a test can tell "written" from "left alone".
+bool EndsUnterminated(duckdb_v2_token_iterator_handle it) {
+	bool out = true;
+	REQUIRE(duckdb_v2_token_iterator_ends_unterminated(it, &out, nullptr) == DUCKDB_V2_ERROR_NONE);
 	return out;
 }
 
-Toks TokenizeAll(duckdb_v2_connection_handle conn, const std::string &sql) {
+// Tokenize a length-delimited view, drain, destroy. The flag is read before and after draining and must agree.
+Lexed TokenizeAll(duckdb_v2_connection_handle conn, duckdb_v2_str sql) {
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(conn, sql, &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(it != nullptr);
+	auto before = EndsUnterminated(it);
+	auto tokens = TokDrain(it, sql.len);
+	auto after = EndsUnterminated(it);
+	REQUIRE(duckdb_v2_token_iterator_destroy(&it) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(it == nullptr);
+	REQUIRE(before == after);
+	return Lexed {std::move(tokens), after};
+}
+
+Lexed TokenizeAll(duckdb_v2_connection_handle conn, const std::string &sql) {
 	return TokenizeAll(conn, Convert(sql));
 }
 
@@ -127,15 +163,16 @@ TEST_CASE("V2 tokenizer: all seven lexical classes in one statement", "[capi_v2]
 	    {COMMENT, 50, 7},    // /* d */
 	    {TERMINATOR, 57, 1}, // ;
 	};
-	REQUIRE(TokenizeAll(fx.conn, sql) == expected);
+	REQUIRE(TokenizeAll(fx.conn, sql) == Complete(expected));
 }
 
 TEST_CASE("V2 tokenizer: keyword versus identifier follows the grammar", "[capi_v2][tokenizer]") {
 	EnvFixture fx;
 	// Casing does not matter for keywords; a non-keyword word is an identifier.
-	REQUIRE(TokenizeAll(fx.conn, "select Select foo") == Toks {{KEYWORD, 0, 6}, {KEYWORD, 7, 6}, {IDENTIFIER, 14, 3}});
+	REQUIRE(TokenizeAll(fx.conn, "select Select foo") ==
+	        Complete({{KEYWORD, 0, 6}, {KEYWORD, 7, 6}, {IDENTIFIER, 14, 3}}));
 	// Quoting a keyword makes it an identifier.
-	REQUIRE(TokenizeAll(fx.conn, "\"select\"") == Toks {{IDENTIFIER, 0, 8}});
+	REQUIRE(TokenizeAll(fx.conn, "\"select\"") == Complete({{IDENTIFIER, 0, 8}}));
 }
 
 TEST_CASE("V2 tokenizer: parameters", "[capi_v2][tokenizer]") {
@@ -149,24 +186,26 @@ TEST_CASE("V2 tokenizer: parameters", "[capi_v2][tokenizer]") {
 	    {OPERATOR, 11, 1},   // $
 	    {IDENTIFIER, 12, 3}, // foo
 	};
-	REQUIRE(TokenizeAll(fx.conn, "SELECT $1, $foo") == expected);
+	REQUIRE(TokenizeAll(fx.conn, "SELECT $1, $foo") == Complete(expected));
 }
 
 TEST_CASE("V2 tokenizer: operators and the trailing-plus trimming rule", "[capi_v2][tokenizer]") {
 	EnvFixture fx;
 	// An operator run cannot end in '+' unless it contains a special character, so '+-' splits.
 	REQUIRE(TokenizeAll(fx.conn, "a+-b") ==
-	        Toks {{IDENTIFIER, 0, 1}, {OPERATOR, 1, 1}, {OPERATOR, 2, 1}, {IDENTIFIER, 3, 1}});
+	        Complete({{IDENTIFIER, 0, 1}, {OPERATOR, 1, 1}, {OPERATOR, 2, 1}, {IDENTIFIER, 3, 1}}));
 	// '~' is special, so '~+' stays one operator.
-	REQUIRE(TokenizeAll(fx.conn, "a~+b") == Toks {{IDENTIFIER, 0, 1}, {OPERATOR, 1, 2}, {IDENTIFIER, 3, 1}});
+	REQUIRE(TokenizeAll(fx.conn, "a~+b") == Complete({{IDENTIFIER, 0, 1}, {OPERATOR, 1, 2}, {IDENTIFIER, 3, 1}}));
 	// Multi-character operators stay whole.
-	REQUIRE(TokenizeAll(fx.conn, "a->>b") == Toks {{IDENTIFIER, 0, 1}, {OPERATOR, 1, 3}, {IDENTIFIER, 4, 1}});
-	REQUIRE(TokenizeAll(fx.conn, "x::int") == Toks {{IDENTIFIER, 0, 1}, {OPERATOR, 1, 2}, {KEYWORD, 3, 3}});
+	REQUIRE(TokenizeAll(fx.conn, "a->>b") == Complete({{IDENTIFIER, 0, 1}, {OPERATOR, 1, 3}, {IDENTIFIER, 4, 1}}));
+	REQUIRE(TokenizeAll(fx.conn, "x::int") == Complete({{IDENTIFIER, 0, 1}, {OPERATOR, 1, 2}, {KEYWORD, 3, 3}}));
 	// Parentheses and commas are operator tokens, one byte each.
-	REQUIRE(
-	    TokenizeAll(fx.conn, "f(1,2)") ==
-	    Toks {
-	        {IDENTIFIER, 0, 1}, {OPERATOR, 1, 1}, {NUMBER, 2, 1}, {OPERATOR, 3, 1}, {NUMBER, 4, 1}, {OPERATOR, 5, 1}});
+	REQUIRE(TokenizeAll(fx.conn, "f(1,2)") == Complete({{IDENTIFIER, 0, 1},
+	                                                    {OPERATOR, 1, 1},
+	                                                    {NUMBER, 2, 1},
+	                                                    {OPERATOR, 3, 1},
+	                                                    {NUMBER, 4, 1},
+	                                                    {OPERATOR, 5, 1}}));
 }
 
 // ===========================================================================
@@ -189,7 +228,7 @@ TEST_CASE("V2 tokenizer: terminators only at statement level", "[capi_v2][tokeni
 	    {NUMBER, 34, 1},     // 2
 	    {TERMINATOR, 35, 1}, // ;
 	};
-	REQUIRE(TokenizeAll(fx.conn, sql) == expected);
+	REQUIRE(TokenizeAll(fx.conn, sql) == Complete(expected));
 }
 
 TEST_CASE("V2 tokenizer: multi-statement input with a trailing comment", "[capi_v2][tokenizer]") {
@@ -204,16 +243,17 @@ TEST_CASE("V2 tokenizer: multi-statement input with a trailing comment", "[capi_
 	    {NUMBER, 17, 1},    // 2
 	    {COMMENT, 19, 5},   // -- x\n
 	};
-	REQUIRE(TokenizeAll(fx.conn, sql) == expected);
+	REQUIRE(TokenizeAll(fx.conn, sql) == Complete(expected));
 }
 
 TEST_CASE("V2 tokenizer: line comment endings", "[capi_v2][tokenizer]") {
 	EnvFixture fx;
 	// No newline: the comment runs to the end of the input, and END_OF_INPUT follows at len.
-	REQUIRE(TokenizeAll(fx.conn, "SELECT 1 -- end") == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {COMMENT, 9, 6}});
+	REQUIRE(TokenizeAll(fx.conn, "SELECT 1 -- end") ==
+	        Unterminated({{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {COMMENT, 9, 6}}));
 	// \r\n: the comment ends after the \r; the \n is whitespace.
 	REQUIRE(TokenizeAll(fx.conn, "SELECT 1 -- x\r\n2") ==
-	        Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {COMMENT, 9, 5}, {NUMBER, 15, 1}});
+	        Complete({{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {COMMENT, 9, 5}, {NUMBER, 15, 1}}));
 }
 
 // ===========================================================================
@@ -222,10 +262,33 @@ TEST_CASE("V2 tokenizer: line comment endings", "[capi_v2][tokenizer]") {
 
 TEST_CASE("V2 tokenizer: unterminated tokens run to the end of the input", "[capi_v2][tokenizer]") {
 	EnvFixture fx;
-	REQUIRE(TokenizeAll(fx.conn, "SELECT 'abc") == Toks {{KEYWORD, 0, 6}, {STRING, 7, 4}});
-	REQUIRE(TokenizeAll(fx.conn, "SELECT \"abc") == Toks {{KEYWORD, 0, 6}, {IDENTIFIER, 7, 4}});
-	REQUIRE(TokenizeAll(fx.conn, "SELECT /* abc") == Toks {{KEYWORD, 0, 6}, {COMMENT, 7, 6}});
-	REQUIRE(TokenizeAll(fx.conn, "SELECT $tag$abc") == Toks {{KEYWORD, 0, 6}, {STRING, 7, 8}});
+	REQUIRE(TokenizeAll(fx.conn, "SELECT 'abc") == Unterminated({{KEYWORD, 0, 6}, {STRING, 7, 4}}));
+	REQUIRE(TokenizeAll(fx.conn, "SELECT \"abc") == Unterminated({{KEYWORD, 0, 6}, {IDENTIFIER, 7, 4}}));
+	REQUIRE(TokenizeAll(fx.conn, "SELECT /* abc") == Unterminated({{KEYWORD, 0, 6}, {COMMENT, 7, 6}}));
+	REQUIRE(TokenizeAll(fx.conn, "SELECT $tag$abc") == Unterminated({{KEYWORD, 0, 6}, {STRING, 7, 8}}));
+
+	// The closed counterparts, each ending the input on its closing delimiter.
+	REQUIRE(TokenizeAll(fx.conn, "SELECT 'abc'") == Complete({{KEYWORD, 0, 6}, {STRING, 7, 5}}));
+	REQUIRE(TokenizeAll(fx.conn, "SELECT \"abc\"") == Complete({{KEYWORD, 0, 6}, {IDENTIFIER, 7, 5}}));
+	REQUIRE(TokenizeAll(fx.conn, "SELECT /* abc */") == Complete({{KEYWORD, 0, 6}, {COMMENT, 7, 9}}));
+	REQUIRE(TokenizeAll(fx.conn, "SELECT $tag$abc$tag$") == Complete({{KEYWORD, 0, 6}, {STRING, 7, 13}}));
+}
+
+TEST_CASE("V2 tokenizer: ends_unterminated is a property of the input", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert("SELECT 'abc"), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	// Before, during and after draining, and after exhaustion, the answer is the same.
+	REQUIRE(EndsUnterminated(it));
+	REQUIRE(TokNext(it) == Tok {KEYWORD, 0, 6});
+	REQUIRE(EndsUnterminated(it));
+	REQUIRE(TokNext(it) == Tok {STRING, 7, 4});
+	REQUIRE(TokNext(it) == Tok {END, 11, 0});
+	REQUIRE(EndsUnterminated(it));
+	REQUIRE(TokNext(it) == Tok {END, 11, 0});
+	REQUIRE(EndsUnterminated(it));
+	duckdb_v2_token_iterator_destroy(&it);
 }
 
 TEST_CASE("V2 tokenizer: bytes, not characters", "[capi_v2][tokenizer]") {
@@ -233,18 +296,19 @@ TEST_CASE("V2 tokenizer: bytes, not characters", "[capi_v2][tokenizer]") {
 	// SELECT 'héllo' AS ü: é and ü are two bytes each, and offsets count bytes.
 	std::string sql = "SELECT 'h\xc3\xa9llo' AS \xc3\xbc";
 	REQUIRE(sql.size() == 21);
-	REQUIRE(TokenizeAll(fx.conn, sql) == Toks {{KEYWORD, 0, 6}, {STRING, 7, 8}, {KEYWORD, 16, 2}, {IDENTIFIER, 19, 2}});
+	REQUIRE(TokenizeAll(fx.conn, sql) ==
+	        Complete({{KEYWORD, 0, 6}, {STRING, 7, 8}, {KEYWORD, 16, 2}, {IDENTIFIER, 19, 2}}));
 
 	// Invalid UTF-8 is not validated: a lone 0xFF byte is an identifier character.
 	std::string invalid = "SELECT a\xff"
 	                      "b";
 	REQUIRE(invalid.size() == 10);
-	REQUIRE(TokenizeAll(fx.conn, invalid) == Toks {{KEYWORD, 0, 6}, {IDENTIFIER, 7, 3}});
+	REQUIRE(TokenizeAll(fx.conn, invalid) == Complete({{KEYWORD, 0, 6}, {IDENTIFIER, 7, 3}}));
 
 	// An interior NUL is an ordinary byte; the view's length, not a terminator, bounds the input.
 	std::string with_nul("SELECT 1\0SELECT 2", 17);
 	REQUIRE(TokenizeAll(fx.conn, with_nul) ==
-	        Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {IDENTIFIER, 8, 7}, {NUMBER, 16, 1}});
+	        Complete({{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {IDENTIFIER, 8, 7}, {NUMBER, 16, 1}}));
 }
 
 // ===========================================================================
@@ -263,16 +327,17 @@ TEST_CASE("V2 tokenizer: exhaustion is in-band and idempotent", "[capi_v2][token
 	for (int i = 0; i < 3; i++) {
 		REQUIRE(TokNext(it) == Tok {END, sql.size(), 0});
 	}
+	REQUIRE_FALSE(EndsUnterminated(it));
 	duckdb_v2_token_iterator_destroy(&it);
 }
 
 TEST_CASE("V2 tokenizer: empty and whitespace-only input", "[capi_v2][tokenizer]") {
 	EnvFixture fx;
-	REQUIRE(TokenizeAll(fx.conn, "") == Toks {});
-	REQUIRE(TokenizeAll(fx.conn, duckdb_v2_str {nullptr, 0}) == Toks {});
+	REQUIRE(TokenizeAll(fx.conn, "") == Complete({}));
+	REQUIRE(TokenizeAll(fx.conn, duckdb_v2_str {nullptr, 0}) == Complete({}));
 	// Whitespace is not a token, and END_OF_INPUT still sits at the input length.
 	std::string blank = " \t\r\n ";
-	REQUIRE(TokenizeAll(fx.conn, blank) == Toks {});
+	REQUIRE(TokenizeAll(fx.conn, blank) == Complete({}));
 }
 
 // ===========================================================================
@@ -289,19 +354,21 @@ TEST_CASE("V2 tokenizer: the input is borrowed for the call only", "[capi_v2][to
 	delete buffer;
 
 	REQUIRE(TokDrain(it, 9) == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 2}});
+	REQUIRE_FALSE(EndsUnterminated(it));
 	duckdb_v2_token_iterator_destroy(&it);
 }
 
 TEST_CASE("V2 tokenizer: the iterator outlives the connection and the database", "[capi_v2][tokenizer]") {
 	EnvFixture fx;
 	duckdb_v2_token_iterator_handle it = nullptr;
-	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert("SELECT 1;"), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert("SELECT 1; 'x"), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
 
 	REQUIRE(duckdb_v2_disconnect(&fx.conn) == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(duckdb_v2_close(&fx.db) == DUCKDB_V2_ERROR_NONE);
 	REQUIRE(duckdb_v2_destroy_environment(&fx.env) == DUCKDB_V2_ERROR_NONE);
 
-	REQUIRE(TokDrain(it, 9) == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {TERMINATOR, 8, 1}});
+	REQUIRE(TokDrain(it, 12) == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}, {TERMINATOR, 8, 1}, {STRING, 10, 2}});
+	REQUIRE(EndsUnterminated(it));
 	duckdb_v2_token_iterator_destroy(&it);
 }
 
@@ -311,15 +378,15 @@ TEST_CASE("V2 tokenizer: the keyword set is the connection's grammar", "[capi_v2
 	duckdb::GrammarExtension::Register(instance, duckdb::make_shared_ptr<TokenizerTestKeywordExtension>());
 
 	// Base grammar: ANSWER is a plain identifier.
-	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Toks {{IDENTIFIER, 0, 6}});
+	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Complete({{IDENTIFIER, 0, 6}}));
 
 	// Selecting the extension makes it a keyword on that connection only.
 	ExecSQL(fx.conn, "SET active_grammar_extensions = ['tokenizer_test_keyword']");
-	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Toks {{KEYWORD, 0, 6}});
+	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Complete({{KEYWORD, 0, 6}}));
 
 	duckdb_v2_connection_handle other = nullptr;
 	REQUIRE(duckdb_v2_connect(fx.db, &other, nullptr) == DUCKDB_V2_ERROR_NONE);
-	REQUIRE(TokenizeAll(other, "ANSWER") == Toks {{IDENTIFIER, 0, 6}});
+	REQUIRE(TokenizeAll(other, "ANSWER") == Complete({{IDENTIFIER, 0, 6}}));
 	duckdb_v2_disconnect(&other);
 
 	// The grammar is read when the iterator is created, not when it is stepped.
@@ -328,7 +395,7 @@ TEST_CASE("V2 tokenizer: the keyword set is the connection's grammar", "[capi_v2
 	ExecSQL(fx.conn, "RESET active_grammar_extensions");
 	REQUIRE(TokDrain(it, 6) == Toks {{KEYWORD, 0, 6}});
 	duckdb_v2_token_iterator_destroy(&it);
-	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Toks {{IDENTIFIER, 0, 6}});
+	REQUIRE(TokenizeAll(fx.conn, "ANSWER") == Complete({{IDENTIFIER, 0, 6}}));
 }
 
 // ===========================================================================
@@ -379,6 +446,21 @@ TEST_CASE("V2 tokenizer: next argument checks", "[capi_v2][tokenizer]") {
 
 	// The failed calls did not advance the iterator.
 	REQUIRE(TokDrain(it, 8) == Toks {{KEYWORD, 0, 6}, {NUMBER, 7, 1}});
+	duckdb_v2_token_iterator_destroy(&it);
+}
+
+TEST_CASE("V2 tokenizer: ends_unterminated argument checks", "[capi_v2][tokenizer]") {
+	EnvFixture fx;
+	duckdb_v2_token_iterator_handle it = nullptr;
+	REQUIRE(duckdb_v2_tokenize_sql(fx.conn, Convert("SELECT 'abc"), &it, nullptr) == DUCKDB_V2_ERROR_NONE);
+
+	// A null slot is an input error; a null iterator fails and resets the slot.
+	REQUIRE(duckdb_v2_token_iterator_ends_unterminated(it, nullptr, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	bool out = true;
+	REQUIRE(duckdb_v2_token_iterator_ends_unterminated(nullptr, &out, nullptr) == DUCKDB_V2_ERROR_INPUT_INVALID);
+	REQUIRE_FALSE(out);
+
+	REQUIRE(EndsUnterminated(it));
 	duckdb_v2_token_iterator_destroy(&it);
 }
 

--- a/test/api/cpp/CMakeLists.txt
+++ b/test/api/cpp/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_replacement_scan.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_scalar_function.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_table_function.cpp
+  ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_tokenizer.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_types_values.cpp
   ${CMAKE_SOURCE_DIR}/tools/cpp/tests/test_cpp_api_vector.cpp)
 

--- a/test/api/test_api.cpp
+++ b/test/api/test_api.cpp
@@ -551,8 +551,36 @@ TEST_CASE("Test connection API", "[api]") {
 }
 
 TEST_CASE("Test parser tokenize", "[api]") {
-	Parser parser;
-	REQUIRE_NOTHROW(parser.Tokenize("SELECT * FROM table WHERE i+1=3 AND j='hello'; --tokenize example query"));
+	string sql = "SELECT * FROM table WHERE i+1=3 AND j='hello'; --tokenize example query";
+	auto tokens = Parser::Tokenize(sql);
+
+	using T = SimplifiedTokenType;
+	vector<pair<T, idx_t>> expected {
+	    {T::SIMPLIFIED_TOKEN_KEYWORD, 0},           // SELECT
+	    {T::SIMPLIFIED_TOKEN_OPERATOR, 7},          // *
+	    {T::SIMPLIFIED_TOKEN_KEYWORD, 9},           // FROM
+	    {T::SIMPLIFIED_TOKEN_KEYWORD, 14},          // table
+	    {T::SIMPLIFIED_TOKEN_KEYWORD, 20},          // WHERE
+	    {T::SIMPLIFIED_TOKEN_IDENTIFIER, 26},       // i
+	    {T::SIMPLIFIED_TOKEN_OPERATOR, 27},         // +
+	    {T::SIMPLIFIED_TOKEN_NUMERIC_CONSTANT, 28}, // 1
+	    {T::SIMPLIFIED_TOKEN_OPERATOR, 29},         // =
+	    {T::SIMPLIFIED_TOKEN_NUMERIC_CONSTANT, 30}, // 3
+	    {T::SIMPLIFIED_TOKEN_KEYWORD, 32},          // AND
+	    {T::SIMPLIFIED_TOKEN_IDENTIFIER, 36},       // j
+	    {T::SIMPLIFIED_TOKEN_OPERATOR, 37},         // =
+	    {T::SIMPLIFIED_TOKEN_STRING_CONSTANT, 38},  // 'hello'
+	    {T::SIMPLIFIED_TOKEN_OPERATOR, 45},         // ;
+	    {T::SIMPLIFIED_TOKEN_COMMENT, 47},          // --tokenize example query
+	};
+	REQUIRE(tokens.size() >= expected.size());
+	for (idx_t i = 0; i < expected.size(); i++) {
+		REQUIRE(tokens[i].type == expected[i].first);
+		REQUIRE(tokens[i].start == expected[i].second);
+	}
+	// The end-of-input sentinel is not a token: nothing starts at or past the input length.
+	REQUIRE(tokens.back().start < sql.size());
+	REQUIRE(tokens.size() == expected.size());
 }
 
 TEST_CASE("Test opening an invalid database file", "[api]") {

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -641,10 +641,10 @@ static_assert(static_cast<uint8_t>(TokenType::COMMENT) == DUCKDB_V2_TOKEN_TYPE_C
 static_assert(static_cast<uint8_t>(TokenType::TERMINATOR) == DUCKDB_V2_TOKEN_TYPE_TERMINATOR,
               "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
 
-auto Connection::Tokenize(std::string_view sql) const -> std::vector<Token> {
+auto Connection::Tokenize(std::string_view sql) const -> TokenList {
 	duckdb_v2_token_iterator_handle iterator = nullptr;
 	CheckedAPICall(duckdb_v2_tokenize_sql, handle(), ToStr(sql), &iterator);
-	std::vector<Token> tokens;
+	TokenList list;
 	try {
 		while (true) {
 			auto type = DUCKDB_V2_TOKEN_TYPE_INVALID;
@@ -654,14 +654,15 @@ auto Connection::Tokenize(std::string_view sql) const -> std::vector<Token> {
 			if (type == DUCKDB_V2_TOKEN_TYPE_END_OF_INPUT) {
 				break;
 			}
-			tokens.push_back(Token {static_cast<TokenType>(type), start, length});
+			list.tokens.push_back(Token {static_cast<TokenType>(type), start, length});
 		}
+		CheckedAPICall(duckdb_v2_token_iterator_ends_unterminated, iterator, &list.ends_unterminated);
 	} catch (...) {
 		duckdb_v2_token_iterator_destroy(&iterator);
 		throw;
 	}
 	duckdb_v2_token_iterator_destroy(&iterator);
-	return tokens;
+	return list;
 }
 
 auto Connection::Execute(const SqlStatement &statement, const Value *parameters, idx_t parameter_count) -> QueryResult {

--- a/tools/cpp/duckdb_cpp.cpp
+++ b/tools/cpp/duckdb_cpp.cpp
@@ -622,6 +622,48 @@ auto Connection::ParseSQL(const char *sql) -> StatementIterator {
 	return detail::Factory::Make<StatementIterator>(iterator);
 }
 
+// TokenType mirrors DUCKDB_V2_TOKEN_TYPE numerically; every member is pinned. END_OF_INPUT has no C++ member: it
+// is the C iterator's exhaustion marker, and the vector simply ends.
+static_assert(static_cast<uint8_t>(TokenType::INVALID) == DUCKDB_V2_TOKEN_TYPE_INVALID,
+              "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
+static_assert(static_cast<uint8_t>(TokenType::KEYWORD) == DUCKDB_V2_TOKEN_TYPE_KEYWORD,
+              "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
+static_assert(static_cast<uint8_t>(TokenType::IDENTIFIER) == DUCKDB_V2_TOKEN_TYPE_IDENTIFIER,
+              "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
+static_assert(static_cast<uint8_t>(TokenType::STRING_LITERAL) == DUCKDB_V2_TOKEN_TYPE_STRING_LITERAL,
+              "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
+static_assert(static_cast<uint8_t>(TokenType::NUMBER_LITERAL) == DUCKDB_V2_TOKEN_TYPE_NUMBER_LITERAL,
+              "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
+static_assert(static_cast<uint8_t>(TokenType::OPERATOR) == DUCKDB_V2_TOKEN_TYPE_OPERATOR,
+              "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
+static_assert(static_cast<uint8_t>(TokenType::COMMENT) == DUCKDB_V2_TOKEN_TYPE_COMMENT,
+              "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
+static_assert(static_cast<uint8_t>(TokenType::TERMINATOR) == DUCKDB_V2_TOKEN_TYPE_TERMINATOR,
+              "TokenType must mirror DUCKDB_V2_TOKEN_TYPE");
+
+auto Connection::Tokenize(std::string_view sql) const -> std::vector<Token> {
+	duckdb_v2_token_iterator_handle iterator = nullptr;
+	CheckedAPICall(duckdb_v2_tokenize_sql, handle(), ToStr(sql), &iterator);
+	std::vector<Token> tokens;
+	try {
+		while (true) {
+			auto type = DUCKDB_V2_TOKEN_TYPE_INVALID;
+			idx_t start = 0;
+			idx_t length = 0;
+			CheckedAPICall(duckdb_v2_token_iterator_next, iterator, &type, &start, &length);
+			if (type == DUCKDB_V2_TOKEN_TYPE_END_OF_INPUT) {
+				break;
+			}
+			tokens.push_back(Token {static_cast<TokenType>(type), start, length});
+		}
+	} catch (...) {
+		duckdb_v2_token_iterator_destroy(&iterator);
+		throw;
+	}
+	duckdb_v2_token_iterator_destroy(&iterator);
+	return tokens;
+}
+
 auto Connection::Execute(const SqlStatement &statement, const Value *parameters, idx_t parameter_count) -> QueryResult {
 	// Borrowed, not consumed: pass the handle without releasing it, so the
 	// caller's SqlStatement keeps ownership and can be executed again.

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -511,6 +511,37 @@ private:
 	explicit StatementIterator(void *impl);
 };
 
+/// The lexical class of a token, as `Connection::Tokenize` reports it: what the tokenizer assigns before parsing, with
+/// no catalog or grammar-role refinement.
+enum class TokenType : uint8_t {
+	/// Never the class of a token; the value of a zero-initialized `Token`.
+	INVALID = 0,
+	/// A keyword of the connection's grammar.
+	KEYWORD = 1,
+	/// A bare or double-quoted identifier, quotes included.
+	IDENTIFIER = 2,
+	/// A quoted or dollar-quoted string, delimiters included.
+	STRING_LITERAL = 3,
+	/// A numeric literal.
+	NUMBER_LITERAL = 4,
+	/// An operator or punctuation run other than the statement terminator.
+	OPERATOR = 5,
+	/// A line or block comment, delimiters included.
+	COMMENT = 6,
+	/// A statement-terminating semicolon.
+	TERMINATOR = 7,
+};
+
+/// One token of a SQL string: its class and its byte range in the input, so `sql.substr(start, length)` is the lexeme.
+struct Token {
+	/// The token's lexical class.
+	TokenType type = TokenType::INVALID;
+	/// Byte offset of the token in the input.
+	idx_t start = 0;
+	/// Byte length of the token.
+	idx_t length = 0;
+};
+
 /// A statement bound and planned once, executable repeatedly. Produced by `Connection::Prepare`.
 /// Where `Connection::Execute` re-binds on every call, this may run the plan it built at prepare time; ask
 /// `ReusesPlan` which one you got. Execution returns the same `QueryResult`, with identical behaviour.
@@ -623,6 +654,14 @@ public:
 	auto ParseSQL(const std::string &sql) -> StatementIterator {
 		return ParseSQL(sql.c_str());
 	}
+
+	/// Splits a SQL string into its tokens without parsing it: no binding, no catalog access, no transaction. The
+	/// connection supplies the grammar whose keyword set decides KEYWORD versus IDENTIFIER. Offsets are byte offsets
+	/// into `sql` exactly as given, and whitespace is not a token. Malformed input does not throw: an unterminated
+	/// string, block comment or dollar-quoted string yields a token that runs to the end of the input.
+	/// @param sql The SQL text; may contain interior null bytes.
+	/// @return The tokens in input order, empty for empty or whitespace-only input.
+	auto Tokenize(std::string_view sql) const -> std::vector<Token>;
 
 	/// Executes a statement, borrowing it rather than consuming it, so the same statement can be executed again.
 	/// @param statement The statement to execute.

--- a/tools/cpp/duckdb_cpp.hpp
+++ b/tools/cpp/duckdb_cpp.hpp
@@ -542,6 +542,16 @@ struct Token {
 	idx_t length = 0;
 };
 
+/// The tokens of a SQL string, as `Connection::Tokenize` reports them.
+struct TokenList {
+	/// The tokens in input order; empty for empty or whitespace-only input.
+	std::vector<Token> tokens;
+	/// Whether the input ended before the closing delimiter of its last token: inside an open string, quoted
+	/// identifier, block comment or dollar-quoted string, or in a line comment with no trailing newline. When true,
+	/// the last token is the open one.
+	bool ends_unterminated = false;
+};
+
 /// A statement bound and planned once, executable repeatedly. Produced by `Connection::Prepare`.
 /// Where `Connection::Execute` re-binds on every call, this may run the plan it built at prepare time; ask
 /// `ReusesPlan` which one you got. Execution returns the same `QueryResult`, with identical behaviour.
@@ -658,10 +668,11 @@ public:
 	/// Splits a SQL string into its tokens without parsing it: no binding, no catalog access, no transaction. The
 	/// connection supplies the grammar whose keyword set decides KEYWORD versus IDENTIFIER. Offsets are byte offsets
 	/// into `sql` exactly as given, and whitespace is not a token. Malformed input does not throw: an unterminated
-	/// string, block comment or dollar-quoted string yields a token that runs to the end of the input.
+	/// string, block comment or dollar-quoted string yields a token that runs to the end of the input, and
+	/// `TokenList::ends_unterminated` reports it.
 	/// @param sql The SQL text; may contain interior null bytes.
-	/// @return The tokens in input order, empty for empty or whitespace-only input.
-	auto Tokenize(std::string_view sql) const -> std::vector<Token>;
+	/// @return The tokens in input order, and whether the input ended inside an open token.
+	auto Tokenize(std::string_view sql) const -> TokenList;
 
 	/// Executes a statement, borrowing it rather than consuming it, so the same statement can be executed again.
 	/// @param statement The statement to execute.

--- a/tools/cpp/tests/test_cpp_api_tokenizer.cpp
+++ b/tools/cpp/tests/test_cpp_api_tokenizer.cpp
@@ -16,17 +16,19 @@
 namespace {
 
 using duckdb::cxx::Token;
+using duckdb::cxx::TokenList;
 using duckdb::cxx::TokenType;
 
 // Token has no operator==; compare field-wise and report the first mismatch.
-void RequireSameTokens(const std::vector<Token> &actual, const std::vector<Token> &expected) {
-	REQUIRE(actual.size() == expected.size());
+void RequireTokenList(const TokenList &actual, const std::vector<Token> &expected, bool ends_unterminated) {
+	REQUIRE(actual.tokens.size() == expected.size());
 	for (size_t i = 0; i < expected.size(); i++) {
 		INFO("token " << i);
-		REQUIRE(static_cast<int>(actual[i].type) == static_cast<int>(expected[i].type));
-		REQUIRE(actual[i].start == expected[i].start);
-		REQUIRE(actual[i].length == expected[i].length);
+		REQUIRE(static_cast<int>(actual.tokens[i].type) == static_cast<int>(expected[i].type));
+		REQUIRE(actual.tokens[i].start == expected[i].start);
+		REQUIRE(actual.tokens[i].length == expected[i].length);
 	}
+	REQUIRE(actual.ends_unterminated == ends_unterminated);
 }
 
 } // namespace
@@ -46,10 +48,11 @@ TEST_CASE("Stable C++API: Tokenize returns typed byte ranges", "[cpp_api]") {
 	    {TokenType::IDENTIFIER, 38, 1},     {TokenType::OPERATOR, 40, 2},       {TokenType::IDENTIFIER, 43, 1},
 	    {TokenType::COMMENT, 45, 5},        {TokenType::COMMENT, 50, 7},        {TokenType::TERMINATOR, 57, 1},
 	};
-	auto tokens = conn.Tokenize(sql);
-	RequireSameTokens(tokens, expected);
+	auto list = conn.Tokenize(sql);
+	RequireTokenList(list, expected, false);
 
 	// Every range slices a lexeme out of the input, and none reaches past its end.
+	auto &tokens = list.tokens;
 	REQUIRE(sql.substr(tokens[1].start, tokens[1].length) == "\"my col\"");
 	REQUIRE(sql.substr(tokens[3].start, tokens[3].length) == "'it''s'");
 	REQUIRE(tokens.back().start + tokens.back().length == sql.size());
@@ -64,12 +67,13 @@ TEST_CASE("Stable C++API: Tokenize honors the view's length, not a terminator", 
 
 	// A view that stops before the terminator, and one that carries an interior NUL.
 	std::string sql = "SELECT 1; SELECT 2";
-	RequireSameTokens(conn.Tokenize(std::string_view(sql).substr(0, 9)),
-	                  {{TokenType::KEYWORD, 0, 6}, {TokenType::NUMBER_LITERAL, 7, 1}, {TokenType::TERMINATOR, 8, 1}});
+	RequireTokenList(conn.Tokenize(std::string_view(sql).substr(0, 9)),
+	                 {{TokenType::KEYWORD, 0, 6}, {TokenType::NUMBER_LITERAL, 7, 1}, {TokenType::TERMINATOR, 8, 1}},
+	                 false);
 	std::string with_nul("1\0 2", 4);
-	RequireSameTokens(
+	RequireTokenList(
 	    conn.Tokenize(with_nul),
-	    {{TokenType::NUMBER_LITERAL, 0, 1}, {TokenType::IDENTIFIER, 1, 1}, {TokenType::NUMBER_LITERAL, 3, 1}});
+	    {{TokenType::NUMBER_LITERAL, 0, 1}, {TokenType::IDENTIFIER, 1, 1}, {TokenType::NUMBER_LITERAL, 3, 1}}, false);
 }
 
 TEST_CASE("Stable C++API: Tokenize on empty and malformed input", "[cpp_api]") {
@@ -79,11 +83,14 @@ TEST_CASE("Stable C++API: Tokenize on empty and malformed input", "[cpp_api]") {
 	auto db = env.Open(":memory:");
 	auto conn = db.Connect();
 
-	REQUIRE(conn.Tokenize("").empty());
-	REQUIRE(conn.Tokenize(" \n\t").empty());
+	RequireTokenList(conn.Tokenize(""), {}, false);
+	RequireTokenList(conn.Tokenize(" \n\t"), {}, false);
 
-	// An unterminated string does not throw; its token runs to the end of the input.
-	RequireSameTokens(conn.Tokenize("SELECT 'abc"), {{TokenType::KEYWORD, 0, 6}, {TokenType::STRING_LITERAL, 7, 4}});
+	// An unterminated string does not throw; its token runs to the end of the input and the list says so.
+	RequireTokenList(conn.Tokenize("SELECT 'abc"), {{TokenType::KEYWORD, 0, 6}, {TokenType::STRING_LITERAL, 7, 4}},
+	                 true);
+	RequireTokenList(conn.Tokenize("SELECT 'abc'"), {{TokenType::KEYWORD, 0, 6}, {TokenType::STRING_LITERAL, 7, 5}},
+	                 false);
 }
 
 TEST_CASE("Stable C++API: Tokenize on a moved-from connection throws", "[cpp_api]") {
@@ -95,5 +102,6 @@ TEST_CASE("Stable C++API: Tokenize on a moved-from connection throws", "[cpp_api
 	auto other = std::move(conn);
 	REQUIRE_THROWS_MATCHES(conn.Tokenize("SELECT 1"), InvalidInputException, // NOLINT: pinning the moved-from state
 	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
-	RequireSameTokens(other.Tokenize("SELECT 1"), {{TokenType::KEYWORD, 0, 6}, {TokenType::NUMBER_LITERAL, 7, 1}});
+	RequireTokenList(other.Tokenize("SELECT 1"), {{TokenType::KEYWORD, 0, 6}, {TokenType::NUMBER_LITERAL, 7, 1}},
+	                 false);
 }

--- a/tools/cpp/tests/test_cpp_api_tokenizer.cpp
+++ b/tools/cpp/tests/test_cpp_api_tokenizer.cpp
@@ -1,0 +1,99 @@
+#include "catch.hpp"
+#include "duckdb_cpp.hpp"
+#include "duckdb_v2.h"
+#include "test_cpp_api.hpp"
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Stable C++ API tests: Connection::Tokenize. The tokenizer's behavior is pinned
+// by the C API tests; these cover what the C++ layer adds on top.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using duckdb::cxx::Token;
+using duckdb::cxx::TokenType;
+
+// Token has no operator==; compare field-wise and report the first mismatch.
+void RequireSameTokens(const std::vector<Token> &actual, const std::vector<Token> &expected) {
+	REQUIRE(actual.size() == expected.size());
+	for (size_t i = 0; i < expected.size(); i++) {
+		INFO("token " << i);
+		REQUIRE(static_cast<int>(actual[i].type) == static_cast<int>(expected[i].type));
+		REQUIRE(actual[i].start == expected[i].start);
+		REQUIRE(actual[i].length == expected[i].length);
+	}
+}
+
+} // namespace
+
+TEST_CASE("Stable C++API: Tokenize returns typed byte ranges", "[cpp_api]") {
+	using namespace duckdb::cxx;
+
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	std::string sql = "SELECT \"my col\", 'it''s', $$d$$, 1e5, a <> b -- c\n/* d */;";
+	std::vector<Token> expected {
+	    {TokenType::KEYWORD, 0, 6},         {TokenType::IDENTIFIER, 7, 8},      {TokenType::OPERATOR, 15, 1},
+	    {TokenType::STRING_LITERAL, 17, 7}, {TokenType::OPERATOR, 24, 1},       {TokenType::STRING_LITERAL, 26, 5},
+	    {TokenType::OPERATOR, 31, 1},       {TokenType::NUMBER_LITERAL, 33, 3}, {TokenType::OPERATOR, 36, 1},
+	    {TokenType::IDENTIFIER, 38, 1},     {TokenType::OPERATOR, 40, 2},       {TokenType::IDENTIFIER, 43, 1},
+	    {TokenType::COMMENT, 45, 5},        {TokenType::COMMENT, 50, 7},        {TokenType::TERMINATOR, 57, 1},
+	};
+	auto tokens = conn.Tokenize(sql);
+	RequireSameTokens(tokens, expected);
+
+	// Every range slices a lexeme out of the input, and none reaches past its end.
+	REQUIRE(sql.substr(tokens[1].start, tokens[1].length) == "\"my col\"");
+	REQUIRE(sql.substr(tokens[3].start, tokens[3].length) == "'it''s'");
+	REQUIRE(tokens.back().start + tokens.back().length == sql.size());
+}
+
+TEST_CASE("Stable C++API: Tokenize honors the view's length, not a terminator", "[cpp_api]") {
+	using namespace duckdb::cxx;
+
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	// A view that stops before the terminator, and one that carries an interior NUL.
+	std::string sql = "SELECT 1; SELECT 2";
+	RequireSameTokens(conn.Tokenize(std::string_view(sql).substr(0, 9)),
+	                  {{TokenType::KEYWORD, 0, 6}, {TokenType::NUMBER_LITERAL, 7, 1}, {TokenType::TERMINATOR, 8, 1}});
+	std::string with_nul("1\0 2", 4);
+	RequireSameTokens(
+	    conn.Tokenize(with_nul),
+	    {{TokenType::NUMBER_LITERAL, 0, 1}, {TokenType::IDENTIFIER, 1, 1}, {TokenType::NUMBER_LITERAL, 3, 1}});
+}
+
+TEST_CASE("Stable C++API: Tokenize on empty and malformed input", "[cpp_api]") {
+	using namespace duckdb::cxx;
+
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+
+	REQUIRE(conn.Tokenize("").empty());
+	REQUIRE(conn.Tokenize(" \n\t").empty());
+
+	// An unterminated string does not throw; its token runs to the end of the input.
+	RequireSameTokens(conn.Tokenize("SELECT 'abc"), {{TokenType::KEYWORD, 0, 6}, {TokenType::STRING_LITERAL, 7, 4}});
+}
+
+TEST_CASE("Stable C++API: Tokenize on a moved-from connection throws", "[cpp_api]") {
+	using namespace duckdb::cxx;
+
+	Environment env;
+	auto db = env.Open(":memory:");
+	auto conn = db.Connect();
+	auto other = std::move(conn);
+	REQUIRE_THROWS_MATCHES(conn.Tokenize("SELECT 1"), InvalidInputException, // NOLINT: pinning the moved-from state
+	                       HasErrorCode(DUCKDB_V2_ERROR_INPUT_INVALID));
+	RequireSameTokens(other.Tokenize("SELECT 1"), {{TokenType::KEYWORD, 0, 6}, {TokenType::NUMBER_LITERAL, 7, 1}});
+}


### PR DESCRIPTION
This exposes the sql tokenizer through the new C API. There's not much interesting happening I think:
- We add a `tokenize_sql(conn, sql, *out_iterator, *err)` function that takes a `duckdb_v2_str sql` string and creates an opaque `token_iterator`. Users can call `token_iterator_next(*out_type, *out_start, *out_length, *err)` to get the token type (from the `TOKEN_TYPE` enum), the start position in the input string, and the length of the lexeme in the input string.
- The C++ API wraps this by adding the `Connection::Tokenize(sql)` method, which returns a vector of `Token`s (a struct that includes the type, start index and length)

The reason that the tokenization happens in the context of a connection is to respect any grammar extensions that might be loaded on that connection. The tokenizer is eager though, so the iterator does not need the connection after its been created.

