### PR TITLE
Do not assert on a scan of a row group collection without committed row groups

### DIFF
--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -236,9 +236,11 @@ void RowGroupCollection::InitializeScan(const QueryContext &context, CollectionS
                                         optional_ptr<TableFilterSet> table_filters) {
 	state.row_groups = GetRowGroups();
 	auto row_group = state.GetRootSegment();
-	D_ASSERT(row_group);
 	state.max_row = state.row_groups->GetBaseRowId() + total_rows;
 	state.Initialize(context, GetTypes());
+	// A collection without any committed row groups (a freshly created table, or a table whose rows are all still
+	// in LocalStorage) has no root segment. That is a legitimate state to start a scan from - the loop below
+	// handles a null root, and DataTable::InitializeScan continues into LocalStorage afterwards.
 	while (row_group && !row_group->GetNode().InitializeScan(state, *row_group)) {
 		row_group = state.GetNextRowGroup(*row_group);
 	}

--- a/src/storage/table/row_group_collection.cpp
+++ b/src/storage/table/row_group_collection.cpp
@@ -238,9 +238,6 @@ void RowGroupCollection::InitializeScan(const QueryContext &context, CollectionS
 	auto row_group = state.GetRootSegment();
 	state.max_row = state.row_groups->GetBaseRowId() + total_rows;
 	state.Initialize(context, GetTypes());
-	// A collection without any committed row groups (a freshly created table, or a table whose rows are all still
-	// in LocalStorage) has no root segment. That is a legitimate state to start a scan from - the loop below
-	// handles a null root, and DataTable::InitializeScan continues into LocalStorage afterwards.
 	while (row_group && !row_group->GetNode().InitializeScan(state, *row_group)) {
 		row_group = state.GetNextRowGroup(*row_group);
 	}

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -39,7 +39,8 @@ set(TEST_API_OBJECTS
     test_object_cache.cpp
     test_partial_executor.cpp
     test_buffer_pool_eviction.cpp
-    test_block_allocator_tls.cpp)
+    test_block_allocator_tls.cpp
+    test_data_table_scan_without_row_groups.cpp)
 
 if(NOT WIN32)
   set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp)

--- a/test/api/test_data_table_scan_without_row_groups.cpp
+++ b/test/api/test_data_table_scan_without_row_groups.cpp
@@ -1,0 +1,88 @@
+#include "catch.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
+#include "test_helpers.hpp"
+
+using namespace duckdb; // NOLINT
+
+namespace {
+
+//! Scan a table through the internal DataTable API, the way extensions (e.g. DuckLake's server-side commit)
+//! read their staged tables: DataTable::InitializeScan followed by a DataTable::Scan loop.
+idx_t ScanTableThroughStorage(Connection &con, const string &table_name) {
+	auto &context = *con.context;
+	auto &table = Catalog::GetEntry<TableCatalogEntry>(context, INVALID_CATALOG, DEFAULT_SCHEMA, table_name);
+	auto &storage = table.GetStorage();
+	auto &transaction = DuckTransaction::Get(context, table.ParentCatalog());
+
+	vector<StorageIndex> column_ids;
+	for (idx_t i = 0; i < table.GetColumns().PhysicalColumnCount(); i++) {
+		column_ids.emplace_back(i);
+	}
+
+	TableScanState state;
+	storage.InitializeScan(context, transaction, state, column_ids);
+
+	DataChunk chunk;
+	chunk.Initialize(Allocator::Get(context), storage.GetTypes());
+
+	idx_t count = 0;
+	while (true) {
+		chunk.Reset();
+		storage.Scan(transaction, chunk, state);
+		if (chunk.size() == 0) {
+			break;
+		}
+		count += chunk.size();
+	}
+	return count;
+}
+
+} // namespace
+
+TEST_CASE("Test scanning a table that has no committed row groups", "[api]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+
+	SECTION("table created and filled inside the scanning transaction") {
+		// all rows live in LocalStorage, the row group collection is empty
+		con.BeginTransaction();
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE t(i INTEGER)"));
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO t VALUES (1), (2), (3)"));
+
+		idx_t count = 0;
+		REQUIRE_NOTHROW(count = ScanTableThroughStorage(con, "t"));
+		REQUIRE(count == 3);
+
+		con.Rollback();
+	}
+
+	SECTION("committed table that never had any rows") {
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE e(i INTEGER)"));
+
+		con.BeginTransaction();
+		idx_t count = 1;
+		REQUIRE_NOTHROW(count = ScanTableThroughStorage(con, "e"));
+		REQUIRE(count == 0);
+		con.Commit();
+	}
+
+	SECTION("committed rows plus transaction-local rows") {
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE m(i INTEGER)"));
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO m VALUES (1), (2)"));
+
+		con.BeginTransaction();
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO m VALUES (3), (4), (5)"));
+
+		idx_t count = 0;
+		REQUIRE_NOTHROW(count = ScanTableThroughStorage(con, "m"));
+		REQUIRE(count == 5);
+
+		con.Rollback();
+	}
+}


