### PR TITLE
CopyToFile/1: Count a partitioned COPY local into its sink state under the global lock

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -2588,9 +2588,7 @@ void PartitionedCopy::Sink(ExecutionContext &execution_context, DataChunk &chunk
 				sinking_state = make_shared_ptr<PartitionedCopyState>(*this, std::move(global_sink_state));
 			}
 			lstate.current_state = sinking_state;
-		}
-
-		{
+			// count in under the global lock, so a flush cannot start between picking the state and counting
 			annotated_lock_guard<annotated_mutex> state_guard(lstate.current_state->lock);
 			lstate.current_state->locals++;
 		}

--- a/test/sql/copy/partitioned/partitioned_flush_join_race.test
+++ b/test/sql/copy/partitioned/partitioned_flush_join_race.test
@@ -1,0 +1,45 @@
+# name: test/sql/copy/partitioned/partitioned_flush_join_race.test
+# description: Stress the window between a thread joining a sink state and another thread moving it to flushing
+# group: [partitioned]
+
+require parquet
+
+statement ok
+PRAGMA threads=16;
+
+# A low threshold makes every state flush after a few chunks. Each flush is followed by a fresh round of
+# threads joining the next state while the threshold is already being crossed again, so the join and the
+# flush trigger overlap many times per COPY.
+statement ok
+SET partitioned_write_flush_threshold=2048;
+
+statement ok
+CREATE TABLE flush_join_src AS SELECT (i % 64)::INTEGER AS p, i::BIGINT AS v FROM range(1048576) tbl(i);
+
+loop i 0 8
+
+statement ok
+COPY flush_join_src TO '{TEST_DIR}/flush_join_race_{i}' (FORMAT PARQUET, PARTITION_BY (p));
+
+# count, sum and distinct count together catch both lost and duplicated rows
+query III
+SELECT count(*), count(DISTINCT v), sum(v)
+FROM read_parquet('{TEST_DIR}/flush_join_race_{i}/**/*.parquet', hive_partitioning = true);
+----
+1048576	1048576	549755289600
+
+endloop
+
+# ORDER_BY makes finalizing a state heavier, which widens the window on the finalizing side
+loop i 0 8
+
+statement ok
+COPY flush_join_src TO '{TEST_DIR}/flush_join_race_ordered_{i}' (FORMAT PARQUET, PARTITION_BY (p), ORDER_BY (v));
+
+query III
+SELECT count(*), count(DISTINCT v), sum(v)
+FROM read_parquet('{TEST_DIR}/flush_join_race_ordered_{i}/**/*.parquet', hive_partitioning = true);
+----
+1048576	1048576	549755289600
+
+endloop


### PR DESCRIPTION
Sink picked the sink state under the global lock but counted itself in only after releasing it. A flush initiated in between finalized the state without the joining local, which then sank into a finalized state and finalized it again on its own combine. Count in inside the same locked section; the state lock nests inside the global lock as Finalize already does.

The test overlaps joins and flush triggers with a low flush threshold and many threads, and checks count, distinct count and sum of the output.

Test is not clear cut red / green, it's more greenish / green, but I think OK to include.