### PR TITLE
Skip all-NULL partitions and add BOOLEAN to MIN/MAX folding

### DIFF
--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -75,7 +75,7 @@ unique_ptr<ValueComparator> GetComparator(const Identifier &fun_name) {
 unique_ptr<ValueComparator> GetComparator(const Identifier &fun_name, const LogicalType &type) {
 	if (type == LogicalType::VARCHAR) {
 		return GetComparator<StringStats>(fun_name);
-	} else if (type.IsNumeric() || type.IsTemporal()) {
+	} else if (type.IsNumeric() || type.IsTemporal() || type.id() == LogicalTypeId::BOOLEAN) {
 		return GetComparator<NumericStats>(fun_name);
 	}
 	return nullptr;

--- a/src/optimizer/statistics/operator/propagate_aggregate.cpp
+++ b/src/optimizer/statistics/operator/propagate_aggregate.cpp
@@ -118,43 +118,123 @@ bool TryGetMinMaxColumnInfo(const Expression &expr, MinMaxColumnInfo &info) {
 	return true;
 }
 
-bool TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &storage_index,
-                          const ValueComparator &comparator, const LogicalType &result_type, Value &result) {
+//! Outcome of reading one partition's statistics for a MIN/MAX aggregate.
+enum class PartitionValueOutcome : uint8_t {
+	//! The statistics are exact and produced a usable min/max value - the only foldable outcome
+	VALUE,
+	//! The partition holds only NULL values, which MIN/MAX ignore entirely - it is neutral
+	ALL_NULL,
+	//! The statistics bound every row of the partition reliably, but are not exact: `result` holds
+	//! the bound. Good enough to vote with, never good enough to fold
+	BOUND,
+	//! No reliable state at all: the statistics do not describe the rows that will be read, or cannot
+	//! be summarized
+	NO_INFO
+};
+
+PartitionValueOutcome TryGetValueFromStats(const PartitionStatistics &stats, const StorageIndex &storage_index,
+                                           const ValueComparator &comparator, const LogicalType &result_type,
+                                           Value &result) {
 	if (!stats.partition_row_group) {
-		return false;
+		return PartitionValueOutcome::NO_INFO;
 	}
 	auto column_stats = stats.partition_row_group->GetColumnStatistics(storage_index);
 	if (!column_stats) {
-		return false;
+		return PartitionValueOutcome::NO_INFO;
 	}
-	if (!stats.partition_row_group->MinMaxIsExact(storage_index) || stats.partition_row_group->HasPendingWrites()) {
-		return false;
+	if (stats.partition_row_group->HasPendingWrites()) {
+		// rows appended to this partition locally are not covered by the statistics, so they are not
+		// even a bound over the rows that will be read
+		return PartitionValueOutcome::NO_INFO;
 	}
-	if (column_stats->GetStatsType() == StatisticsType::NUMERIC_STATS) {
-		if (!NumericStats::HasMinMax(*column_stats)) {
-			// TODO: This also returns if an entire row group is null. In that case, we could skip/compare null
-			return false;
-		}
+
+	const bool is_numeric = column_stats->GetStatsType() == StatisticsType::NUMERIC_STATS;
+	bool has_min_max;
+	if (is_numeric) {
+		has_min_max = NumericStats::HasMinMax(*column_stats);
 	} else {
 		D_ASSERT(column_stats->GetStatsType() == StatisticsType::STRING_STATS);
-		if (!StringStats::HasMinMax(*column_stats)) {
-			return false;
-		}
-		if (StringStats::GetMinType(*column_stats) != StringStatsType::EXACT_STATS ||
-		    StringStats::GetMaxType(*column_stats) != StringStatsType::EXACT_STATS) {
-			// string stats are not exact - we cannot use the value from the stats
-			return false;
-		}
+		has_min_max = StringStats::HasMinMax(*column_stats);
 	}
+
+	const bool min_max_exact = stats.partition_row_group->MinMaxIsExact(storage_index);
+	if (!has_min_max) {
+		if (!min_max_exact) {
+			// with deleted rows in play the missing min/max says nothing about the surviving rows
+			return PartitionValueOutcome::NO_INFO;
+		}
+		// A partition without min/max holds no non-null values at all. MIN/MAX ignore NULLs, so such
+		// a partition is neutral rather than a reason to abandon the rewrite for the whole table.
+		return column_stats->CanHaveNoNull() ? PartitionValueOutcome::NO_INFO : PartitionValueOutcome::ALL_NULL;
+	}
+
+	// the statistics bound the surviving rows; deleted rows and truncated string statistics make
+	// them a bound instead of an exact value
+	bool value_is_exact = min_max_exact;
+	if (!is_numeric) {
+		value_is_exact = value_is_exact && StringStats::GetMinType(*column_stats) == StringStatsType::EXACT_STATS &&
+		                 StringStats::GetMaxType(*column_stats) == StringStatsType::EXACT_STATS;
+	}
+
 	result = comparator.GetVal(*column_stats);
-	if (result.type() == result_type) {
-		return true;
+	if (result.type() != result_type) {
+		auto cast = result.DefaultTryCastAs(result_type);
+		if (!cast) {
+			// the value cannot be represented in the result type
+			return PartitionValueOutcome::NO_INFO;
+		}
+		result = std::move(*cast);
 	}
-	auto cast = result.DefaultTryCastAs(result_type);
-	if (!cast) {
-		return false;
+	return value_is_exact ? PartitionValueOutcome::VALUE : PartitionValueOutcome::BOUND;
+}
+
+//! Fold the MIN/MAX aggregates over the partition statistics, appending one constant per aggregate to
+//! `types` and `agg_results` in the order of `storage_indexes`. Returns false if some partition's
+//! statistics cannot answer an aggregate.
+bool TryFoldMinMaxAggregates(const vector<PartitionStatistics> &partition_stats,
+                             const vector<StorageIndex> &storage_indexes,
+                             const vector<MinMaxColumnInfo> &min_max_columns,
+                             const vector<unique_ptr<ValueComparator>> &comparators, vector<LogicalType> &types,
+                             vector<unique_ptr<Expression>> &agg_results) {
+	for (idx_t agg_idx = 0; agg_idx < storage_indexes.size(); agg_idx++) {
+		const auto &storage_index = storage_indexes[agg_idx];
+		const auto &result_type = min_max_columns[agg_idx].result_type;
+		auto &comparator = comparators[agg_idx];
+
+		Value agg_result;
+		bool found_value = false;
+		for (const auto &stats : partition_stats) {
+			Value value;
+			switch (TryGetValueFromStats(stats, storage_index, *comparator, result_type, value)) {
+			case PartitionValueOutcome::VALUE:
+				if (!found_value || !comparator->Compare(agg_result, value)) {
+					agg_result = std::move(value);
+					found_value = true;
+				}
+				break;
+			case PartitionValueOutcome::ALL_NULL:
+				// the partition holds no non-null values, so it cannot affect the extremum
+				break;
+			case PartitionValueOutcome::BOUND:
+				// a bound always carries the value that bounds the partition
+				D_ASSERT(!value.IsNull());
+				// a bound is never exact: only an exact value can become a folded constant
+				// TODO: a BOUND partition is meant to be handled by the scan-and-merge path once that
+				// is reachable
+				return false;
+			case PartitionValueOutcome::NO_INFO:
+				// the statistics cannot answer the aggregate
+				return false;
+			}
+		}
+		if (!found_value) {
+			// every partition holds only NULLs - MIN/MAX over no non-null values is NULL
+			agg_result = Value(result_type);
+		}
+		types.push_back(agg_result.type());
+		auto expr = make_uniq<BoundConstantExpression>(agg_result);
+		agg_results.push_back(std::move(expr));
 	}
-	result = std::move(*cast);
 	return true;
 }
 
@@ -351,28 +431,9 @@ void StatisticsPropagator::TryExecuteAggregates(LogicalAggregate &aggr, unique_p
 
 	if (!min_max_columns.empty()) {
 		// Execute min/max aggregates on partition statistics
-		for (idx_t agg_idx = 0; agg_idx < min_max_storage_indexes.size(); agg_idx++) {
-			const auto &storage_index = min_max_storage_indexes[agg_idx];
-			const auto &result_type = min_max_columns[agg_idx].result_type;
-			auto &comparator = comparators[agg_idx];
-
-			Value agg_result;
-			if (!TryGetValueFromStats(partition_stats[0], storage_index, *comparator, result_type, agg_result)) {
-				return;
-			}
-			for (idx_t partition_idx = 1; partition_idx < partition_stats.size(); partition_idx++) {
-				Value rhs;
-				if (!TryGetValueFromStats(partition_stats[partition_idx], storage_index, *comparator, result_type,
-				                          rhs)) {
-					return;
-				}
-				if (!comparator->Compare(agg_result, rhs)) {
-					agg_result = rhs;
-				}
-			}
-			types.push_back(agg_result.type());
-			auto expr = make_uniq<BoundConstantExpression>(agg_result);
-			agg_results.push_back(std::move(expr));
+		if (!TryFoldMinMaxAggregates(partition_stats, min_max_storage_indexes, min_max_columns, comparators, types,
+		                             agg_results)) {
+			return;
 		}
 	}
 	if (!count_star_idxs.empty()) {

--- a/test/configs/verify_aggregate_state_export.json
+++ b/test/configs/verify_aggregate_state_export.json
@@ -11,6 +11,7 @@
         "test/optimizer/pushdown/filter_cannot_pushdown.test",
         "test/optimizer/eager_aggregate_execution.test",
         "test/optimizer/eager_aggregate_execution_parquet.test",
+        "test/optimizer/eager_aggregate_execution_all_null.test",
         "test/optimizer/partial_aggregate_precomputation.test",
         "test/optimizer/partition_stats_exactness.test",
         "test/optimizer/statistics/statistics_count_not_null_join_pruning.test",

--- a/test/configs/wal_verification.json
+++ b/test/configs/wal_verification.json
@@ -32,6 +32,7 @@
       "paths": [
         "test/sql/topn/top_n_pruning.test",
         "test/optimizer/eager_aggregate_execution.test",
+        "test/optimizer/eager_aggregate_execution_all_null.test",
         "test/optimizer/partial_aggregate_precomputation.test"
       ]
     },

--- a/test/optimizer/eager_aggregate_execution_all_null.test
+++ b/test/optimizer/eager_aggregate_execution_all_null.test
@@ -1,0 +1,191 @@
+# name: test/optimizer/eager_aggregate_execution_all_null.test
+# description: Test that a partition holding only NULL values does not disable eager min/max execution
+# group: [optimizer]
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+# Alternative verify disables eager aggregate execution
+require no_alternative_verify
+
+statement ok
+ATTACH '{TEST_DIR}/eager_agg_null.duckdb' AS db (ROW_GROUP_SIZE 2048)
+
+statement ok
+USE db
+
+# MIN/MAX ignore NULLs, so a partition that holds only NULL values cannot affect the result.
+# It must be treated as neutral instead of aborting the rewrite for the whole table.
+statement ok
+CREATE TABLE t_null (i INTEGER)
+
+statement ok
+INSERT INTO t_null SELECT NULL::INTEGER FROM range(2048)
+
+statement ok
+INSERT INTO t_null SELECT * FROM range(2048, 8192)
+
+statement ok
+CREATE TABLE t_null_str (s VARCHAR)
+
+statement ok
+INSERT INTO t_null_str SELECT NULL::VARCHAR FROM range(2048)
+
+statement ok
+INSERT INTO t_null_str SELECT 'a' || i::VARCHAR FROM range(2048, 8192) _(i)
+
+statement ok
+CREATE TABLE t_all_null (i INTEGER)
+
+statement ok
+INSERT INTO t_all_null SELECT NULL::INTEGER FROM range(4096)
+
+# Work-around for unsetting version info
+statement ok
+ATTACH '{TEST_DIR}/eager_agg_null_tmp.duckdb' AS tmp
+
+statement ok
+USE tmp
+
+statement ok
+DETACH db
+
+statement ok
+ATTACH '{TEST_DIR}/eager_agg_null.duckdb' AS db (ROW_GROUP_SIZE 2048)
+
+statement ok
+USE db
+
+statement ok
+DETACH tmp
+
+# the premise of this test: the first row group holds no non-null values, the others do
+query I
+SELECT count(DISTINCT row_group_id) FROM pragma_storage_info('t_null') WHERE stats.has_no_null = false
+----
+1
+
+query I
+SELECT count(DISTINCT row_group_id) FROM pragma_storage_info('t_null')
+----
+4
+
+# an all-NULL partition is neutral: the fold still happens, and the extremum is unchanged
+query II
+EXPLAIN SELECT max(i) FROM t_null
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query II
+EXPLAIN SELECT min(i) FROM t_null
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT max(i) FROM t_null
+----
+8191
+
+query I
+SELECT min(i) FROM t_null
+----
+2048
+
+# the all-NULL partition still counts towards count(*)
+query II
+EXPLAIN SELECT max(i), count(*) FROM t_null
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query II
+SELECT max(i), count(*) FROM t_null
+----
+8191	8192
+
+# same for the string statistics branch
+query II
+EXPLAIN SELECT max(s) FROM t_null_str
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query T
+SELECT min(s) FROM t_null_str
+----
+a2048
+
+query T
+SELECT max(s) FROM t_null_str
+----
+a8191
+
+# when every partition is all-NULL the aggregate is NULL, which is also foldable
+query II
+EXPLAIN SELECT max(i) FROM t_all_null
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT max(i) FROM t_all_null
+----
+NULL
+
+query I
+SELECT count(*) FROM t_all_null
+----
+4096
+
+# A row group that is entirely NaN does carry min/max statistics, because DuckDB orders NaN
+# above every other value. It therefore folds through the regular path and yields the same NaN
+# a real scan would - it is not the no-non-null-values case handled above.
+statement ok
+CREATE TABLE t_nan (d DOUBLE)
+
+statement ok
+INSERT INTO t_nan SELECT 'nan'::DOUBLE FROM range(2048)
+
+statement ok
+INSERT INTO t_nan SELECT * FROM (VALUES (1.0), (2.0), (3.0), (4.0)) _(d)
+
+query I
+SELECT count(DISTINCT row_group_id) FROM pragma_storage_info('t_nan') WHERE stats.max = 'nan'::DOUBLE
+----
+1
+
+query II
+EXPLAIN SELECT max(d) FROM t_nan
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT max(d) FROM t_nan
+----
+nan
+
+# A row group with pending writes does not describe all of its rows yet, so the all-NULL
+# treatment must not apply to it. Appending only NULLs inside an open transaction makes the new
+# rows look exactly like the neutral case when judged by statistics alone, so the fold has to be
+# abandoned instead - this is what pins the pending-writes check ahead of the all-NULL check.
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+INSERT INTO t_null SELECT NULL::INTEGER FROM range(2048)
+
+query II
+EXPLAIN SELECT max(i) FROM t_null
+----
+physical_plan	<REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query I
+SELECT max(i) FROM t_null
+----
+8191
+
+statement ok
+ROLLBACK
+
+# once the transaction is rolled back the fold is available again
+query II
+EXPLAIN SELECT max(i) FROM t_null
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*

--- a/test/optimizer/eager_aggregate_execution_all_null.test
+++ b/test/optimizer/eager_aggregate_execution_all_null.test
@@ -40,6 +40,16 @@ CREATE TABLE t_all_null (i INTEGER)
 statement ok
 INSERT INTO t_all_null SELECT NULL::INTEGER FROM range(4096)
 
+# BOOLEAN folds as well: the first row group holds only false, the second only true
+statement ok
+CREATE TABLE t_bool (b BOOLEAN)
+
+statement ok
+INSERT INTO t_bool SELECT false AS b FROM range(2048)
+
+statement ok
+INSERT INTO t_bool SELECT true AS b FROM range(2048)
+
 # Work-around for unsetting version info
 statement ok
 ATTACH '{TEST_DIR}/eager_agg_null_tmp.duckdb' AS tmp
@@ -189,3 +199,15 @@ query II
 EXPLAIN SELECT max(i) FROM t_null
 ----
 physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+# BOOLEAN is orderable and keeps its min/max in the numeric statistics, but it is not covered by
+# LogicalType::IsNumeric(), so min/max over a BOOLEAN column used to always fall back to a scan
+query II
+EXPLAIN SELECT min(b), max(b) FROM t_bool
+----
+physical_plan	<!REGEX>:.*UNGROUPED_AGGREGATE.*
+
+query II
+SELECT min(b), max(b) FROM t_bool
+----
+false	true


### PR DESCRIPTION
Hi team!

This extends the basic MIN/MAX path: an all-NULL partition is now treated as neutral instead of vetoing the fold, and BOOLEAN columns can be folded from row group statistics.

`min`/`max` orders each partition's surviving values, so a partition that holds only NULLs cannot affect the extremum - but the basic path treated the absence of min/max stats as a reason to abandon the rewrite for the whole table. BOOLEAN also keeps its min/max in the numeric statistics, but `LogicalType::IsNumeric()` does not cover it, so `GetComparator()` returned nothing and the rewrite bailed.

`TryFoldMinMaxAggregates` now returns `PartitionValueOutcome` with four states (VALUE / ALL_NULL / BOUND / NO_INFO). ALL_NULL is consumed by the fold; BOUND and NO_INFO both keep abandoning the rewrite for now - BOUND is the slot the scan-and-merge path will fill once it is reachable.