### PR DESCRIPTION
## What the assert is

`RowGroupCollection::InitializeScan` (`src/storage/table/row_group_collection.cpp`) asserts that the
collection has a root segment:

```cpp
state.row_groups = GetRowGroups();
auto row_group = state.GetRootSegment();
D_ASSERT(row_group);                      // <- this one
state.max_row = state.row_groups->GetBaseRowId() + total_rows;
state.Initialize(context, GetTypes());
while (row_group && !row_group->GetNode().InitializeScan(state, *row_group)) {
	row_group = state.GetNextRowGroup(*row_group);
}
```

A `DataTable` with no committed row group has no root segment. That happens for a table created in
the current transaction, for a committed table that never had rows, and for a table whose rows are
all still transaction-local in `LocalStorage`.

## Who hits it

No SQL path inside DuckDB reaches it: `TableScanFunction` uses
`InitializeParallelScan`/`NextParallelScan`, and `RebuildIndexes` only runs after a vacuum has
changed row ids. However, the DuckLake extension uses this path in 

`DuckLakeServerSideCommit::ScanStagedTable` (ducklake, `src/storage/ducklake_server_side_commit.cpp`)
when it reads reads its staged temp tables with the internal API:

```cpp
storage.InitializeScan(context, duck_transaction, scan_state, column_ids);
while (true) {
	chunk.Reset();
	storage.Scan(duck_transaction, chunk, scan_state);
	...
}
```

`DuckLakeStagedCommit::Build` creates those staged temp tables (`DuckLakeStagedTable::CreateAllSql`)
and fills them inside the same, still-open transaction that then runs
`SELECT * FROM ducklake_commit(<metadata schema>, <schema version>)`. Every staged row is therefore
transaction-local and the collection has no root row group. The empty staged tables - most of them
are empty in any given commit - have no root row group either, even outside a transaction.

The PR removes the asserts and adds tests to test various scan types at this lower level.


## Reproducing with an assertion-enabled DuckLake

In a `duckdb/ducklake` checkout, run:

```sh
ENABLE_QUACK=ON GEN=ninja make debug
python3 scripts/run_quack_tests.py --build-dir build/debug --no-install \
    test/sql/quack/server_side_commit_atomicity.test
```

which fails with :

```
[1/1] (100%): test/sql/quack/server_side_commit_atomicity.test
  ===============================================================================
  test cases: 1 | 1 failed
  assertions: 3 | 2 passed | 1 failed
  --- stderr ---

  1. test/sql/quack/server_side_commit_atomicity.test:19
  ================================================================================
  Query unexpectedly failed! (test/sql/quack/server_side_commit_atomicity.test:19)!
  ================================================================================
  INSERT INTO ducklake.test VALUES (1);
  ================================================================================
  TransactionContext Error: Failed to commit: Failed to invoke server-side ducklake_commit: Assertion triggered in file "/Users/boaz/src/md/ducklake/duckdb/src/storage/table/row_group_collection.cpp" on line 238: row_group

  Stack Trace:

  0        duckdb::Exception::ToJSON(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 60
  1        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 52
  2        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 40
  3        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 36
  4        duckdb::InternalException::InternalException<char const*&, int&, char const*&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, char const*&, int&, char const*&) + 80
  5        duckdb::DuckDBAssertInternal(bool, char const*, char const*, int) + 124
  6        duckdb::RowGroupCollection::InitializeScan(duckdb::QueryContext const&, duckdb::CollectionScanState&, duckdb::vector<duckdb::StorageIndex, true, std::__1::allocator<duckdb::StorageIndex>> const&, duckdb::optional_ptr<duckdb::TableFilterSet, true>) + 124
  7        duckdb::DataTable::InitializeScan(duckdb::ClientContext&, duckdb::DuckTransaction&, duckdb::TableScanState&, duckdb::vector<duckdb::StorageIndex, true, std::__1::allocator<duckdb::StorageIndex>> const&, duckdb::optional_ptr<duckdb::TableFilterSet, true>) + 216
  8        duckdb::DuckLakeServerSideCommit::ScanStagedTable(duckdb::DuckLakeStagedTableType) + 716
  9        duckdb::DuckLakeServerSideCommit::ReadColumnTypes() + 52
  10       duckdb::DuckLakeServerSideCommit::Run() + 64
  11       duckdb::DuckLakeCommitExecute(duckdb::ClientContext&, duckdb::TableFunctionInput&, duckdb::DataChunk&) + 184
```

