### PR TITLE
Improve exception message for unsupported seq rename

### DIFF
--- a/src/parser/peg/transformer/transform_alter.cpp
+++ b/src/parser/peg/transformer/transform_alter.cpp
@@ -149,7 +149,7 @@ QualifiedName PEGTransformerFactory::TransformQualifiedSequenceName(PEGTransform
 unique_ptr<AlterInfo>
 PEGTransformerFactory::TransformRenameAlterSequenceOptions(PEGTransformer &transformer,
                                                            unique_ptr<AlterTableInfo> rename_alter) {
-	return std::move(rename_alter);
+	throw NotImplementedException("Renaming sequences is not yet supported");
 }
 
 unique_ptr<AlterInfo>


### PR DESCRIPTION
Renaming a sequence is not supported for now, but the exception message is confusion.
```sql
DuckDB v2.0.0-dev84224 (Development Version, ad49ec518a)
Enter ".help" for usage hints.
memory D CREATE SEQUENCE s;
memory D ALTER SEQUENCE s RENAME TO s2;
Catalog Error:
Table with name s does not exist!
Did you mean "pg_sequence"?
```
I confirm the feature is not supported in v1.5.5, so not a regression
```sql
DuckDB v1.5.5 (Variegata)
Enter ".help" for usage hints.
memory D CREATE SEQUENCE s;
memory D ALTER SEQUENCE s RENAME TO s2;
Not implemented Error:
Schema element not supported yet!
```