### PR TITLE
Add parser microbenchmarks

### DIFF
--- a/.github/regression/parser.csv
+++ b/.github/regression/parser.csv
@@ -1,0 +1,9 @@
+ParserSimpleSelect
+ParserKeywordIdentifiers
+ParserWideSelect
+ParserNestedExpressions
+ParserCTEs
+ParserStatements
+ParserTPCH
+ParserTPCDS
+ParserFlummi

--- a/.github/regression/parser.csv
+++ b/.github/regression/parser.csv
@@ -1,9 +1,9 @@
-ParserSimpleSelect
 ParserKeywordIdentifiers
 ParserWideSelect
 ParserNestedExpressions
-ParserCTEs
+ParserMalformedSelect
 ParserStatements
 ParserTPCH
 ParserTPCDS
 ParserFlummi
+ParserGrammarConstruction

--- a/.github/regression/parser.csv
+++ b/.github/regression/parser.csv
@@ -6,4 +6,5 @@ ParserStatements
 ParserTPCH
 ParserTPCDS
 ParserFlummi
+ParserAoC
 ParserGrammarConstruction

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -142,6 +142,8 @@ jobs:
             benchmark: .github/regression/ingestion.csv
           - name: Micro
             benchmark: .github/regression/micro.csv
+          - name: Parser
+            benchmark: .github/regression/parser.csv
           - name: H2OAI
             benchmark: .github/regression/h2oai.csv
           - name: IMDB

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -52,6 +52,12 @@ Not specifying any argument will run all benchmarks.
 
 `build/release/benchmark/benchmark_runner`
 
+#### Parser-only microbenchmarks
+
+Use the `Parser.*` benchmarks to measure `Parser::ParseQuery()` without query execution.
+See [the parser benchmark guide](micro/parser/README.md) for workloads, timing boundaries,
+and revision comparisons using `.github/regression/parser.csv`.
+
 #### Other options
 `--info` gives you some other information about the benchmark.
 
