### PR TITLE
Fix filter pushdown for table in-out functions

### DIFF
--- a/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -34,10 +34,12 @@ public:
 
 PhysicalTableInOutFunction::PhysicalTableInOutFunction(PhysicalPlan &physical_plan, vector<LogicalType> types,
                                                        TableFunction function_p, unique_ptr<FunctionData> bind_data_p,
-                                                       vector<ColumnIndex> column_ids_p, idx_t estimated_cardinality,
-                                                       vector<column_t> project_input_p)
+                                                       vector<ColumnIndex> column_ids_p, vector<idx_t> projection_ids_p,
+                                                       unique_ptr<TableFilterSet> table_filters_p,
+                                                       idx_t estimated_cardinality, vector<column_t> project_input_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::INOUT_FUNCTION, std::move(types), estimated_cardinality),
       function(std::move(function_p)), bind_data(std::move(bind_data_p)), column_ids(std::move(column_ids_p)),
+      projection_ids(std::move(projection_ids_p)), table_filters(std::move(table_filters_p)),
       projected_input(std::move(project_input_p)) {
 }
 
@@ -45,7 +47,7 @@ unique_ptr<OperatorState> PhysicalTableInOutFunction::GetOperatorState(Execution
 	auto &gstate = op_state->Cast<TableInOutGlobalState>();
 	auto result = make_uniq<TableInOutLocalState>();
 	if (function.init_local) {
-		TableFunctionInitInput input(bind_data.get(), column_ids, vector<idx_t>(), nullptr);
+		TableFunctionInitInput input(bind_data.get(), column_ids, projection_ids, table_filters.get());
 		result->local_state = function.init_local(context, input, gstate.global_state.get());
 	}
 	if (!projected_input.empty()) {
@@ -66,7 +68,7 @@ unique_ptr<OperatorState> PhysicalTableInOutFunction::GetOperatorState(Execution
 unique_ptr<GlobalOperatorState> PhysicalTableInOutFunction::GetGlobalOperatorState(ClientContext &context) const {
 	auto result = make_uniq<TableInOutGlobalState>();
 	if (function.init_global) {
-		TableFunctionInitInput input(bind_data.get(), column_ids, vector<idx_t>(), nullptr);
+		TableFunctionInitInput input(bind_data.get(), column_ids, projection_ids, table_filters.get());
 		result->global_state = function.init_global(context, input);
 	}
 	return std::move(result);

--- a/src/execution/physical_plan/plan_get.cpp
+++ b/src/execution/physical_plan/plan_get.cpp
@@ -67,12 +67,31 @@ PhysicalOperator &PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
 			child = proj;
 		}
 
-		auto &table_in_out =
-		    Make<PhysicalTableInOutFunction>(op.types, op.function, std::move(op.bind_data), column_ids,
-		                                     op.estimated_cardinality, std::move(op.projected_input));
+		unique_ptr<TableFilterSet> table_filters;
+		if (op.table_filters.HasFilters() || op.table_filters.HasMultiColumnFilters()) {
+			table_filters = MoveTableFilters(op.table_filters);
+		}
+		vector<idx_t> projection_indices;
+		for (auto &projection_id : op.projection_ids) {
+			projection_indices.push_back(projection_id);
+		}
+		optional_idx ordinality_idx;
+		if (op.ordinality_idx.IsValid()) {
+			auto output_count = projection_indices.empty() ? column_ids.size() : projection_indices.size();
+			for (idx_t output_idx = 0; output_idx < output_count; output_idx++) {
+				auto column_idx = projection_indices.empty() ? output_idx : projection_indices[output_idx];
+				if (column_ids[column_idx].GetPrimaryIndex() == op.ordinality_idx.GetIndex()) {
+					ordinality_idx = output_idx;
+					break;
+				}
+			}
+		}
+		auto &table_in_out = Make<PhysicalTableInOutFunction>(
+		    op.types, op.function, std::move(op.bind_data), column_ids, std::move(projection_indices),
+		    std::move(table_filters), op.estimated_cardinality, std::move(op.projected_input));
 		table_in_out.children.push_back(child);
 		auto &cast_table_in_out = table_in_out.Cast<PhysicalTableInOutFunction>();
-		cast_table_in_out.ordinality_idx = op.ordinality_idx;
+		cast_table_in_out.ordinality_idx = ordinality_idx;
 		return table_in_out;
 	}
 

--- a/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
+++ b/src/include/duckdb/execution/operator/projection/physical_tableinout_function.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 
 namespace duckdb {
 
@@ -21,6 +22,7 @@ public:
 public:
 	PhysicalTableInOutFunction(PhysicalPlan &physical_plan, vector<LogicalType> types, TableFunction function_p,
 	                           unique_ptr<FunctionData> bind_data_p, vector<ColumnIndex> column_ids_p,
+	                           vector<idx_t> projection_ids_p, unique_ptr<TableFilterSet> table_filters_p,
 	                           idx_t estimated_cardinality, vector<column_t> projected_input);
 
 public:
@@ -57,6 +59,10 @@ private:
 	unique_ptr<FunctionData> bind_data;
 	//! The set of column ids to fetch
 	vector<ColumnIndex> column_ids;
+	//! The projected-out column ids
+	vector<idx_t> projection_ids;
+	//! Filters pushed into the table in-out function
+	unique_ptr<TableFilterSet> table_filters;
 	//! The set of input columns to project out
 	vector<column_t> projected_input;
 };

--- a/src/optimizer/pushdown/pushdown_get.cpp
+++ b/src/optimizer/pushdown/pushdown_get.cpp
@@ -121,7 +121,8 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 			}
 		}
 	}
