### PR TITLE
Fix uninitialized list and map entries during struct remapping (#25271)

### DIFF
--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -149,7 +149,9 @@ void RemapList(Vector &input, Vector &default_vector, Vector &result, idx_t resu
 		}
 		auto list_data = ConstantVector::GetData<list_entry_t>(input);
 		auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
-		memcpy(result_list_data, list_data, sizeof(list_entry_t));
+		for (idx_t i = 0; i < result_size; i++) {
+			result_list_data[i] = list_data[0];
+		}
 	} else {
 		auto writer = FlatVector::Writer<list_entry_t>(result, result_size);
 		for (const auto entry : input.Values<list_entry_t>()) {

--- a/src/function/scalar/struct/remap_struct.cpp
+++ b/src/function/scalar/struct/remap_struct.cpp
@@ -107,7 +107,9 @@ void RemapMap(Vector &input, Vector &default_vector, Vector &result, idx_t resul
 		}
 		auto list_data = ConstantVector::GetData<list_entry_t>(input);
 		auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
-		memcpy(result_list_data, list_data, sizeof(list_entry_t));
+		for (idx_t i = 0; i < result_size; i++) {
+			result_list_data[i] = list_data[0];
+		}
 	} else {
 		auto writer = FlatVector::Writer<list_entry_t>(result, result_size);
 		for (const auto entry : input.Values<list_entry_t>()) {

--- a/test/sql/types/struct/remap_struct.test
+++ b/test/sql/types/struct/remap_struct.test
@@ -217,3 +217,18 @@ SELECT remap_struct(
   );
 ----
 <REGEX>:.*Binder Error.*No child remaps found.*
+
+# constant list child in a flat struct
+query I
+SELECT remap_struct(
+    {'id': i, 'lst': list_value(1, 2, 3)},
+    NULL::STRUCT(id INTEGER, lst2 INTEGER[]),
+    {'id': 'id', 'lst2': ROW('lst', {'list': 'list'})},
+    NULL
+) FROM range(5) tbl(i);
+----
+{'id': 0, 'lst2': [1, 2, 3]}
+{'id': 1, 'lst2': [1, 2, 3]}
+{'id': 2, 'lst2': [1, 2, 3]}
+{'id': 3, 'lst2': [1, 2, 3]}
+{'id': 4, 'lst2': [1, 2, 3]}

--- a/test/sql/types/struct/remap_struct.test
+++ b/test/sql/types/struct/remap_struct.test
@@ -232,3 +232,18 @@ SELECT remap_struct(
 {'id': 2, 'lst2': [1, 2, 3]}
 {'id': 3, 'lst2': [1, 2, 3]}
 {'id': 4, 'lst2': [1, 2, 3]}
+
+# constant map child in a flat struct
+query I
+SELECT remap_struct(
+    {'id': i, 'mp': map([1], ['one'])},
+    NULL::STRUCT(id INTEGER, mp2 MAP(INTEGER, VARCHAR)),
+    {'id': 'id', 'mp2': ROW('mp', {'key': 'key', 'value': 'value'})},
+    NULL
+) FROM range(5) tbl(i);
+----
+{'id': 0, 'mp2': {1=one}}
+{'id': 1, 'mp2': {1=one}}
+{'id': 2, 'mp2': {1=one}}
+{'id': 3, 'mp2': {1=one}}
+{'id': 4, 'mp2': {1=one}}


### PR DESCRIPTION
Fixes #25271

### Summary
Fixes an assertion failure / heap corruption bug in `RemapList` and `RemapMap` when remapping structs containing constant `LIST` or `MAP` children.
### Root Cause
In `src/function/scalar/struct/remap_struct.cpp`, both `RemapList()` and `RemapMap()` handled `input.GetVectorType() == VectorType::CONSTANT_VECTOR` by copying only index 0 via `memcpy`:
```cpp
auto list_data = ConstantVector::GetData<list_entry_t>(input);
auto result_list_data = FlatVector::GetDataMutable<list_entry_t>(result);
memcpy(result_list_data, list_data, sizeof(list_entry_t));
```

When the enclosing struct is a `FLAT_VECTOR` (varying per row) with constant list or map sub-fields, `result` expects `result_size` valid entries. Indices `1..result_size-1` were left containing stale heap memory. Downstream consumers using the garbage offset/length triggered `D_ASSERT(size < MAXIMUM_ALLOC_SIZE)` in `Allocator::AllocateData` or caused memory corruption in release builds.

### Changes
- replaced the single-element `memcpy` in `RemapList` and `RemapMap` with an index loop populating `result_list_data[i] = list_data[0]` for all `0 <= i < result_size`.
- Added regression test cases for both constant list and constant map sub-fields in `test/sql/types/struct/remap_struct.test`.