### PR TITLE
Fix temp file deadloop

### DIFF
--- a/src/storage/temporary_file_manager.cpp
+++ b/src/storage/temporary_file_manager.cpp
@@ -838,13 +838,16 @@ void TemporaryDirectoryHandle::ClaimOwner() {
 	// count from zero. It is not locked, and nothing ever opens anybody else's: existing is its job.
 	for (;;) {
 		owner.instance = NextInstanceId();
+		auto marker_path = fs.JoinPath(temp_directory, TemporaryOwnerMarkerName(owner));
 		try {
-			auto marker = fs.OpenFile(fs.JoinPath(temp_directory, TemporaryOwnerMarkerName(owner)),
-			                          FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
+			auto marker = fs.OpenFile(marker_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
 			marker->Close();
 			break;
 		} catch (std::exception &) {
 			// taken, by a live instance or by one that died holding it - either way not ours
+			if (!fs.FileExists(marker_path)) {
+				throw;
+			}
 		}
 	}
 	file_prefix = TemporaryFilePrefix(owner);


### PR DESCRIPTION
DuckDB spills in-memory block to disk when memory threshold reaches and temp directory configured.
To prevent concurrent access, we acquire a file lock identified by [PID and instance id](https://github.com/duckdb/duckdb/blob/70e7a857595b5872842b6ec242ac79c182e58dde/src/storage/temporary_file_manager.cpp#L722-L724); when it's been acquired by someone else we busyloop until lock released.

But with current implementation, we [retry on whatever exception](https://github.com/duckdb/duckdb/blob/70e7a857595b5872842b6ec242ac79c182e58dde/src/storage/temporary_file_manager.cpp#L846-L848), even if the marker file doesn't exist, which could lead to unnecessary indefinite loop. For example,
```sh
[~/Desktop/duckdb (v2.0-cyanoptera)]
haojiang@HaoJiangs-MacBook-Pro$ mkdir /tmp/rodir-hjiang && chmod 555 /tmp/rodir-hjiang 

[~/Desktop/duckdb (v2.0-cyanoptera)] 
haojiang@HaoJiangs-MacBook-Pro$ ./build/reldebug/duckdb
DuckDB v2.0.0-dev84402 (Development Version, 88902aaa39)
Enter ".help" for usage hints.
memory D PRAGMA memory_limit='48MB';
memory D PRAGMA temp_directory='/tmp/rodir';
memory D SET preserve_insertion_order=false;
memory D CREATE TABLE big AS SELECT range a, md5(range::VARCHAR) b FROM range(800000);
memory D SELECT count(*) FROM (SELECT b, count(*) FROM big GROUP BY b) t; 
-- stall, should throw exception directly
```
In this PR, I update the retry criteria to only attempt on non-existent files.