-	if (get.function.pushdown_complex_filter) {
+	const bool assigns_ordinality = get.ordinality_idx.IsValid();
+	if (get.function.pushdown_complex_filter && !assigns_ordinality) {
 		// for the remaining filters, check if we can push any of them into the scan as well
 		vector<unique_ptr<Expression>> expressions;
 		expressions.reserve(filters.size());
@@ -144,9 +145,13 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperat
 			filters.push_back(std::move(f));
 		}
 	}
-
-	if (get.table_filters.HasFilters() || !get.function.filter_pushdown) {
-		// the table function does not support filter pushdown: push a LogicalFilter on top
+	// Partial type-based filter pushdown is not implemented for table in-out functions.
+	const bool requires_partial_pushdown = !get.children.empty() && get.function.supports_pushdown_type;
+	// WITH ORDINALITY numbers the rows the function emits, so pushing a filter into the function would renumber the
+	// surviving rows rather than report their original positions
+	if (get.table_filters.HasFilters() || !get.function.filter_pushdown || requires_partial_pushdown ||
+	    assigns_ordinality) {
+		// these filters cannot be pushed into the scan: push a LogicalFilter on top
 		restore_barrier_filters();
 		return FinishPushdown(std::move(op));
 	}

--- a/test/sql/function/table/table_in_out.cpp
+++ b/test/sql/function/table/table_in_out.cpp
@@ -1,5 +1,9 @@
 #include "catch.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/vector/vector_writer.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
@@ -142,6 +146,119 @@ struct LateralStructEcho {
 	}
 };
 
