### PR TITLE
Reduce stack usage in clustered aggregate

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -727,7 +727,7 @@ jobs:
         tar -xzf build/release-artifact.tar.gz -C build
 
     - name: Run all release unit tests
-      run: make allunit
+      run: make allunit T="--test-flags='--thread-stack-size 131072'"
 
     - name: Release tests
       shell: bash

--- a/extension/core_functions/aggregate/distributive/sum.cpp
+++ b/extension/core_functions/aggregate/distributive/sum.cpp
@@ -92,10 +92,10 @@ struct ClusteredSumOperation : public ClusteredSumStateCopy<BASE> {
 	static void ExecuteFlatI64HugeintSum(const INPUT_TYPE *vals, const ClusteredAggr &clustered,
 	                                     const SelectionVector *isel, const sel_t *cluster_iter) {
 		idx_t pos = 0;
-		for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-			auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state);
-			const auto *run_sel = clustered.group_runs[r].sel;
-			const idx_t run_count = clustered.group_runs[r].count;
+		for (auto &run : clustered.runs()) {
+			auto &state = *reinterpret_cast<STATE_TYPE *>(run.state);
+			const auto *run_sel = run.sel;
+			const idx_t run_count = run.count;
 			if (run_count == 0) {
 				continue;
 			}
@@ -141,10 +141,10 @@ struct ClusteredSumOperation : public ClusteredSumStateCopy<BASE> {
 		input.ToUnifiedFormat(idata);
 		const auto *dict_sel = idata.sel->data();
 		auto &validity = idata.validity;
-		for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-			auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state);
-			const auto *run_sel = clustered.group_runs[r].sel;
-			const idx_t run_count = clustered.group_runs[r].count;
+		for (auto &run : clustered.runs()) {
+			auto &state = *reinterpret_cast<STATE_TYPE *>(run.state);
+			const auto *run_sel = run.sel;
+			const idx_t run_count = run.count;
 			int64_t local64 = 0;
 			if (run_sel) {
 				for (idx_t k = 0; k < run_count; k++) {

--- a/src/common/clustered_aggregate.cpp
+++ b/src/common/clustered_aggregate.cpp
@@ -269,7 +269,23 @@ const sel_t *ClusteredAggr::ClusterIter(const Vector &input, idx_t count) const 
 		return nullptr;
 	}
 	if (cached_dict_sel == dict_data) {
-		return composed_sel_data;
+		return state ? state->composed_sel_data.get() : local_composed_sel_data.get();
+	}
+	// Most clustered updates operate on flat or unified vectors. Only dictionary vectors need a
+	// composed selection, so allocate this scratch lazily. Hash-table users reuse the buffer in
+	// ClusteredAggrState; SetSingleRun users keep a private heap-backed buffer.
+	sel_t *composed_sel_data;
+	if (state) {
+		if (!state->composed_sel_data) {
+			state->composed_sel_data =
+			    make_unsafe_uniq_array_uninitialized<sel_t>(STANDARD_VECTOR_SIZE);
+		}
+		composed_sel_data = state->composed_sel_data.get();
+	} else {
+		if (!local_composed_sel_data) {
+			local_composed_sel_data = make_unsafe_uniq_array_uninitialized<sel_t>(STANDARD_VECTOR_SIZE);
+		}
+		composed_sel_data = local_composed_sel_data.get();
 	}
 	idx_t pos = 0;
 	for (idx_t r = 0; r < n_group_runs; r++) {
@@ -290,19 +306,21 @@ void ClusteredAggrState::Initialize() {
 	// Total = 2 * (MAX_HOTKEYS/2 + 1) * HALF_VEC = (MAX_HOTKEYS/2 + 1) * STANDARD_VECTOR_SIZE.
 	arena = make_unsafe_uniq_array_uninitialized<sel_t>((ClusteredAggr::MAX_HOTKEYS / 2 + 1) * STANDARD_VECTOR_SIZE);
 	slots = make_unsafe_uniq_array_uninitialized<uint64_t>(2 * ClusteredAggr::HASHTAB_SZ);
+	group_runs = make_unsafe_uniq_array_uninitialized<ClusteredAggr::GroupRun>(ClusteredAggr::MAX_RUNS);
 	std::fill_n(slots.get(), 2 * ClusteredAggr::HASHTAB_SZ, ClusteredAggr::FREE_SLOT);
 	skipped_opportunities = 0;
 	retry_backoff = 1;
 }
 
 bool ClusteredAggrState::TryBuild(ClusteredAggr &clustered, const uint64_t *group_ids, idx_t count) {
-	if (!arena) {
+	if (!arena || !group_runs) {
 		return false;
 	}
 	if (skipped_opportunities > 0) {
 		skipped_opportunities--;
 		return false;
 	}
+	clustered.BindGroupRuns(group_runs.get());
 	if (count >= ClusteredAggr::SAMPLE_SIZE &&
 	    clustered.TryClustered(group_ids, static_cast<sel_t>(count), arena.get(), slots.get())) {
 		clustered.state = this;

--- a/src/common/clustered_aggregate.cpp
+++ b/src/common/clustered_aggregate.cpp
@@ -89,7 +89,10 @@ static inline uint64_t slot_hash(uint64_t gid) {
 	return ((gid * 3217161767) ^ (gid >> ClusteredAggr::HASHTAB_LOG2)) & (ClusteredAggr::HASHTAB_SZ - 1);
 }
 
-bool ClusteredAggr::TryClustered(const uint64_t *group_ids, sel_t count, sel_t *arena, uint64_t *slots) {
+bool ClusteredAggr::TryClustered(const uint64_t *group_ids, sel_t count, sel_t *arena, uint64_t *slots,
+                                 GroupRun *runs) {
+	group_runs = runs;
+
 	constexpr sel_t HALF_VEC = STANDARD_VECTOR_SIZE / 2;
 	constexpr idx_t MAX_HOT_PER_CURSOR = MAX_HOTKEYS / 2;
 	idx_t tuples_in_large = 0;
@@ -241,6 +244,7 @@ bool ClusteredAggr::TryClustered(const uint64_t *group_ids, sel_t count, sel_t *
 }
 
 void ClusteredAggr::SetSingleRun(data_ptr_t state, idx_t count) {
+	D_ASSERT(group_runs == &single_run);
 	n_group_runs = 1;
 	group_runs[0].state = state;
 	group_runs[0].sel = nullptr;
@@ -277,8 +281,7 @@ const sel_t *ClusteredAggr::ClusterIter(const Vector &input, idx_t count) const 
 	sel_t *composed_sel_data;
 	if (state) {
 		if (!state->composed_sel_data) {
-			state->composed_sel_data =
-			    make_unsafe_uniq_array_uninitialized<sel_t>(STANDARD_VECTOR_SIZE);
+			state->composed_sel_data = make_unsafe_uniq_array_uninitialized<sel_t>(STANDARD_VECTOR_SIZE);
 		}
 		composed_sel_data = state->composed_sel_data.get();
 	} else {
@@ -288,14 +291,12 @@ const sel_t *ClusteredAggr::ClusterIter(const Vector &input, idx_t count) const 
 		composed_sel_data = local_composed_sel_data.get();
 	}
 	idx_t pos = 0;
-	for (idx_t r = 0; r < n_group_runs; r++) {
-		const auto *run_sel = group_runs[r].sel;
-		const auto run_count = group_runs[r].count;
-		for (idx_t k = 0; k < run_count; k++) {
-			auto idx = run_sel ? run_sel[k] : k;
+	for (auto &run : runs()) {
+		for (idx_t k = 0; k < run.count; k++) {
+			auto idx = run.sel ? run.sel[k] : k;
 			composed_sel_data[pos + k] = dict_data[idx];
 		}
-		pos += run_count;
+		pos += run.count;
 	}
 	cached_dict_sel = dict_data;
 	return composed_sel_data;
@@ -320,9 +321,8 @@ bool ClusteredAggrState::TryBuild(ClusteredAggr &clustered, const uint64_t *grou
 		skipped_opportunities--;
 		return false;
 	}
-	clustered.BindGroupRuns(group_runs.get());
 	if (count >= ClusteredAggr::SAMPLE_SIZE &&
-	    clustered.TryClustered(group_ids, static_cast<sel_t>(count), arena.get(), slots.get())) {
+	    clustered.TryClustered(group_ids, static_cast<sel_t>(count), arena.get(), slots.get(), group_runs.get())) {
 		clustered.state = this;
 		skipped_opportunities = 0;
 		retry_backoff = 1;

--- a/src/function/aggregate/distributive/count.cpp
+++ b/src/function/aggregate/distributive/count.cpp
@@ -149,10 +149,10 @@ struct CountFunction : public BaseCountFunction {
 	static void CountClusteredRuns(const ClusteredAggr &cs, const ValidityMask &validity, INDEXER indexer) {
 		const bool all_valid = !validity.CanHaveNull();
 		idx_t pos = 0;
-		for (idx_t r = 0; r < cs.n_group_runs; r++) {
-			auto &state = *reinterpret_cast<STATE *>(cs.group_runs[r].state);
-			const auto *run_sel = cs.group_runs[r].sel;
-			const auto run_count = cs.group_runs[r].count;
+		for (auto &run : cs.runs()) {
+			auto &state = *reinterpret_cast<STATE *>(run.state);
+			const auto *run_sel = run.sel;
+			const auto run_count = run.count;
 			if (all_valid) {
 				state += UnsafeNumericCast<STATE>(run_count);
 			} else {
@@ -200,9 +200,9 @@ struct CountFunction : public BaseCountFunction {
 			if (ConstantVector::IsNull(inputs[0])) {
 				return;
 			}
-			for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-				auto &state = *reinterpret_cast<STATE *>(clustered.group_runs[r].state);
-				state += UnsafeNumericCast<STATE>(clustered.group_runs[r].count);
+			for (auto &run : clustered.runs()) {
+				auto &state = *reinterpret_cast<STATE *>(run.state);
+				state += UnsafeNumericCast<STATE>(run.count);
 			}
 			return;
 		}

--- a/src/function/aggregate/distributive/first_last_any.cpp
+++ b/src/function/aggregate/distributive/first_last_any.cpp
@@ -384,10 +384,10 @@ void FirstFunctionClusterUpdate(Vector inputs[], AggregateInputData &aggregate_i
 	inputs[0].ToUnifiedFormat(idata);
 	auto input_data = UnifiedVectorFormat::GetData<T>(idata);
 	AggregateUnaryInput unary_input(aggregate_input_data, idata.validity);
-	for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-		auto &state = *reinterpret_cast<FirstState<T> *>(clustered.group_runs[r].state);
-		const auto *run_sel = clustered.group_runs[r].sel;
-		const auto run_count = clustered.group_runs[r].count;
+	for (auto &run : clustered.runs()) {
+		auto &state = *reinterpret_cast<FirstState<T> *>(run.state);
+		const auto *run_sel = run.sel;
+		const auto run_count = run.count;
 		FirstFunction<LAST, SKIP_NULLS>::template ClusteredOp<T, FirstState<T>, FirstFunction<LAST, SKIP_NULLS>>(
 		    state, input_data, unary_input, run_sel, *idata.sel, idata.validity, 0, run_count);
 	}

--- a/src/include/duckdb/common/clustered_aggregate.hpp
+++ b/src/include/duckdb/common/clustered_aggregate.hpp
@@ -50,14 +50,24 @@ struct ClusteredAggr {
 		idx_t count;      //! number of tuples in this group
 	};
 
+	ClusteredAggr() : group_runs(&single_run) {
+	}
+
 	idx_t n_group_runs = 0;
-	GroupRun group_runs[MAX_RUNS];
+	//! The single-run storage is used by SetSingleRun. Multi-run storage is bound from ClusteredAggrState.
+	GroupRun single_run;
+	GroupRun *group_runs;
 
 	const ClusteredAggrState *state = nullptr;
 
 	//! Build a clustered permutation of 0..count-1 from raw integer group ids.
 	//! On success fills group_runs[].sel/gid/count.
 	bool TryClustered(const uint64_t *group_ids, sel_t count, sel_t *arena, uint64_t *slots);
+
+	//! Bind reusable multi-run scratch storage before building a clustered representation.
+	void BindGroupRuns(GroupRun *runs) {
+		group_runs = runs;
+	}
 
 	//! Initialize a single run covering 0..count-1 for one aggregate state.
 	void SetSingleRun(data_ptr_t state, idx_t count);
@@ -76,14 +86,21 @@ struct ClusteredAggr {
 	const sel_t *ClusterIter(const Vector &input, idx_t count) const;
 
 private:
-	mutable sel_t composed_sel_data[STANDARD_VECTOR_SIZE];
+	//! Used by SetSingleRun callers that do not have a ClusteredAggrState.
+	mutable unsafe_unique_array<sel_t> local_composed_sel_data;
 	mutable const sel_t *cached_dict_sel = nullptr;
 };
+
+static_assert(sizeof(ClusteredAggr) <= 128, "ClusteredAggr must remain a small stack descriptor");
 
 //! Scratch state shared by GroupedAggregateHashTable and PerfectAggregateHashTable.
 struct ClusteredAggrState {
 	unsafe_unique_array<sel_t> arena;
 	unsafe_unique_array<uint64_t> slots;
+	//! Reusable run storage for ClusteredAggr instances owned by this hash table.
+	unsafe_unique_array<ClusteredAggr::GroupRun> group_runs;
+	//! Lazily allocated because it is only needed for dictionary vectors.
+	mutable unsafe_unique_array<sel_t> composed_sel_data;
 	bool all_clustered = false;
 	idx_t n_clustered = 0;
 	idx_t skipped_opportunities = 0;

--- a/src/include/duckdb/common/clustered_aggregate.hpp
+++ b/src/include/duckdb/common/clustered_aggregate.hpp
@@ -53,21 +53,28 @@ struct ClusteredAggr {
 	ClusteredAggr() : group_runs(&single_run) {
 	}
 
-	idx_t n_group_runs = 0;
-	//! The single-run storage is used by SetSingleRun. Multi-run storage is bound from ClusteredAggrState.
-	GroupRun single_run;
-	GroupRun *group_runs;
+	//! Read-only view over the runs of the permutation.
+	struct RunRange {
+		const GroupRun *begin_ptr;
+		const GroupRun *end_ptr;
+		const GroupRun *begin() const {
+			return begin_ptr;
+		}
+		const GroupRun *end() const {
+			return end_ptr;
+		}
+		idx_t size() const {
+			return static_cast<idx_t>(end_ptr - begin_ptr);
+		}
+		const GroupRun &operator[](idx_t i) const {
+			return begin_ptr[i];
+		}
+	};
+	RunRange runs() const {
+		return RunRange {group_runs, group_runs + n_group_runs};
+	}
 
 	const ClusteredAggrState *state = nullptr;
-
-	//! Build a clustered permutation of 0..count-1 from raw integer group ids.
-	//! On success fills group_runs[].sel/gid/count.
-	bool TryClustered(const uint64_t *group_ids, sel_t count, sel_t *arena, uint64_t *slots);
-
-	//! Bind reusable multi-run scratch storage before building a clustered representation.
-	void BindGroupRuns(GroupRun *runs) {
-		group_runs = runs;
-	}
 
 	//! Initialize a single run covering 0..count-1 for one aggregate state.
 	void SetSingleRun(data_ptr_t state, idx_t count);
@@ -86,6 +93,17 @@ struct ClusteredAggr {
 	const sel_t *ClusterIter(const Vector &input, idx_t count) const;
 
 private:
+	friend struct ClusteredAggrState;
+
+	//! Build a clustered permutation of 0..count-1 from group ids into runs.
+	//! On success fills runs[].sel/gid/count.
+	bool TryClustered(const uint64_t *group_ids, sel_t count, sel_t *arena, uint64_t *slots, GroupRun *runs);
+
+	idx_t n_group_runs = 0;
+	//! Used by SetSingleRun. Multi-run storage is bound by TryClustered.
+	GroupRun single_run;
+	GroupRun *group_runs;
+
 	//! Used by SetSingleRun callers that do not have a ClusteredAggrState.
 	mutable unsafe_unique_array<sel_t> local_composed_sel_data;
 	mutable const sel_t *cached_dict_sel = nullptr;

--- a/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
+++ b/src/include/duckdb/common/vector_operations/aggregate_executor.hpp
@@ -312,9 +312,9 @@ public:
 		// COUNT(*) can add run lengths directly.
 		if (aggr_input_data.clustered) {
 			auto &cs = *aggr_input_data.clustered;
-			for (idx_t r = 0; r < cs.n_group_runs; r++) {
-				OP::template ConstantOperation<STATE_TYPE, OP>(*reinterpret_cast<STATE_TYPE *>(cs.group_runs[r].state),
-				                                               aggr_input_data, cs.group_runs[r].count);
+			for (auto &run : cs.runs()) {
+				OP::template ConstantOperation<STATE_TYPE, OP>(*reinterpret_cast<STATE_TYPE *>(run.state),
+				                                               aggr_input_data, run.count);
 			}
 			return;
 		}
@@ -335,10 +335,9 @@ public:
 
 	template <class STATE_TYPE, class OP>
 	static void NullaryClustUpdate(AggregateInputData &aggr_input_data, const ClusteredAggr &clustered, idx_t count) {
-		for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-			OP::template ConstantOperation<STATE_TYPE, OP>(
-			    *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state), aggr_input_data,
-			    clustered.group_runs[r].count);
+		for (auto &run : clustered.runs()) {
+			OP::template ConstantOperation<STATE_TYPE, OP>(*reinterpret_cast<STATE_TYPE *>(run.state), aggr_input_data,
+			                                               run.count);
 		}
 	}
 
@@ -451,34 +450,34 @@ public:
 		idx_t pos = 0;
 		using local_type = clustered_local_state_t<OP, STATE_TYPE>;
 		if (cluster_iter) {
-			for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-				auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state);
+			for (auto &run : clustered.runs()) {
+				auto &state = *reinterpret_cast<STATE_TYPE *>(run.state);
 				local_type local;
 				OP::template InitializeClusteredLocal<STATE_TYPE>(local, state);
-				auto run_count = clustered.group_runs[r].count;
+				auto run_count = run.count;
 				auto saw_value = UpdateUnaryClusteredOpt<CHECK_VALIDITY, local_type, INPUT_TYPE, OP>(
 				    vals, local, run_count, validity, cluster_iter + pos);
 				OP::template FlushClusteredLocal<STATE_TYPE>(state, local, saw_value);
 				pos += run_count;
 			}
 		} else if (isel) {
-			for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-				auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state);
+			for (auto &run : clustered.runs()) {
+				auto &state = *reinterpret_cast<STATE_TYPE *>(run.state);
 				local_type local;
 				OP::template InitializeClusteredLocal<STATE_TYPE>(local, state);
-				auto run_count = clustered.group_runs[r].count;
+				auto run_count = run.count;
 				auto saw_value = UpdateUnaryClusteredOpt<CHECK_VALIDITY, local_type, INPUT_TYPE, OP>(
-				    vals, local, run_count, validity, clustered.group_runs[r].sel, isel);
+				    vals, local, run_count, validity, run.sel, isel);
 				OP::template FlushClusteredLocal<STATE_TYPE>(state, local, saw_value);
 			}
 		} else {
-			for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-				auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state);
+			for (auto &run : clustered.runs()) {
+				auto &state = *reinterpret_cast<STATE_TYPE *>(run.state);
 				local_type local;
 				OP::template InitializeClusteredLocal<STATE_TYPE>(local, state);
-				auto run_count = clustered.group_runs[r].count;
+				auto run_count = run.count;
 				auto saw_value = UpdateUnaryClusteredOpt<CHECK_VALIDITY, local_type, INPUT_TYPE, OP>(
-				    vals, local, run_count, validity, clustered.group_runs[r].sel);
+				    vals, local, run_count, validity, run.sel);
 				OP::template FlushClusteredLocal<STATE_TYPE>(state, local, saw_value);
 			}
 		}
@@ -502,8 +501,8 @@ public:
 	}
 
 	static inline bool IsDenseSingleRun(const ClusteredAggr &clustered, idx_t count) {
-		return clustered.n_group_runs == 1 && clustered.group_runs[0].count == count &&
-		       clustered.group_runs[0].sel == nullptr;
+		auto runs = clustered.runs();
+		return runs.size() == 1 && runs[0].count == count && runs[0].sel == nullptr;
 	}
 
 	template <bool SIMPLE_DICT, class STATE_TYPE, class INPUT_TYPE, class OP>
@@ -525,7 +524,8 @@ public:
 		auto vals = FlatVector::GetData<INPUT_TYPE>(input);
 		auto &validity = FlatVector::Validity(input);
 		if (IsDenseSingleRun(clustered, count)) {
-			auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[0].state);
+			auto runs = clustered.runs();
+			auto &state = *reinterpret_cast<STATE_TYPE *>(runs[0].state);
 			using local_type = clustered_local_state_t<OP, STATE_TYPE>;
 			local_type local;
 			OP::template InitializeClusteredLocal<STATE_TYPE>(local, state);
@@ -544,11 +544,11 @@ public:
 		}
 		const auto &constant_input = *ConstantVector::GetData<INPUT_TYPE>(input);
 		using has_repeat_count = HasClusteredLocalRepeatCount<OP, INPUT_TYPE, local_type>;
-		for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-			auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state);
+		for (auto &run : clustered.runs()) {
+			auto &state = *reinterpret_cast<STATE_TYPE *>(run.state);
 			local_type local;
 			OP::template InitializeClusteredLocal<STATE_TYPE>(local, state);
-			auto run_count = clustered.group_runs[r].count;
+			auto run_count = run.count;
 			if (run_count != 0) {
 				UpdateUnaryClusteredLocalRepeat<local_type, INPUT_TYPE, OP>(local, constant_input, run_count,
 				                                                            has_repeat_count {});
@@ -589,10 +589,9 @@ public:
 		}
 		auto idata = ConstantVector::GetData<INPUT_TYPE>(input);
 		AggregateUnaryInput unary_input(aggr_input_data, ConstantVector::Validity(input));
-		for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-			auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state);
-			OP::template ConstantOperation<INPUT_TYPE, STATE_TYPE, OP>(state, *idata, unary_input,
-			                                                           clustered.group_runs[r].count);
+		for (auto &run : clustered.runs()) {
+			auto &state = *reinterpret_cast<STATE_TYPE *>(run.state);
+			OP::template ConstantOperation<INPUT_TYPE, STATE_TYPE, OP>(state, *idata, unary_input, run.count);
 		}
 	}
 
@@ -608,11 +607,10 @@ public:
 		input.ToUnifiedFormat(idata);
 		auto vals = UnifiedVectorFormat::GetData<INPUT_TYPE>(idata);
 		AggregateUnaryInput unary_input(aggr_input_data, idata.validity);
-		for (idx_t r = 0; r < clustered.n_group_runs; r++) {
-			auto &state = *reinterpret_cast<STATE_TYPE *>(clustered.group_runs[r].state);
-			OP::template ClusteredOp<INPUT_TYPE, STATE_TYPE, OP>(state, vals, unary_input, clustered.group_runs[r].sel,
-			                                                     *idata.sel, idata.validity, 0,
-			                                                     clustered.group_runs[r].count);
+		for (auto &run : clustered.runs()) {
+			auto &state = *reinterpret_cast<STATE_TYPE *>(run.state);
+			OP::template ClusteredOp<INPUT_TYPE, STATE_TYPE, OP>(state, vals, unary_input, run.sel, *idata.sel,
+			                                                     idata.validity, 0, run.count);
 		}
 	}
 

--- a/src/include/duckdb/function/aggregate/list_aggregate.hpp
+++ b/src/include/duckdb/function/aggregate/list_aggregate.hpp
@@ -72,8 +72,7 @@ inline void ListClusterUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 	ListSegmentFunctions functions;
 	GetSegmentDataFunctions(functions, input.GetType());
 
-	for (idx_t run_idx = 0; run_idx < clustered.n_group_runs; run_idx++) {
-		auto &run = clustered.group_runs[run_idx];
+	for (auto &run : clustered.runs()) {
 		auto &state = *reinterpret_cast<ListAggState *>(run.state);
 		auto run_sel = run.sel;
 

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -5,6 +5,7 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 #include <stdlib.h>
+#include <cerrno>
 #include <cstring>
 #include <fstream>
 #include <limits>
@@ -62,6 +63,88 @@ static string PthreadError(const char *function, int error) {
 	return string(function) + " failed: " + std::strerror(error);
 }
 
+enum class ThreadStackProbeResult : uint8_t { SUCCESS, TOO_SMALL, ERROR };
+
+// glibc's fixed Linux minimum excludes the binary-specific static TLS overhead.
+static constexpr size_t GLIBC_PTHREAD_STACK_MIN = 16384;
+
+static void *MinimumThreadStackProbe(void *) {
+	return nullptr;
+}
+
+static ThreadStackProbeResult TryThreadStackSize(size_t stack_size, string &error) {
+	pthread_attr_t attributes;
+	auto result = pthread_getattr_default_np(&attributes);
+	if (result != 0) {
+		error = PthreadError("pthread_getattr_default_np", result);
+		return ThreadStackProbeResult::ERROR;
+	}
+
+	result = pthread_attr_setstacksize(&attributes, stack_size);
+	if (result != 0) {
+		pthread_attr_destroy(&attributes);
+		if (result == EINVAL) {
+			return ThreadStackProbeResult::TOO_SMALL;
+		}
+		error = PthreadError("pthread_attr_setstacksize", result);
+		return ThreadStackProbeResult::ERROR;
+	}
+
+	pthread_t probe;
+	result = pthread_create(&probe, &attributes, MinimumThreadStackProbe, nullptr);
+	auto destroy_result = pthread_attr_destroy(&attributes);
+	if (result != 0) {
+		if (result == EINVAL) {
+			return ThreadStackProbeResult::TOO_SMALL;
+		}
+		error = PthreadError("pthread_create", result);
+		return ThreadStackProbeResult::ERROR;
+	}
+	auto join_result = pthread_join(probe, nullptr);
+	if (join_result != 0) {
+		error = PthreadError("pthread_join", join_result);
+		return ThreadStackProbeResult::ERROR;
+	}
+	if (destroy_result != 0) {
+		error = PthreadError("pthread_attr_destroy", destroy_result);
+		return ThreadStackProbeResult::ERROR;
+	}
+	return ThreadStackProbeResult::SUCCESS;
+}
+
+static bool GetMinimumThreadStackSize(size_t default_stack_size, size_t page_size, size_t &minimum_stack_size,
+                                      string &error) {
+	auto lower_page = (GLIBC_PTHREAD_STACK_MIN + page_size - 1) / page_size;
+	auto upper_page = default_stack_size / page_size;
+	if (upper_page < lower_page) {
+		error = "Default pthread stack size is below the glibc minimum";
+		return false;
+	}
+	auto default_probe_result = TryThreadStackSize(upper_page * page_size, error);
+	if (default_probe_result != ThreadStackProbeResult::SUCCESS) {
+		if (default_probe_result == ThreadStackProbeResult::TOO_SMALL) {
+			error = "Unable to create a thread with the default pthread stack size";
+		} else {
+			error = "Unable to create a thread with the default pthread stack size: " + error;
+		}
+		return false;
+	}
+
+	while (lower_page < upper_page) {
+		auto middle_page = lower_page + (upper_page - lower_page) / 2;
+		auto probe_result = TryThreadStackSize(middle_page * page_size, error);
+		if (probe_result == ThreadStackProbeResult::SUCCESS) {
+			upper_page = middle_page;
+		} else if (probe_result == ThreadStackProbeResult::TOO_SMALL) {
+			lower_page = middle_page + 1;
+		} else {
+			return false;
+		}
+	}
+	minimum_stack_size = lower_page * page_size;
+	return true;
+}
+
 static bool SetThreadStackSize(size_t requested_stack_size, string &error) {
 	pthread_attr_t default_attributes;
 	auto result = pthread_getattr_default_np(&default_attributes);
@@ -70,7 +153,34 @@ static bool SetThreadStackSize(size_t requested_stack_size, string &error) {
 		return false;
 	}
 
-	result = pthread_attr_setstacksize(&default_attributes, requested_stack_size);
+	size_t default_stack_size;
+	result = pthread_attr_getstacksize(&default_attributes, &default_stack_size);
+	if (result != 0) {
+		pthread_attr_destroy(&default_attributes);
+		error = PthreadError("pthread_attr_getstacksize", result);
+		return false;
+	}
+	auto page_size_result = sysconf(_SC_PAGESIZE);
+	if (page_size_result <= 0) {
+		pthread_attr_destroy(&default_attributes);
+		error = "Failed to determine the system page size";
+		return false;
+	}
+	auto page_size = static_cast<size_t>(page_size_result);
+	size_t minimum_stack_size;
+	if (!GetMinimumThreadStackSize(default_stack_size, page_size, minimum_stack_size, error)) {
+		pthread_attr_destroy(&default_attributes);
+		return false;
+	}
+	auto stack_overhead = minimum_stack_size - GLIBC_PTHREAD_STACK_MIN;
+	if (requested_stack_size > std::numeric_limits<size_t>::max() - stack_overhead) {
+		pthread_attr_destroy(&default_attributes);
+		error = "--thread-stack-size is too large";
+		return false;
+	}
+	auto configured_stack_size = requested_stack_size + stack_overhead;
+
+	result = pthread_attr_setstacksize(&default_attributes, configured_stack_size);
 	if (result == 0) {
 		result = pthread_setattr_default_np(&default_attributes);
 	}
@@ -109,15 +219,12 @@ static bool SetThreadStackSize(size_t requested_stack_size, string &error) {
 		return false;
 	}
 
-	auto page_size = sysconf(_SC_PAGESIZE);
-	if (page_size <= 0) {
-		error = "Failed to determine the system page size";
-		return false;
-	}
-	auto difference = observed_stack_size > requested_stack_size ? observed_stack_size - requested_stack_size
-	                                                             : requested_stack_size - observed_stack_size;
-	if (difference > static_cast<size_t>(page_size)) {
-		error = "Thread stack size probe reported " + to_string(observed_stack_size) + " bytes after requesting " +
+	auto effective_stack_size = observed_stack_size > stack_overhead ? observed_stack_size - stack_overhead : 0;
+	auto difference = effective_stack_size > requested_stack_size ? effective_stack_size - requested_stack_size
+	                                                              : requested_stack_size - effective_stack_size;
+	if (difference > page_size) {
+		error = "Thread stack size probe reported " + to_string(observed_stack_size) + " total bytes (" +
+		        to_string(effective_stack_size) + " after glibc overhead) after requesting " +
 		        to_string(requested_stack_size) + " bytes";
 		return false;
 	}

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -1,8 +1,21 @@
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 #include <stdlib.h>
+#include <cstring>
 #include <fstream>
+#include <limits>
+#include <thread>
 #include <unordered_set>
+
+#if defined(__linux__)
+#include <features.h>
+#include <pthread.h>
+#include <unistd.h>
+#endif
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -15,6 +28,137 @@
 using namespace duckdb;
 
 namespace {
+
+#if defined(__linux__) && !defined(DUCKDB_NO_THREADS) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 18)
+#define DUCKDB_UNITTEST_HAS_DEFAULT_PTHREAD_ATTRIBUTES
+#endif
+#endif
+
+static bool TryParseThreadStackSize(const string &value, size_t &result) {
+	if (value.empty()) {
+		return false;
+	}
+	size_t parsed_value = 0;
+	for (auto character : value) {
+		if (character < '0' || character > '9') {
+			return false;
+		}
+		auto digit = static_cast<size_t>(character - '0');
+		if (parsed_value > (std::numeric_limits<size_t>::max() - digit) / 10) {
+			return false;
+		}
+		parsed_value = parsed_value * 10 + digit;
+	}
+	if (parsed_value == 0) {
+		return false;
+	}
+	result = parsed_value;
+	return true;
+}
+
+#ifdef DUCKDB_UNITTEST_HAS_DEFAULT_PTHREAD_ATTRIBUTES
+static string PthreadError(const char *function, int error) {
+	return string(function) + " failed: " + std::strerror(error);
+}
+
+static bool SetThreadStackSize(size_t requested_stack_size, string &error) {
+	pthread_attr_t default_attributes;
+	auto result = pthread_getattr_default_np(&default_attributes);
+	if (result != 0) {
+		error = PthreadError("pthread_getattr_default_np", result);
+		return false;
+	}
+
+	result = pthread_attr_setstacksize(&default_attributes, requested_stack_size);
+	if (result == 0) {
+		result = pthread_setattr_default_np(&default_attributes);
+	}
+	auto destroy_result = pthread_attr_destroy(&default_attributes);
+	if (result != 0) {
+		error = PthreadError("setting the default pthread stack size", result);
+		return false;
+	}
+	if (destroy_result != 0) {
+		error = PthreadError("pthread_attr_destroy", destroy_result);
+		return false;
+	}
+
+	size_t observed_stack_size = 0;
+	int probe_result = 0;
+	try {
+		std::thread probe([&]() {
+			pthread_attr_t probe_attributes;
+			probe_result = pthread_getattr_np(pthread_self(), &probe_attributes);
+			if (probe_result != 0) {
+				return;
+			}
+			probe_result = pthread_attr_getstacksize(&probe_attributes, &observed_stack_size);
+			auto probe_destroy_result = pthread_attr_destroy(&probe_attributes);
+			if (probe_result == 0) {
+				probe_result = probe_destroy_result;
+			}
+		});
+		probe.join();
+	} catch (std::exception &ex) {
+		error = string("Failed to create thread stack size probe: ") + ex.what();
+		return false;
+	}
+	if (probe_result != 0) {
+		error = PthreadError("reading the probe thread stack size", probe_result);
+		return false;
+	}
+
+	auto page_size = sysconf(_SC_PAGESIZE);
+	if (page_size <= 0) {
+		error = "Failed to determine the system page size";
+		return false;
+	}
+	auto difference = observed_stack_size > requested_stack_size ? observed_stack_size - requested_stack_size
+	                                                             : requested_stack_size - observed_stack_size;
+	if (difference > static_cast<size_t>(page_size)) {
+		error = "Thread stack size probe reported " + to_string(observed_stack_size) + " bytes after requesting " +
+		        to_string(requested_stack_size) + " bytes";
+		return false;
+	}
+	return true;
+}
+#endif
+
+static bool ConfigureThreadStackSize(int argc, char *argv[], string &error) {
+	bool stack_size_specified = false;
+	size_t requested_stack_size = 0;
+	for (int i = 1; i < argc; i++) {
+		if (string(argv[i]) != "--thread-stack-size") {
+			continue;
+		}
+		if (stack_size_specified) {
+			error = "--thread-stack-size may only be specified once";
+			return false;
+		}
+		if (++i >= argc) {
+			error = "--thread-stack-size expected a size in bytes";
+			return false;
+		}
+		size_t parsed_stack_size;
+		if (!TryParseThreadStackSize(argv[i], parsed_stack_size)) {
+			error = "--thread-stack-size expected a positive integer size in bytes";
+			return false;
+		}
+		requested_stack_size = parsed_stack_size;
+		stack_size_specified = true;
+	}
+	if (!stack_size_specified) {
+		return true;
+	}
+
+#ifdef DUCKDB_UNITTEST_HAS_DEFAULT_PTHREAD_ATTRIBUTES
+	return SetThreadStackSize(requested_stack_size, error);
+#else
+	error = "--thread-stack-size is only supported on Linux with glibc 2.18 or newer";
+	return false;
+#endif
+}
 
 struct TempDirReclaimer {
 	~TempDirReclaimer() {
@@ -65,6 +209,12 @@ static bool TryReadExactSQLLogicTestFilter(const vector<string> &input_files, ve
 }
 
 int main(int argc_in, char *argv[]) {
+	string thread_stack_error;
+	if (!ConfigureThreadStackSize(argc_in, argv, thread_stack_error)) {
+		fprintf(stderr, "%s\n", thread_stack_error.c_str());
+		return 1;
+	}
+
 	string test_directory = DUCKDB_ROOT_DIRECTORY;
 
 	// route the sqllogictest runner's verdicts into the Catch session
@@ -104,6 +254,8 @@ int main(int argc_in, char *argv[]) {
 			use_stdin = true;
 		} else if (argument == "--emit-test-events") {
 			SetEmitTestEvents(true);
+		} else if (argument == "--thread-stack-size") {
+			i++;
 		} else {
 			try {
 				if (!test_config.ParseArgument(argument, argc, argv, i)) {


### PR DESCRIPTION
Possibly resolves https://github.com/duckdblabs/duckdb-internal/issues/10522 by reducing stack usage by moving scratch buffers to the heap.