@@ -109,5 +115,4 @@ SELECT MIN(i + 1) FROM integers
 │          (0.08s)          │
 └───────────────────────────┘      
 ```
-
 

--- a/benchmark/micro/CMakeLists.txt
+++ b/benchmark/micro/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
   cast.cpp
   executor.cpp
   in.cpp
+  parser.cpp
   storage.cpp
   string_serialize.cpp)
 

--- a/benchmark/micro/parser.cpp
+++ b/benchmark/micro/parser.cpp
@@ -1,0 +1,215 @@
+#include "benchmark_runner.hpp"
+#include "duckdb/common/atomic.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/fstream.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/peg/compiled_grammar.hpp"
+
+#include <sstream>
+
+namespace duckdb {
+
+enum class ParserWorkload : uint8_t {
+	SIMPLE_SELECT,
+	KEYWORD_IDENTIFIERS,
+	WIDE_SELECT,
+	NESTED_EXPRESSIONS,
+	CTES,
+	STATEMENTS,
+	TPCH,
+	TPCDS,
+	FLUMMI
+};
+
+struct ParserBenchmarkState : public BenchmarkState {
+	ParserOptions options;
+	vector<string> queries;
+	idx_t statements_parsed = 0;
+	bool valid_statement_counts = true;
+	atomic<bool> interrupted {false};
+};
+
+class ParserMicroBenchmark : public Benchmark {
+public:
+	ParserMicroBenchmark(const string &name, ParserWorkload workload_p, idx_t iterations_p, idx_t statement_count_p = 1)
+	    : Benchmark(true, name, "[parser]"), workload(workload_p), iterations(iterations_p),
+	      statement_count(statement_count_p) {
+	}
+
+	unique_ptr<BenchmarkState> Initialize(BenchmarkConfiguration &config) override {
+		auto state = make_uniq<ParserBenchmarkState>();
+		state->queries = LoadQueries();
+		state->options.compiled_grammar = CompiledGrammar::Create();
+		for (idx_t i = 0; i < state->queries.size(); i++) {
+			Parser parser(state->options);
+			parser.ParseQuery(state->queries[i]);
+			if (parser.statements.size() != statement_count) {
+				throw InvalidInputException("Parser benchmark '%s' input %llu expected %llu statements, got %llu", name,
+				                            i + 1, statement_count, parser.statements.size());
+			}
+		}
+		return std::move(state);
+	}
+
+	void Run(BenchmarkState *state_p) override {
+		auto &state = static_cast<ParserBenchmarkState &>(*state_p);
+		state.statements_parsed = 0;
+		state.valid_statement_counts = true;
+		for (idx_t i = 0; i < iterations; i++) {
+			for (auto &query : state.queries) {
+				if (state.interrupted.load()) {
+					return;
+				}
+				Parser parser(state.options);
+				parser.ParseQuery(query);
+				state.statements_parsed += parser.statements.size();
+				state.valid_statement_counts &= parser.statements.size() == statement_count;
+			}
+		}
+	}
+
+	void Cleanup(BenchmarkState *state_p) override {
+		auto &state = static_cast<ParserBenchmarkState &>(*state_p);
+		state.interrupted.store(false);
+	}
+
+	string Verify(BenchmarkState *state_p) override {
+		auto &state = static_cast<ParserBenchmarkState &>(*state_p);
+		if (!state.valid_statement_counts || state.statements_parsed != iterations * QueryCount() * statement_count) {
+			return "Unexpected number of parsed statements";
+		}
+		return string();
+	}
+
+	void Interrupt(BenchmarkState *state_p) override {
+		auto &state = static_cast<ParserBenchmarkState &>(*state_p);
+		state.interrupted.store(true);
+	}
+
+	string GetLogOutput(BenchmarkState *state) override {
+		return string();
+	}
+
+	string DisplayName() override {
+		return StringUtil::Format("%s (%llu inputs x %llu repetitions, %llu statements/input)", name, QueryCount(),
+		                          iterations, statement_count);
+	}
+
+	string BenchmarkInfo() override {
+		return StringUtil::Format("Parser::ParseQuery, %llu calls/run, %llu statements/call; "
+		                          "default parser options, reused compiled grammar, no query execution",
+		                          iterations * QueryCount(), statement_count);
+	}
+
+	string GetQuery() override {
+		switch (workload) {
+		case ParserWorkload::SIMPLE_SELECT:
+			return "SELECT 1";
+		case ParserWorkload::KEYWORD_IDENTIFIERS:
+			return "SeLeCt abort, action, comment, database, first, last FROM source_table "
+			       "WHERE action IS NOT NULL AND comment <> 'value' ORDER BY first, last";
+		case ParserWorkload::WIDE_SELECT: {
+			string query = "SELECT ";
+			for (idx_t i = 0; i < 128; i++) {
+				if (i > 0) {
+					query += ", ";
+				}
+				query += "column_" + to_string(i) + " + " + to_string(i) + " AS alias_" + to_string(i);
+			}
+			return query + " FROM source_table";
+		}
+		case ParserWorkload::NESTED_EXPRESSIONS: {
+			string expression = "value_column";
+			for (idx_t i = 0; i < 32; i++) {
+				expression = "coalesce(" + expression + ", " + to_string(i) + ")";
+			}
+			return "SELECT " + expression + " FROM source_table";
+		}
+		case ParserWorkload::CTES: {
+			string query = "WITH cte_0 AS (SELECT 1 AS value_column)";
+			for (idx_t i = 1; i < 16; i++) {
+				query += ", cte_" + to_string(i) + " AS (SELECT value_column + 1 AS value_column FROM cte_" +
+				         to_string(i - 1) + " WHERE value_column < 100)";
+			}
+			return query + " SELECT * FROM cte_15";
+		}
+		case ParserWorkload::STATEMENTS: {
+			string query;
+			for (idx_t i = 0; i < 32; i++) {
+				query += "SELECT " + to_string(i) + " AS \"quoted column\"; -- statement boundary\n";
+			}
+			return query;
+		}
+		case ParserWorkload::TPCH:
+		case ParserWorkload::TPCDS:
+		case ParserWorkload::FLUMMI:
+			return StringUtil::Join(LoadQueries(), "\n");
+		default:
+			throw InternalException("Unknown parser benchmark workload");
+		}
+	}
+
+private:
+	idx_t QueryCount() const {
+		switch (workload) {
+		case ParserWorkload::TPCH:
+			return 22;
+		case ParserWorkload::TPCDS:
+			return 99;
+		default:
+			return 1;
+		}
+	}
+
+	static string ReadQuery(const string &path) {
+		ifstream input(path, ios::binary);
+		if (!input.is_open()) {
+			throw IOException("Cannot open parser benchmark input '%s'; provide the query files under --root-dir",
+			                  path);
+		}
+		std::ostringstream buffer;
+		buffer << input.rdbuf();
+		if (input.bad() || buffer.bad()) {
+			throw IOException("Cannot read parser benchmark input '%s'", path);
+		}
+		auto query = buffer.str();
+		if (query.empty()) {
+			throw InvalidInputException("Parser benchmark input '%s' is empty", path);
+		}
+		return query;
+	}
+
+	vector<string> LoadQueries() {
+		if (workload == ParserWorkload::FLUMMI) {
+			return {ReadQuery("benchmark/recursive_cte/queries/performance/flummi_ray.sql")};
+		}
+		if (workload != ParserWorkload::TPCH && workload != ParserWorkload::TPCDS) {
+			return {GetQuery()};
+		}
+		const string prefix =
+		    workload == ParserWorkload::TPCH ? "extension/tpch/dbgen/queries/q" : "extension/tpcds/dsdgen/queries/";
+		vector<string> queries;
+		for (idx_t i = 1; i <= QueryCount(); i++) {
+			queries.push_back(ReadQuery(prefix + (i < 10 ? "0" : "") + to_string(i) + ".sql"));
+		}
+		return queries;
+	}
+
+private:
+	ParserWorkload workload;
+	idx_t iterations;
+	idx_t statement_count;
+};
+
+ParserMicroBenchmark parser_simple_select("ParserSimpleSelect", ParserWorkload::SIMPLE_SELECT, 10000);
+ParserMicroBenchmark parser_keyword_identifiers("ParserKeywordIdentifiers", ParserWorkload::KEYWORD_IDENTIFIERS, 2000);
+ParserMicroBenchmark parser_wide_select("ParserWideSelect", ParserWorkload::WIDE_SELECT, 500);
+ParserMicroBenchmark parser_nested_expressions("ParserNestedExpressions", ParserWorkload::NESTED_EXPRESSIONS, 1000);
+ParserMicroBenchmark parser_ctes("ParserCTEs", ParserWorkload::CTES, 500);
+ParserMicroBenchmark parser_statements("ParserStatements", ParserWorkload::STATEMENTS, 1000, 32);
+ParserMicroBenchmark parser_tpch("ParserTPCH", ParserWorkload::TPCH, 50);
+ParserMicroBenchmark parser_tpcds("ParserTPCDS", ParserWorkload::TPCDS, 10);
+ParserMicroBenchmark parser_flummi("ParserFlummi", ParserWorkload::FLUMMI, 5);
+
+} // namespace duckdb

--- a/benchmark/micro/parser.cpp
+++ b/benchmark/micro/parser.cpp
@@ -1,6 +1,7 @@
 #include "benchmark_runner.hpp"
 #include "duckdb/common/atomic.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/exception/parser_exception.hpp"
 #include "duckdb/common/fstream.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/parser.hpp"
@@ -11,11 +12,10 @@
 namespace duckdb {
 
 enum class ParserWorkload : uint8_t {
-	SIMPLE_SELECT,
 	KEYWORD_IDENTIFIERS,
 	WIDE_SELECT,
 	NESTED_EXPRESSIONS,
-	CTES,
+	MALFORMED_SELECT,
 	STATEMENTS,
 	TPCH,
 	TPCDS,
@@ -26,6 +26,7 @@ struct ParserBenchmarkState : public BenchmarkState {
 	ParserOptions options;
 	vector<string> queries;
 	idx_t statements_parsed = 0;
+	idx_t parser_errors = 0;
 	bool valid_statement_counts = true;
 	atomic<bool> interrupted {false};
 };
@@ -41,6 +42,10 @@ public:
 		auto state = make_uniq<ParserBenchmarkState>();
 		state->queries = LoadQueries();
 		state->options.compiled_grammar = CompiledGrammar::Create();
+		// Keep malformed-input backtracking under the runner's timeout in Run.
+		if (workload == ParserWorkload::MALFORMED_SELECT) {
+			return std::move(state);
+		}
 		for (idx_t i = 0; i < state->queries.size(); i++) {
 			Parser parser(state->options);
 			parser.ParseQuery(state->queries[i]);
@@ -55,11 +60,16 @@ public:
 	void Run(BenchmarkState *state_p) override {
 		auto &state = static_cast<ParserBenchmarkState &>(*state_p);
 		state.statements_parsed = 0;
+		state.parser_errors = 0;
 		state.valid_statement_counts = true;
 		for (idx_t i = 0; i < iterations; i++) {
 			for (auto &query : state.queries) {
 				if (state.interrupted.load()) {
 					return;
+				}
+				if (workload == ParserWorkload::MALFORMED_SELECT) {
+					state.parser_errors += RejectMalformedQuery(state.options, query);
+					continue;
 				}
 				Parser parser(state.options);
 				parser.ParseQuery(query);
@@ -76,6 +86,10 @@ public:
 
 	string Verify(BenchmarkState *state_p) override {
 		auto &state = static_cast<ParserBenchmarkState &>(*state_p);
+		if (workload == ParserWorkload::MALFORMED_SELECT) {
+			return state.parser_errors == iterations * QueryCount() ? string()
+			                                                        : "Expected a ParserException on every call";
+		}
 		if (!state.valid_statement_counts || state.statements_parsed != iterations * QueryCount() * statement_count) {
 			return "Unexpected number of parsed statements";
 		}
@@ -92,11 +106,19 @@ public:
 	}
 
 	string DisplayName() override {
+		if (workload == ParserWorkload::MALFORMED_SELECT) {
+			return StringUtil::Format("%s (%llu expected ParserExceptions/run)", name, iterations);
+		}
 		return StringUtil::Format("%s (%llu inputs x %llu repetitions, %llu statements/input)", name, QueryCount(),
 		                          iterations, statement_count);
 	}
 
 	string BenchmarkInfo() override {
+		if (workload == ParserWorkload::MALFORMED_SELECT) {
+			return StringUtil::Format("Parser::ParseQuery, %llu rejected inputs/run; reused compiled grammar, "
+			                          "includes failed matching, error construction and cleanup",
+			                          iterations);
+		}
 		return StringUtil::Format("Parser::ParseQuery, %llu calls/run, %llu statements/call; "
 		                          "default parser options, reused compiled grammar, no query execution",
 		                          iterations * QueryCount(), statement_count);
@@ -104,8 +126,6 @@ public:
 
 	string GetQuery() override {
 		switch (workload) {
-		case ParserWorkload::SIMPLE_SELECT:
-			return "SELECT 1";
 		case ParserWorkload::KEYWORD_IDENTIFIERS:
 			return "SeLeCt abort, action, comment, database, first, last FROM source_table "
 			       "WHERE action IS NOT NULL AND comment <> 'value' ORDER BY first, last";
@@ -126,14 +146,8 @@ public:
 			}
 			return "SELECT " + expression + " FROM source_table";
 		}
-		case ParserWorkload::CTES: {
-			string query = "WITH cte_0 AS (SELECT 1 AS value_column)";
-			for (idx_t i = 1; i < 16; i++) {
-				query += ", cte_" + to_string(i) + " AS (SELECT value_column + 1 AS value_column FROM cte_" +
-				         to_string(i - 1) + " WHERE value_column < 100)";
-			}
-			return query + " SELECT * FROM cte_15";
-		}
+		case ParserWorkload::MALFORMED_SELECT:
+			return "select (((((((((((((;";
 		case ParserWorkload::STATEMENTS: {
 			string query;
 			for (idx_t i = 0; i < 32; i++) {
@@ -151,6 +165,16 @@ public:
 	}
 
 private:
+	static bool RejectMalformedQuery(const ParserOptions &options, const string &query) {
+		Parser parser(options);
+		try {
+			parser.ParseQuery(query);
+		} catch (const ParserException &) {
+			return true;
+		}
+		return false;
+	}
+
 	idx_t QueryCount() const {
 		switch (workload) {
 		case ParserWorkload::TPCH:
@@ -202,14 +226,73 @@ private:
 	idx_t statement_count;
 };
 
-ParserMicroBenchmark parser_simple_select("ParserSimpleSelect", ParserWorkload::SIMPLE_SELECT, 10000);
 ParserMicroBenchmark parser_keyword_identifiers("ParserKeywordIdentifiers", ParserWorkload::KEYWORD_IDENTIFIERS, 2000);
 ParserMicroBenchmark parser_wide_select("ParserWideSelect", ParserWorkload::WIDE_SELECT, 500);
 ParserMicroBenchmark parser_nested_expressions("ParserNestedExpressions", ParserWorkload::NESTED_EXPRESSIONS, 1000);
-ParserMicroBenchmark parser_ctes("ParserCTEs", ParserWorkload::CTES, 500);
+ParserMicroBenchmark parser_malformed_select("ParserMalformedSelect", ParserWorkload::MALFORMED_SELECT, 1000, 0);
 ParserMicroBenchmark parser_statements("ParserStatements", ParserWorkload::STATEMENTS, 1000, 32);
 ParserMicroBenchmark parser_tpch("ParserTPCH", ParserWorkload::TPCH, 50);
 ParserMicroBenchmark parser_tpcds("ParserTPCDS", ParserWorkload::TPCDS, 10);
 ParserMicroBenchmark parser_flummi("ParserFlummi", ParserWorkload::FLUMMI, 5);
+
+struct ParserGrammarConstructionState : public BenchmarkState {
+	idx_t grammars_constructed = 0;
+	atomic<bool> interrupted {false};
+};
+
+class ParserGrammarConstructionBenchmark : public Benchmark {
+public:
+	ParserGrammarConstructionBenchmark() : Benchmark(true, "ParserGrammarConstruction", "[parser]") {
+	}
+
+	unique_ptr<BenchmarkState> Initialize(BenchmarkConfiguration &config) override {
+		return make_uniq<ParserGrammarConstructionState>();
+	}
+
+	void Run(BenchmarkState *state_p) override {
+		auto &state = static_cast<ParserGrammarConstructionState &>(*state_p);
+		state.grammars_constructed = 0;
+		for (idx_t i = 0; i < ITERATIONS; i++) {
+			if (state.interrupted.load()) {
+				return;
+			}
+			auto grammar = CompiledGrammar::Create();
+			state.grammars_constructed += grammar != nullptr;
+		}
+	}
+
+	void Cleanup(BenchmarkState *state_p) override {
+		auto &state = static_cast<ParserGrammarConstructionState &>(*state_p);
+		state.interrupted.store(false);
+	}
+
+	string Verify(BenchmarkState *state_p) override {
+		auto &state = static_cast<ParserGrammarConstructionState &>(*state_p);
+		return state.grammars_constructed == ITERATIONS ? string() : "Unexpected number of constructed grammars";
+	}
+
+	void Interrupt(BenchmarkState *state_p) override {
+		auto &state = static_cast<ParserGrammarConstructionState &>(*state_p);
+		state.interrupted.store(true);
+	}
+
+	string GetLogOutput(BenchmarkState *state) override {
+		return string();
+	}
+
+	string DisplayName() override {
+		return StringUtil::Format("%s (%llu grammar constructions/run)", name, ITERATIONS);
+	}
+
+	string BenchmarkInfo() override {
+		return "Construct and destroy the compiled base grammar; includes grammar parsing, keyword tables and matcher "
+		       "construction, excludes SQL parsing and grammar extensions";
+	}
+
+private:
+	static constexpr idx_t ITERATIONS = 500;
+};
+
+ParserGrammarConstructionBenchmark parser_grammar_construction;
 
 } // namespace duckdb

--- a/benchmark/micro/parser.cpp
+++ b/benchmark/micro/parser.cpp
@@ -128,7 +128,7 @@ public:
 	string GetQuery() override {
 		switch (workload) {
 		case ParserWorkload::KEYWORD_IDENTIFIERS:
-			return "SeLeCt abort, action, comment, database, first, last FROM source_table "
+			return "SELECT abort, action, comment, database, first, last FROM source_table "
 			       "WHERE action IS NOT NULL AND comment <> 'value' ORDER BY first, last";
 		case ParserWorkload::WIDE_SELECT: {
 			string query = "SELECT ";

--- a/benchmark/micro/parser.cpp
+++ b/benchmark/micro/parser.cpp
@@ -19,7 +19,8 @@ enum class ParserWorkload : uint8_t {
 	STATEMENTS,
 	TPCH,
 	TPCDS,
-	FLUMMI
+	FLUMMI,
+	AOC
 };
 
 struct ParserBenchmarkState : public BenchmarkState {
@@ -158,6 +159,7 @@ public:
 		case ParserWorkload::TPCH:
 		case ParserWorkload::TPCDS:
 		case ParserWorkload::FLUMMI:
+		case ParserWorkload::AOC:
 			return StringUtil::Join(LoadQueries(), "\n");
 		default:
 			throw InternalException("Unknown parser benchmark workload");
@@ -181,6 +183,8 @@ private:
 			return 22;
 		case ParserWorkload::TPCDS:
 			return 99;
+		case ParserWorkload::AOC:
+			return 25;
 		default:
 			return 1;
 		}
@@ -205,14 +209,22 @@ private:
 	}
 
 	vector<string> LoadQueries() {
-		if (workload == ParserWorkload::FLUMMI) {
+		string prefix;
+		switch (workload) {
+		case ParserWorkload::FLUMMI:
 			return {ReadQuery("benchmark/recursive_cte/queries/performance/flummi_ray.sql")};
-		}
-		if (workload != ParserWorkload::TPCH && workload != ParserWorkload::TPCDS) {
+		case ParserWorkload::TPCH:
+			prefix = "extension/tpch/dbgen/queries/q";
+			break;
+		case ParserWorkload::TPCDS:
+			prefix = "extension/tpcds/dsdgen/queries/";
+			break;
+		case ParserWorkload::AOC:
+			prefix = "benchmark/aoc24/queries/day";
+			break;
+		default:
 			return {GetQuery()};
 		}
-		const string prefix =
-		    workload == ParserWorkload::TPCH ? "extension/tpch/dbgen/queries/q" : "extension/tpcds/dsdgen/queries/";
 		vector<string> queries;
 		for (idx_t i = 1; i <= QueryCount(); i++) {
 			queries.push_back(ReadQuery(prefix + (i < 10 ? "0" : "") + to_string(i) + ".sql"));
@@ -234,6 +246,7 @@ ParserMicroBenchmark parser_statements("ParserStatements", ParserWorkload::STATE
 ParserMicroBenchmark parser_tpch("ParserTPCH", ParserWorkload::TPCH, 50);
 ParserMicroBenchmark parser_tpcds("ParserTPCDS", ParserWorkload::TPCDS, 10);
 ParserMicroBenchmark parser_flummi("ParserFlummi", ParserWorkload::FLUMMI, 5);
+ParserMicroBenchmark parser_aoc("ParserAoC", ParserWorkload::AOC, 10);
 
 struct ParserGrammarConstructionState : public BenchmarkState {
 	idx_t grammars_constructed = 0;

--- a/benchmark/micro/parser/README.md
+++ b/benchmark/micro/parser/README.md
@@ -38,7 +38,7 @@ Grammar extensions are not included in any of these benchmarks.
 
 | Benchmark | Input | Calls per timed batch | Statements per call |
 |---|---|---:|---:|
-| `ParserKeywordIdentifiers` | Mixed-case SELECT with keyword identifiers, filtering and ordering | 2,000 | 1 |
+| `ParserKeywordIdentifiers` | SELECT with keyword identifiers, filtering and ordering | 2,000 | 1 |
 | `ParserWideSelect` | 128 arithmetic projection expressions and aliases | 500 | 1 |
 | `ParserNestedExpressions` | 32 nested `coalesce` calls | 1,000 | 1 |
 | `ParserMalformedSelect` | `select (((((((((((((;` (13 unmatched opening parentheses) | 1,000 | Expected syntax error |
@@ -101,14 +101,13 @@ backtracking test below. The expressions are never evaluated.
 `ParserKeywordIdentifiers` parses this exact query:
 
 ```sql
-SeLeCt abort, action, comment, database, first, last FROM source_table
+SELECT abort, action, comment, database, first, last FROM source_table
 WHERE action IS NOT NULL AND comment <> 'value' ORDER BY first, last
 ```
 
 All six projected column names are built-in unreserved keywords. The parser must
 recognize them as keywords while allowing them in identifier positions; `action`,
-`comment`, `first` and `last` recur in other clauses. The mixed-case `SeLeCt` also
-exercises case-insensitive literal matching. This measures the full parse of a
+`comment`, `first` and `last` recur in other clauses. This measures the full parse of a
 keyword-heavy query, not just one lookup operation, and does not cover every keyword
 category. No table lookup, column binding or extension helper is involved.
 

--- a/benchmark/micro/parser/README.md
+++ b/benchmark/micro/parser/README.md
@@ -1,0 +1,117 @@
+# Parser microbenchmarks
+
+These C++ benchmarks call `Parser::ParseQuery()` directly. They do not bind, optimize,
+or execute SQL, and do not require tables, generated datasets, or optional extensions.
+The realistic workloads read existing SQL files from the checkout before timing.
+The implementation is in `benchmark/micro/parser.cpp`; the regression list is
+`.github/regression/parser.csv`.
+
+## Measurement boundary
+
+Before timing, each benchmark constructs or loads its SQL inputs, compiles the base grammar
+once, and checks that the input parses to the expected number of statements.
+The runner then performs one warmup batch and five timed batches by default.
+
+Each timed batch repeats the same fixed inputs in order and includes:
+
+- Construction of a fresh `Parser` using the shared compiled grammar.
+- `ParseQuery`: tokenization, matching, and transformation into SQL statement ASTs.
+- Statement-count checks and destruction of the parser and its results.
+
+Grammar construction, query generation, file loading, database setup, and SQL execution are not
+timed. This measures warm-grammar parsing, not first-query startup or just matching.
+Parser options use their production defaults, including the choice of matcher.
+There is no parsed-result cache shared between calls.
+
+## Fixed workloads
+
+| Benchmark | Input | Calls per timed batch | Statements per call |
+|---|---|---:|---:|
+| `ParserSimpleSelect` | `SELECT 1` | 10,000 | 1 |
+| `ParserKeywordIdentifiers` | Mixed-case SELECT with keyword identifiers, filtering and ordering | 2,000 | 1 |
+| `ParserWideSelect` | 128 arithmetic projection expressions and aliases | 500 | 1 |
+| `ParserNestedExpressions` | 32 nested `coalesce` calls | 1,000 | 1 |
+| `ParserCTEs` | 16 chained CTEs | 500 | 1 |
+| `ParserStatements` | 32 SELECT statements, quoted aliases and comments | 1,000 | 32 |
+| `ParserTPCH` | All 22 TPC-H queries, repeated 50 times | 1,100 | 1 |
+| `ParserTPCDS` | All 99 TPC-DS query files, repeated 10 times | 990 | 1 |
+| `ParserFlummi` | The approximately 373 KiB generated Flummi ray-tracing query, repeated 5 times | 5 | 1 |
+
+The small synthetic cases help isolate regressions. TPC-H and TPC-DS cover realistic
+joins, subqueries, aggregation, CTEs and window functions; Flummi stresses parsing
+one very large generated SQL statement with a recursive CTE.
+
+SQL sources, loaded in numeric query order:
+
+- TPC-H: `extension/tpch/dbgen/queries/q01.sql` through `q22.sql`.
+- TPC-DS: `extension/tpcds/dsdgen/queries/01.sql` through `99.sql`.
+- Flummi: `benchmark/recursive_cte/queries/performance/flummi_ray.sql`.
+
+Each file is a separate `ParseQuery` call, not one concatenated script. Missing,
+empty or invalid files fail the benchmark rather than silently reducing the corpus.
+TPC scale factors do not apply: only the SQL text is parsed, without generating data.
+
+The runner reports **seconds per fixed batch**. To calculate microseconds per
+`ParseQuery` call, multiply seconds by 1,000,000 and divide by the call count.
+For `ParserStatements`, divide by another 32 for time per statement.
+
+Keep the SQL files, input sizes and iteration counts unchanged when comparing revisions. If a
+workload changes materially, give it a new benchmark name to preserve its history.
+The count checks detect parse failures and missing statements; they are not a
+replacement for parser correctness tests.
+
+## Build and run
+
+From the repository root, build an optimized runner:
+
+```sh
+BUILD_BENCHMARK=1 make reldebug
+```
+
+Keep runtime artifacts outside the checkout. Make the existing SQL inputs visible
+under the temporary root using symlinks (run this from the repository root):
+
+```sh
+parser_benchmark_tmp=$(mktemp -d /tmp/duckdb-parser-bench.XXXXXX)
+ln -s "$PWD/benchmark" "$parser_benchmark_tmp/benchmark"
+ln -s "$PWD/extension" "$parser_benchmark_tmp/extension"
+build/reldebug/benchmark/benchmark_runner 'Parser.*' \
+  --root-dir "$parser_benchmark_tmp" --timed-runs 10
+```
+
+Use `ParserSimpleSelect` instead of `Parser.*` to select one case. Add `--query` to
+print its exact SQL, or `--info` for the fixed batch size. Query-execution profiling
+does not apply to these parser-only benchmarks.
+For a corpus, `--query` prints all of its input files in their parsing order.
+
+## Compare revisions with the regression runner
+
+Both binaries must contain these C++ benchmark registrations. Adding the CSV to
+an old checkout alone is insufficient. For an older baseline, apply the same
+benchmark harness and build-system addition there before building its runner;
+keep the parser implementation under comparison unchanged.
+The harness requires `CompiledGrammar` and `ParserOptions::compiled_grammar`;
+older yacc-based revisions need an adapter that preserves the inputs and timed loop.
+
+From the checkout containing the regression scripts:
+
+```sh
+python3 scripts/regression/test_runner.py \
+  --old /path/to/base/build/reldebug/benchmark/benchmark_runner \
+  --new /path/to/current/build/reldebug/benchmark/benchmark_runner \
+  --benchmarks .github/regression/parser.csv \
+  --samples 10 --threads 1
+```
+
+The regression script uses isolated temporary working directories and paired,
+alternating samples. Both binaries read the same SQL files from the checkout where
+the script is invoked. Use identical optimized build settings on both revisions,
+the same machine and power mode, and avoid concurrent builds or other CPU-heavy
+work. The parser workloads themselves are single-threaded.
+
+Use clean build directories for comparisons. The regression script rejects a
+build directory containing extension artifacts from multiple revisions.
+
+The parser list is deliberately not yet added to the automatic regression workflow:
+its baseline runner must first contain this harness. Enable that CI comparison
+once both sides can recognize these benchmarks.

--- a/benchmark/micro/parser/README.md
+++ b/benchmark/micro/parser/README.md
@@ -173,6 +173,6 @@ work. The parser workloads themselves are single-threaded.
 Use clean build directories for comparisons. The regression script rejects a
 build directory containing extension artifacts from multiple revisions.
 
-The parser list is deliberately not yet added to the automatic regression workflow:
-its baseline runner must first contain this harness. Enable that CI comparison
-once both sides can recognize these benchmarks.
+The automatic regression workflow runs this list in its `Bench Parser` matrix job.
+Both the baseline and current runner must contain the C++ benchmark registrations;
+a baseline predating this harness will fail with a missing-benchmark error.

--- a/benchmark/micro/parser/README.md
+++ b/benchmark/micro/parser/README.md
@@ -1,6 +1,7 @@
 # Parser microbenchmarks
 
-These C++ benchmarks call `Parser::ParseQuery()` directly. They do not bind, optimize,
+The query benchmarks call `Parser::ParseQuery()` directly. A separate benchmark
+measures compiled-grammar construction. They do not bind, optimize,
 or execute SQL, and do not require tables, generated datasets, or optional extensions.
 The realistic workloads read existing SQL files from the checkout before timing.
 The implementation is in `benchmark/micro/parser.cpp`; the regression list is
@@ -8,8 +9,10 @@ The implementation is in `benchmark/micro/parser.cpp`; the regression list is
 
 ## Measurement boundary
 
-Before timing, each benchmark constructs or loads its SQL inputs, compiles the base grammar
-once, and checks that the input parses to the expected number of statements.
+Before timing, each query benchmark constructs or loads its SQL inputs, compiles the base grammar
+once, and checks that valid input parses to the expected number of statements.
+The deliberately malformed input is checked during the runs instead, so failed
+parsing is covered by the runner's timeout.
 The runner then performs one warmup batch and five timed batches by default.
 
 Each timed batch repeats the same fixed inputs in order and includes:
@@ -23,15 +26,22 @@ timed. This measures warm-grammar parsing, not first-query startup or just match
 Parser options use their production defaults, including the choice of matcher.
 There is no parsed-result cache shared between calls.
 
+`ParserGrammarConstruction` is the exception: it times 500 independent calls to
+`CompiledGrammar::Create()`, including destruction of each resulting grammar.
+That includes reading/parsing the base grammar definition, constructing its keyword
+helper/tables, and building its matchers. No compiled grammar is reused between
+iterations, and no SQL query is parsed. The standard warmup still applies, so this
+measures repeatable construction cost, not a cold process launch or cold filesystem.
+Grammar extensions are not included in any of these benchmarks.
+
 ## Fixed workloads
 
 | Benchmark | Input | Calls per timed batch | Statements per call |
 |---|---|---:|---:|
-| `ParserSimpleSelect` | `SELECT 1` | 10,000 | 1 |
 | `ParserKeywordIdentifiers` | Mixed-case SELECT with keyword identifiers, filtering and ordering | 2,000 | 1 |
 | `ParserWideSelect` | 128 arithmetic projection expressions and aliases | 500 | 1 |
 | `ParserNestedExpressions` | 32 nested `coalesce` calls | 1,000 | 1 |
-| `ParserCTEs` | 16 chained CTEs | 500 | 1 |
+| `ParserMalformedSelect` | `select (((((((((((((;` (13 unmatched opening parentheses) | 1,000 | Expected syntax error |
 | `ParserStatements` | 32 SELECT statements, quoted aliases and comments | 1,000 | 32 |
 | `ParserTPCH` | All 22 TPC-H queries, repeated 50 times | 1,100 | 1 |
 | `ParserTPCDS` | All 99 TPC-DS query files, repeated 10 times | 990 | 1 |
@@ -54,11 +64,61 @@ TPC scale factors do not apply: only the SQL text is parsed, without generating 
 The runner reports **seconds per fixed batch**. To calculate microseconds per
 `ParseQuery` call, multiply seconds by 1,000,000 and divide by the call count.
 For `ParserStatements`, divide by another 32 for time per statement.
+For `ParserGrammarConstruction`, divide batch seconds by 500 for seconds per
+grammar construction/destruction cycle; do not interpret that result as SQL parsing time.
 
 Keep the SQL files, input sizes and iteration counts unchanged when comparing revisions. If a
 workload changes materially, give it a new benchmark name to preserve its history.
 The count checks detect parse failures and missing statements; they are not a
 replacement for parser correctness tests.
+
+## What the targeted cases measure
+
+### Nested expressions
+
+`ParserNestedExpressions` starts with `value_column` and wraps it 32 times in
+`coalesce(expression, i)`, for `i = 0` through `31`, then places it in a SELECT.
+For example, three layers would be:
+
+```sql
+SELECT coalesce(coalesce(coalesce(value_column, 0), 1), 2)
+FROM source_table
+```
+
+The actual benchmark uses 32 layers, not three. It exercises entering nested
+expression rules, retaining parent matcher state, and building/destroying a nested
+AST. `COALESCE` has a dedicated grammar rule, so this is not a benchmark of generic
+function calls alone. It is a successful-parse depth test, not the malformed-input
+backtracking test below. The expressions are never evaluated.
+
+### Keyword identifiers
+
+`ParserKeywordIdentifiers` parses this exact query:
+
+```sql
+SeLeCt abort, action, comment, database, first, last FROM source_table
+WHERE action IS NOT NULL AND comment <> 'value' ORDER BY first, last
+```
+
+All six projected column names are built-in unreserved keywords. The parser must
+recognize them as keywords while allowing them in identifier positions; `action`,
+`comment`, `first` and `last` recur in other clauses. The mixed-case `SeLeCt` also
+exercises case-insensitive literal matching. This measures the full parse of a
+keyword-heavy query, not just one lookup operation, and does not cover every keyword
+category. No table lookup, column binding or extension helper is involved.
+
+### Malformed SELECT and packrat
+
+`ParserMalformedSelect` parses the exact input `select (((((((((((((;` on every
+iteration, with the normal production packrat behavior. Unfinished parentheses make
+the parser explore failing expression alternatives; packrat memoization can avoid
+repeating work for the same matcher at the same token position. Each parse call gets
+fresh parsing state and its own packrat cache.
+
+Every call must throw `ParserException`. Unexpected success fails verification, and
+other exception types are not counted as expected syntax errors. Timing includes
+tokenization, failed matching, error construction/exception handling, and cleanup;
+this is not an isolated measurement of cache lookups or a packrat-on/off comparison.
 
 ## Build and run
 
@@ -79,10 +139,11 @@ build/reldebug/benchmark/benchmark_runner 'Parser.*' \
   --root-dir "$parser_benchmark_tmp" --timed-runs 10
 ```
 
-Use `ParserSimpleSelect` instead of `Parser.*` to select one case. Add `--query` to
+Use `ParserNestedExpressions` instead of `Parser.*` to select one case. Add `--query` to
 print its exact SQL, or `--info` for the fixed batch size. Query-execution profiling
 does not apply to these parser-only benchmarks.
 For a corpus, `--query` prints all of its input files in their parsing order.
+`ParserGrammarConstruction` has no SQL input, so `--query` prints nothing for it.
 
 ## Compare revisions with the regression runner
 

--- a/benchmark/micro/parser/README.md
+++ b/benchmark/micro/parser/README.md
@@ -46,16 +46,21 @@ Grammar extensions are not included in any of these benchmarks.
 | `ParserTPCH` | All 22 TPC-H queries, repeated 50 times | 1,100 | 1 |
 | `ParserTPCDS` | All 99 TPC-DS query files, repeated 10 times | 990 | 1 |
 | `ParserFlummi` | The approximately 373 KiB generated Flummi ray-tracing query, repeated 5 times | 5 | 1 |
+| `ParserAoC` | All 25 Advent of Code 2024 query files, repeated 10 times | 250 | 1 |
 
 The small synthetic cases help isolate regressions. TPC-H and TPC-DS cover realistic
 joins, subqueries, aggregation, CTEs and window functions; Flummi stresses parsing
 one very large generated SQL statement with a recursive CTE.
+AoC adds varied algorithmic SQL with recursive CTEs, string processing, nested queries
+and embedded input strings. It measures parsing, not solving the puzzles.
 
 SQL sources, loaded in numeric query order:
 
 - TPC-H: `extension/tpch/dbgen/queries/q01.sql` through `q22.sql`.
 - TPC-DS: `extension/tpcds/dsdgen/queries/01.sql` through `99.sql`.
 - Flummi: `benchmark/recursive_cte/queries/performance/flummi_ray.sql`.
+- AoC: `benchmark/aoc24/queries/day01.sql` through `day25.sql`; provenance and license
+  are documented in `benchmark/aoc24/README.md` and `benchmark/aoc24/LICENSE`.
 
 Each file is a separate `ParseQuery` call, not one concatenated script. Missing,
 empty or invalid files fail the benchmark rather than silently reducing the corpus.


### PR DESCRIPTION
Given the recent spree of parser optimizations we are doing, I figured it might be a good time to add parser specific microbenchmarks. It only calls `Parser::ParseQuery()`, so no execution is happening. There's a couple of queries included: 
- all of TPC-H
- All of TPC-DS
- AoC
- Flummi (significantly regressed at some point, large query)
- Malformed `SELECT ((((((((((` to test the packrat caching
- Nested expression
- Multi-statement

Timings are reported in seconds per batch, not per query. For example, one TPC-H run parses all 22 queries 50 times, so its reported time covers 1,100 parses. Batch sizes are documented in the README and must remain unchanged when comparing revisions. Query benchmarks reuse the compiled grammar. The grammar creation time is tested separately. 

They are included in the regression CI.