### PR TITLE
TaskExecution API improvements, fixing up some users

### DIFF
--- a/.github/patches/extensions/iceberg/0004-manifest-read-task-execute-step.patch
+++ b/.github/patches/extensions/iceberg/0004-manifest-read-task-execute-step.patch
@@ -1,0 +1,53 @@
+diff --git a/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp b/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
+index f07d2acc65..8e6339691e 100644
+--- a/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
++++ b/src/planning/scan_plan/iceberg_client_scan_plan_provider.cpp
+@@ -40,11 +40,9 @@ public:
+ 	    : BaseExecutorTask(state.executor), state(state), reader(*state.scan) {
+ 	}
+ 
+-	void ExecuteTask() override {
+-		throw InternalException("Simple ExecuteTask should never be called!");
+-	}
+-
+-	TaskExecutionResult ExecuteTaskIncremental() {
++	//! One manifest read per step: the TaskExecutor wrapper loops this to completion when draining and yields
++	//! between steps on a background thread. Cancellation, error capture and task accounting live in the wrapper.
++	TaskExecutionResult ExecuteTaskStep() override {
+ 		while (!reader.Finished()) {
+ 			reader.Read();
+ 			return TaskExecutionResult::TASK_NOT_FINISHED;
+@@ -53,33 +51,6 @@ public:
+ 		return TaskExecutionResult::TASK_FINISHED;
+ 	}
+ 
+-	TaskExecutionResult Execute(TaskExecutionMode mode) override {
+-		if (executor.HasError()) {
+-			executor.FinishTask();
+-			return TaskExecutionResult::TASK_FINISHED;
+-		}
+-		try {
+-			{
+-				TaskNotifier task_notifier {state.context};
+-				auto res = TaskExecutionResult::TASK_NOT_FINISHED;
+-				while (res == TaskExecutionResult::TASK_NOT_FINISHED) {
+-					res = ExecuteTaskIncremental();
+-					if (res == TaskExecutionResult::TASK_NOT_FINISHED && mode == TaskExecutionMode::PROCESS_PARTIAL) {
+-						return res;
+-					}
+-				}
+-			}
+-			executor.FinishTask();
+-			return TaskExecutionResult::TASK_FINISHED;
+-		} catch (std::exception &ex) {
+-			executor.PushError(ErrorData(ex));
+-		} catch (...) { // LCOV_EXCL_START
+-			executor.PushError(ErrorData("Unknown exception during Checkpoint!"));
+-		} // LCOV_EXCL_STOP
+-		executor.FinishTask();
+-		return TaskExecutionResult::TASK_ERROR;
+-	}
+-
+ private:
+ 	IcebergManifestScanningState &state;
+ 	manifest_file::ManifestReader reader;

--- a/extension/tpcds/dsdgen/dsdgen.cpp
+++ b/extension/tpcds/dsdgen/dsdgen.cpp
@@ -632,9 +632,6 @@ private:
 				parallel_work_offset++;
 			}
 			executor.WorkOnTasks();
-			if (executor.HasError()) {
-				executor.ThrowError();
-			}
 			for (idx_t appender_idx = 0; appender_idx < new_appenders.size(); appender_idx++) {
 				auto work_item_idx = parallel_work_offset - new_appenders.size() + appender_idx;
 				finished_appenders.push_back(make_uniq<FinishedDSDGenAppender>(

--- a/extension/tpch/dbgen/dbgen.cpp
+++ b/extension/tpch/dbgen/dbgen.cpp
@@ -1365,9 +1365,6 @@ private:
 				parallel_work_offset++;
 			}
 			executor.WorkOnTasks();
-			if (executor.HasError()) {
-				executor.ThrowError();
-			}
 			for (idx_t appender_idx = 0; appender_idx < new_appenders.size(); appender_idx++) {
 				auto work_item_idx = parallel_work_offset - new_appenders.size() + appender_idx;
 				finished_appenders.push_back(make_uniq<FinishedDBGenAppender>(

--- a/src/common/serializer/async_task_queue.cpp
+++ b/src/common/serializer/async_task_queue.cpp
@@ -114,14 +114,7 @@ void AsyncTaskQueue::Submit(AsyncTaskRequest request) {
 	}
 	auto request_size = request.Size();
 	if (executor && executor->HasError()) {
-		ErrorData error;
-		try {
-			executor->ThrowError();
-		} catch (const std::exception &ex) {
-			error = ErrorData(ex);
-		} catch (...) { // LCOV_EXCL_START
-			error = ErrorData("Unknown exception during async task");
-		} // LCOV_EXCL_STOP
+		auto error = executor->GetError();
 		request.task.reset();
 		CompleteRequest(request, request_size, error);
 		error.Throw();
@@ -299,15 +292,10 @@ void AsyncTaskQueue::Flush() {
 		return;
 	}
 
-	try {
+	{
+		// join before leaving this scope, whether the scheduling succeeds or throws
+		TaskExecutor::JoinGuard join(*executor);
 		ScheduleTasksInternal();
-		executor->WorkOnTasks();
-	} catch (...) {
-		try {
-			executor->WorkOnTasks();
-		} catch (...) {
-		}
-		throw;
 	}
 	RethrowTaskError();
 }

--- a/src/common/serializer/async_write_queue.cpp
+++ b/src/common/serializer/async_write_queue.cpp
@@ -124,14 +124,7 @@ void AsyncWriteQueue::Submit(AsyncWriteRequest request) {
 	}
 	auto request_size = request.Size();
 	if (executor && executor->HasError()) {
-		ErrorData error;
-		try {
-			executor->ThrowError();
-		} catch (const std::exception &ex) {
-			error = ErrorData(ex);
-		} catch (...) { // LCOV_EXCL_START
-			error = ErrorData("Unknown exception during async write");
-		} // LCOV_EXCL_STOP
+		auto error = executor->GetError();
 		request.payload.reset();
 		CompleteRequest(request, request_size, error);
 		error.Throw();
@@ -316,14 +309,7 @@ void AsyncWriteQueue::DrainRequests() {
 		}
 	} catch (...) {
 		auto error_ptr = std::current_exception();
-		ErrorData error;
-		try {
-			std::rethrow_exception(error_ptr);
-		} catch (const std::exception &ex) {
-			error = ErrorData(ex);
-		} catch (...) { // LCOV_EXCL_START
-			error = ErrorData("Unknown exception during async write");
-		} // LCOV_EXCL_STOP
+		auto error = ErrorDataFromExceptionPtr(error_ptr);
 		request_idx++;
 		for (; request_idx < requests.size(); request_idx++) {
 			auto &request = requests[request_idx].request;
@@ -419,15 +405,10 @@ void AsyncWriteQueue::Flush() {
 		return;
 	}
 
-	try {
+	{
+		// join before leaving this scope, whether the scheduling succeeds or throws
+		TaskExecutor::JoinGuard join(*executor);
 		ScheduleTasksInternal(true);
-		executor->WorkOnTasks();
-	} catch (...) {
-		try {
-			executor->WorkOnTasks();
-		} catch (...) {
-		}
-		throw;
 	}
 	RethrowTaskError();
 }

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -323,6 +323,8 @@ public:
 	void WorkOnTaskOrYield();
 	void FinishTask();
 	void PushError(const std::exception_ptr &error);
+	//! The first error pushed by a task, if any
+	std::exception_ptr GetError();
 
 private:
 	bool WorkOnTask(bool throw_error = true);
@@ -341,8 +343,7 @@ private:
 
 class CopyFileLifecycleTaskFinishGuard {
 public:
-	CopyFileLifecycleTaskFinishGuard(TaskExecutor &executor_p, CopyFileLifecycleExecutor &lifecycle_p)
-	    : executor(executor_p), lifecycle(lifecycle_p) {
+	explicit CopyFileLifecycleTaskFinishGuard(CopyFileLifecycleExecutor &lifecycle_p) : lifecycle(lifecycle_p) {
 	}
 
 	~CopyFileLifecycleTaskFinishGuard() {
@@ -352,28 +353,26 @@ public:
 	void Finish() {
 		if (!finished) {
 			lifecycle.FinishTask();
-			executor.FinishTask();
 			finished = true;
 		}
 	}
 
 private:
-	TaskExecutor &executor;
 	CopyFileLifecycleExecutor &lifecycle;
 	bool finished = false;
 };
 
 template <class FUNC>
-class CopyFileLifecycleTask : public Task {
+class CopyFileLifecycleTask : public BaseExecutorTask {
 public:
 	CopyFileLifecycleTask(TaskExecutor &executor_p, CopyFileLifecycleExecutor &lifecycle_p,
 	                      shared_ptr<CopyFileLifecycleJob> job_p, FUNC task_p)
-	    : executor(executor_p), lifecycle(lifecycle_p), job(std::move(job_p)), task(std::move(task_p)) {
+	    : BaseExecutorTask(executor_p), lifecycle(lifecycle_p), job(std::move(job_p)), task(std::move(task_p)) {
 	}
 
 public:
-	TaskExecutionResult Execute(TaskExecutionMode mode) override {
-		CopyFileLifecycleTaskFinishGuard finish_guard(executor, lifecycle);
+	void ExecuteTask() override {
+		CopyFileLifecycleTaskFinishGuard finish_guard(lifecycle);
 		try {
 			task();
 			if (!job->IsFinished()) {
@@ -384,7 +383,19 @@ public:
 			job->CompleteException(error);
 			lifecycle.PushError(error);
 		}
-		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+	void Cancel() override {
+		// the task is retired without running - settle the job, WaitForJob spins until it is finished
+		CopyFileLifecycleTaskFinishGuard finish_guard(lifecycle);
+		if (job->IsFinished()) {
+			return;
+		}
+		auto error = lifecycle.GetError();
+		if (!error) {
+			error = std::make_exception_ptr(InternalException("COPY file task was cancelled before it could run"));
+		}
+		job->CompleteException(error);
 	}
 
 	string TaskType() const override {
@@ -392,7 +403,6 @@ public:
 	}
 
 private:
-	TaskExecutor &executor;
 	CopyFileLifecycleExecutor &lifecycle;
 	shared_ptr<CopyFileLifecycleJob> job;
 	FUNC task;
@@ -1540,6 +1550,11 @@ void CopyFileLifecycleExecutor::PushError(const std::exception_ptr &error_p) {
 	if (!error) {
 		error = error_p;
 	}
+}
+
+std::exception_ptr CopyFileLifecycleExecutor::GetError() {
+	lock_guard<mutex> guard(error_lock);
+	return error;
 }
 
 bool CopyFileLifecycleExecutor::WorkOnTask(bool throw_error) {

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -315,6 +315,13 @@ public:
 		max_pending_tasks = MaxValue<idx_t>(MIN_PENDING_TASKS, (async_threads + regular_threads) * 4);
 	}
 
+	~CopyFileLifecycleExecutor() {
+		// A queued task's Cancel reaches back into this object (GetError, FinishTask). Join here, while every
+		// member is still alive, rather than leaving it to ~TaskExecutor, which runs after error_lock and error
+		// have already been destroyed. CancelAndDrain does not throw.
+		executor.CancelAndDrain();
+	}
+
 public:
 	template <class FUNC>
 	void Schedule(shared_ptr<CopyFileLifecycleJob> job, CopyFileLifecycleWaitMode mode, FUNC &&task);

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -413,14 +413,11 @@ void CopyFileLifecycleExecutor::Schedule(shared_ptr<CopyFileLifecycleJob> job, C
                                          FUNC &&task) {
 	WaitForTaskSlot(mode);
 	auto job_ref = job;
+	using TaskType = CopyFileLifecycleTask<typename std::decay<FUNC>::type>;
+	auto lifecycle_task = make_uniq<TaskType>(executor, *this, std::move(job), std::forward<FUNC>(task));
+	// past this point the task settles pending_tasks itself, on the execute path and on the cancel path
 	++pending_tasks;
-	try {
-		using TaskType = CopyFileLifecycleTask<typename std::decay<FUNC>::type>;
-		executor.ScheduleTask(make_uniq<TaskType>(executor, *this, std::move(job), std::forward<FUNC>(task)));
-	} catch (...) {
-		--pending_tasks;
-		throw;
-	}
+	executor.ScheduleTask(std::move(lifecycle_task));
 	if (async_threads == 0) {
 		WaitForJob(*job_ref, mode);
 	}

--- a/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -377,8 +377,21 @@ public:
 	    : BaseExecutorTask(executor_p), lifecycle(lifecycle_p), job(std::move(job_p)), task(std::move(task_p)) {
 	}
 
+	~CopyFileLifecycleTask() override {
+		// Neither ExecuteTask nor Cancel ran, because the executor could not take the task at all. The job
+		// waiter and pending_tasks still have to be settled, or a waiter spins with nothing left to run.
+		if (settled) {
+			return;
+		}
+		try {
+			Cancel();
+		} catch (...) { // NOLINT
+		}
+	}
+
 public:
 	void ExecuteTask() override {
+		settled = true;
 		CopyFileLifecycleTaskFinishGuard finish_guard(lifecycle);
 		try {
 			task();
@@ -394,6 +407,7 @@ public:
 
 	void Cancel() override {
 		// the task is retired without running - settle the job, WaitForJob spins until it is finished
+		settled = true;
 		CopyFileLifecycleTaskFinishGuard finish_guard(lifecycle);
 		if (job->IsFinished()) {
 			return;
@@ -413,6 +427,8 @@ private:
 	CopyFileLifecycleExecutor &lifecycle;
 	shared_ptr<CopyFileLifecycleJob> job;
 	FUNC task;
+	//! Whether ExecuteTask or Cancel ran, so the destructor knows the job and the count are settled
+	bool settled = false;
 };
 
 template <class FUNC>

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -646,6 +646,10 @@ public:
 
 		while (true) {
 			if (gstate.error_opening_file) {
+				// the flag only says a file failed, the error itself lives on the read-ahead - report before ending
+				if (gstate.read_ahead) {
+					gstate.read_ahead->ThrowIfError();
+				}
 				return MultiFileClaimResult::EXHAUSTED;
 			}
 

--- a/src/include/duckdb/common/multi_file/multi_file_function.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_function.hpp
@@ -452,9 +452,14 @@ public:
 				reader_data.file_state = MultiFileFileState::OPENING;
 				{
 					MultiFileReaderData *reader_ptr = &reader_data;
-					read_ahead.ScheduleFileOpen([&context, &bind_data, &gstate, reader_ptr, current_file_index]() {
-						OpenMarkedFileAsync(context, bind_data, gstate, *reader_ptr, current_file_index);
-					});
+					read_ahead.ScheduleFileOpen(
+					    [&context, &bind_data, &gstate, reader_ptr, current_file_index]() {
+						    OpenMarkedFileAsync(context, bind_data, gstate, *reader_ptr, current_file_index);
+					    },
+					    [&gstate]() {
+						    // the reader stays in OPENING, so tell every waiter to stop instead of polling forever
+						    gstate.error_opening_file = true;
+					    });
 				}
 				progress_guaranteed = true;
 				break;

--- a/src/include/duckdb/common/multi_file/multi_file_states.hpp
+++ b/src/include/duckdb/common/multi_file/multi_file_states.hpp
@@ -168,7 +168,8 @@ struct MultiFileGlobalState : public GlobalTableFunctionState {
 	//! Lock
 	mutable mutex lock;
 	//! Signal to other threads that a file failed to open, letting every thread abort.
-	bool error_opening_file = false;
+	//! Atomic because a cancelled file open settles it while the scheduling thread may hold the lock.
+	atomic<bool> error_opening_file {false};
 
 	//! Index of file currently up for scanning
 	atomic<idx_t> file_index;

--- a/src/include/duckdb/parallel/scan_read_ahead.hpp
+++ b/src/include/duckdb/parallel/scan_read_ahead.hpp
@@ -160,6 +160,8 @@ public:
 	bool CanScheduleOpen() const;
 	//! Run one queued async task inline, throwing any recorded async error; returns false when none is queued
 	bool TryRunPendingTask();
+	//! Throw the first error recorded on the async executor, if there is one
+	void ThrowIfError();
 
 private:
 	//! Settles the reservation taken by TryReserveSlot
@@ -196,8 +198,6 @@ private:
 	bool TryReserveSlot();
 	//! Schedule the job's I/O and admit the job to the queue
 	void PushJob(unique_ptr<ScanReadAheadJob> job, vector<unique_ptr<AsyncTask>> io_tasks);
-	//! Throw if any read-ahead thread or task pushed an error
-	void ThrowIfError();
 	//! Release a read-ahead slot
 	void ReleaseSlot();
 

--- a/src/include/duckdb/parallel/scan_read_ahead.hpp
+++ b/src/include/duckdb/parallel/scan_read_ahead.hpp
@@ -158,7 +158,7 @@ public:
 	void ScheduleFileOpen(std::function<void()> open_fn, std::function<void()> cancel_fn);
 	//! Whether another file-open may be scheduled without exceeding the open-ahead window
 	bool CanScheduleOpen() const;
-	//! Run one queued async task inline, throwing any recorded async error; returns false when none is queued
+	//! Run one queued async task inline, returns false when none is queued
 	bool TryRunPendingTask();
 	//! Throw the first error recorded on the async executor, if there is one
 	void ThrowIfError();

--- a/src/include/duckdb/parallel/scan_read_ahead.hpp
+++ b/src/include/duckdb/parallel/scan_read_ahead.hpp
@@ -154,7 +154,8 @@ public:
 	void PushError(ErrorData error);
 
 	//! Schedule a file-open closure on the async pool, opening files ahead of decoding
-	void ScheduleFileOpen(std::function<void()> open_fn);
+	//! cancel_fn runs instead when the open is retired without running, and must settle whatever a scan waits on
+	void ScheduleFileOpen(std::function<void()> open_fn, std::function<void()> cancel_fn);
 	//! Whether another file-open may be scheduled without exceeding the open-ahead window
 	bool CanScheduleOpen() const;
 	//! Run one queued async task inline, throwing any recorded async error; returns false when none is queued

--- a/src/include/duckdb/parallel/task_executor.hpp
+++ b/src/include/duckdb/parallel/task_executor.hpp
@@ -17,6 +17,34 @@
 
 namespace duckdb {
 
+class TaskExecutor;
+class TaskExecutorTask;
+
+//! A unit of work scheduled on a TaskExecutor
+//! Deliberately not a Task: it cannot be handed to the TaskScheduler directly, it cannot be descheduled or
+//! rescheduled, and it cannot report partial progress. The executor wraps it and owns cancellation, error handling
+//! and task accounting, so implementations only have to describe their work.
+class BaseExecutorTask {
+public:
+	explicit BaseExecutorTask(TaskExecutor &executor);
+	virtual ~BaseExecutorTask() = default;
+
+public:
+	//! Perform the task's work - throwing is allowed, the executor captures the error and cancels the other tasks
+	virtual void ExecuteTask() = 0;
+	//! Called instead of ExecuteTask when the task is retired without running its work, because another task errored
+	//! or because the executor was cancelled. Exactly one of ExecuteTask or Cancel runs for every scheduled task.
+	//! Anything a waiter watches must be settled here as well as in ExecuteTask, or that waiter never wakes up.
+	virtual void Cancel() {
+	}
+	virtual string TaskType() const {
+		return "UnnamedTask";
+	}
+
+protected:
+	TaskExecutor &executor;
+};
+
 //! The TaskExecutor is a helper class that enables parallel scheduling and execution of tasks
 class TaskExecutor {
 public:
@@ -30,11 +58,11 @@ public:
 	bool HasError();
 	//! Throw an error that was encountered during execution (if HasError() is true)
 	void ThrowError();
+	//! Whether the executor has been cancelled
+	bool IsCancelled() const;
 
 	//! Schedule a new task
-	void ScheduleTask(unique_ptr<Task> task);
-	//! Label a task as finished
-	void FinishTask();
+	void ScheduleTask(unique_ptr<BaseExecutorTask> task);
 
 	//! Work on tasks until all tasks are finished. Throws an exception if any error occurred while executing the tasks.
 	void WorkOnTasks();
@@ -47,9 +75,11 @@ public:
 private:
 	//! Work on tasks until all tasks are finished
 	void DrainTasks();
+	//! Label a task as finished - called by the wrapper the executor puts around every scheduled task
+	void FinishTask();
 
 private:
-	friend class BaseExecutorTask;
+	friend class TaskExecutorTask;
 
 	TaskScheduler &scheduler;
 	const TaskSchedulerType type;
@@ -59,17 +89,6 @@ private:
 	idx_t total_tasks DUCKDB_GUARDED_BY(token->producer_lock) = 0;
 	atomic<bool> cancelled {false};
 	optional_ptr<ClientContext> context;
-};
-
-class BaseExecutorTask : public Task {
-public:
-	explicit BaseExecutorTask(TaskExecutor &executor);
-
-	virtual void ExecuteTask() = 0;
-	TaskExecutionResult Execute(TaskExecutionMode mode) override;
-
-protected:
-	TaskExecutor &executor;
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/parallel/task_executor.hpp
+++ b/src/include/duckdb/parallel/task_executor.hpp
@@ -35,7 +35,10 @@ public:
 	//! Called instead of ExecuteTask when the task is retired without running its work, because another task errored,
 	//! because the executor was cancelled, or because the task could not be queued at all. Exactly one of ExecuteTask
 	//! or Cancel runs for every task passed to TaskExecutor::ScheduleTask.
-	//! Anything a waiter watches must be settled here as well as in ExecuteTask, or that waiter never wakes up.
+	//! Anything a waiter watches must change on every exit path, or that waiter never wakes up. Either settle it here
+	//! as well as in ExecuteTask, or settle it in the destructor, which also covers a task that was constructed but
+	//! never scheduled. A destructor settle runs after the executor has already counted the task as finished, so it
+	//! must not be something a drain is expected to observe.
 	virtual void Cancel() {
 	}
 	virtual string TaskType() const {

--- a/src/include/duckdb/parallel/task_executor.hpp
+++ b/src/include/duckdb/parallel/task_executor.hpp
@@ -30,8 +30,19 @@ public:
 	virtual ~BaseExecutorTask() = default;
 
 public:
-	//! Perform the task's work - throwing is allowed, the executor captures the error and cancels the other tasks
-	virtual void ExecuteTask() = 0;
+	//! Perform the task's work in one call - throwing is allowed, the executor captures the error and cancels the
+	//! other tasks. Run-to-completion tasks override this.
+	virtual void ExecuteTask() {
+		throw InternalException("BaseExecutorTask::ExecuteTask was not implemented");
+	}
+	//! Perform one unit of work, returning TASK_NOT_FINISHED while more remains and TASK_FINISHED when done.
+	//! Incremental tasks override this instead of ExecuteTask; the default runs the whole task in one call. The
+	//! executor loops this to completion while draining, and calls it once per turn on a background thread so the
+	//! task yields cooperatively. The mode never reaches the task: the wrapper owns the loop.
+	virtual TaskExecutionResult ExecuteTaskStep() {
+		ExecuteTask();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
 	//! Called instead of ExecuteTask when the task is retired without running its work, because another task errored,
 	//! because the executor was cancelled, or because the task could not be queued at all. Exactly one of ExecuteTask
 	//! or Cancel runs for every task passed to TaskExecutor::ScheduleTask.

--- a/src/include/duckdb/parallel/task_executor.hpp
+++ b/src/include/duckdb/parallel/task_executor.hpp
@@ -58,6 +58,8 @@ public:
 	bool HasError();
 	//! Throw an error that was encountered during execution (if HasError() is true)
 	void ThrowError();
+	//! Get the first error that was encountered during execution (if HasError() is true)
+	ErrorData GetError();
 	//! Whether the executor has been cancelled
 	bool IsCancelled() const;
 
@@ -71,6 +73,19 @@ public:
 
 	//! Get a task - returns true if a task was found
 	bool GetTask(shared_ptr<Task> &task);
+
+public:
+	//! Joins the executor when the scope is left, so that its tasks never outlive the state they reference.
+	//! Only needed for an executor that outlives the scope scheduling onto it, where its own destructor is not the
+	//! join. Errors are swallowed: the exception that is unwinding wins, and a recorded task error is still there.
+	class JoinGuard {
+	public:
+		explicit JoinGuard(TaskExecutor &executor);
+		~JoinGuard();
+
+	private:
+		TaskExecutor &executor;
+	};
 
 private:
 	//! Work on tasks until all tasks are finished

--- a/src/include/duckdb/parallel/task_executor.hpp
+++ b/src/include/duckdb/parallel/task_executor.hpp
@@ -32,8 +32,9 @@ public:
 public:
 	//! Perform the task's work - throwing is allowed, the executor captures the error and cancels the other tasks
 	virtual void ExecuteTask() = 0;
-	//! Called instead of ExecuteTask when the task is retired without running its work, because another task errored
-	//! or because the executor was cancelled. Exactly one of ExecuteTask or Cancel runs for every scheduled task.
+	//! Called instead of ExecuteTask when the task is retired without running its work, because another task errored,
+	//! because the executor was cancelled, or because the task could not be queued at all. Exactly one of ExecuteTask
+	//! or Cancel runs for every task passed to TaskExecutor::ScheduleTask.
 	//! Anything a waiter watches must be settled here as well as in ExecuteTask, or that waiter never wakes up.
 	virtual void Cancel() {
 	}

--- a/src/parallel/scan_read_ahead.cpp
+++ b/src/parallel/scan_read_ahead.cpp
@@ -255,7 +255,7 @@ void ScanReadAhead::PushJob(unique_ptr<ScanReadAheadJob> job, vector<unique_ptr<
 	auto completion = make_shared_ptr<ReadAheadJobCompletion>(executor);
 	job->io_completion = completion;
 	// wrap all reads before scheduling any, a wrapped task settles the completion even when scheduling throws
-	vector<unique_ptr<Task>> read_tasks;
+	vector<unique_ptr<BaseExecutorTask>> read_tasks;
 	read_tasks.reserve(io_tasks.size());
 	for (auto &task : io_tasks) {
 		job->io_bytes += task->GetIOSize();

--- a/src/parallel/scan_read_ahead.cpp
+++ b/src/parallel/scan_read_ahead.cpp
@@ -92,8 +92,10 @@ private:
 //! Async task that opens one file ahead of decoding and releases the pending-open count when destroyed
 class FileOpenTask : public BaseExecutorTask {
 public:
-	FileOpenTask(TaskExecutor &executor, shared_ptr<atomic<idx_t>> pending_opens_p, std::function<void()> open_fn_p)
-	    : BaseExecutorTask(executor), pending_opens(std::move(pending_opens_p)), open_fn(std::move(open_fn_p)) {
+	FileOpenTask(TaskExecutor &executor, shared_ptr<atomic<idx_t>> pending_opens_p, std::function<void()> open_fn_p,
+	             std::function<void()> cancel_fn_p)
+	    : BaseExecutorTask(executor), pending_opens(std::move(pending_opens_p)), open_fn(std::move(open_fn_p)),
+	      cancel_fn(std::move(cancel_fn_p)) {
 		++*pending_opens;
 	}
 	~FileOpenTask() override {
@@ -105,9 +107,15 @@ public:
 		open_fn();
 	}
 
+	//! The open never runs, so settle the state the scan waits on - it only ever leaves OPENING in one of these two
+	void Cancel() override {
+		cancel_fn();
+	}
+
 private:
 	shared_ptr<atomic<idx_t>> pending_opens;
 	std::function<void()> open_fn;
+	std::function<void()> cancel_fn;
 };
 
 ScanReadAheadJob::~ScanReadAheadJob() = default;
@@ -290,9 +298,9 @@ void ScanReadAhead::PushError(ErrorData error) {
 	executor->PushError(std::move(error));
 }
 
-void ScanReadAhead::ScheduleFileOpen(std::function<void()> open_fn) {
+void ScanReadAhead::ScheduleFileOpen(std::function<void()> open_fn, std::function<void()> cancel_fn) {
 	// the task holds the count from construction to destruction, so it stays balanced even if scheduling throws
-	executor->ScheduleTask(make_uniq<FileOpenTask>(*executor, pending_opens, std::move(open_fn)));
+	executor->ScheduleTask(make_uniq<FileOpenTask>(*executor, pending_opens, std::move(open_fn), std::move(cancel_fn)));
 }
 
 bool ScanReadAhead::CanScheduleOpen() const {

--- a/src/parallel/scan_read_ahead.cpp
+++ b/src/parallel/scan_read_ahead.cpp
@@ -308,13 +308,11 @@ bool ScanReadAhead::CanScheduleOpen() const {
 }
 
 bool ScanReadAhead::TryRunPendingTask() {
-	ThrowIfError();
 	shared_ptr<Task> task;
 	if (!executor->GetTask(task)) {
 		return false;
 	}
 	task->Execute(TaskExecutionMode::PROCESS_ALL);
-	ThrowIfError();
 	return true;
 }
 

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -36,6 +36,11 @@ public:
 		return task->TaskType();
 	}
 
+	//! Retire a task that never made it into the queue, without touching the executor's accounting
+	void Retire() {
+		RunGuarded([&]() { task->Cancel(); }, "Unknown exception while cancelling a task");
+	}
+
 private:
 	//! Settles the executor's task counter on every exit path, so that a drain always terminates
 	class FinishGuard {
@@ -109,19 +114,23 @@ bool TaskExecutor::IsCancelled() const {
 
 void TaskExecutor::ScheduleTask(unique_ptr<BaseExecutorTask> task) {
 	// wrap before taking ownership of a slot, so that a failure to allocate the wrapper needs no rollback
-	auto scheduled_task = make_uniq<TaskExecutorTask>(*this, std::move(task));
+	auto scheduled_task = make_shared_ptr<TaskExecutorTask>(*this, std::move(task));
 	{
 		const annotated_lock_guard<annotated_mutex> lock(token->producer_lock);
 		++total_tasks;
 	}
 	try {
-		scheduler.ScheduleTask(*token, std::move(scheduled_task), type);
+		// hold on to our own reference, so that a task that fails to queue can still be retired
+		scheduler.ScheduleTask(*token, scheduled_task, type);
 	} catch (...) {
-		const annotated_lock_guard<annotated_mutex> lock(token->producer_lock);
-		// We failed to schedule the task, so we decrement the total number of tasks, instead of incrementing completed
-		// tasks count.
-		--total_tasks;
-		token->producer_cv.notify_one();
+		{
+			const annotated_lock_guard<annotated_mutex> lock(token->producer_lock);
+			// We failed to schedule the task, so we decrement the total number of tasks, instead of incrementing
+			// completed tasks count.
+			--total_tasks;
+			token->producer_cv.notify_one();
+		}
+		scheduled_task->Retire();
 		throw;
 	}
 }

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -4,6 +4,71 @@
 
 namespace duckdb {
 
+//! The wrapper the executor puts around every scheduled task
+//! It owns the cancel check, the task notifier, the error handling and the task accounting, so that none of those
+//! depend on what the task itself does
+class TaskExecutorTask : public Task {
+public:
+	TaskExecutorTask(TaskExecutor &executor, unique_ptr<BaseExecutorTask> task_p)
+	    : executor(executor), task(std::move(task_p)) {
+	}
+
+public:
+	TaskExecutionResult Execute(TaskExecutionMode mode) override {
+		FinishGuard guard(executor);
+		if (executor.HasError() || executor.IsCancelled()) {
+			// another task encountered an error, or the executor was cancelled - retire without doing the work
+			return RunGuarded([&]() { task->Cancel(); }, "Unknown exception while cancelling a task");
+		}
+		TaskNotifier task_notifier {executor.context};
+		return RunGuarded([&]() { task->ExecuteTask(); }, "Unknown exception during task execution");
+	}
+
+	void Deschedule() override {
+		throw InternalException("Tasks scheduled on a TaskExecutor cannot be descheduled");
+	}
+
+	void Reschedule() override {
+		throw InternalException("Tasks scheduled on a TaskExecutor cannot be rescheduled");
+	}
+
+	string TaskType() const override {
+		return task->TaskType();
+	}
+
+private:
+	//! Settles the executor's task counter on every exit path, so that a drain always terminates
+	class FinishGuard {
+	public:
+		explicit FinishGuard(TaskExecutor &executor) : executor(executor) {
+		}
+		~FinishGuard() {
+			executor.FinishTask();
+		}
+
+	private:
+		TaskExecutor &executor;
+	};
+
+	template <class FUNC>
+	TaskExecutionResult RunGuarded(FUNC &&callback, const char *unknown_error) {
+		try {
+			callback();
+		} catch (std::exception &ex) {
+			executor.PushError(ErrorData(ex));
+			return TaskExecutionResult::TASK_ERROR;
+		} catch (...) { // LCOV_EXCL_START
+			executor.PushError(ErrorData(unknown_error));
+			return TaskExecutionResult::TASK_ERROR;
+		} // LCOV_EXCL_STOP
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	TaskExecutor &executor;
+	unique_ptr<BaseExecutorTask> task;
+};
+
 TaskExecutor::TaskExecutor(TaskScheduler &scheduler, TaskSchedulerType type_p)
     : scheduler(scheduler), type(type_p), token(scheduler.CreateProducer()) {
 }
@@ -34,13 +99,19 @@ void TaskExecutor::ThrowError() {
 	error_manager.ThrowException();
 }
 
-void TaskExecutor::ScheduleTask(unique_ptr<Task> task) {
+bool TaskExecutor::IsCancelled() const {
+	return cancelled;
+}
+
+void TaskExecutor::ScheduleTask(unique_ptr<BaseExecutorTask> task) {
+	// wrap before taking ownership of a slot, so that a failure to allocate the wrapper needs no rollback
+	auto scheduled_task = make_uniq<TaskExecutorTask>(*this, std::move(task));
 	{
 		const annotated_lock_guard<annotated_mutex> lock(token->producer_lock);
 		++total_tasks;
 	}
 	try {
-		scheduler.ScheduleTask(*token, std::move(task), type);
+		scheduler.ScheduleTask(*token, std::move(scheduled_task), type);
 	} catch (...) {
 		const annotated_lock_guard<annotated_mutex> lock(token->producer_lock);
 		// We failed to schedule the task, so we decrement the total number of tasks, instead of incrementing completed
@@ -99,28 +170,6 @@ bool TaskExecutor::GetTask(shared_ptr<Task> &task) {
 }
 
 BaseExecutorTask::BaseExecutorTask(TaskExecutor &executor) : executor(executor) {
-}
-
-TaskExecutionResult BaseExecutorTask::Execute(TaskExecutionMode mode) {
-	if (executor.HasError() || executor.cancelled) {
-		// another task encountered an error or the executor was cancelled - bailout
-		executor.FinishTask();
-		return TaskExecutionResult::TASK_FINISHED;
-	}
-	try {
-		{
-			TaskNotifier task_notifier {executor.context};
-			ExecuteTask();
-		}
-		executor.FinishTask();
-		return TaskExecutionResult::TASK_FINISHED;
-	} catch (std::exception &ex) {
-		executor.PushError(ErrorData(ex));
-	} catch (...) { // LCOV_EXCL_START
-		executor.PushError(ErrorData("Unknown exception during Checkpoint!"));
-	} // LCOV_EXCL_STOP
-	executor.FinishTask();
-	return TaskExecutionResult::TASK_ERROR;
 }
 
 } // namespace duckdb

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -20,8 +20,27 @@ public:
 			// another task encountered an error, or the executor was cancelled - retire without doing the work
 			return RunGuarded([&]() { task->Cancel(); }, "Unknown exception while cancelling a task");
 		}
-		TaskNotifier task_notifier {executor.context};
-		return RunGuarded([&]() { task->ExecuteTask(); }, "Unknown exception during task execution");
+		TaskExecutionResult result;
+		try {
+			TaskNotifier task_notifier {executor.context};
+			// PROCESS_ALL must run to completion, so loop the steps; PROCESS_PARTIAL does one and yields
+			do {
+				result = task->ExecuteTaskStep();
+			} while (result == TaskExecutionResult::TASK_NOT_FINISHED && mode == TaskExecutionMode::PROCESS_ALL);
+		} catch (std::exception &ex) {
+			executor.PushError(ErrorData(ex));
+			return TaskExecutionResult::TASK_ERROR;
+		} catch (...) { // LCOV_EXCL_START
+			executor.PushError(ErrorData("Unknown exception during task execution"));
+			return TaskExecutionResult::TASK_ERROR;
+		} // LCOV_EXCL_STOP
+		if (result == TaskExecutionResult::TASK_NOT_FINISHED) {
+			// yielded under PROCESS_PARTIAL: the scheduler re-enqueues this wrapper, keep the task's slot open
+			guard.Dismiss();
+			return TaskExecutionResult::TASK_NOT_FINISHED;
+		}
+		D_ASSERT(result == TaskExecutionResult::TASK_FINISHED);
+		return TaskExecutionResult::TASK_FINISHED;
 	}
 
 	void Deschedule() override {
@@ -48,11 +67,18 @@ private:
 		explicit FinishGuard(TaskExecutor &executor) : executor(executor) {
 		}
 		~FinishGuard() {
-			executor.FinishTask();
+			if (!dismissed) {
+				executor.FinishTask();
+			}
+		}
+		//! Keep the task's slot open across a yield - the wrapper will run again and finish it later
+		void Dismiss() {
+			dismissed = true;
 		}
 
 	private:
 		TaskExecutor &executor;
+		bool dismissed = false;
 	};
 
 	template <class FUNC>
@@ -157,7 +183,8 @@ void TaskExecutor::DrainTasks() {
 
 		const auto res = task_from_producer->Execute(TaskExecutionMode::PROCESS_ALL);
 		std::ignore = res;
-		D_ASSERT(res != TaskExecutionResult::TASK_BLOCKED);
+		// PROCESS_ALL runs a task to completion, so a drain only ever sees a finished or errored task
+		D_ASSERT(res == TaskExecutionResult::TASK_FINISHED || res == TaskExecutionResult::TASK_ERROR);
 		task_from_producer.reset();
 	}
 }

--- a/src/parallel/task_executor.cpp
+++ b/src/parallel/task_executor.cpp
@@ -99,6 +99,10 @@ void TaskExecutor::ThrowError() {
 	error_manager.ThrowException();
 }
 
+ErrorData TaskExecutor::GetError() {
+	return error_manager.GetError();
+}
+
 bool TaskExecutor::IsCancelled() const {
 	return cancelled;
 }
@@ -170,6 +174,16 @@ bool TaskExecutor::GetTask(shared_ptr<Task> &task) {
 }
 
 BaseExecutorTask::BaseExecutorTask(TaskExecutor &executor) : executor(executor) {
+}
+
+TaskExecutor::JoinGuard::JoinGuard(TaskExecutor &executor) : executor(executor) {
+}
+
+TaskExecutor::JoinGuard::~JoinGuard() {
+	try {
+		executor.WorkOnTasks();
+	} catch (...) { // NOLINT
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -1086,6 +1086,18 @@ void RowGroupCollection::UpdateColumn(TransactionData transaction, DuckTableEntr
 //===--------------------------------------------------------------------===//
 // Checkpoint State
 //===--------------------------------------------------------------------===//
+struct VacuumState {
+	bool can_vacuum_deletes = true;
+	bool can_change_row_ids = false;
+	//! How vacuum handles the table's indexes when it changes rowids.
+	VacuumIndexStrategy index_strategy = VacuumIndexStrategy::KEEP_ROW_IDS;
+	//! The indexes to remap, populated only when index_strategy == REMAP.
+	vector<shared_ptr<IndexEntry>> remap_indexes;
+	idx_t row_start = 0;
+	idx_t next_vacuum_idx = 0;
+	vector<optional_idx> row_group_counts;
+};
+
 struct CollectionCheckpointState {
 	CollectionCheckpointState(RowGroupCollection &collection, TableDataWriter &writer, TableStatistics &global_stats,
 	                          RowGroupSegmentTree &row_groups)
@@ -1098,11 +1110,19 @@ struct CollectionCheckpointState {
 		overridden_segments.resize(segment_count);
 	}
 
+	~CollectionCheckpointState() {
+		// the tasks reference this state, so join here rather than relying on the executor's own destructor
+		// doing it after the members declared below it are already gone
+		executor->CancelAndDrain();
+	}
+
 	RowGroupCollection &collection;
 	TableDataWriter &writer;
 	unique_ptr<TaskExecutor> executor;
 	vector<unique_ptr<RowGroupWriter>> writers;
 	vector<RowGroupWriteData> write_data;
+	//! Owned here so that no task can outlive it, the destructor above joins before anything is torn down
+	VacuumState vacuum_state;
 	TableStatistics &global_stats;
 	RowGroupSegmentTree &row_groups;
 
@@ -1286,18 +1306,6 @@ private:
 	vector<column_t> table_column_ids;
 	//! Table-column view of the scan chunk handed back to the merge append.
 	DataChunk append_chunk;
-};
-
-struct VacuumState {
-	bool can_vacuum_deletes = true;
-	bool can_change_row_ids = false;
-	//! How vacuum handles the table's indexes when it changes rowids.
-	VacuumIndexStrategy index_strategy = VacuumIndexStrategy::KEEP_ROW_IDS;
-	//! The indexes to remap, populated only when index_strategy == REMAP.
-	vector<shared_ptr<IndexEntry>> remap_indexes;
-	idx_t row_start = 0;
-	idx_t next_vacuum_idx = 0;
-	vector<optional_idx> row_group_counts;
 };
 
 class VacuumTask : public BaseCheckpointTask {
@@ -1714,12 +1722,12 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 
 	CollectionCheckpointState checkpoint_state(*this, writer, global_stats, *row_groups);
 
-	VacuumState vacuum_state;
+	auto &vacuum_state = checkpoint_state.vacuum_state;
 	InitializeVacuumState(checkpoint_state, vacuum_state, writer.GetRowGroupCount());
 
 	auto &transaction_manager = DuckTransactionManager::Get(GetAttached());
 	auto lowest_visibility_bound = transaction_manager.LowestVisibilityBound();
-	try {
+	{
 		// schedule tasks
 		idx_t total_vacuum_tasks = 0;
 		auto max_vacuum_tasks = Settings::Get<MaxVacuumTasksSetting>(writer.GetDatabase());
@@ -1753,11 +1761,6 @@ void RowGroupCollection::Checkpoint(TableDataWriter &writer, TableStatistics &gl
 			}
 			vacuum_state.row_start += row_group.count;
 		}
-	} catch (const std::exception &e) {
-		ErrorData error(e);
-		checkpoint_state.executor->PushError(std::move(error));
-		checkpoint_state.executor->WorkOnTasks(); // ensure all tasks have completed first before rethrowing
-		throw;
 	}
 	// all tasks have been successfully scheduled - execute tasks until we are done
 	checkpoint_state.executor->WorkOnTasks();

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_API_OBJECTS
     test_query_profiler.cpp
     test_read_ahead_abandon.cpp
     test_read_ahead_progress.cpp
+    test_read_ahead_failure.cpp
     test_row_id_deduplicator.cpp
     test_dbdir.cpp
     test_pending_with_parameters.cpp

--- a/test/api/test_partial_executor.cpp
+++ b/test/api/test_partial_executor.cpp
@@ -75,3 +75,32 @@ TEST_CASE("TaskExecutor runs exactly one of ExecuteTask or Cancel for every sche
 	}
 	REQUIRE(executed + cancelled == TASK_COUNT);
 }
+
+struct SteppingTask : BaseExecutorTask {
+	SteppingTask(TaskExecutor &executor, std::atomic<int> &steps, int total)
+	    : BaseExecutorTask(executor), steps(steps), total(total) {
+	}
+
+	TaskExecutionResult ExecuteTaskStep() override {
+		if (++steps >= total) {
+			return TaskExecutionResult::TASK_FINISHED;
+		}
+		return TaskExecutionResult::TASK_NOT_FINISHED;
+	}
+
+	std::atomic<int> &steps;
+	int total;
+};
+
+TEST_CASE("TaskExecutor drains an incremental task to completion") {
+	static constexpr int STEPS = 8;
+
+	DuckDB db;
+	Connection con {db};
+	std::atomic<int> steps {0};
+	TaskExecutor executor {*con.context};
+	executor.ScheduleTask(make_uniq<SteppingTask>(executor, steps, STEPS));
+	// WorkOnTasks drains inline with PROCESS_ALL, which must loop the steps to completion
+	executor.WorkOnTasks();
+	REQUIRE(steps == STEPS);
+}

--- a/test/api/test_partial_executor.cpp
+++ b/test/api/test_partial_executor.cpp
@@ -2,29 +2,39 @@
 #include "test_helpers.hpp"
 #include "duckdb/parallel/task_executor.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <future>
 #include <thread>
 
 using namespace duckdb;
 
-struct WeirdTask : BaseExecutorTask {
+struct SleepingTask : BaseExecutorTask {
 	using BaseExecutorTask::BaseExecutorTask;
 
 	void ExecuteTask() override {
-	}
-
-	TaskExecutionResult Execute(TaskExecutionMode mode) override {
-		if (mode == TaskExecutionMode::PROCESS_PARTIAL) {
-			std::this_thread::sleep_for(std::chrono::milliseconds(300));
-			return TaskExecutionResult::TASK_NOT_FINISHED;
-		}
-		executor.FinishTask();
-		return TaskExecutionResult::TASK_FINISHED;
+		std::this_thread::sleep_for(std::chrono::milliseconds(300));
 	}
 };
 
-TEST_CASE("TaskExecutor can execute partial tasks without busy spinning forever") {
+struct CountingTask : BaseExecutorTask {
+	CountingTask(TaskExecutor &executor, std::atomic<int> &executed, std::atomic<int> &cancelled)
+	    : BaseExecutorTask(executor), executed(executed), cancelled(cancelled) {
+	}
+
+	void ExecuteTask() override {
+		++executed;
+	}
+
+	void Cancel() override {
+		++cancelled;
+	}
+
+	std::atomic<int> &executed;
+	std::atomic<int> &cancelled;
+};
+
+TEST_CASE("TaskExecutor drains tasks that are in flight when the workers are removed") {
 	DuckDB db;
 	Connection con {db};
 	REQUIRE_NO_FAIL(con.Query("SET threads=5"));
@@ -33,21 +43,35 @@ TEST_CASE("TaskExecutor can execute partial tasks without busy spinning forever"
 
 	// One task per background worker (threads=5, external=1 -> 4 workers).
 	for (auto i = 0; i < 4; i++) {
-		executor.ScheduleTask(make_uniq<WeirdTask>(executor));
+		executor.ScheduleTask(make_uniq<SleepingTask>(executor));
 	}
 
-	// Let each worker grab a task and enter its PROCESS_PARTIAL sleep.
+	// Let each worker grab a task and enter its sleep.
 	std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-	// WorkOnTasks finds the producer queue empty (all tasks in worker hands),
-	// exits its first loop, and enters `while (completed_tasks != total_tasks) {}`.
+	// WorkOnTasks finds the producer queue empty, all tasks are in worker hands.
 	auto finished = std::async(std::launch::async, [&] { executor.WorkOnTasks(); });
 
-	// Kill background workers. Their in-flight tasks get re-enqueued as
-	// TASK_NOT_FINISHED and stranded — WorkOnTasks is already busy-spinning
-	// and never re-checks the queue.
+	// Kill the background workers while their tasks are still running.
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
 
-	REQUIRE(finished.wait_for(std::chrono::milliseconds(100)) == std::future_status::ready);
+	REQUIRE(finished.wait_for(std::chrono::seconds(30)) == std::future_status::ready);
+}
+
+TEST_CASE("TaskExecutor runs exactly one of ExecuteTask or Cancel for every scheduled task") {
+	static constexpr int TASK_COUNT = 64;
+
+	DuckDB db;
+	Connection con {db};
+	std::atomic<int> executed {0};
+	std::atomic<int> cancelled {0};
+	{
+		TaskExecutor executor {*con.context};
+		for (auto i = 0; i < TASK_COUNT; i++) {
+			executor.ScheduleTask(make_uniq<CountingTask>(executor, executed, cancelled));
+		}
+		executor.CancelAndDrain();
+	}
+	REQUIRE(executed + cancelled == TASK_COUNT);
 }

--- a/test/api/test_read_ahead_failure.cpp
+++ b/test/api/test_read_ahead_failure.cpp
@@ -1,0 +1,207 @@
+#include "catch.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/parallel/task_executor.hpp"
+#include "test_helpers.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+
+using namespace duckdb;
+
+namespace {
+
+static std::atomic<idx_t> total_reads {0};
+static std::atomic<idx_t> data_reads {0};
+
+//! Serves read-ahead-fault://<name> from a local file and fails every read of row-group data.
+//! Footer reads pass so files open, the first I/O task then fails, and the opens queued behind it are retired.
+class ReadAheadFaultFileSystem : public LocalFileSystem {
+public:
+	static const string &Prefix() {
+		static const string prefix = "read-ahead-fault://";
+		return prefix;
+	}
+
+	static string MapPath(const string &path) {
+		if (!StringUtil::StartsWith(path, Prefix())) {
+			return path;
+		}
+		return TestCreatePath("read_ahead_fault_" + path.substr(Prefix().size()));
+	}
+
+	string GetName() const override {
+		return "ReadAheadFaultFileSystem";
+	}
+
+	bool CanHandleFile(const string &path) override {
+		return StringUtil::StartsWith(path, Prefix());
+	}
+
+	//! Pretend to be remote, so the scan prefetches through read-ahead I/O tasks instead of reading inline
+	bool IsLocalFileSystem() const override {
+		return false;
+	}
+
+	bool FileExists(const string &path, optional_ptr<FileOpener> opener) override {
+		return LocalFileSystem::FileExists(MapPath(path), opener);
+	}
+
+	vector<OpenFileInfo> Glob(const string &path, FileOpener *opener) override {
+		if (!CanHandleFile(path)) {
+			return LocalFileSystem::Glob(path, opener);
+		}
+		vector<OpenFileInfo> result;
+		if (LocalFileSystem::FileExists(MapPath(path), opener)) {
+			result.emplace_back(path);
+		}
+		return result;
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener) override {
+		return LocalFileSystem::OpenFile(MapPath(path), flags, opener);
+	}
+
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		++total_reads;
+		if (IsDataRead(handle, nr_bytes, location)) {
+			++data_reads;
+			throw IOException("injected read-ahead I/O failure");
+		}
+		LocalFileSystem::Read(handle, buffer, nr_bytes, location);
+	}
+
+private:
+	bool IsDataRead(FileHandle &handle, int64_t nr_bytes, idx_t location) {
+		if (!StringUtil::StartsWith(handle.GetPath(), TestCreatePath("read_ahead_fault_"))) {
+			return false;
+		}
+		// the footer sits at the end of the file, row-group data well before it
+		auto file_size = NumericCast<idx_t>(LocalFileSystem::GetFileSize(handle));
+		return location + NumericCast<idx_t>(nr_bytes) < file_size / 2;
+	}
+};
+
+class AsyncPoolBlockerState {
+public:
+	bool WaitForStarted() {
+		unique_lock<mutex> guard(lock);
+		return cv.wait_for(guard, std::chrono::seconds(5), [&]() { return started; });
+	}
+
+	void Enter() {
+		unique_lock<mutex> guard(lock);
+		started = true;
+		cv.notify_all();
+		cv.wait(guard, [&]() { return released; });
+	}
+
+	void Release() {
+		{
+			lock_guard<mutex> guard(lock);
+			released = true;
+		}
+		cv.notify_all();
+	}
+
+private:
+	mutex lock;
+	std::condition_variable cv;
+	bool started = false;
+	bool released = false;
+};
+
+class AsyncPoolBlockerTask : public BaseExecutorTask {
+public:
+	AsyncPoolBlockerTask(TaskExecutor &executor, AsyncPoolBlockerState &state_p)
+	    : BaseExecutorTask(executor), state(state_p) {
+	}
+
+	void ExecuteTask() override {
+		state.Enter();
+	}
+
+private:
+	AsyncPoolBlockerState &state;
+};
+
+//! Parks the only async worker, so every read-ahead task runs inline on the scan thread in queue order
+class AsyncPoolBlocker {
+public:
+	explicit AsyncPoolBlocker(ClientContext &context) : executor(context, TaskSchedulerType::ASYNC) {
+		executor.ScheduleTask(make_uniq<AsyncPoolBlockerTask>(executor, state));
+	}
+
+	~AsyncPoolBlocker() {
+		Release();
+	}
+
+	bool WaitForStarted() {
+		return state.WaitForStarted();
+	}
+
+	void Release() {
+		if (released) {
+			return;
+		}
+		state.Release();
+		executor.WorkOnTasks();
+		released = true;
+	}
+
+private:
+	AsyncPoolBlockerState state;
+	TaskExecutor executor;
+	bool released = false;
+};
+
+} // namespace
+
+TEST_CASE("Read-ahead reports an async I/O failure instead of hanging or ending the scan early", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("SET threads=1"));
+	REQUIRE_NO_FAIL(con.Query("SET async_threads=1"));
+	// a fixed depth has no memory governor, so the scan produces every job before it claims one and never parks
+	// on I/O that only the parked worker could run
+	REQUIRE_NO_FAIL(con.Query("SET read_ahead_depth=64"));
+
+	// a few MB per file, so row-group reads sit well away from the footer and cannot ride along with it
+	const vector<string> names {"a.parquet", "b.parquet", "c.parquet"};
+	string file_list;
+	for (auto &name : names) {
+		auto path = ReadAheadFaultFileSystem::MapPath(ReadAheadFaultFileSystem::Prefix() + name);
+		REQUIRE_NO_FAIL(con.Query(StringUtil::Format(
+		    "COPY (SELECT hash(i) AS h, i FROM range(400000) t(i)) TO '%s' (FORMAT parquet)", path)));
+		file_list +=
+		    (file_list.empty() ? "" : ", ") + StringUtil::Format("'%s%s'", ReadAheadFaultFileSystem::Prefix(), name);
+	}
+	FileSystem::GetFileSystem(*con.context).RegisterSubSystem(make_uniq<ReadAheadFaultFileSystem>());
+
+	// with the worker parked the scan thread drains the queue itself, in order: the first file's I/O fails and
+	// records the error, and the file open queued behind it is retired instead of run, leaving that reader in
+	// OPENING - exactly the state the scan then waits on
+	AsyncPoolBlocker blocker(*con.context);
+	REQUIRE(blocker.WaitForStarted());
+
+	auto pending = std::async(std::launch::async, [&]() {
+		// read a real column: count(*) is answered from the footer and never touches row-group data
+		return con.Query("SELECT sum(h) FROM read_parquet([" + file_list + "])");
+	});
+	// a hang trips the timeout, a short read produces rows instead of an error, only a thrown error passes both
+	const bool finished = pending.wait_for(std::chrono::seconds(60)) == std::future_status::ready;
+	if (!finished) {
+		// unwind a hung scan so the failure is an assertion, not a process that never exits
+		con.Interrupt();
+	}
+	auto result = pending.get();
+	INFO("reads seen by the fault file system: " << total_reads.load() << ", data reads: " << data_reads.load()
+	                                             << ", result: " << (result->HasError() ? result->GetError() : "ok"));
+	REQUIRE(finished);
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "injected read-ahead I/O failure"));
+	blocker.Release();
+}

--- a/test/api/test_read_ahead_progress.cpp
+++ b/test/api/test_read_ahead_progress.cpp
@@ -46,15 +46,6 @@ TEST_CASE("Read-ahead progress only counts the assignments a thread is decoding"
 	stream.reset();
 }
 
-TEST_CASE("Read-ahead inline task draining surfaces async errors", "[api]") {
-	DuckDB db(nullptr);
-	Connection con(db);
-
-	ScanReadAhead read_ahead(*con.context, 1, nullptr);
-	read_ahead.PushError(ErrorData("injected read-ahead error"));
-	REQUIRE_THROWS(read_ahead.TryRunPendingTask());
-}
-
 TEST_CASE("Read-ahead settles a file open that never runs", "[api]") {
 	DuckDB db(nullptr);
 	Connection con(db);

--- a/test/api/test_read_ahead_progress.cpp
+++ b/test/api/test_read_ahead_progress.cpp
@@ -54,3 +54,19 @@ TEST_CASE("Read-ahead inline task draining surfaces async errors", "[api]") {
 	read_ahead.PushError(ErrorData("injected read-ahead error"));
 	REQUIRE_THROWS(read_ahead.TryRunPendingTask());
 }
+
+TEST_CASE("Read-ahead settles a file open that never runs", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	std::atomic<bool> opened {false};
+	std::atomic<bool> settled {false};
+	{
+		ScanReadAhead read_ahead(*con.context, 1, nullptr);
+		read_ahead.PushError(ErrorData("injected read-ahead error"));
+		read_ahead.ScheduleFileOpen([&]() { opened = true; }, [&]() { settled = true; });
+		// leaving the scope cancels and drains, retiring the open without running it
+	}
+	REQUIRE(settled);
+	REQUIRE(!opened);
+}


### PR DESCRIPTION
This started while looking into https://github.com/duckdb/duckdb/pull/25557 and then the local fix at https://github.com/duckdb/duckdb/pull/25600.

Question was: why local fix? what's the actual shape to solidify usage of `TaskExecutor` ?
Down the rabbit hole, I centralized into capabilities of the `TaskExecutor` class patterns like:
```c++
	try {
		ScheduleTasksInternal();
		executor->WorkOnTasks();
	} catch (...) {
		try {
			executor->WorkOnTasks();
		} catch (...) {
		}
		throw;
	}
	RethrowTaskError();
```
to
```c++
	{
		// join before leaving this scope, whether the scheduling succeeds or throws
		TaskExecutor::JoinGuard join(*executor);
		ScheduleTasksInternal();
	}
```

Adds 3 capabilities to TaskExecutor, centralizing them

### Add Cancel(), and ensure one (and only one) of ExecuteTask() and Cancel() are called

This gives a place where to execute tear down, depending on whether on actual task execution OR on cancellation.

Cancel() is then used to solve both the issue reported and solved at https://github.com/duckdb/duckdb/pull/25600 and a potential issue where a throw at a bad moment would contribute to hang a `COPY ... TO`. Now invariant is simple to reason about, and should solve all those cases properly.

### Add `virtual TaskExecutionResult ExecuteTaskStep()`

Iceberg code hand rolled a stepped ExecuteTask, that required returning a TaskExecutionResult. That has also been moved into core, and the `iceberg` code can be then simplified


### TaskExecutor::JoinGuard

This ensures `WorkOnTasks()` is performed before leaving a given scope, avoiding repeated patterns.


Note this does add code in:
```
src/include/duckdb/parallel/task_executor.hpp
src/parallel/task_executor.cpp
--- plus for solving bug at
src/execution/operator/persistent/physical_copy_to_file.cpp
```
while removing code AND complexity elsewhere.