### PR TITLE
Bump spatial to take the && join operand check

### DIFF
--- a/.github/config/extensions/spatial.cmake
+++ b/.github/config/extensions/spatial.cmake
@@ -3,7 +3,7 @@ if (${BUILD_COMPLETE_EXTENSION_SET})
 duckdb_extension_load(spatial
     DONT_LINK LOAD_TESTS
     GIT_URL https://github.com/duckdb/duckdb-spatial
-    GIT_TAG eb1e57c9d92c0f3f76eb03eaa52c315090f328cc
+    GIT_TAG c0c9fc9e1f8c8fa8bacac54ac692cc488b9661ee
     INCLUDE_DIR src/spatial
     TEST_DIR test/sql
     APPLY_PATCHES


### PR DESCRIPTION
spatial eb1e57c's join optimizer plans any two-argument boolean function
named && as a spatial join, deciding on the function name alone. An
extension that registers && over its own types sees those joins planned as
spatial joins over values that are not GEOMETRY: MobilityDuck's index-join
tests fail against the repository build of spatial eb1e57c on v1.5.5.

duckdb/duckdb-spatial PR 853 (c27bc2b00, on v1.5-variegata) restricts the
rewrite to GEOMETRY operands. eb1e57c is 6 commits behind it; c0c9fc9e,
the head of spatial's v1.5-variegata, is 12 ahead. 0001-reset-storage.patch
still applies there through apply_extension_patches.py's patch -p1
--forward. DuckDB v1.5.5 with spatial c0c9fc9e and APPLY_PATCHES is the
pairing MobilityDuck builds on Linux, macOS and MinGW.

The bump also brings the other fixes on that branch: ST_Contains on a
polygon vertex, RTREE WAL replay of non-flat row ids, NaN and zero-length
cases in linear referencing, a truncated WKB raising an input error, and
ST_Subdivide.

