### PR TITLE
Fix fetch row implementation for chimp compression

### DIFF
--- a/src/include/duckdb/storage/compression/chimp/chimp_fetch.hpp
+++ b/src/include/duckdb/storage/compression/chimp/chimp_fetch.hpp
@@ -22,7 +22,7 @@ void ChimpFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id
 
 	ChimpScanState<T> scan_state(segment);
 	scan_state.Skip(segment, UnsafeNumericCast<idx_t>(row_id));
-	auto result_data = FlatVector::GetDataMutable<INTERNAL_TYPE>(result);
+	auto result_data = FlatVector::GetDataMutableUnsafe<INTERNAL_TYPE>(result);
 
 	if (scan_state.GroupFinished() && scan_state.total_value_count < scan_state.segment_count) {
 		scan_state.LoadGroup(scan_state.group_state.values);

--- a/test/sql/storage/compression/chimp/chimp_fetch_row.test
+++ b/test/sql/storage/compression/chimp/chimp_fetch_row.test
@@ -1,0 +1,25 @@
+# name: test/sql/storage/compression/chimp/chimp_fetch_row.test
+# description: Fetch-row over Chimp compressed floating point columns
+# group: [chimp]
+
+# The database is written with a vector size of 2048.
+require vector_size 2048
+
+load test/sql/storage/compression/chimp/chimp.db readonly
+
+statement ok
+SET debug_force_fetch_row=true;
+
+query T
+SELECT temperature::VARCHAR FROM temperatures_double LIMIT 3;
+----
+49.4
+48.8
+46.4
+
+query T
+SELECT temperature::VARCHAR FROM temperatures_float LIMIT 3;
+----
+49.4
+48.8
+46.4


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25636

I think the issue is, for the failure case mentioned in the issue, chimp decompresses into a uint64_t value, and that uint64's 8 bytes are the double's 8 bytes.
In one word, the bytes are correct and identical at the bit level; only the type names disagree.

I confirmed with the [`patas`](https://github.com/duckdb/duckdb/blob/10de9573794001c649621013bdd93553b54e00c9/src/include/duckdb/storage/compression/patas/patas_fetch.hpp#L25) and [`alp`](https://github.com/duckdb/duckdb/blob/10de9573794001c649621013bdd93553b54e00c9/src/include/duckdb/storage/compression/alp/alp_fetch.hpp#L29) have the same implementation as well.