### PR TITLE
Fix OOB read in SortedAggregateBindData reconstruction (#25281)

### DIFF
--- a/src/function/scalar/system/aggregate_export.cpp
+++ b/src/function/scalar/system/aggregate_export.cpp
@@ -355,6 +355,10 @@ unique_ptr<ExportAggregateBindData> BindAggregateStateInternal(ClientContext &co
 	ParseOrderBys(order_entry->second, column_count, orders);
 	// the leading buffered columns are the inner aggregate's bound arguments (post constant-erasure)
 	const idx_t argument_count = inner->aggr.GetArguments().size();
+	if (argument_count > column_count) {
+		throw BinderException("to_aggregate_state: argument count %llu exceeds the number of state columns (%llu)",
+							(uint64_t)argument_count, (uint64_t)column_count);
+	}
 
 	auto reconstructed = FunctionBinder::BindSortedAggregateState(context, inner->aggr, std::move(inner->bind_data),
 	                                                              buffer_struct, orders, argument_count);

--- a/test/sql/aggregate/aggregate_state_export/test_sorted_aggregate_state_bounds.test
+++ b/test/sql/aggregate/aggregate_state_export/test_sorted_aggregate_state_bounds.test
@@ -1,0 +1,15 @@
+# name: test/sql/aggregate/aggregate_state_export/test_sorted_aggregate_state_bounds.test
+# description: Test validation of argument_count and order-by column indices against the buffered struct 
+# group: [aggregate_state_export]
+
+# case1: argument_count exceeds the count of fields in buffered struct
+statement error
+SELECT finalize(to_aggregate_state([{'v0': 1}], 'string_agg', ['VARCHAR','VARCHAR'], NULL, [{'column': 0, 'order': 'ASC NULLS FIRST'}]));
+----
+Binder Error: to_aggregate_state: argument count 2 exceeds the number of state columns (1)
+
+# case2: argument_count correctly match the buffered struct shape 
+query I
+SELECT finalize(to_aggregate_state([{'v0': 'b'}, {'v0': 'a'}], 'string_agg', ['VARCHAR'], NULL, [{'column': 0, 'order': 'ASC NULLS FIRST'}]));
+----
+a,b


### PR DESCRIPTION
### Problem

The problem was calling `finalize(to_aggregate_state(...))` on an ordered aggregate state whose declared argument signature had more entries than the buffered values struct fields causes an OOB read. I reproduceced it in debug/ASan build and it aborts with a memory safety error. However, in a release build it silently reads past the end of the `buffered_types` vector (reading garbage memory is dangerous).

fixes and closes https://github.com/duckdb/duckdb/issues/25281

**Repro:**

```sql
SELECT finalize(to_aggregate_state([{'v0': 1}], 'string_agg', ['VARCHAR','VARCHAR'], NULL, [{'column': 0, 'order': 'ASC NULLS FIRST'}]));
```

Here the buffered value `{'v0': 1}` has 1 field, but the declared signature (`['VARCHAR','VARCHAR']`) implies 2 arguments. These two were not validated beforehand and were assumed to be matching before `SortedAggregateBindData`'s reconstruction constructor indexed into `buffered_types` up to `argument_count`.

### Root Cause

`BindAggregateStateInternal` (in `src/function/scalar/system/aggregate_export.cpp`) derives `column_count` from the buffer struct's actual shape and `argument_count` from the inner aggregate's bound arguments, then passes both to `FunctionBinder::BindSortedAggregateState` without checking `argument_count <= column_count`. I also checked the existing `ParseOrderBys`  already validates  `column` index against `column_count`  but this same validation was not present for `argument_count`.

### Fix

Instead of validating  in `SortedAggregateBindData`'s constructor  I added a bounds check in `BindAggregateStateInternal`, right after `argument_count` is computed and before it's used to construct the sorted aggregate wrapper.

This throws `BinderException` and does not let a invalid arguments to reach `SortedAggregateBindData`'s constructor.

### Testing

Added `test/sql/aggregate/aggregate_state_export/test_sorted_aggregate_state_bounds.test`:

- A `statement error` case reproducing the original OOB scenario, showing it throws  `BinderException` now.
- A `query` case confirming a valid case where `argument_count` matches buffered struct  is correct.
Ran the new test in isolation and the broader `test/sql/aggregate/aggregate_state_export/*` suite to confirm no regressions.

### Summary

Fixes out of bound read in `SortedAggregateBindData` reconstruction, where `BindAggregateStateInternal` computed `argument_count` and the buffered struct's actual field count independently and never validated with each other allowing `finalize(to_aggregate_state(...))` to index past the end of a vector on specific inputs. Added a validation check that throws a clean `BinderException` instead, plus a  test covering both the bug and a valid case.

### Notes for reviewers

This is my first pull request here. Please let me know if there is any thing wrong with the PR or any kind of issues.
Thankyou for your attention.