### PR TITLE
Improve exception message for cast failure

### DIFF
--- a/src/function/cast/enum_casts.cpp
+++ b/src/function/cast/enum_casts.cpp
@@ -16,7 +16,9 @@ static bool EnumEnumCast(Vector &source, Vector &result, idx_t count, CastParame
 		auto key = EnumType::GetPos(res_enum_type, dictionary_data[value]);
 		if (key == -1) {
 			if (!parameters.error_message) {
-				HandleCastError::AssignError(CastExceptionText<SRC_TYPE, RES_TYPE>(value), vector_cast_data.parameters);
+				HandleCastError::AssignError(
+				    CastExceptionText<string_t>(dictionary_data[value], source.GetType(), res_enum_type),
+				    vector_cast_data.parameters);
 				vector_cast_data.all_converted = false;
 			}
 			return nullopt;

--- a/src/function/cast/string_cast.cpp
+++ b/src/function/cast/string_cast.cpp
@@ -27,7 +27,7 @@ static bool StringEnumCastLoop(const VectorIterator<string_t> &source_data, Vect
 		auto &source_val = source_entry.GetValue();
 		auto pos = EnumType::GetPos(result_type, source_val);
 		if (pos == -1) {
-			result_data[i] = HandleVectorCastError::Operation<T>(CastExceptionText<string_t, T>(source_val),
+			result_data[i] = HandleVectorCastError::Operation<T>(CastExceptionText<string_t>(source_val, result_type),
 			                                                     result_data, i, vector_cast_data);
 		} else {
 			result_data[i] = UnsafeNumericCast<T>(pos);

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -72,7 +72,7 @@ static string CastExceptionText(SRC input) {
 
 template <class SRC>
 static string CastExceptionText(SRC input, const LogicalType &target_type) {
-	if (std::is_same<SRC, string_t>()) {
+	if constexpr (std::is_same<SRC, string_t>::value) {
 		return StringUtil::Format("Could not convert string '%s' to %s", ConvertToString::Operation<SRC>(input),
 		                          target_type.ToString());
 	}
@@ -83,8 +83,8 @@ static string CastExceptionText(SRC input, const LogicalType &target_type) {
 
 template <class SRC>
 static string CastExceptionText(SRC input, const LogicalType &source_type, const LogicalType &target_type) {
-	return StringUtil::Format("Type %s with value %s can't be cast to the destination type %s",
-	                          source_type.ToString(), ConvertToString::Operation<SRC>(input), target_type.ToString());
+	return StringUtil::Format("Type %s with value %s can't be cast to the destination type %s", source_type.ToString(),
+	                          ConvertToString::Operation<SRC>(input), target_type.ToString());
 }
 
 struct Cast {

--- a/src/include/duckdb/common/operator/cast_operators.hpp
+++ b/src/include/duckdb/common/operator/cast_operators.hpp
@@ -23,6 +23,7 @@
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector/string_vector.hpp"
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 struct CastParameters;
@@ -67,6 +68,23 @@ static string CastExceptionText(SRC input) {
 	}
 	return "Type " + TypeIdToString(GetTypeId<SRC>()) + " with value " + ConvertToString::Operation<SRC>(input) +
 	       " can't be cast to the destination type " + TypeIdToString(GetTypeId<DST>());
+}
+
+template <class SRC>
+static string CastExceptionText(SRC input, const LogicalType &target_type) {
+	if (std::is_same<SRC, string_t>()) {
+		return StringUtil::Format("Could not convert string '%s' to %s", ConvertToString::Operation<SRC>(input),
+		                          target_type.ToString());
+	}
+	return StringUtil::Format("Type %s with value %s can't be cast to the destination type %s",
+	                          TypeIdToString(GetTypeId<SRC>()), ConvertToString::Operation<SRC>(input),
+	                          target_type.ToString());
+}
+
+template <class SRC>
+static string CastExceptionText(SRC input, const LogicalType &source_type, const LogicalType &target_type) {
+	return StringUtil::Format("Type %s with value %s can't be cast to the destination type %s",
+	                          source_type.ToString(), ConvertToString::Operation<SRC>(input), target_type.ToString());
 }
 
 struct Cast {

--- a/src/include/duckdb/function/cast/vector_cast_helpers.hpp
+++ b/src/include/duckdb/function/cast/vector_cast_helpers.hpp
@@ -76,8 +76,8 @@ struct VectorTryCastStringOperator {
 		        OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data.result, data.parameters))) {
 			return output;
 		}
-		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
-		                                                     idx, data);
+		return HandleVectorCastError::Operation<RESULT_TYPE>(
+		    CastExceptionText<INPUT_TYPE>(input, data.result.GetType()), mask, idx, data);
 	}
 };
 

--- a/test/sql/cast/cast_error_logical_types.test
+++ b/test/sql/cast/cast_error_logical_types.test
@@ -1,0 +1,37 @@
+# name: test/sql/cast/cast_error_logical_types.test
+# description: Cast error messages should report the logical type, not the physical storage type
+# group: [cast]
+
+statement error
+SELECT 'x'::UUID;
+----
+Could not convert string 'x' to UUID
+
+statement error
+SELECT 'abc'::BIGNUM;
+----
+Could not convert string 'abc' to BIGNUM
+
+statement ok
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+
+statement error
+SELECT 'nope'::mood;
+----
+Could not convert string 'nope' to ENUM('sad', 'ok', 'happy')
+
+statement ok
+CREATE TYPE empty_enum AS ENUM ();
+
+statement error
+SELECT ''::empty_enum;
+----
+Could not convert string '' to ENUM()
+
+statement ok
+CREATE TYPE ab AS ENUM ('a', 'b');
+
+statement error
+SELECT 'sad'::mood::ab;
+----
+Type ENUM('sad', 'ok', 'happy') with value sad can't be cast to the destination type ENUM('a', 'b')

--- a/test/sql/types/enum/test_3479.test
+++ b/test/sql/types/enum/test_3479.test
@@ -24,4 +24,4 @@ insert into m_2 values ('1')
 statement error
 insert into m SELECT * FROM m_2
 ----
-<REGEX>:.*Conversion Error.*out of range for the destination type.*
+Type ENUM('1', '2', '3') with value 1 can't be cast to the destination type ENUM('sad', 'ok', 'happy')

--- a/test/sql/types/enum/test_3641.test
+++ b/test/sql/types/enum/test_3641.test
@@ -43,4 +43,4 @@ SELECT * FROM m WHERE m=m_2
 statement error
 SELECT * FROM m WHERE m::mood_2=m_2
 ----
-<REGEX>:.*Conversion Error.*out of range for the destination type.*
+Type ENUM('sad', 'ok', 'happy') with value sad can't be cast to the destination type ENUM('very sad', 'very ok', 'very happy')


### PR DESCRIPTION
Hi team, I found currently a bunch of cast failure message reports DuckDB internal physical type, instead of user-specified logical type, which could be confusing to users. For example,
```sql
memory D SELECT 'x'::UUID;
Conversion Error:
Could not convert string 'x' to INT128

LINE 1: SELECT 'x'::UUID;
                  ^^^^^^
```
