### PR TITLE
Fix dangling pointer in RemoveUnusedColumns filter collection (#25430)

### DIFF
--- a/src/optimizer/remove_unused_columns.cpp
+++ b/src/optimizer/remove_unused_columns.cpp
@@ -1135,8 +1135,10 @@ void RemoveUnusedColumns::RemoveColumnsFromLogicalGet(LogicalGet &get, unique_pt
 			filter_expr = std::move(column_ref);
 		}
 		filter_expressions.push_back(std::move(filter_expr));
+	}
+	for (auto &filter_expression : filter_expressions) {
 		//! Now visit the filter to add to the 'column_references'
-		VisitExpression(&filter_expressions.back());
+		VisitExpression(&filter_expression);
 	}
 	for (const auto &filter : get.table_filters.GetMultiColumnFilters()) {
 		const auto &expression_filter = ExpressionFilter::GetExpressionFilter(*filter, "RemoveUnusedColumns::VisitGet");

--- a/test/sql/types/struct/struct_projection_pushdown_optimizer_bug.test
+++ b/test/sql/types/struct/struct_projection_pushdown_optimizer_bug.test
@@ -30,3 +30,13 @@ FROM subq
 GROUP BY id;
 ----
 0	1	2024-01-30
+
+statement ok
+CREATE TABLE t0(c1 BOOLEAN, c2 STRUCT(k0 BOOLEAN, k1 VARCHAR));
+
+statement ok
+CREATE TABLE t1(c0 INT, c1 VARCHAR(500));
+
+query IT
+SELECT t1.* FROM t1, t0 INNER JOIN (SELECT t0.c2 AS col0 FROM t0) AS sub0 ON t0.c2['k0'] WHERE ((true)IS NOT DISTINCT FROM(t0.c1));
+----


### PR DESCRIPTION
Summary
Fix a dangling pointer bug in RemoveUnusedColumns::RemoveColumnsFromLogicalGet.
filter_expressions is a vector<unique_ptr>. When push_back(std::move(filter_expr)) triggers vector reallocation, all pointers/references to existing vector elements are invalidated.

The original implementation visited &filter_expressions.back() right after each push_back. If reallocation happened during insertion, previously stored pointers became dangling and caused undefined behavior.

Changes
Collect all filter expressions into filter_expressions first
After the loop finishes collecting all filters, iterate the vector and invoke VisitExpression on every entry
Add regression test with join + struct field predicate to reproduce the issue
Testing
Added struct_projection_pushdown_optimizer_bug.test case.

Fixes https://github.com/duckdb/duckdb/issues/25430