### PR TITLE
CopyToFile/3: Check that a partitioned COPY state is finalized once and never blocks

### DIFF
--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -2572,8 +2572,14 @@ void PartitionedCopy::InitializeFlush() {
 
 void PartitionedCopy::FinalizeState(PartitionedCopyState &state, InterruptState &interrupt_state) {
 	D_ASSERT(state.combined == state.locals);
+	// a state is finalized exactly once, by whoever observes its last combine
+	D_ASSERT(!state.global_source_state);
 	OperatorSinkFinalizeInput sort_strategy_finalize_input {*state.global_sink_state, interrupt_state};
-	sort_strategy->Finalize(context, sort_strategy_finalize_input);
+	auto finalize_result = sort_strategy->Finalize(context, sort_strategy_finalize_input);
+	if (finalize_result == SinkFinalizeType::BLOCKED) {
+		// the flush runs the strategy's tasks itself, so there is nothing that could resume it
+		throw InternalException("PartitionedCopy cannot resume a blocked sort strategy finalize");
+	}
 	state.CreateTaskList();
 }
 


### PR DESCRIPTION
`FinalizeState` is reached from three places under three conditions; assert the invariant they share, that a state is finalized once. Its sort strategy result was discarded: the flush runs the strategy's tasks itself, so a `BLOCKED` result could not be resumed. Make that an internal error.

Idea is basically: `sort_strategy->Finalize`'s result is thrown away, we could as well assert it shouldn't be `BLOCKED`.

This is not a correctness fix, just clean up / future proofing.