+struct FilterPushdownEcho {
+	struct GlobalState : public GlobalTableFunctionState {
+		GlobalState(optional_ptr<TableFilterSet> filters_p, vector<column_t> column_ids_p,
+		            vector<idx_t> projection_ids_p)
+		    : filters(filters_p && (filters_p->HasFilters() || filters_p->HasMultiColumnFilters()) ? filters_p
+		                                                                                           : nullptr),
+		      column_ids(std::move(column_ids_p)), projection_ids(std::move(projection_ids_p)),
+		      received_filters(filters != nullptr) {
+		}
+
+		optional_ptr<TableFilterSet> filters;
+		vector<column_t> column_ids;
+		vector<idx_t> projection_ids;
+		bool received_filters;
+	};
+
+	struct LocalState : public LocalTableFunctionState {
+		explicit LocalState(bool received_filters_p) : received_filters(received_filters_p) {
+		}
+
+		bool received_filters;
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<Identifier> &names) {
+		return_types.emplace_back(LogicalType::INTEGER);
+		names.emplace_back("value");
+		return_types.emplace_back(LogicalType::INTEGER);
+		names.emplace_back("filter_state");
+		return make_uniq<TableFunctionData>();
+	}
+
+	static unique_ptr<GlobalTableFunctionState> GlobalInit(ClientContext &context, TableFunctionInitInput &input) {
+		return make_uniq<GlobalState>(input.filters, input.column_ids, input.projection_ids);
+	}
+
+	static unique_ptr<LocalTableFunctionState> LocalInit(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state) {
+		return make_uniq<LocalState>(input.filters &&
+		                             (input.filters->HasFilters() || input.filters->HasMultiColumnFilters()));
+	}
+
+	static OperatorResultType Function(ExecutionContext &context, TableFunctionInput &data, DataChunk &input,
+	                                   DataChunk &output) {
+		auto &global_state = data.global_state->Cast<GlobalState>();
+		auto &local_state = data.local_state->Cast<LocalState>();
+		vector<LogicalType> output_types(global_state.column_ids.size(), LogicalType::INTEGER);
+		DataChunk candidates;
+		candidates.Initialize(context.client, output_types);
+		for (idx_t output_idx = 0; output_idx < global_state.column_ids.size(); output_idx++) {
+			switch (global_state.column_ids[output_idx]) {
+			case 0:
+				candidates.data[output_idx].Reference(input.data[0]);
+				break;
+			case 1: {
+				// Bit 0 records global delivery; bit 1 records local delivery.
+				auto filter_state = static_cast<int32_t>(global_state.received_filters) +
+				                    2 * static_cast<int32_t>(local_state.received_filters);
+				candidates.data[output_idx].Reference(Value::INTEGER(filter_state), count_t(input.size()));
+				break;
+			}
+			default:
+				throw InternalException("Unexpected filter pushdown test column id");
+			}
+		}
+		candidates.SetChildCardinality(input.size());
+
+		if (global_state.filters) {
+			D_ASSERT(!global_state.filters->HasMultiColumnFilters());
+			for (const auto &entry : *global_state.filters) {
+				auto filter_idx = entry.GetIndex().GetIndex();
+				auto column = make_uniq<BoundReferenceExpression>(candidates.data[filter_idx].GetType(), filter_idx);
+				auto expression = entry.Filter().ToExpression(*column);
+				ExpressionExecutor executor(context.client, *expression);
+				SelectionVector selection(candidates.size());
+				auto count = executor.SelectExpression(candidates, selection);
+				candidates.Slice(selection, count);
+			}
+		}
+
+		auto output_count =
+		    global_state.projection_ids.empty() ? candidates.ColumnCount() : global_state.projection_ids.size();
+		for (idx_t output_idx = 0; output_idx < output_count; output_idx++) {
+			auto source_idx =
+			    global_state.projection_ids.empty() ? output_idx : global_state.projection_ids[output_idx];
+			output.data[output_idx].Reference(candidates.data[source_idx]);
+		}
+		output.SetChildCardinality(candidates.size());
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	static bool SupportsPushdownType(const FunctionData &bind_data, idx_t column_idx) {
+		return column_idx == 0;
+	}
+
+	static void Register(Connection &con, const string &name, vector<LogicalType> arguments, bool filter_prune = true,
+	                     bool type_filter = false) {
+		con.BeginTransaction();
+		auto &catalog = Catalog::GetSystemCatalog(*con.context);
+		TableFunction function(Identifier(name), std::move(arguments), nullptr, Bind, GlobalInit, LocalInit);
+		function.in_out_function = Function;
+		function.projection_pushdown = true;
+		function.filter_pushdown = true;
+		function.filter_prune = filter_prune;
+		if (type_filter) {
+			function.supports_pushdown_type = SupportsPushdownType;
+		}
+		CreateTableFunctionInfo info(function);
+		catalog.CreateTableFunction(*con.context, info);
+		con.Commit();
+	}
+};
+
 TEST_CASE("Caching TableInOutFunction", "[filter][.]") {
 	DuckDB db(nullptr);
 	Connection con(db);
@@ -197,4 +314,260 @@ TEST_CASE("Lateral table in out function preserves constant struct fields", "[ta
 	REQUIRE(CHECK_COLUMN(result, 0, {0, 1, 2}));
 	REQUIRE(CHECK_COLUMN(result, 1, {1, 1, 1}));
 	REQUIRE(CHECK_COLUMN(result, 2, {"fixed", "fixed", "fixed"}));
+}
+
+TEST_CASE("Filter pushdown into table in-out functions", "[tablefunction]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	FilterPushdownEcho::Register(con, "filter_pushdown_echo", {LogicalType::TABLE});
+
+	auto filtered = con.Query(R"(
+		SELECT value, filter_state
+		FROM filter_pushdown_echo((SELECT i::INTEGER AS value FROM range(3) t(i)))
+		WHERE value = 1
+	)");
+	REQUIRE_NO_FAIL(*filtered);
+	REQUIRE(CHECK_COLUMN(filtered, 0, {1}));
+	REQUIRE(CHECK_COLUMN(filtered, 1, {3}));
+
+	auto filter_only_column = con.Query(R"(
+		SELECT filter_state
+		FROM filter_pushdown_echo((SELECT i::INTEGER AS value FROM range(3) t(i)))
+		WHERE value > 0 AND value < 2
+	)");
+	REQUIRE_NO_FAIL(*filter_only_column);
+	REQUIRE(CHECK_COLUMN(filter_only_column, 0, {3}));
+
+	FilterPushdownEcho::Register(con, "filter_pushdown_echo_no_prune", {LogicalType::TABLE}, false);
+	auto no_filter_pruning = con.Query(R"(
+		SELECT filter_state
+		FROM filter_pushdown_echo_no_prune((SELECT i::INTEGER AS value FROM range(3) t(i)))
+		WHERE value = 1
+	)");
+	REQUIRE_NO_FAIL(*no_filter_pruning);
+	REQUIRE(CHECK_COLUMN(no_filter_pruning, 0, {3}));
+}
+
+TEST_CASE("Type-limited filters remain above table in-out functions", "[tablefunction]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	FilterPushdownEcho::Register(con, "type_limited_filter_echo", {LogicalType::TABLE}, false, true);
+
+	auto supported_filter = con.Query(R"(
+		SELECT value, filter_state
+		FROM type_limited_filter_echo((SELECT i::INTEGER AS value FROM range(3) t(i)))
+		WHERE value = 1
+	)");
+	REQUIRE_NO_FAIL(*supported_filter);
+	REQUIRE(CHECK_COLUMN(supported_filter, 0, {1}));
+	REQUIRE(CHECK_COLUMN(supported_filter, 1, {0}));
+
+	auto unsupported_filter = con.Query(R"(
+		SELECT count(*)
+		FROM type_limited_filter_echo((SELECT i::INTEGER AS value FROM range(3) t(i)))
+		WHERE filter_state = 3
+	)");
+	REQUIRE_NO_FAIL(*unsupported_filter);
+	REQUIRE(CHECK_COLUMN(unsupported_filter, 0, {0}));
+}
+
+TEST_CASE("Correlated filters remain above table in-out functions", "[tablefunction]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	FilterPushdownEcho::Register(con, "lateral_filter_pushdown_echo", {LogicalType::INTEGER});
+
+	auto result = con.Query(R"(
+		SELECT echoed.value, echoed.filter_state
+		FROM range(3) outer_rows(i),
+		LATERAL lateral_filter_pushdown_echo(i::INTEGER) echoed
+		WHERE echoed.value = outer_rows.i % 2
+		ORDER BY echoed.value
+	)");
+	REQUIRE_NO_FAIL(*result);
+	REQUIRE(CHECK_COLUMN(result, 0, {0, 1}));
+	REQUIRE(CHECK_COLUMN(result, 1, {0, 0}));
+
+	FilterPushdownEcho::Register(con, "lateral_type_limited_filter_echo", {LogicalType::INTEGER}, true, true);
+	auto type_limited_filter = con.Query(R"(
+		SELECT outer_rows.i, echoed.value
+		FROM range(3) outer_rows(i),
+		LATERAL lateral_type_limited_filter_echo(i::INTEGER) echoed
+		WHERE echoed.filter_state = 3
+		ORDER BY outer_rows.i
+	)");
+	REQUIRE_NO_FAIL(*type_limited_filter);
+	REQUIRE(type_limited_filter->RowCount() == 0);
+}
+
+// Emits value = 1..n for every input row n and records whether it received pushed filters.
+// Used to verify that WITH ORDINALITY keeps filters above the function and reports unfiltered positions.
+struct OrdinalityEcho {
+	//! Column count returned by Bind - the binder appends the ordinality column after these
+	static constexpr idx_t BOUND_COLUMN_COUNT = 2;
+
+	struct LocalState : public LocalTableFunctionState {
+		idx_t offset = 0;
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<Identifier> &names) {
+		return_types.emplace_back(LogicalType::INTEGER);
+		names.emplace_back("value");
+		return_types.emplace_back(LogicalType::INTEGER);
+		names.emplace_back("filter_state");
+		return make_uniq<TableFunctionData>();
+	}
+
+	static unique_ptr<GlobalTableFunctionState> GlobalInit(ClientContext &context, TableFunctionInitInput &input) {
+		return make_uniq<FilterPushdownEcho::GlobalState>(input.filters, input.column_ids, input.projection_ids);
+	}
+
+	static unique_ptr<LocalTableFunctionState> LocalInit(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state) {
+		return make_uniq<LocalState>();
+	}
+
+	static OperatorResultType Function(ExecutionContext &context, TableFunctionInput &data, DataChunk &input,
+	                                   DataChunk &output) {
+		auto &global_state = data.global_state->Cast<FilterPushdownEcho::GlobalState>();
+		auto &local_state = data.local_state->Cast<LocalState>();
+		auto count = NumericCast<idx_t>(input.data[0].GetValue(0).GetValue<int32_t>());
+		auto batch_count = MinValue<idx_t>(count - local_state.offset, STANDARD_VECTOR_SIZE);
+
+		vector<LogicalType> candidate_types;
+		for (auto column_id : global_state.column_ids) {
+			candidate_types.push_back(column_id < BOUND_COLUMN_COUNT ? LogicalType::INTEGER : LogicalType::BIGINT);
+		}
+		DataChunk candidates;
+		candidates.Initialize(context.client, candidate_types);
+		for (idx_t output_idx = 0; output_idx < global_state.column_ids.size(); output_idx++) {
+			auto &candidate = candidates.data[output_idx];
+			switch (global_state.column_ids[output_idx]) {
+			case 0: {
+				auto writer = FlatVector::Writer<int32_t>(candidate, batch_count);
+				for (idx_t i = 0; i < batch_count; i++) {
+					writer.WriteValue(NumericCast<int32_t>(local_state.offset + i + 1));
+				}
+				break;
+			}
+			case 1:
+				candidate.Reference(Value::INTEGER(static_cast<int32_t>(global_state.received_filters)),
+				                    count_t(batch_count));
+				break;
+			default:
+				// the ordinality column is filled in by the operator
+				candidate.Reference(Value::BIGINT(0), count_t(batch_count));
+				break;
+			}
+		}
+		candidates.SetChildCardinality(batch_count);
+
+		auto projected_count =
+		    global_state.projection_ids.empty() ? candidates.ColumnCount() : global_state.projection_ids.size();
+		for (idx_t output_idx = 0; output_idx < projected_count; output_idx++) {
+			auto source_idx =
+			    global_state.projection_ids.empty() ? output_idx : global_state.projection_ids[output_idx];
+			output.data[output_idx].Reference(candidates.data[source_idx]);
+		}
+		output.SetChildCardinality(candidates.size());
+
+		local_state.offset += batch_count;
+		if (local_state.offset < count) {
+			return OperatorResultType::HAVE_MORE_OUTPUT;
+		}
+		local_state.offset = 0;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	static void PushdownComplexFilter(ClientContext &context, LogicalGet &get, FunctionData *bind_data,
+	                                  vector<unique_ptr<Expression>> &filters) {
+		filters.clear();
+	}
+
+	static void Register(Connection &con, const string &name, bool complex_filter = false) {
+		con.BeginTransaction();
+		auto &catalog = Catalog::GetSystemCatalog(*con.context);
+		TableFunction function(Identifier(name), {LogicalType::INTEGER}, nullptr, Bind, GlobalInit, LocalInit);
+		function.in_out_function = Function;
+		function.projection_pushdown = true;
+		function.filter_pushdown = true;
+		function.filter_prune = true;
+		if (complex_filter) {
+			function.pushdown_complex_filter = PushdownComplexFilter;
+		}
+		CreateTableFunctionInfo info(function);
+		catalog.CreateTableFunction(*con.context, info);
+		con.Commit();
+	}
+};
+
+TEST_CASE("WITH ORDINALITY reports unfiltered positions for table in-out functions", "[tablefunction]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	OrdinalityEcho::Register(con, "ordinality_echo");
+	OrdinalityEcho::Register(con, "complex_ordinality_echo", true);
+
+	// without a filter the function emits 1..5 and is numbered 1..5
+	auto unfiltered = con.Query(R"(
+		SELECT echoed.value, echoed.ordinality, echoed.filter_state
+		FROM range(1) outer_rows(i),
+		LATERAL ordinality_echo((5 + outer_rows.i)::INTEGER) WITH ORDINALITY echoed
+		ORDER BY echoed.value
+	)");
+	REQUIRE_NO_FAIL(*unfiltered);
+	REQUIRE(CHECK_COLUMN(unfiltered, 0, {1, 2, 3, 4, 5}));
+	REQUIRE(CHECK_COLUMN(unfiltered, 1, {1, 2, 3, 4, 5}));
+	REQUIRE(CHECK_COLUMN(unfiltered, 2, {0, 0, 0, 0, 0}));
+
+	// the filter must not be pushed into the function: the surviving row keeps its original ordinality
+	auto filtered = con.Query(R"(
+		SELECT echoed.value, echoed.ordinality, echoed.filter_state
+		FROM range(1) outer_rows(i),
+		LATERAL ordinality_echo((5 + outer_rows.i)::INTEGER) WITH ORDINALITY echoed
+		WHERE echoed.value = 4
+	)");
+	REQUIRE_NO_FAIL(*filtered);
+	REQUIRE(CHECK_COLUMN(filtered, 0, {4}));
+	REQUIRE(CHECK_COLUMN(filtered, 1, {4}));
+	REQUIRE(CHECK_COLUMN(filtered, 2, {0}));
+
+	// the ordinality restarts at 1 for every input row
+	auto per_row = con.Query(R"(
+		SELECT outer_rows.i, echoed.value, echoed.ordinality
+		FROM range(1, 4) outer_rows(i),
+		LATERAL ordinality_echo(i::INTEGER) WITH ORDINALITY echoed
+		WHERE echoed.value >= 2
+		ORDER BY outer_rows.i, echoed.value
+	)");
+	REQUIRE_NO_FAIL(*per_row);
+	REQUIRE(CHECK_COLUMN(per_row, 0, {2, 3, 3}));
+	REQUIRE(CHECK_COLUMN(per_row, 1, {2, 2, 3}));
+	REQUIRE(CHECK_COLUMN(per_row, 2, {2, 2, 3}));
+
+	// a filter on the ordinality column itself is also evaluated above the function
+	auto ordinality_filter = con.Query(R"(
+		SELECT echoed.value, echoed.ordinality
+		FROM range(1) outer_rows(i),
+		LATERAL ordinality_echo((5 + outer_rows.i)::INTEGER) WITH ORDINALITY echoed
+		WHERE echoed.ordinality > 3
+		ORDER BY echoed.ordinality
+	)");
+	REQUIRE_NO_FAIL(*ordinality_filter);
+	REQUIRE(CHECK_COLUMN(ordinality_filter, 0, {4, 5}));
+	REQUIRE(CHECK_COLUMN(ordinality_filter, 1, {4, 5}));
+
+	// a complex-filter callback must not consume the predicate before ordinality is assigned
+	auto complex_filter = con.Query(R"(
+		SELECT echoed.value, echoed.ordinality
+		FROM range(1) outer_rows(i),
+		LATERAL complex_ordinality_echo((5 + outer_rows.i)::INTEGER) WITH ORDINALITY echoed
+		WHERE echoed.value = 4
+	)");
+	REQUIRE_NO_FAIL(*complex_filter);
+	REQUIRE(CHECK_COLUMN(complex_filter, 0, {4}));
+	REQUIRE(CHECK_COLUMN(complex_filter, 1, {4}));
 }


### PR DESCRIPTION
This PR fixes issue #25647.

Table in-out functions can advertise filter and projection pushdown, but the physical table in-out operator did not pass the generated `TableFilterSet` or projection IDs to `init_global` and `init_local`. Filters removed from the logical plan could therefore be silently skipped, producing incorrect results.

This PR:

1. forwards pushed filters and projection IDs to table in-out initialization;
2. keeps type-selective pushdown conservative, without changing partial or correlated-filter semantics;
3. retains filters above functions using `WITH ORDINALITY`, so surviving rows preserve their original ordinal positions;
4. remaps the ordinality column correctly after projection pruning.

The tests cover filter delivery to global and local initialization, filter-only columns, `filter_prune = false`, type-limited and correlated filters, lateral projection mapping, and `WITH ORDINALITY` behavior.