### PR TITLE
Avoid delete-and-insert for non-indexed UPDATE RETURNING

### DIFF
--- a/.github/patches/extensions/ducklake/0013-update-api-update.patch
+++ b/.github/patches/extensions/ducklake/0013-update-api-update.patch
@@ -1,0 +1,49 @@
+commit 86b967deef641cbca2561f66b77af37a08e0db58
+Author: dentinyhao <dentinyhao@gmail.com>
+Date:   Sat Sep 12 22:57:12 2026 -0700
+
+    update API update
+
+diff --git a/src/storage/ducklake_update.cpp b/src/storage/ducklake_update.cpp
+index 95fe20d5..5e0d9c84 100644
+--- a/src/storage/ducklake_update.cpp
++++ b/src/storage/ducklake_update.cpp
+@@ -237,15 +237,15 @@ DuckLakeUpdate &DuckLakeUpdate::PlanUpdateOperator(ClientContext &context, Physi
+ 	// build update expressions (physical columns only, no partition cols, no casts)
+ 	vector<unique_ptr<Expression>> expressions;
+ 	unordered_map<idx_t, idx_t> expression_map;
+-	for (idx_t i = 0; i < op.columns.size(); i++) {
+-		expression_map[op.columns[i].index] = i;
++	for (idx_t i = 0; i < op.referenced_columns.size(); i++) {
++		expression_map[op.referenced_columns[i].index] = i;
+ 	}
+-	for (idx_t i = 0; i < op.columns.size(); i++) {
++	for (idx_t i = 0; i < op.referenced_columns.size(); i++) {
+ 		expressions.push_back(op.expressions[expression_map[i]]->Copy());
+ 	}
+ 
+-	auto &update_op =
+-	    planner.Make<DuckLakeUpdate>(table, op.columns, child_plan, delete_op, expressions).Cast<DuckLakeUpdate>();
++	auto &update_op = planner.Make<DuckLakeUpdate>(table, op.referenced_columns, child_plan, delete_op, expressions)
++	                      .Cast<DuckLakeUpdate>();
+ 
+ 	// set output types we use physical column types + BIGINT row_id
+ 	vector<LogicalType> update_output_types;
+@@ -299,7 +299,7 @@ void DuckLakeTableEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get,
+ 	for (auto &column : columns.Physical()) {
+ 		auto physical_index = column.Physical();
+ 		bool found = false;
+-		for (auto &col : update.columns) {
++		for (auto &col : update.referenced_columns) {
+ 			if (col == physical_index) {
+ 				found = true;
+ 				break;
+@@ -328,7 +328,7 @@ void DuckLakeTableEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get,
+ 		proj.expressions.push_back(make_uniq<BoundColumnRefExpression>(
+ 		    column.Type(), ColumnBinding(get.table_index, ProjectionIndex(column_id_index.GetIndex()))));
+ 		get.AddColumnId(physical_index.index);
+-		update.columns.push_back(physical_index);
++		update.referenced_columns.push_back(physical_index);
+ 	}
+ }
+ 

--- a/.github/patches/extensions/iceberg/0004-update-api-sync.patch
+++ b/.github/patches/extensions/iceberg/0004-update-api-sync.patch
@@ -1,0 +1,50 @@
+commit 523be5ca8d8922ae215543a0a8c4bf207e699b5a
+Author: dentinyhao <dentinyhao@gmail.com>
+Date:   Sun Sep 13 00:31:24 2026 -0700
+
+    update API sync
+
+diff --git a/src/execution/operator/iceberg_update.cpp b/src/execution/operator/iceberg_update.cpp
+index e6183220..71c8f770 100644
+--- a/src/execution/operator/iceberg_update.cpp
++++ b/src/execution/operator/iceberg_update.cpp
+@@ -57,16 +57,17 @@ IcebergUpdate &IcebergUpdate::PlanUpdateOperator(ClientContext &context, Physica
+ 	// build update expressions (physical columns only, no partition cols, no casts)
+ 	vector<unique_ptr<Expression>> expressions;
+ 	unordered_map<idx_t, idx_t> expression_map;
+-	for (idx_t i = 0; i < op.columns.size(); i++) {
+-		expression_map[op.columns[i].index] = i;
++	for (idx_t i = 0; i < op.referenced_columns.size(); i++) {
++		expression_map[op.referenced_columns[i].index] = i;
+ 	}
+-	for (idx_t i = 0; i < op.columns.size(); i++) {
++	for (idx_t i = 0; i < op.referenced_columns.size(); i++) {
+ 		expressions.push_back(op.expressions[expression_map[i]]->Copy());
+ 	}
+ 
+ 	// Create the IcebergUpdate intermediate operator
+ 	auto &update_op = planner
+-	                      .Make<IcebergUpdate>(table, op.columns, child_plan, delete_op, std::move(expressions),
++	                      .Make<IcebergUpdate>(table, op.referenced_columns, child_plan, delete_op,
++	                                           std::move(expressions),
+ 	                                           std::move(op.bound_defaults))
+ 	                      .Cast<IcebergUpdate>();
+ 
+@@ -265,7 +266,7 @@ void IcebergTableSchemaVersion::BindUpdateConstraints(Binder &binder, LogicalGet
+ 	for (auto &column : columns.Physical()) {
+ 		auto physical_index = column.Physical();
+ 		bool found = false;
+-		for (auto &col : update.columns) {
++		for (auto &col : update.referenced_columns) {
+ 			if (col == physical_index) {
+ 				found = true;
+ 				break;
+@@ -294,7 +295,7 @@ void IcebergTableSchemaVersion::BindUpdateConstraints(Binder &binder, LogicalGet
+ 		proj.expressions.push_back(make_uniq<BoundColumnRefExpression>(
+ 		    column.Type(), ColumnBinding(get.table_index, ProjectionIndex(column_id_index.GetIndex()))));
+ 		get.AddColumnId(physical_index.index);
+-		update.columns.push_back(physical_index);
++		update.referenced_columns.push_back(physical_index);
+ 	}
+ }
+ 

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -305,7 +305,7 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	update.update_is_del_and_insert = Settings::Get<ForceUpdateToDelAndInsertSetting>(context);
 	TableStorageInfo table_storage_info = GetStorageInfo(context);
 	for (auto index : table_storage_info.index_info) {
-		for (auto &column : update.updated_columns) {
+		for (auto &column : update.columns_to_update) {
 			if (index.column_set.find(column.index) != index.column_set.end()) {
 				update.update_is_del_and_insert = true;
 				break;
@@ -314,7 +314,7 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	}
 
 	// we also convert any updates on LIST columns into delete + insert
-	for (auto &col_index : update.updated_columns) {
+	for (auto &col_index : update.columns_to_update) {
 		auto &column = GetColumns().GetColumn(col_index);
 		if (!column.Type().SupportsRegularUpdate()) {
 			update.update_is_del_and_insert = true;

--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -238,22 +238,22 @@ void LogicalUpdate::BindExtraColumns(TableCatalogEntry &table, LogicalGet &get, 
 	}
 	idx_t found_column_count = 0;
 	physical_index_set_t found_columns;
-	for (idx_t i = 0; i < update.columns.size(); i++) {
-		if (bound_columns.find(update.columns[i]) != bound_columns.end()) {
+	for (idx_t i = 0; i < update.referenced_columns.size(); i++) {
+		if (bound_columns.find(update.referenced_columns[i]) != bound_columns.end()) {
 			// this column is referenced in the CHECK constraint
 			found_column_count++;
-			found_columns.insert(update.columns[i]);
+			found_columns.insert(update.referenced_columns[i]);
 		}
 	}
 	if (found_column_count != bound_columns.size()) {
-		// columns that were required are not all part of the UPDATE
-		// add them to the scan and update set
+		// columns that were required are not all materialized
+		// add them to the scan and referenced column set
 		for (auto &physical_id : bound_columns) {
 			if (found_columns.find(physical_id) != found_columns.end()) {
 				// column is already projected
 				continue;
 			}
-			// column is not projected yet: project it by adding the clause "i=i" to the set of updated columns
+			// column is not projected yet: project its existing value
 			auto &column = table.GetColumns().GetColumn(physical_id);
 			auto proj_ref = make_uniq<BoundColumnRefExpression>(
 			    column.Type(), ColumnBinding(get.table_index, ProjectionIndex(get.GetColumnIds().size())));
@@ -261,7 +261,7 @@ void LogicalUpdate::BindExtraColumns(TableCatalogEntry &table, LogicalGet &get, 
 			update.expressions.push_back(
 			    make_uniq<BoundColumnRefExpression>(column.Type(), ColumnBinding(proj.table_index, proj_index)));
 			get.AddColumnId(column.Logical().index);
-			update.columns.push_back(physical_id);
+			update.referenced_columns.push_back(physical_id);
 		}
 	}
 }
@@ -284,8 +284,7 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	// check the constraints and indexes of the table to see if we need to project any additional columns
 	// we do this for indexes with multiple columns and CHECK constraints in the UPDATE clause
 	// suppose we have a constraint CHECK(i + j < 10); now we need both i and j to check the constraint
-	// if we are only updating one of the two columns we add the other one to the UPDATE set
-	// with a "useless" update (i.e. i=i) so we can verify that the CHECK constraint is not violated
+	// if we are only updating one of the two columns we also materialize the other column
 	auto bound_constraints = binder.BindConstraints(constraints, name, GetColumns());
 	for (auto &constraint : bound_constraints) {
 		if (constraint->type == ConstraintType::CHECK) {
@@ -303,12 +302,10 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	}
 	// for index updates we always turn any update into an insert and a delete
 	// we thus need all the columns to be available, hence we check if the update touches any index columns
-	// If the returning keyword is used, we need access to the whole row in case the user requests it.
-	// Therefore switch the update to a delete and insert.
 	update.update_is_del_and_insert = Settings::Get<ForceUpdateToDelAndInsertSetting>(context);
 	TableStorageInfo table_storage_info = GetStorageInfo(context);
 	for (auto index : table_storage_info.index_info) {
-		for (auto &column : update.columns) {
+		for (auto &column : update.updated_columns) {
 			if (index.column_set.find(column.index) != index.column_set.end()) {
 				update.update_is_del_and_insert = true;
 				break;
@@ -317,7 +314,7 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	}
 
 	// we also convert any updates on LIST columns into delete + insert
-	for (auto &col_index : update.columns) {
+	for (auto &col_index : update.updated_columns) {
 		auto &column = GetColumns().GetColumn(col_index);
 		if (!column.Type().SupportsRegularUpdate()) {
 			update.update_is_del_and_insert = true;
@@ -326,8 +323,7 @@ void TableCatalogEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, L
 	}
 
 	if (update.update_is_del_and_insert) {
-		// the update updates a column required by an index or requires returning the updated rows,
-		// push projections for all columns
+		// the update updates a column required by an index, so push projections for all columns
 		physical_index_set_t all_columns;
 		for (auto &column : GetColumns().Physical()) {
 			all_columns.insert(column.Physical());

--- a/src/execution/operator/persistent/physical_insert.cpp
+++ b/src/execution/operator/persistent/physical_insert.cpp
@@ -273,7 +273,7 @@ static idx_t PerformOnConflictAction(InsertLocalState &lstate, InsertGlobalState
 
 		if (GLOBAL) {
 			auto update_state = data_table.InitializeUpdate(table, context.client, op.bound_constraints);
-			data_table.Update(*update_state, context.client, table, row_ids, set_columns, update_chunk);
+			data_table.Update(*update_state, context.client, table, row_ids, set_columns, set_columns, update_chunk);
 			return update_chunk.size();
 		}
 		auto &local_storage = LocalStorage::Get(context.client, data_table.db);

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -19,31 +19,32 @@
 namespace duckdb {
 
 PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref,
-                               DataTable &table, vector<PhysicalIndex> columns,
-                               vector<unique_ptr<Expression>> expressions,
+                               DataTable &table, vector<PhysicalIndex> referenced_columns,
+                               vector<PhysicalIndex> updated_columns, vector<unique_ptr<Expression>> expressions,
                                vector<unique_ptr<Expression>> bound_defaults,
                                vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality,
                                bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
                                RowIdHandling row_id_handling)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::UPDATE, std::move(types), estimated_cardinality),
-      tableref(tableref), table(table), columns(std::move(columns)), expressions(std::move(expressions)),
+      tableref(tableref), table(table), referenced_columns(std::move(referenced_columns)),
+      updated_columns(std::move(updated_columns)), expressions(std::move(expressions)),
       bound_defaults(std::move(bound_defaults)), bound_constraints(std::move(bound_constraints)),
       return_chunk(return_chunk), capture_old_rows(capture_old_rows), old_row_columns(std::move(old_row_columns)),
       row_id_handling(row_id_handling), index_update(false) {
 	auto &indexes = table.GetDataTableInfo().get()->GetIndexes();
 	auto index_columns = indexes.GetIndexedColumns();
 
-	unordered_set<column_t> update_columns;
-	update_columns.reserve(this->columns.size());
-	for (const auto col : this->columns) {
-		update_columns.insert(col.index);
+	unordered_set<column_t> referenced_column_set;
+	referenced_column_set.reserve(this->referenced_columns.size());
+	for (const auto col : this->referenced_columns) {
+		referenced_column_set.insert(col.index);
 	}
 
 	for (const auto &col : table.Columns()) {
 		if (index_columns.find(col.Physical().index) == index_columns.end()) {
 			continue;
 		}
-		if (update_columns.find(col.Physical().index) == update_columns.end()) {
+		if (referenced_column_set.find(col.Physical().index) == referenced_column_set.end()) {
 			continue;
 		}
 		index_update = true;
@@ -155,7 +156,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	for (idx_t i = 0; i < expressions.size(); i++) {
 		// Default expression, set to the default value of the column.
 		if (expressions[i]->GetExpressionType() == ExpressionType::VALUE_DEFAULT) {
-			l_state.default_executor.ExecuteExpression(columns[i].index, update_chunk.data[i]);
+			l_state.default_executor.ExecuteExpression(referenced_columns[i].index, update_chunk.data[i]);
 			continue;
 		}
 
@@ -192,13 +193,14 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 		if (return_chunk) {
 			// (re)reference all output columns first, then validate + set the cardinality. mock_chunk is not reset
 			// here, but with return_chunk the update projects every table column, so all columns are referenced.
-			for (idx_t i = 0; i < columns.size(); i++) {
-				mock_chunk.data[columns[i].index].Reference(update_chunk.data[i]);
+			for (idx_t i = 0; i < referenced_columns.size(); i++) {
+				mock_chunk.data[referenced_columns[i].index].Reference(update_chunk.data[i]);
 			}
 			mock_chunk.CheckCardinality(update_count);
 		}
 		auto &update_state = l_state.GetUpdateState(table, tableref, context.client);
-		table.Update(update_state, context.client, tableref, update_row_ids, columns, update_chunk);
+		table.Update(update_state, context.client, tableref, update_row_ids, referenced_columns, update_chunk,
+		             updated_columns);
 
 		if (return_chunk) {
 			lock_guard<mutex> glock(g_state.lock);
@@ -260,8 +262,8 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	// Arrange the columns in the standard table order, then validate + set the cardinality from the referenced
 	// columns. The del+insert path projects every table column (it re-inserts the full row), so all are referenced.
-	for (idx_t i = 0; i < columns.size(); i++) {
-		mock_chunk.data[columns[i].index].Reference(update_chunk.data[i]);
+	for (idx_t i = 0; i < referenced_columns.size(); i++) {
+		mock_chunk.data[referenced_columns[i].index].Reference(update_chunk.data[i]);
 	}
 	mock_chunk.CheckCardinality(update_count);
 

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -20,14 +20,14 @@ namespace duckdb {
 
 PhysicalUpdate::PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref,
                                DataTable &table, vector<PhysicalIndex> referenced_columns,
-                               vector<PhysicalIndex> updated_columns, vector<unique_ptr<Expression>> expressions,
+                               vector<PhysicalIndex> columns_to_update, vector<unique_ptr<Expression>> expressions,
                                vector<unique_ptr<Expression>> bound_defaults,
                                vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality,
                                bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
                                RowIdHandling row_id_handling)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::UPDATE, std::move(types), estimated_cardinality),
       tableref(tableref), table(table), referenced_columns(std::move(referenced_columns)),
-      updated_columns(std::move(updated_columns)), expressions(std::move(expressions)),
+      columns_to_update(std::move(columns_to_update)), expressions(std::move(expressions)),
       bound_defaults(std::move(bound_defaults)), bound_constraints(std::move(bound_constraints)),
       return_chunk(return_chunk), capture_old_rows(capture_old_rows), old_row_columns(std::move(old_row_columns)),
       row_id_handling(row_id_handling), index_update(false) {
@@ -199,7 +199,7 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 			mock_chunk.CheckCardinality(update_count);
 		}
 		auto &update_state = l_state.GetUpdateState(table, tableref, context.client);
-		table.Update(update_state, context.client, tableref, update_row_ids, referenced_columns, updated_columns,
+		table.Update(update_state, context.client, tableref, update_row_ids, referenced_columns, columns_to_update,
 		             update_chunk);
 
 		if (return_chunk) {

--- a/src/execution/operator/persistent/physical_update.cpp
+++ b/src/execution/operator/persistent/physical_update.cpp
@@ -199,8 +199,8 @@ SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 			mock_chunk.CheckCardinality(update_count);
 		}
 		auto &update_state = l_state.GetUpdateState(table, tableref, context.client);
-		table.Update(update_state, context.client, tableref, update_row_ids, referenced_columns, update_chunk,
-		             updated_columns);
+		table.Update(update_state, context.client, tableref, update_row_ids, referenced_columns, updated_columns,
+		             update_chunk);
 
 		if (return_chunk) {
 			lock_guard<mutex> glock(g_state.lock);

--- a/src/execution/physical_plan/plan_merge_into.cpp
+++ b/src/execution/physical_plan/plan_merge_into.cpp
@@ -66,12 +66,12 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 			defaults.push_back(def->Copy());
 		}
 		auto &action_input = PlanMergeActionSource(planner, plan, condition, *result);
-		result->op = planner.Make<PhysicalUpdate>(std::move(return_types), op.table.Cast<DuckTableEntry>(),
-		                                          op.table.GetStorage(), std::move(action.columns),
-		                                          std::move(action.expressions), std::move(defaults),
-		                                          std::move(bound_constraints), cardinality, op.return_chunk,
-		                                          /*capture_old_rows=*/false, /*old_row_columns=*/vector<idx_t>(),
-		                                          /*row_id_handling=*/RowIdHandling::ASSUME_UNIQUE);
+		result->op = planner.Make<PhysicalUpdate>(
+		    std::move(return_types), op.table.Cast<DuckTableEntry>(), op.table.GetStorage(),
+		    std::move(action.referenced_columns), std::move(action.updated_columns), std::move(action.expressions),
+		    std::move(defaults), std::move(bound_constraints), cardinality, op.return_chunk, /*capture_old_rows=*/false,
+		    /*old_row_columns=*/vector<idx_t>(),
+		    /*row_id_handling=*/RowIdHandling::ASSUME_UNIQUE);
 		auto &cast_update = result->op->Cast<PhysicalUpdate>();
 		cast_update.update_is_del_and_insert = action.update_is_del_and_insert;
 		result->op->children.push_back(action_input);
@@ -219,7 +219,7 @@ static unique_ptr<MergeIntoOperator> PlanGenericMergeIntoAction(ClientContext &c
 		// that layout so that we can plan the update exactly like a regular update
 		vector<unique_ptr<Expression>> select_list;
 		vector<unique_ptr<Expression>> update_expressions;
-		CastActionExpressionsToColumnTypes(context, op.table, action.expressions, action.columns);
+		CastActionExpressionsToColumnTypes(context, op.table, action.expressions, action.referenced_columns);
 		for (auto &expr : action.expressions) {
 			update_expressions.push_back(
 			    make_uniq<BoundReferenceExpression>(expr->GetReturnType(), select_list.size()));
@@ -232,7 +232,8 @@ static unique_ptr<MergeIntoOperator> PlanGenericMergeIntoAction(ClientContext &c
 		auto &action_input = PlanMergeActionSource(planner, plan, condition, *result);
 
 		LogicalUpdate update(op.table);
-		update.columns = std::move(action.columns);
+		update.referenced_columns = std::move(action.referenced_columns);
+		update.updated_columns = std::move(action.updated_columns);
 		update.expressions = std::move(update_expressions);
 		update.update_is_del_and_insert = action.update_is_del_and_insert;
 		update.bound_constraints = CopyBoundConstraints(op);

--- a/src/execution/physical_plan/plan_merge_into.cpp
+++ b/src/execution/physical_plan/plan_merge_into.cpp
@@ -68,7 +68,7 @@ unique_ptr<MergeIntoOperator> PlanMergeIntoAction(ClientContext &context, Logica
 		auto &action_input = PlanMergeActionSource(planner, plan, condition, *result);
 		result->op = planner.Make<PhysicalUpdate>(
 		    std::move(return_types), op.table.Cast<DuckTableEntry>(), op.table.GetStorage(),
-		    std::move(action.referenced_columns), std::move(action.updated_columns), std::move(action.expressions),
+		    std::move(action.referenced_columns), std::move(action.columns_to_update), std::move(action.expressions),
 		    std::move(defaults), std::move(bound_constraints), cardinality, op.return_chunk, /*capture_old_rows=*/false,
 		    /*old_row_columns=*/vector<idx_t>(),
 		    /*row_id_handling=*/RowIdHandling::ASSUME_UNIQUE);
@@ -233,7 +233,7 @@ static unique_ptr<MergeIntoOperator> PlanGenericMergeIntoAction(ClientContext &c
 
 		LogicalUpdate update(op.table);
 		update.referenced_columns = std::move(action.referenced_columns);
-		update.updated_columns = std::move(action.updated_columns);
+		update.columns_to_update = std::move(action.columns_to_update);
 		update.expressions = std::move(update_expressions);
 		update.update_is_del_and_insert = action.update_is_del_and_insert;
 		update.bound_constraints = CopyBoundConstraints(op);

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 PhysicalOperator &DuckCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
                                           PhysicalOperator &plan) {
 	auto &update = planner.Make<PhysicalUpdate>(op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(),
-	                                            op.referenced_columns, op.updated_columns, std::move(op.expressions),
+	                                            op.referenced_columns, op.columns_to_update, std::move(op.expressions),
 	                                            std::move(op.bound_defaults), std::move(op.bound_constraints),
 	                                            op.estimated_cardinality, op.return_chunk, op.capture_old_rows,
 	                                            std::move(op.old_row_columns), op.row_id_handling);

--- a/src/execution/physical_plan/plan_update.cpp
+++ b/src/execution/physical_plan/plan_update.cpp
@@ -9,10 +9,11 @@ namespace duckdb {
 
 PhysicalOperator &DuckCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
                                           PhysicalOperator &plan) {
-	auto &update = planner.Make<PhysicalUpdate>(
-	    op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(), op.columns, std::move(op.expressions),
-	    std::move(op.bound_defaults), std::move(op.bound_constraints), op.estimated_cardinality, op.return_chunk,
-	    op.capture_old_rows, std::move(op.old_row_columns), op.row_id_handling);
+	auto &update = planner.Make<PhysicalUpdate>(op.types, op.table.Cast<DuckTableEntry>(), op.table.GetStorage(),
+	                                            op.referenced_columns, op.updated_columns, std::move(op.expressions),
+	                                            std::move(op.bound_defaults), std::move(op.bound_constraints),
+	                                            op.estimated_cardinality, op.return_chunk, op.capture_old_rows,
+	                                            std::move(op.old_row_columns), op.row_id_handling);
 	auto &cast_update = update.Cast<PhysicalUpdate>();
 	cast_update.update_is_del_and_insert = op.update_is_del_and_insert;
 	cast_update.children.push_back(plan);

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -24,7 +24,7 @@ public:
 
 public:
 	PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref, DataTable &table,
-	               vector<PhysicalIndex> referenced_columns, vector<PhysicalIndex> updated_columns,
+	               vector<PhysicalIndex> referenced_columns, vector<PhysicalIndex> columns_to_update,
 	               vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> bound_defaults,
 	               vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality,
 	               bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
@@ -35,7 +35,7 @@ public:
 	//! Columns materialized for constraint checks, RETURNING, or reinsertion
 	vector<PhysicalIndex> referenced_columns;
 	//! Columns targeted by the SET clause
-	vector<PhysicalIndex> updated_columns;
+	vector<PhysicalIndex> columns_to_update;
 	vector<unique_ptr<Expression>> expressions;
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;

--- a/src/include/duckdb/execution/operator/persistent/physical_update.hpp
+++ b/src/include/duckdb/execution/operator/persistent/physical_update.hpp
@@ -24,14 +24,18 @@ public:
 
 public:
 	PhysicalUpdate(PhysicalPlan &physical_plan, vector<LogicalType> types, DuckTableEntry &tableref, DataTable &table,
-	               vector<PhysicalIndex> columns, vector<unique_ptr<Expression>> expressions,
-	               vector<unique_ptr<Expression>> bound_defaults, vector<unique_ptr<BoundConstraint>> bound_constraints,
-	               idx_t estimated_cardinality, bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
+	               vector<PhysicalIndex> referenced_columns, vector<PhysicalIndex> updated_columns,
+	               vector<unique_ptr<Expression>> expressions, vector<unique_ptr<Expression>> bound_defaults,
+	               vector<unique_ptr<BoundConstraint>> bound_constraints, idx_t estimated_cardinality,
+	               bool return_chunk, bool capture_old_rows, vector<idx_t> old_row_columns,
 	               RowIdHandling row_id_handling);
 
 	DuckTableEntry &tableref;
 	DataTable &table;
-	vector<PhysicalIndex> columns;
+	//! Columns materialized for constraint checks, RETURNING, or reinsertion
+	vector<PhysicalIndex> referenced_columns;
+	//! Columns targeted by the SET clause
+	vector<PhysicalIndex> updated_columns;
 	vector<unique_ptr<Expression>> expressions;
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;

--- a/src/include/duckdb/planner/operator/logical_merge_into.hpp
+++ b/src/include/duckdb/planner/operator/logical_merge_into.hpp
@@ -26,7 +26,9 @@ public:
 	//! Condition - or NULL if this should always be performed for the given action
 	unique_ptr<Expression> condition;
 	//! The set of referenced physical columns (for UPDATE)
-	vector<PhysicalIndex> columns;
+	vector<PhysicalIndex> referenced_columns;
+	//! Columns targeted by the UPDATE action
+	vector<PhysicalIndex> updated_columns;
 	//! Set of expressions for INSERT or UPDATE
 	vector<unique_ptr<Expression>> expressions;
 	//! Deprecated: Column index map (for INSERT)

--- a/src/include/duckdb/planner/operator/logical_merge_into.hpp
+++ b/src/include/duckdb/planner/operator/logical_merge_into.hpp
@@ -28,7 +28,7 @@ public:
 	//! The set of referenced physical columns (for UPDATE)
 	vector<PhysicalIndex> referenced_columns;
 	//! Columns targeted by the UPDATE action
-	vector<PhysicalIndex> updated_columns;
+	vector<PhysicalIndex> columns_to_update;
 	//! Set of expressions for INSERT or UPDATE
 	vector<unique_ptr<Expression>> expressions;
 	//! Deprecated: Column index map (for INSERT)

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -39,7 +39,7 @@ public:
 	//! Columns materialized for constraint checks, RETURNING, or reinsertion
 	vector<PhysicalIndex> referenced_columns;
 	//! Columns targeted by the SET clause
-	vector<PhysicalIndex> updated_columns;
+	vector<PhysicalIndex> columns_to_update;
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	bool update_is_del_and_insert;

--- a/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/src/include/duckdb/planner/operator/logical_update.hpp
@@ -36,7 +36,10 @@ public:
 	bool capture_old_rows = false;
 	//! input-chunk index of each captured OLD physical column, in physical table order (only when capture_old_rows)
 	vector<idx_t> old_row_columns;
-	vector<PhysicalIndex> columns;
+	//! Columns materialized for constraint checks, RETURNING, or reinsertion
+	vector<PhysicalIndex> referenced_columns;
+	//! Columns targeted by the SET clause
+	vector<PhysicalIndex> updated_columns;
 	vector<unique_ptr<Expression>> bound_defaults;
 	vector<unique_ptr<BoundConstraint>> bound_constraints;
 	bool update_is_del_and_insert;

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -163,6 +163,10 @@ public:
 	//! Update the entries with the specified row identifier from the table
 	void Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
 	            const vector<PhysicalIndex> &column_ids, DataChunk &data);
+	//! Verify constraints using referenced columns, but write only updated columns
+	void Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
+	            const vector<PhysicalIndex> &referenced_column_ids, DataChunk &data,
+	            const vector<PhysicalIndex> &updated_column_ids);
 	//! Update a single (sub-)column along a column path
 	//! The column_path vector is a *path* towards a column within the table
 	//! i.e. if we have a table with a single column S STRUCT(A INT, B INT)
@@ -301,9 +305,10 @@ private:
 	//! Verify the new added constraints against current persistent&local data
 	void VerifyNewConstraint(LocalStorage &local_storage, DataTable &parent, const BoundConstraint &constraint);
 
-	//! Verify constraints with a chunk from the Update containing only the specified column_ids
+	//! Verify constraints using referenced columns and verify that updated columns are not indexed
 	void VerifyUpdateConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
-	                             const vector<PhysicalIndex> &column_ids);
+	                             const vector<PhysicalIndex> &referenced_column_ids,
+	                             const vector<PhysicalIndex> &updated_column_ids);
 	//! Verify constraints with a chunk from the Delete containing all columns of the table
 	void VerifyDeleteConstraints(optional_ptr<LocalTableStorage> storage, TableDeleteState &state,
 	                             ClientContext &context, DataChunk &chunk);

--- a/src/include/duckdb/storage/data_table.hpp
+++ b/src/include/duckdb/storage/data_table.hpp
@@ -160,13 +160,10 @@ public:
 
 	unique_ptr<TableUpdateState> InitializeUpdate(TableCatalogEntry &table, ClientContext &context,
 	                                              const vector<unique_ptr<BoundConstraint>> &bound_constraints);
-	//! Update the entries with the specified row identifier from the table
-	void Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
-	            const vector<PhysicalIndex> &column_ids, DataChunk &data);
 	//! Verify constraints using referenced columns, but write only updated columns
 	void Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
-	            const vector<PhysicalIndex> &referenced_column_ids, DataChunk &data,
-	            const vector<PhysicalIndex> &updated_column_ids);
+	            const vector<PhysicalIndex> &referenced_column_ids, const vector<PhysicalIndex> &updated_column_ids,
+	            DataChunk &data);
 	//! Update a single (sub-)column along a column path
 	//! The column_path vector is a *path* towards a column within the table
 	//! i.e. if we have a table with a single column S STRUCT(A INT, B INT)

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -856,6 +856,7 @@
       {
         "id": 204,
         "name": "columns",
+        "property": "referenced_columns",
         "type": "vector<PhysicalIndex>"
       },
       {
@@ -884,6 +885,11 @@
         "name": "row_id_handling",
         "type": "RowIdHandling",
         "default": "RowIdHandling::ASSUME_UNIQUE"
+      },
+      {
+        "id": 210,
+        "name": "updated_columns",
+        "type": "vector<PhysicalIndex>"
       }
     ],
     "constructor": [
@@ -956,6 +962,7 @@
       {
         "id": 202,
         "name": "columns",
+        "property": "referenced_columns",
         "type": "vector<PhysicalIndex>"
       },
       {
@@ -974,7 +981,17 @@
         "id": 205,
         "name": "update_is_del_and_insert",
         "type": "bool"
+      },
+      {
+        "id": 206,
+        "name": "updated_columns",
+        "type": "vector<PhysicalIndex>"
       }
+    ],
+    "finalize_deserialization": [
+      "if (result->updated_columns.empty()) {",
+      "\tresult->updated_columns = result->referenced_columns;",
+      "}"
     ]
   },
   {

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -855,8 +855,7 @@
       },
       {
         "id": 204,
-        "name": "columns",
-        "property": "referenced_columns",
+        "name": "referenced_columns",
         "type": "vector<PhysicalIndex>"
       },
       {
@@ -961,8 +960,7 @@
       },
       {
         "id": 202,
-        "name": "columns",
-        "property": "referenced_columns",
+        "name": "referenced_columns",
         "type": "vector<PhysicalIndex>"
       },
       {
@@ -987,11 +985,6 @@
         "name": "updated_columns",
         "type": "vector<PhysicalIndex>"
       }
-    ],
-    "finalize_deserialization": [
-      "if (result->updated_columns.empty()) {",
-      "\tresult->updated_columns = result->referenced_columns;",
-      "}"
     ]
   },
   {

--- a/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/src/include/duckdb/storage/serialization/logical_operator.json
@@ -887,7 +887,7 @@
       },
       {
         "id": 210,
-        "name": "updated_columns",
+        "name": "columns_to_update",
         "type": "vector<PhysicalIndex>"
       }
     ],
@@ -982,7 +982,7 @@
       },
       {
         "id": 206,
-        "name": "updated_columns",
+        "name": "columns_to_update",
         "type": "vector<PhysicalIndex>"
       }
     ]

--- a/src/planner/binder/query_node/bind_trigger_expansion.cpp
+++ b/src/planner/binder/query_node/bind_trigger_expansion.cpp
@@ -64,14 +64,15 @@ unique_ptr<BoundStatement> Binder::TryExpandTriggers(QueryNode &node, TableCatal
 	// Triggers without an OF list are unrestricted and always fire.
 	if (event_type == TriggerEventType::UPDATE_EVENT && node.type == QueryNodeType::UPDATE_QUERY_NODE) {
 		auto &update_node = node.Cast<UpdateQueryNode>();
-		identifier_set_t updated_columns;
+		identifier_set_t columns_to_update;
 		if (update_node.set_info) {
-			updated_columns.insert(update_node.set_info->columns.begin(), update_node.set_info->columns.end());
+			columns_to_update.insert(update_node.set_info->columns.begin(), update_node.set_info->columns.end());
 		}
 		auto trigger_does_not_fire = [&](const_reference<TriggerCatalogEntry> trig) {
 			const auto &of_cols = trig.get().columns;
-			return !of_cols.empty() && std::none_of(of_cols.begin(), of_cols.end(),
-			                                        [&](const Identifier &c) { return updated_columns.count(c) > 0; });
+			return !of_cols.empty() && std::none_of(of_cols.begin(), of_cols.end(), [&](const Identifier &c) {
+				return columns_to_update.count(c) > 0;
+			});
 		};
 		auto drop_non_firing = [&](vector<const_reference<TriggerCatalogEntry>> &triggers) {
 			triggers.erase(std::remove_if(triggers.begin(), triggers.end(), trigger_does_not_fire), triggers.end());

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -84,7 +84,7 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 		LogicalUpdate update(table);
 		update.return_chunk = merge_into.return_chunk;
 		update.referenced_columns = std::move(result->referenced_columns);
-		update.updated_columns = update.referenced_columns;
+		update.columns_to_update = update.referenced_columns;
 		update.expressions = std::move(result->expressions);
 		update.bound_defaults = std::move(merge_into.bound_defaults);
 		update.bound_constraints = std::move(merge_into.bound_constraints);
@@ -98,7 +98,7 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 		merge_into.bound_constraints = std::move(update.bound_constraints);
 		expressions = std::move(proj.expressions);
 		result->referenced_columns = std::move(update.referenced_columns);
-		result->updated_columns = std::move(update.updated_columns);
+		result->columns_to_update = std::move(update.columns_to_update);
 		result->expressions = std::move(update.expressions);
 		result->update_is_del_and_insert = update.update_is_del_and_insert;
 		break;

--- a/src/planner/binder/statement/bind_merge_into.cpp
+++ b/src/planner/binder/statement/bind_merge_into.cpp
@@ -74,8 +74,8 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 			}
 		}
 		unique_ptr<LogicalOperator> fake_root;
-		BindUpdateSet(proj_index, fake_root, *action.update_info, table, result->columns, merge_into.bound_defaults,
-		              result->expressions, expressions);
+		BindUpdateSet(proj_index, fake_root, *action.update_info, table, result->referenced_columns,
+		              merge_into.bound_defaults, result->expressions, expressions);
 
 		// bind any additional columns that need to be bound for update constraints
 		// FIXME: this is pretty hacky
@@ -83,7 +83,8 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 		LogicalProjection proj(proj_index, std::move(expressions));
 		LogicalUpdate update(table);
 		update.return_chunk = merge_into.return_chunk;
-		update.columns = std::move(result->columns);
+		update.referenced_columns = std::move(result->referenced_columns);
+		update.updated_columns = update.referenced_columns;
 		update.expressions = std::move(result->expressions);
 		update.bound_defaults = std::move(merge_into.bound_defaults);
 		update.bound_constraints = std::move(merge_into.bound_constraints);
@@ -96,7 +97,8 @@ Binder::BindMergeAction(LogicalMergeInto &merge_into, TableCatalogEntry &table, 
 		merge_into.bound_defaults = std::move(update.bound_defaults);
 		merge_into.bound_constraints = std::move(update.bound_constraints);
 		expressions = std::move(proj.expressions);
-		result->columns = std::move(update.columns);
+		result->referenced_columns = std::move(update.referenced_columns);
+		result->updated_columns = std::move(update.updated_columns);
 		result->expressions = std::move(update.expressions);
 		result->update_is_del_and_insert = update.update_is_del_and_insert;
 		break;

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -231,9 +231,10 @@ BoundStatement Binder::BindNode(UpdateQueryNode &node) {
 	D_ASSERT(node.set_info->columns.size() == node.set_info->expressions.size());
 
 	auto proj_tmp = BindUpdateSet(*update, std::move(root), *node.set_info, table, update->bound_defaults,
-	                              update->columns, node.prioritize_table_when_binding);
+	                              update->referenced_columns, node.prioritize_table_when_binding);
 	D_ASSERT(proj_tmp->type == LogicalOperatorType::LOGICAL_PROJECTION);
 	auto proj = unique_ptr_cast<LogicalOperator, LogicalProjection>(std::move(proj_tmp));
+	update->updated_columns = update->referenced_columns;
 
 	// bind any extra columns necessary for CHECK constraints or indexes
 	table.BindUpdateConstraints(*this, *get, *proj, *update, context);

--- a/src/planner/binder/statement/bind_update.cpp
+++ b/src/planner/binder/statement/bind_update.cpp
@@ -234,7 +234,7 @@ BoundStatement Binder::BindNode(UpdateQueryNode &node) {
 	                              update->referenced_columns, node.prioritize_table_when_binding);
 	D_ASSERT(proj_tmp->type == LogicalOperatorType::LOGICAL_PROJECTION);
 	auto proj = unique_ptr_cast<LogicalOperator, LogicalProjection>(std::move(proj_tmp));
-	update->updated_columns = update->referenced_columns;
+	update->columns_to_update = update->referenced_columns;
 
 	// bind any extra columns necessary for CHECK constraints or indexes
 	table.BindUpdateConstraints(*this, *get, *proj, *update, context);

--- a/src/planner/operator/logical_update.cpp
+++ b/src/planner/operator/logical_update.cpp
@@ -65,7 +65,7 @@ void LogicalUpdate::RewriteInPlaceUpdates(LogicalOperator &update_op) {
 		return;
 	}
 	auto needs_reinsert = false;
-	for (auto &col_idx : update.updated_columns) {
+	for (auto &col_idx : update.columns_to_update) {
 		auto &column = update.table.GetColumns().GetColumn(col_idx);
 		if (!column.Type().SupportsRegularUpdate()) {
 			needs_reinsert = true;

--- a/src/planner/operator/logical_update.cpp
+++ b/src/planner/operator/logical_update.cpp
@@ -60,12 +60,16 @@ string LogicalUpdate::GetName() const {
 
 void LogicalUpdate::RewriteInPlaceUpdates(LogicalOperator &update_op) {
 	auto &update = update_op.Cast<LogicalUpdate>();
+	if (update.updated_columns.empty()) {
+		// Plans serialized before updated_columns was added treated every materialized column as updated.
+		update.updated_columns = update.referenced_columns;
+	}
 
 	if (update.update_is_del_and_insert) {
 		return;
 	}
 	auto needs_reinsert = false;
-	for (auto &col_idx : update.columns) {
+	for (auto &col_idx : update.updated_columns) {
 		auto &column = update.table.GetColumns().GetColumn(col_idx);
 		if (!column.Type().SupportsRegularUpdate()) {
 			needs_reinsert = true;
@@ -150,11 +154,11 @@ void LogicalUpdate::RewriteInPlaceUpdates(LogicalOperator &update_op) {
 
 	idx_t found_column_count = 0;
 	physical_index_set_t found_columns;
-	for (idx_t i = 0; i < update.columns.size(); i++) {
-		if (all_columns.find(update.columns[i]) != all_columns.end()) {
+	for (idx_t i = 0; i < update.referenced_columns.size(); i++) {
+		if (all_columns.find(update.referenced_columns[i]) != all_columns.end()) {
 			// this column is referenced already
 			found_column_count++;
-			found_columns.insert(update.columns[i]);
+			found_columns.insert(update.referenced_columns[i]);
 		}
 	}
 
@@ -198,7 +202,7 @@ void LogicalUpdate::RewriteInPlaceUpdates(LogicalOperator &update_op) {
 			}
 
 			// Finally, add the column to the UPDATE operator too
-			update.columns.push_back(physical_id);
+			update.referenced_columns.push_back(physical_id);
 			update.expressions.push_back(
 			    make_uniq<BoundColumnRefExpression>(column.Type(), ColumnBinding(prev_tbl_idx, prev_col_idx)));
 		}

--- a/src/planner/operator/logical_update.cpp
+++ b/src/planner/operator/logical_update.cpp
@@ -60,10 +60,6 @@ string LogicalUpdate::GetName() const {
 
 void LogicalUpdate::RewriteInPlaceUpdates(LogicalOperator &update_op) {
 	auto &update = update_op.Cast<LogicalUpdate>();
-	if (update.updated_columns.empty()) {
-		// Plans serialized before updated_columns was added treated every materialized column as updated.
-		update.updated_columns = update.referenced_columns;
-	}
 
 	if (update.update_is_del_and_insert) {
 		return;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1481,13 +1481,8 @@ unique_ptr<TableUpdateState> DataTable::InitializeUpdate(TableCatalogEntry &tabl
 }
 
 void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
-                       const vector<PhysicalIndex> &column_ids, DataChunk &updates) {
-	Update(state, context, table_entry, row_ids, column_ids, updates, column_ids);
-}
-
-void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
-                       const vector<PhysicalIndex> &referenced_column_ids, DataChunk &updates,
-                       const vector<PhysicalIndex> &updated_column_ids) {
+                       const vector<PhysicalIndex> &referenced_column_ids,
+                       const vector<PhysicalIndex> &updated_column_ids, DataChunk &updates) {
 	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
 	D_ASSERT(referenced_column_ids.size() == updates.ColumnCount());
 	updates.Verify(context.db);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -40,6 +40,8 @@
 #include "duckdb/transaction/local_storage.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 
+#include <algorithm>
+
 namespace duckdb {
 
 DataTableInfo::DataTableInfo(AttachedDatabase &db, shared_ptr<TableIOManager> table_io_manager_p,
@@ -1390,21 +1392,21 @@ idx_t DataTable::Delete(TableDeleteState &state, ClientContext &context, DuckTab
 //===--------------------------------------------------------------------===//
 // Update
 //===--------------------------------------------------------------------===//
-static void CreateMockChunk(vector<LogicalType> &types, const vector<PhysicalIndex> &column_ids, DataChunk &chunk,
-                            DataChunk &mock_chunk) {
+static void CreateMockChunk(vector<LogicalType> &types, const vector<PhysicalIndex> &referenced_column_ids,
+                            DataChunk &chunk, DataChunk &mock_chunk) {
 	// construct a mock DataChunk
 	mock_chunk.InitializeEmpty(types);
-	for (column_t i = 0; i < column_ids.size(); i++) {
-		mock_chunk.data[column_ids[i].index].Reference(chunk.data[i]);
+	for (column_t i = 0; i < referenced_column_ids.size(); i++) {
+		mock_chunk.data[referenced_column_ids[i].index].Reference(chunk.data[i]);
 	}
 }
 
-static bool CreateMockChunk(TableCatalogEntry &table, const vector<PhysicalIndex> &column_ids,
+static bool CreateMockChunk(TableCatalogEntry &table, const vector<PhysicalIndex> &referenced_column_ids,
                             physical_index_set_t &desired_column_ids, DataChunk &chunk, DataChunk &mock_chunk) {
 	idx_t found_columns = 0;
 	// check whether the desired columns are present in the UPDATE clause
-	for (column_t i = 0; i < column_ids.size(); i++) {
-		if (desired_column_ids.find(column_ids[i]) != desired_column_ids.end()) {
+	for (column_t i = 0; i < referenced_column_ids.size(); i++) {
+		if (desired_column_ids.find(referenced_column_ids[i]) != desired_column_ids.end()) {
 			found_columns++;
 		}
 	}
@@ -1419,12 +1421,13 @@ static bool CreateMockChunk(TableCatalogEntry &table, const vector<PhysicalIndex
 	}
 	// construct a mock DataChunk
 	auto types = table.GetTypes();
-	CreateMockChunk(types, column_ids, chunk, mock_chunk);
+	CreateMockChunk(types, referenced_column_ids, chunk, mock_chunk);
 	return true;
 }
 
 void DataTable::VerifyUpdateConstraints(ConstraintState &state, ClientContext &context, DataChunk &chunk,
-                                        const vector<PhysicalIndex> &column_ids) {
+                                        const vector<PhysicalIndex> &referenced_column_ids,
+                                        const vector<PhysicalIndex> &updated_column_ids) {
 	auto &table = state.table;
 	auto &constraints = table.GetConstraints();
 	auto &bound_constraints = state.bound_constraints;
@@ -1435,9 +1438,9 @@ void DataTable::VerifyUpdateConstraints(ConstraintState &state, ClientContext &c
 		case ConstraintType::NOT_NULL: {
 			auto &bound_not_null = constraint->Cast<BoundNotNullConstraint>();
 			auto &not_null = base_constraint->Cast<NotNullConstraint>();
-			// check if the constraint is in the list of column_ids
-			for (idx_t col_idx = 0; col_idx < column_ids.size(); col_idx++) {
-				if (column_ids[col_idx] == bound_not_null.index) {
+			// check if the constraint column is materialized
+			for (idx_t col_idx = 0; col_idx < referenced_column_ids.size(); col_idx++) {
+				if (referenced_column_ids[col_idx] == bound_not_null.index) {
 					// found the column id: check the data in
 					auto &col = table.GetColumn(LogicalIndex(not_null.index));
 					VerifyNotNullConstraint(table, chunk.data[col_idx], col.Name());
@@ -1451,7 +1454,7 @@ void DataTable::VerifyUpdateConstraints(ConstraintState &state, ClientContext &c
 			auto &bound_check = constraint->Cast<BoundCheckConstraint>();
 
 			DataChunk mock_chunk;
-			if (CreateMockChunk(table, column_ids, bound_check.bound_columns, chunk, mock_chunk)) {
+			if (CreateMockChunk(table, referenced_column_ids, bound_check.bound_columns, chunk, mock_chunk)) {
 				VerifyCheckConstraint(context, table, *bound_check.expression, mock_chunk, check);
 			}
 			break;
@@ -1465,7 +1468,7 @@ void DataTable::VerifyUpdateConstraints(ConstraintState &state, ClientContext &c
 	}
 	// Ensure that we never call UPDATE for indexed columns.
 	// Instead, we must rewrite these updates into DELETE + INSERT.
-	info->indexes.VerifyUpdate(column_ids);
+	info->indexes.VerifyUpdate(updated_column_ids);
 }
 
 unique_ptr<TableUpdateState> DataTable::InitializeUpdate(TableCatalogEntry &table, ClientContext &context,
@@ -1479,8 +1482,14 @@ unique_ptr<TableUpdateState> DataTable::InitializeUpdate(TableCatalogEntry &tabl
 
 void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
                        const vector<PhysicalIndex> &column_ids, DataChunk &updates) {
+	Update(state, context, table_entry, row_ids, column_ids, updates, column_ids);
+}
+
+void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTableEntry &table_entry, Vector &row_ids,
+                       const vector<PhysicalIndex> &referenced_column_ids, DataChunk &updates,
+                       const vector<PhysicalIndex> &updated_column_ids) {
 	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
-	D_ASSERT(column_ids.size() == updates.ColumnCount());
+	D_ASSERT(referenced_column_ids.size() == updates.ColumnCount());
 	updates.Verify(context.db);
 
 	auto count = updates.size();
@@ -1495,13 +1504,30 @@ void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTabl
 	}
 
 	// first verify that no constraints are violated
-	VerifyUpdateConstraints(*state.constraint_state, context, updates, column_ids);
+	VerifyUpdateConstraints(*state.constraint_state, context, updates, referenced_column_ids, updated_column_ids);
+
+	vector<column_t> update_projection_ids;
+	vector<LogicalType> update_types;
+	update_projection_ids.reserve(updated_column_ids.size());
+	update_types.reserve(updated_column_ids.size());
+	for (const auto &updated_column : updated_column_ids) {
+		auto entry = std::find(referenced_column_ids.begin(), referenced_column_ids.end(), updated_column);
+		if (entry == referenced_column_ids.end()) {
+			throw InternalException("Updated column is not present in the materialized update columns");
+		}
+		auto update_index = NumericCast<column_t>(entry - referenced_column_ids.begin());
+		update_projection_ids.push_back(update_index);
+		update_types.push_back(updates.data[update_index].GetType());
+	}
+	DataChunk write_updates;
+	write_updates.InitializeEmpty(update_types);
+	write_updates.ReferenceColumns(updates, update_projection_ids);
 
 	// now perform the actual update
 	Vector max_row_id_vec(Value::BIGINT(MAX_ROW_ID), count_t(count));
 	Vector row_ids_slice(LogicalType::BIGINT);
 	DataChunk updates_slice;
-	updates_slice.InitializeEmpty(updates.GetTypes());
+	updates_slice.InitializeEmpty(write_updates.GetTypes());
 
 	SelectionVector sel_local_update(count), sel_global_update(count);
 	auto n_local_update = VectorOperations::GreaterThanEquals(row_ids, max_row_id_vec, nullptr, count,
@@ -1510,24 +1536,24 @@ void DataTable::Update(TableUpdateState &state, ClientContext &context, DuckTabl
 
 	// row id > MAX_ROW_ID? transaction-local storage
 	if (n_local_update > 0) {
-		updates_slice.Slice(updates, sel_local_update, n_local_update);
+		updates_slice.Slice(write_updates, sel_local_update, n_local_update);
 		updates_slice.Flatten();
 		row_ids_slice.Slice(row_ids, sel_local_update, n_local_update);
 		row_ids_slice.Flatten();
 
-		LocalStorage::Get(context, db).Update(*this, table_entry, row_ids_slice, column_ids, updates_slice);
+		LocalStorage::Get(context, db).Update(*this, table_entry, row_ids_slice, updated_column_ids, updates_slice);
 	}
 
 	// otherwise global storage
 	if (n_global_update > 0) {
 		auto &transaction = DuckTransaction::Get(context, db);
-		updates_slice.Slice(updates, sel_global_update, n_global_update);
+		updates_slice.Slice(write_updates, sel_global_update, n_global_update);
 		updates_slice.Flatten();
 		row_ids_slice.Slice(row_ids, sel_global_update, n_global_update);
 		row_ids_slice.Flatten();
 
-		row_groups->Update(transaction, table_entry, FlatVector::GetDataMutable<row_t>(row_ids_slice), column_ids,
-		                   updates_slice);
+		row_groups->Update(transaction, table_entry, FlatVector::GetDataMutable<row_t>(row_ids_slice),
+		                   updated_column_ids, updates_slice);
 	}
 }
 

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -214,7 +214,7 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 void BoundMergeIntoAction::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<MergeActionType>(200, "action_type", action_type);
 	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(201, "condition", condition);
-	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(202, "columns", columns);
+	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(202, "columns", referenced_columns);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", expressions);
 	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
 		serializer.WritePropertyWithDefault<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", column_index_map, IndexVector<idx_t, PhysicalIndex>());
@@ -222,16 +222,21 @@ void BoundMergeIntoAction::Serialize(Serializer &serializer) const {
 		serializer.WriteProperty<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", column_index_map);
 	}
 	serializer.WritePropertyWithDefault<bool>(205, "update_is_del_and_insert", update_is_del_and_insert);
+	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(206, "updated_columns", updated_columns);
 }
 
 unique_ptr<BoundMergeIntoAction> BoundMergeIntoAction::Deserialize(Deserializer &deserializer) {
 	auto result = duckdb::unique_ptr<BoundMergeIntoAction>(new BoundMergeIntoAction());
 	deserializer.ReadProperty<MergeActionType>(200, "action_type", result->action_type);
 	deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(201, "condition", result->condition);
-	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(202, "columns", result->columns);
+	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(202, "columns", result->referenced_columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
 	deserializer.ReadPropertyWithExplicitDefault<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", result->column_index_map, IndexVector<idx_t, PhysicalIndex>());
 	deserializer.ReadPropertyWithDefault<bool>(205, "update_is_del_and_insert", result->update_is_del_and_insert);
+	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(206, "updated_columns", result->updated_columns);
+	if (result->updated_columns.empty()) {
+		result->updated_columns = result->referenced_columns;
+	}
 	return result;
 }
 
@@ -922,12 +927,13 @@ void LogicalUpdate::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<TableIndex>(201, "table_index", table_index);
 	serializer.WritePropertyWithDefault<bool>(202, "return_chunk", return_chunk);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", expressions);
-	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(204, "columns", columns);
+	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(204, "columns", referenced_columns);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", bound_defaults);
 	serializer.WritePropertyWithDefault<bool>(206, "update_is_del_and_insert", update_is_del_and_insert);
 	serializer.WritePropertyWithDefault<bool>(207, "capture_old_rows", capture_old_rows, false);
 	serializer.WritePropertyWithDefault<vector<idx_t>>(208, "old_row_columns", old_row_columns);
 	serializer.WritePropertyWithDefault<RowIdHandling>(209, "row_id_handling", row_id_handling, RowIdHandling::ASSUME_UNIQUE);
+	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(210, "updated_columns", updated_columns);
 }
 
 unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserializer) {
@@ -936,12 +942,13 @@ unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<TableIndex>(201, "table_index", result->table_index);
 	deserializer.ReadPropertyWithDefault<bool>(202, "return_chunk", result->return_chunk);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
-	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(204, "columns", result->columns);
+	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(204, "columns", result->referenced_columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", result->bound_defaults);
 	deserializer.ReadPropertyWithDefault<bool>(206, "update_is_del_and_insert", result->update_is_del_and_insert);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(207, "capture_old_rows", result->capture_old_rows, false);
 	deserializer.ReadPropertyWithDefault<vector<idx_t>>(208, "old_row_columns", result->old_row_columns);
 	deserializer.ReadPropertyWithExplicitDefault<RowIdHandling>(209, "row_id_handling", result->row_id_handling, RowIdHandling::ASSUME_UNIQUE);
+	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(210, "updated_columns", result->updated_columns);
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -222,7 +222,7 @@ void BoundMergeIntoAction::Serialize(Serializer &serializer) const {
 		serializer.WriteProperty<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", column_index_map);
 	}
 	serializer.WritePropertyWithDefault<bool>(205, "update_is_del_and_insert", update_is_del_and_insert);
-	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(206, "updated_columns", updated_columns);
+	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(206, "columns_to_update", columns_to_update);
 }
 
 unique_ptr<BoundMergeIntoAction> BoundMergeIntoAction::Deserialize(Deserializer &deserializer) {
@@ -233,7 +233,7 @@ unique_ptr<BoundMergeIntoAction> BoundMergeIntoAction::Deserialize(Deserializer 
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
 	deserializer.ReadPropertyWithExplicitDefault<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", result->column_index_map, IndexVector<idx_t, PhysicalIndex>());
 	deserializer.ReadPropertyWithDefault<bool>(205, "update_is_del_and_insert", result->update_is_del_and_insert);
-	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(206, "updated_columns", result->updated_columns);
+	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(206, "columns_to_update", result->columns_to_update);
 	return result;
 }
 
@@ -930,7 +930,7 @@ void LogicalUpdate::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(207, "capture_old_rows", capture_old_rows, false);
 	serializer.WritePropertyWithDefault<vector<idx_t>>(208, "old_row_columns", old_row_columns);
 	serializer.WritePropertyWithDefault<RowIdHandling>(209, "row_id_handling", row_id_handling, RowIdHandling::ASSUME_UNIQUE);
-	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(210, "updated_columns", updated_columns);
+	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(210, "columns_to_update", columns_to_update);
 }
 
 unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserializer) {
@@ -945,7 +945,7 @@ unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithExplicitDefault<bool>(207, "capture_old_rows", result->capture_old_rows, false);
 	deserializer.ReadPropertyWithDefault<vector<idx_t>>(208, "old_row_columns", result->old_row_columns);
 	deserializer.ReadPropertyWithExplicitDefault<RowIdHandling>(209, "row_id_handling", result->row_id_handling, RowIdHandling::ASSUME_UNIQUE);
-	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(210, "updated_columns", result->updated_columns);
+	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(210, "columns_to_update", result->columns_to_update);
 	return std::move(result);
 }
 

--- a/src/storage/serialization/serialize_logical_operator.cpp
+++ b/src/storage/serialization/serialize_logical_operator.cpp
@@ -214,7 +214,7 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 void BoundMergeIntoAction::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<MergeActionType>(200, "action_type", action_type);
 	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(201, "condition", condition);
-	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(202, "columns", referenced_columns);
+	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(202, "referenced_columns", referenced_columns);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", expressions);
 	if (serializer.ShouldSerialize(StorageVersion::V2_0_0)) {
 		serializer.WritePropertyWithDefault<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", column_index_map, IndexVector<idx_t, PhysicalIndex>());
@@ -229,14 +229,11 @@ unique_ptr<BoundMergeIntoAction> BoundMergeIntoAction::Deserialize(Deserializer 
 	auto result = duckdb::unique_ptr<BoundMergeIntoAction>(new BoundMergeIntoAction());
 	deserializer.ReadProperty<MergeActionType>(200, "action_type", result->action_type);
 	deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(201, "condition", result->condition);
-	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(202, "columns", result->referenced_columns);
+	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(202, "referenced_columns", result->referenced_columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
 	deserializer.ReadPropertyWithExplicitDefault<IndexVector<idx_t, PhysicalIndex>>(204, "column_index_map", result->column_index_map, IndexVector<idx_t, PhysicalIndex>());
 	deserializer.ReadPropertyWithDefault<bool>(205, "update_is_del_and_insert", result->update_is_del_and_insert);
 	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(206, "updated_columns", result->updated_columns);
-	if (result->updated_columns.empty()) {
-		result->updated_columns = result->referenced_columns;
-	}
 	return result;
 }
 
@@ -927,7 +924,7 @@ void LogicalUpdate::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<TableIndex>(201, "table_index", table_index);
 	serializer.WritePropertyWithDefault<bool>(202, "return_chunk", return_chunk);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", expressions);
-	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(204, "columns", referenced_columns);
+	serializer.WritePropertyWithDefault<vector<PhysicalIndex>>(204, "referenced_columns", referenced_columns);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", bound_defaults);
 	serializer.WritePropertyWithDefault<bool>(206, "update_is_del_and_insert", update_is_del_and_insert);
 	serializer.WritePropertyWithDefault<bool>(207, "capture_old_rows", capture_old_rows, false);
@@ -942,7 +939,7 @@ unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<TableIndex>(201, "table_index", result->table_index);
 	deserializer.ReadPropertyWithDefault<bool>(202, "return_chunk", result->return_chunk);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
-	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(204, "columns", result->referenced_columns);
+	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(204, "referenced_columns", result->referenced_columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", result->bound_defaults);
 	deserializer.ReadPropertyWithDefault<bool>(206, "update_is_del_and_insert", result->update_is_del_and_insert);
 	deserializer.ReadPropertyWithExplicitDefault<bool>(207, "capture_old_rows", result->capture_old_rows, false);

--- a/test/sql/returning/returning_update.test
+++ b/test/sql/returning/returning_update.test
@@ -303,6 +303,24 @@ SELECT * FROM table4;
 7	8	9
 1	10	3
 
+# RETURNING must not turn a non-key update into a delete and insert
+statement ok
+CREATE TABLE returning_parent (id INTEGER PRIMARY KEY, value INTEGER);
+
+statement ok
+CREATE TABLE returning_child (parent_id INTEGER REFERENCES returning_parent(id));
+
+statement ok
+INSERT INTO returning_parent VALUES (1, 10);
+
+statement ok
+INSERT INTO returning_child VALUES (1);
+
+query I
+UPDATE returning_parent SET value = 11 WHERE id = 1 RETURNING value;
+----
+11
+
 query I
 SELECT count(*) FROM table1;
 ----


### PR DESCRIPTION
Closes https://github.com/duckdb/duckdb/issues/25654

In the current implementation, [`LogicalUpdate::columns`](https://github.com/dentiny/duckdb/blob/ca5ce12b7dd33555f58d81ade0990442cb6eefca/src/include/duckdb/planner/operator/logical_update.hpp#L38) represents both columns explicitly modified by SET and columns merely materialized for constraint checks or RETURNING.

For `UPDATE ... RETURNING`, [BindUpdateConstraints](https://github.com/duckdb/duckdb/blob/88902aaa3972216c928c8e79a89217a413be414c/src/catalog/catalog_entry/table_catalog_entry.cpp#L297-L302) materialized every physical column through `BindExtraColumns`. Those columns were appended to `update.columns`, which was subsequently used to check constraints.

As a result, RETURNING made an update to a non-key column appear to modify the primary key, incorrectly rewriting it as DELETE + INSERT. Deleting the referenced parent row then produced a false foreign key violation.

In this PR, I split the responsibility into two parts:
- `referenced_columns`, which represents columns materialized for constraints, RETURNING, or reinsertion
- `columns_to_update`: columns explicitly targeted by the SET clause
