### PR TITLE
Fix header handling in CSV minimal sniff

### DIFF
--- a/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
+++ b/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp
@@ -106,8 +106,10 @@ AdaptiveSnifferResult CSVSniffer::MinimalSniff() {
 	// Parse chunk and read csv with info candidate
 	auto &data_chunk = scanner->ParseChunk().ToChunk();
 	idx_t start_row = 0;
-	if (sniffed_column_counts.result_position == 2) {
-		// If equal to two, we will only use the second row for type checking
+	const bool should_skip_header =
+	    !options.dialect_options.header.IsSetByUser() || options.dialect_options.header.GetValue();
+	if (sniffed_column_counts.result_position > 1 && should_skip_header) {
+		// Skip the potential header when detecting types
 		start_row = 1;
 	}
 

--- a/src/include/duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp
+++ b/src/include/duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp
@@ -87,13 +87,13 @@ public:
 	SnifferResult SniffCSV(bool force_match = false);
 
 	//! I call it adaptive, since that's a sexier term.
-	//! In practice this Function that only sniffs the first two rows, to verify if a header exists and what are the
-	//! data types It does this considering a priorly set CSV schema. If there is a mismatch of the schema it runs the
+	//! In practice this function sniffs up to STANDARD_VECTOR_SIZE rows to verify if a header exists and determine the
+	//! data types. It does this considering a priorly set CSV schema. If there is a mismatch of the schema it runs the
 	//! full on blazing all guns sniffer, if that still fails it tells the user to union_by_name.
 	//! It returns the projection order.
 	SnifferResult AdaptiveSniff(const CSVSchema &file_schema);
 
-	//! Function that only sniffs the first two rows, to verify if a header exists and what are the data types
+	//! Function that sniffs up to STANDARD_VECTOR_SIZE rows to detect a header and data types
 	AdaptiveSnifferResult MinimalSniff();
 
 	static NewLineIdentifier DetectNewLineDelimiter(CSVBufferManager &buffer_manager);


### PR DESCRIPTION
Hi team, when I read through the CSV schema sniff code, I found when multiple files involved, we seem to degrade from happy path [minimal sniff](https://github.com/duckdb/duckdb/blob/10de9573794001c649621013bdd93553b54e00c9/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp#L147) to the fallback slow path [full sniff](https://github.com/duckdb/duckdb/blob/10de9573794001c649621013bdd93553b54e00c9/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp#L159).

### Problem statement
The issue is
- During binding, schema discovery runs the full CSV sniffer on the first file, then on additional files until it has sampled at least 20,480 rows in total or reached 10 files, and merges the resulting schemas.
- [`MinimalSniff`](https://github.com/duckdb/duckdb/blob/10de9573794001c649621013bdd93553b54e00c9/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp#L80) is called in [`AdaptiveSniff`](https://github.com/duckdb/duckdb/blob/10de9573794001c649621013bdd93553b54e00c9/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp#L146), which used to decide whether all CSV files match the discovered schema
- In the current implementation, MinimalSniff will likely [set start row as 0](https://github.com/duckdb/duckdb/blob/10de9573794001c649621013bdd93553b54e00c9/src/execution/operator/csv_scanner/sniffer/csv_sniffer.cpp#L108-L112), so header (all columns `VARCHAR`) is used as type, which likely disagrees with the discovered schema and falls back to full schema detection for all file

Pseudocode here:
```sh
minimal_result = MinimalSniff();
if (minimal_result matches known_schema) {
    return minimal_result; // fast path
}
return SniffCSV();         // sniff all csvs
```

Difference between fast path and full sniff
- For the minimal sniff fast path, we only need to validate whether the discovered schema matches csv rows
- While in the full sniff path, we also need to detect dialect, detect type, detect header, etc

### Background investigation

I checked the git commit, it reads to me that once upon a time, we were using the first two rows to decide schema, that's where the if statement `start_position == 2` comes from.
Related PR: https://github.com/duckdb/duckdb/pull/13703, which switches the number of rows to detect schema from 2 to `VECTOR_SIZE`.
<img width="3376" height="356" alt="image" src="https://github.com/user-attachments/assets/fec4bf33-e78e-446f-844d-3bd9dc8cdeb6" />

### Performance evaluation

I wrote a benchmark to evaluate the performance gain for this change
```sql
# name: benchmark/csv/multi_file_adaptive_sniff.benchmark
# description: Measure adaptive schema sniffing over many small CSV files
# group: [csv]

name CSV Multi-File Adaptive Sniff Benchmark
group csv

load
CREATE TABLE csv_files AS
SELECT file_id, row_id::BIGINT AS id, DATE '2026-01-01' + row_id::INTEGER AS event_date,
       (row_id * 1.5)::DOUBLE AS amount
FROM range(500) files(file_id), range(3) rows(row_id);
COPY csv_files TO '${BENCHMARK_DIR}/adaptive_sniff'
    (FORMAT CSV, PARTITION_BY ('file_id'), HEADER, OVERWRITE_OR_IGNORE TRUE);

init
SET threads=1;

run
SELECT count(*)
FROM read_csv('${BENCHMARK_DIR}/adaptive_sniff/**/*.csv', hive_partitioning=false);

result I
1500
```
Benchmark result
| Release Build | Median Time | Relative Performance |
|---|---:|---:|
| Before fix | 78.6 ms | 1.00× |
| After fix | 32.9 ms | 2.39× faster |